### PR TITLE
fix: published npm scope + catalog-validation CI

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -1,0 +1,24 @@
+name: validate-catalog
+
+on:
+  pull_request:
+    paths:
+      - "catalog/plugins/**"
+      - "schemas/**"
+      - ".github/workflows/validate-catalog.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  catalog-validation:
+    name: catalog-validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Validate catalog
+        run: npx --yes @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,25 +156,24 @@ or verified co-author, but must not replace the creator's authorship. See
 
 ## Validation commands and availability
 
-The npm CLI has not been released yet. The commands below are implemented, but they become
-available through `npx` only after `@diegosouzapw/dsh-plugins` is published. They are not a claim
-that a public CI workflow or install path is currently available, and contributors should not
-invent substitute commands.
+The npm CLI is published as `@diegosouza.pw/dsh-plugins@0.1.0`, so the commands below are
+available through `npx` today. Use them exactly as written; contributors should not invent
+substitute commands.
 
-After the npm release, run these commands from the repository root:
+Run these commands from the repository root:
 
 ```bash
-npx @diegosouzapw/dsh-plugins catalog validate --catalog .
-npx @diegosouzapw/dsh-plugins catalog docs-check .
-npx @diegosouzapw/dsh-plugins catalog github-forms-check .
+npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
+npx @diegosouza.pw/dsh-plugins catalog docs-check .
+npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` performs only the local YAML, schema, SPDX, exact SemVer, SHA-512 SRI and
 duplicate checks described above, and accepts the intentional zero-entry catalog. It does not
 prove remote repository identity or pinned-source evidence. The other commands check the required
-public documentation and structured GitHub issue forms. Until the package is released,
-maintainers apply the corresponding release gates; the absence of a published command does not
-relax the evidence requirements.
+public documentation and structured GitHub issue forms. Passing these commands locally does not
+relax the evidence requirements; maintainers still apply every corresponding release gate before
+merging.
 
 ## Review gates, collisions and merge
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ creator repository, with a pinned source commit and explicit attribution.
 npx @diegosouza.pw/dsh-plugins --help
 ```
 
-The scoped package is released through a separate publication gate. The command above is the
-canonical invocation once that release is available; no installer script is hosted here.
+The scoped package is published as `@diegosouza.pw/dsh-plugins@0.1.0` and the command above is
+the canonical invocation today; no installer script is hosted here.
 
 ## Catalog sections
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ creator repository, with a pinned source commit and explicit attribution.
 ## Install the CLI
 
 ```bash
-npx @diegosouzapw/dsh-plugins --help
+npx @diegosouza.pw/dsh-plugins --help
 ```
 
 The scoped package is released through a separate publication gate. The command above is the


### PR DESCRIPTION
Closes the two public-facing findings of the 2026-08-18 post-launch deep review:

- REV-01: the 5 remaining references to the unpublished @diegosouzapw/dsh-plugins scope now point at the published @diegosouza.pw/dsh-plugins@0.1.0 (README install command and the contributor validation flow were returning E404).
- REV-02: adds the .github/workflows/validate-catalog.yml workflow (job catalog-validation) pinned to the immutable 0.1.0 CLI, per implementation plan 01 task 5. Validated locally: exit 0, "0 entries valid; catalog is empty". Uses --catalog . because the published 0.1.0 rejects the positional form.
- Follow-up: the install section states the published package plainly.

Catalog remains at exactly zero entries; no contract or schema change.