### PR TITLE
docs: detailed README + technical docs (schema, CLI, governance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,25 @@
 > **Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.**
 > DeepSeek names and marks belong to their respective owner.
 
-Creator-first discovery and one-command installation for DeepSeek Harness plugins.
+Creator-first discovery and one-command installation for DeepSeek Harness (DSH) plugins.
+
+This repository is the public source of truth for the catalog. Every listing is one YAML file
+under `catalog/plugins/`, validated against a published JSON Schema, added through one
+individually reviewed pull request, and always credited to the plugin's original creator.
+Nothing in the catalog is generated from another catalog or list: each entry is reconstructed
+from the original creator repository at a pinned commit.
+
+## At a glance
+
+| Surface     | What it is                                                       | Where                                                                    |
+| ----------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **Catalog** | One YAML file per plugin, the single source of truth             | [`catalog/plugins/`](catalog/plugins)                                    |
+| **Schema**  | Public JSON Schema (draft 2020-12) every entry validates against | [`schemas/plugin.schema.yaml`](schemas/plugin.schema.yaml)               |
+| **CLI**     | Search, inspect, validate and install from the catalog           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **Website** | Rendered catalog browser                                         | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
+
+The website and the CLI are maintained from private source; this repository carries the public
+catalog data, schema and policies they consume.
 
 ## Catalog status
 
@@ -20,6 +38,118 @@ npx @diegosouza.pw/dsh-plugins --help
 
 The scoped package is published as `@diegosouza.pw/dsh-plugins@0.1.0` and the command above is
 the canonical invocation today; no installer script is hosted here.
+
+## Use the CLI today
+
+Version 0.1.0 ships read-only discovery and validation commands plus consent-gated install
+commands. The full command reference, including flags, exit codes and the code-execution
+consent gate, is in [docs/CLI.md](docs/CLI.md).
+
+| Command                        | What it does                                                        | Touches your system?                    |
+| ------------------------------ | ------------------------------------------------------------------- | --------------------------------------- |
+| `catalog validate --catalog .` | Validate catalog YAML, schema and local semantics                   | No — read-only                          |
+| `search <query...>`            | Search public catalog fields locally                                | No — read-only                          |
+| `info <id>`                    | Show one public catalog entry                                       | No — read-only                          |
+| `list`                         | List catalog-managed installs without modifying profiles            | No — read-only                          |
+| `doctor`                       | Read-only Node, DSH, native Windows policy and catalog diagnostics  | No — read-only                          |
+| `add <id> --profile <name> --dry-run` | Show the verified install plan without files or subprocesses | No — dry-run                            |
+| `add <id> --profile <name> --allow-code-execution` | Install through official DSH delegation        | Yes — only with explicit consent flag   |
+
+```bash
+# Validate the catalog in this repository (what CI runs):
+npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+
+# Search and inspect locally, without installing anything:
+npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
+npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+
+# Preview an install plan; nothing is written and no subprocess runs:
+npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+```
+
+Mutating commands (`add`, `update`, `remove`) never execute plugin lifecycle code unless you
+pass `--allow-code-execution`. On native Windows those mutations are disabled in v0.1.0; use
+WSL. Read-only and dry-run commands work everywhere.
+
+## How a plugin enters the catalog
+
+1. **One plugin, one branch, one pull request.** The PR adds or changes exactly one YAML file
+   under `catalog/plugins/`.
+2. **Creator-first.** A PR opened by the plugin's creator or owning organization always takes
+   precedence over community curation or automation for the same plugin — see
+   [docs/CREDIT.md](docs/CREDIT.md).
+3. **Evidence from the original source.** Every field is reconstructed from the creator's
+   repository at a pinned 40-character commit: description, license, DSH integration, install
+   descriptor, stars.
+4. **Local validation.** `catalog validate` checks structure and local semantics; it is the same
+   check the `catalog-validation` CI job runs on the PR.
+5. **Maintainer gates.** Before merge, maintainers separately verify repository identity,
+   creator binding and pinned evidence. A green local validation is necessary, never sufficient.
+
+The complete contract — required evidence, YAML rules, stars policy, collision handling and the
+review gates — is in [CONTRIBUTING.md](CONTRIBUTING.md). How decisions are made and by whom is
+in [docs/GOVERNANCE.md](docs/GOVERNANCE.md).
+
+## Anatomy of an entry
+
+Each entry is one YAML file named after its ID. The example below validates against the current
+schema (field-by-field reference in [docs/SCHEMA.md](docs/SCHEMA.md)):
+
+```yaml
+schemaVersion: 1
+id: example-notes-search
+name: Example Notes Search
+description:
+  en: >-
+    Searches a local Markdown notes folder from DSH sessions and returns
+    matching snippets with file paths.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - search
+  - notes
+  - cli
+source:
+  repository: https://github.com/example-creator/example-notes-search
+  repositoryNodeId: R_kgDOExample01
+  subpath: null
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: example-creator
+package:
+  ecosystem: npm
+  name: example-notes-search
+  version: 1.4.2
+dsh:
+  profiles:
+    - default
+  evidencePath: dsh-plugin.json
+repositoryScope: dedicated
+popularity:
+  starsPolicy: exact-repository
+  stars: 128
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: "2026-08-18T12:00:00Z"
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
+Key invariants enforced by the schema:
+
+- `unofficial: true` and `schemaVersion: 1` are constants.
+- A monorepo plugin must use `stars: null` — parent-project stars are never inherited.
+- The install descriptor is either an exact-version npm package or the pinned source itself;
+  it is data, never a shell command.
+- `verified` status requires reviewable smoke-test evidence; otherwise the entry is `eligible`
+  with `smokeTest: null`.
 
 ## Catalog sections
 
@@ -66,6 +196,20 @@ catalog. Creator-authored pull requests take precedence over automated catalog p
 
 Structured issue forms are available for creator claims, corrections and removals. Never submit
 credentials, private contact details or other secrets.
+
+## Documentation
+
+| Document                                     | What it covers                                                       |
+| -------------------------------------------- | -------------------------------------------------------------------- |
+| [CONTRIBUTING.md](CONTRIBUTING.md)           | The full contribution contract: evidence, YAML rules, review gates    |
+| [SECURITY.md](SECURITY.md)                   | Reporting plugin or catalog vulnerabilities; secrets policy           |
+| [docs/SCHEMA.md](docs/SCHEMA.md)             | Field-by-field reference for `schemas/plugin.schema.yaml`             |
+| [docs/CLI.md](docs/CLI.md)                   | CLI command reference for `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/GOVERNANCE.md](docs/GOVERNANCE.md)     | How the catalog is governed: precedence, gates, claims and removals   |
+| [docs/CATEGORIES.md](docs/CATEGORIES.md)     | Artifact kinds, primary capability categories, tags, repository scope |
+| [docs/CREDIT.md](docs/CREDIT.md)             | Creator credit, PR precedence and Git identity policy                 |
+| [docs/RANKING.md](docs/RANKING.md)           | The public ranking predicate and verification states                  |
+| [docs/UNOFFICIAL.md](docs/UNOFFICIAL.md)     | Unofficial status and trademark posture                               |
 
 ## Language roadmap
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,191 @@
+# CLI Reference — `@diegosouza.pw/dsh-plugins@0.1.0`
+
+> **Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.**
+> DeepSeek names and marks belong to their respective owner.
+
+This page documents the published CLI exactly as it behaves in version `0.1.0`. Every synopsis
+and flag below comes from the published command's own `--help` output; nothing here describes
+unreleased behavior. The CLI is maintained from private source and released to npm as the
+scoped package [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+
+```bash
+npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+```
+
+## Design principles in v0.1.0
+
+- **Read-only by default.** `catalog`, `search`, `info`, `list` and `doctor` never modify
+  profiles, write files or spawn plugin code.
+- **Consent gate for code execution.** `add`, `update` and `remove` refuse to run DSH/pnpm
+  lifecycle code unless you pass `--allow-code-execution`. Without it, use `--dry-run` to see
+  the verified plan.
+- **Native Windows policy.** Native Windows `add`/`update`/`remove` with code execution are
+  disabled in v0.1.0; use WSL. Dry-run and the read-only commands remain available, and native
+  Windows recovery markers require documented manual recovery.
+- **Pinned inputs.** Catalog input can be a local directory, a snapshot file, or a pinned
+  public snapshot URL, optionally locked to an exact 40-character revision.
+
+## Common options
+
+These options appear on the catalog-consuming commands (`catalog validate`, `search`, `info`,
+`add`, `update`, `remove`, `doctor`):
+
+| Option                    | Meaning                                                            |
+| ------------------------- | ------------------------------------------------------------------ |
+| `--catalog <path-or-url>` | Local catalog directory, snapshot file, or pinned public snapshot URL |
+| `--revision <sha>`        | Exact 40-character snapshot revision                               |
+| `--json`                  | Emit stable JSON output                                            |
+
+Global options: `-V, --version` prints the CLI version; `-h, --help` prints help for any
+command (`dsh-plugins help [command]` works too).
+
+## Exit codes
+
+The CLI uses conventional process exit codes:
+
+| Exit code | Meaning                                                                    |
+| --------: | -------------------------------------------------------------------------- |
+| `0`       | Success (including "empty but valid" results such as an empty catalog)     |
+| `1`       | Failure: validation error, entry not found, missing required option, or a diagnostic check reporting an error |
+
+Examples observed with v0.1.0: `catalog validate` on a valid empty catalog exits `0` with
+`0 entries valid; catalog is empty`; `info <unknown-id>` exits `1` with `Plugin not found`;
+`doctor` exits `1` when any check (such as a missing `dsh` executable) reports an error.
+
+## Commands
+
+### `catalog` — validate the public catalog surfaces
+
+```text
+dsh-plugins catalog validate [--catalog <path-or-url>] [--revision <sha>] [--json]
+dsh-plugins catalog docs-check [root]
+dsh-plugins catalog github-forms-check [root]
+```
+
+- **`catalog validate`** — validates catalog YAML and semantics: safe YAML parsing, the public
+  schema, SPDX expression parsing, exact SemVer, SHA-512 SRI, and duplicate ID /
+  repository-node-plus-subpath rejection. It is local and read-only: it does not contact
+  GitHub, resolve repository identity or inspect evidence at the pinned commit. This is the
+  exact command the `catalog-validation` CI job runs on every catalog pull request.
+- **`catalog docs-check [root]`** — checks that the required public catalog documentation
+  exists and that Markdown fences are balanced.
+- **`catalog github-forms-check [root]`** — checks the structured public GitHub issue forms
+  (claim, correction, removal).
+
+```bash
+# From the repository root:
+npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
+npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+```
+
+### `search` — search public catalog fields locally
+
+```text
+dsh-plugins search [options] <query...>
+```
+
+Searches public catalog fields locally against the selected catalog input. Prints matching
+entries, or `No plugins found.` (exit `0`) when nothing matches.
+
+```bash
+npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
+npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+```
+
+### `info` — show one public catalog entry
+
+```text
+dsh-plugins info [options] <id>
+```
+
+Shows one public catalog entry by canonical plugin ID. Exits `1` with `Plugin not found: <id>`
+when the ID is not in the catalog.
+
+```bash
+npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+```
+
+### `add` — add one catalog plugin through official DSH delegation
+
+```text
+dsh-plugins add [options] <id>
+```
+
+| Option                   | Meaning                                                            |
+| ------------------------ | ------------------------------------------------------------------ |
+| `--profile <name>`       | DSH profile to mutate (required in practice; the command errors without it) |
+| `--dry-run`              | Show the verified plan without files or subprocesses               |
+| `--allow-code-execution` | Consent to DSH/pnpm lifecycle code (native Windows disabled; use WSL) |
+| `--catalog` / `--revision` / `--json` | Common options above                                  |
+
+Dry-run semantics in this version: the command resolves and verifies the plan for the pinned
+entry and prints it, creating no files and spawning no subprocesses. Actual installation
+delegates to official DSH tooling and only proceeds with `--allow-code-execution`.
+
+```bash
+# Preview only — nothing is written, nothing executes:
+npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+
+# Real install — explicit consent to lifecycle code:
+npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+```
+
+### `update` — update one catalog plugin through official DSH delegation
+
+```text
+dsh-plugins update [options] <id>
+```
+
+Same options and consent semantics as `add`: `--profile <name>`, `--dry-run`,
+`--allow-code-execution`, plus the common catalog options.
+
+### `remove` — remove one catalog-managed plugin through official DSH delegation
+
+```text
+dsh-plugins remove [options] <id>
+```
+
+Same options and consent semantics as `add`. Only catalog-managed installs are removed.
+
+### `recover` — recover a retained POSIX mutation
+
+```text
+dsh-plugins recover
+```
+
+Recovers a retained POSIX mutation after an interrupted `add`/`update`/`remove`. With nothing
+pending it prints `No mutation recovery is pending.` and exits `0`. Native Windows recovery
+remains manual, per the documented policy.
+
+### `list` — list catalog-managed installs
+
+```text
+dsh-plugins list [--profile <name>] [--json]
+```
+
+Lists catalog-managed installs without modifying profiles. `--profile <name>` filters by DSH
+profile. With no installs it prints `No catalog-managed plugins installed.` and exits `0`.
+
+### `doctor` — read-only diagnostics
+
+```text
+dsh-plugins doctor [--catalog <path-or-url>] [--revision <sha>] [--json]
+```
+
+Runs read-only Node, DSH, native Windows policy and catalog diagnostics. Each check reports
+`ok` or `error`; any `error` makes the overall exit code `1`. Example output on a machine
+without the `dsh` executable:
+
+```text
+node [ok]: Node 24.16.0 is supported
+dsh [error]: dsh executable was not found
+catalog [ok]: catalog is valid and empty
+```
+
+## What local validation does not prove
+
+A green `catalog validate` run confirms structure and local semantics only. It does not prove
+remote repository identity, creator ownership, or evidence at the pinned commit — maintainers
+apply those separate provenance gates before any merge, as described in
+[CONTRIBUTING.md](../CONTRIBUTING.md) and [docs/GOVERNANCE.md](GOVERNANCE.md).

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,117 @@
+# Catalog Governance
+
+> **Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.**
+> DeepSeek names and marks belong to their respective owner.
+
+How the public catalog is governed: who decides what enters, in which order competing
+contributions are honored, which checks run automatically, and which judgments remain human.
+The policies referenced here live in [CONTRIBUTING.md](../CONTRIBUTING.md),
+[docs/CREDIT.md](CREDIT.md) and [docs/RANKING.md](RANKING.md); this page describes how they fit
+together.
+
+## Principles
+
+1. **Creator-first.** The catalog exists to make creators' work discoverable, never to take
+   ownership of it. For the same canonical plugin, a direct creator pull request supersedes any
+   open community curation or automation pull request — full precedence order and Git identity
+   rules in [docs/CREDIT.md](CREDIT.md).
+2. **One plugin, one reviewed pull request.** No batch merges, no generated bulk imports into
+   the public catalog. Each entry earns its own review.
+3. **Evidence over trust.** Every public field traces to the original creator repository at a
+   pinned commit. A green automated check is never accepted as proof of origin.
+4. **Unofficial, always.** No catalog state is presented as DeepSeek review, certification or
+   endorsement.
+
+## How changes land on `main`
+
+All changes reach `main` through reviewed pull requests — there are no direct pushes. The
+working policy for the default branch:
+
+- **Pull requests only.** Catalog entries, documentation and schema changes all enter through a
+  PR; catalog PRs must follow the one-plugin-per-branch rule in
+  [CONTRIBUTING.md](../CONTRIBUTING.md).
+- **Linear history.** PRs are integrated so `main` keeps a linear, auditable history; merged
+  public history is not rewritten. If a curated entry merged before a creator came forward, the
+  creator claims or corrects it in a follow-up contribution instead of a history rewrite.
+- **Review-thread resolution.** Review conversations are resolved before merge; unresolved
+  feedback blocks integration.
+- **Maintainer merge.** Only a maintainer merges a plugin entry, and only after every gate in
+  [CONTRIBUTING.md](../CONTRIBUTING.md) → "Review gates, collisions and merge" passes on the
+  current PR commit.
+
+## The `catalog-validation` check
+
+Every pull request touching `catalog/plugins/`, `schemas/` or the workflow itself runs the
+`catalog-validation` job (`.github/workflows/validate-catalog.yml`), pinned to the published
+CLI:
+
+```bash
+npx --yes @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+```
+
+**What it validates** — local structure and semantics only:
+
+- Safe YAML parsing of every entry under `catalog/plugins/`.
+- Conformance to the public schema (see [docs/SCHEMA.md](SCHEMA.md)).
+- SPDX expression parsing, exact SemVer versions, valid SHA-512 SRI integrity values.
+- Duplicate rejection: no repeated entry IDs and no repeated canonical
+  repository-node-plus-subpath keys.
+- The intentional zero-entry catalog passes (`0 entries valid; catalog is empty`).
+
+**What it does NOT validate** — and therefore what a green check never proves:
+
+- Remote repository identity: it does not contact GitHub or resolve the repository node ID
+  against the URL.
+- Evidence at the pinned commit: descriptions, licenses, DSH integration and smoke evidence are
+  not fetched or inspected.
+- Creator ownership, star counts, or collision with open pull requests.
+
+Those judgments belong to the maintainers' separate provenance gates, applied before merge and
+described in [CONTRIBUTING.md](../CONTRIBUTING.md). The local check is the floor, not the bar.
+
+## Verification states
+
+Verification is recorded per entry against its exact pinned commit, using the states defined in
+the public schema (`eligible`, `verified`, `stale`, `unavailable`, `archived`, `quarantined`).
+The two positive states are deliberately narrow:
+
+- `eligible` — the public structure and native DSH integration were validated.
+- `verified` — additionally, an installation smoke test passed for the pinned source or
+  package; the schema requires the smoke-test record to be present.
+
+Neither state — nor any other — is an endorsement, guarantee or security certification. The
+full semantics, including how states interact with ranking, are in
+[docs/RANKING.md](RANKING.md); the record shape is in [docs/SCHEMA.md](SCHEMA.md).
+
+## Claims, corrections and removals
+
+Structured GitHub issue forms (`.github/ISSUE_TEMPLATE/`) are the governed path for changing an
+entry you did not submit:
+
+| Form           | Who uses it                              | Outcome                                             |
+| -------------- | ---------------------------------------- | --------------------------------------------------- |
+| **Claim**      | A creator whose plugin was curated by someone else | Ownership is bound to the original source; the creator can then contribute directly |
+| **Correction** | Anyone who spots inaccurate public metadata | A reviewed fix to the affected entry             |
+| **Removal**    | A creator who wants their listing removed, or a reporter of a policy violation | Reviewed removal or quarantine of the entry |
+
+Rules that apply to all three flows:
+
+- Ownership claims must be supported by verifiable public evidence (repository ownership,
+  package authorship, manifest metadata or pinned source history) — commenting on a Discussion
+  does not establish creatorship ([docs/CREDIT.md](CREDIT.md)).
+- Security problems in a listed plugin go to that plugin's own maintainer first; the catalog
+  side then handles correction or quarantine without publishing exploit detail
+  ([SECURITY.md](../SECURITY.md)).
+- Never include credentials, private contact details or other secrets in a form.
+
+## Roles
+
+- **Creators** own their plugins and their listings' precedence. They can contribute directly,
+  approve community curation, or claim/correct/remove an existing entry.
+- **Community contributors** may curate entries for creators who have not contributed yet,
+  under the respectful-contact and credit rules in [docs/CREDIT.md](CREDIT.md). Curation never
+  outranks a later direct creator contribution.
+- **Maintainers** review, apply the provenance gates, resolve collisions and merge. They also
+  maintain the website ([dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online))
+  and the published CLI from private source; this repository's public data, schema and policies
+  are what those surfaces consume.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,224 @@
+# Catalog Entry Schema Reference
+
+> **Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.**
+> DeepSeek names and marks belong to their respective owner.
+
+This is the field-by-field reference for [`schemas/plugin.schema.yaml`](../schemas/plugin.schema.yaml),
+the public JSON Schema (draft 2020-12) that every file under `catalog/plugins/` must satisfy.
+The schema file itself is the source of truth; when this page and the schema disagree, the
+schema wins.
+
+Two layers of validation apply. The public schema enforces bounded *safe shapes* (patterns and
+lengths that reject option-like or unbounded values). On top of it, `catalog validate` applies
+mandatory semantic parsers: exact SemVer for versions, SHA-512 SRI for integrity values, SPDX
+expression parsing for licenses, and duplicate-key rejection. A value can match the schema
+pattern and still be rejected semantically.
+
+Top-level rules: the entry is a single YAML object, `additionalProperties: false` (unknown
+fields are rejected), and **all** of the following fields are required.
+
+## Top-level fields
+
+| Field             | Type    | Required | Summary                                                       |
+| ----------------- | ------- | :------: | ------------------------------------------------------------- |
+| `schemaVersion`   | const   |   yes    | Must be exactly `1`                                           |
+| `id`              | string  |   yes    | Lowercase kebab-case entry ID; must match the filename        |
+| `name`            | string  |   yes    | Display name, 1–120 characters                                |
+| `description`     | object  |   yes    | Curated English summary plus its evidence path                |
+| `unofficial`      | const   |   yes    | Must be exactly `true`                                        |
+| `kind`            | enum    |   yes    | Canonical artifact discriminator                              |
+| `primaryCategory` | enum    |   yes    | Single primary capability category                            |
+| `tags`            | array   |   yes    | Unique lowercase kebab-case tags (may be empty)               |
+| `source`          | object  |   yes    | Original repository, node ID, subpath and pinned commit       |
+| `creator`         | object  |   yes    | Creator's public GitHub handle                                |
+| `package`         | object  |   yes    | Canonical install descriptor (npm **or** source)              |
+| `dsh`             | object  |   yes    | DSH profiles and native-integration evidence path             |
+| `repositoryScope` | enum    |   yes    | `dedicated` or `monorepo`                                     |
+| `popularity`      | object  |   yes    | Stars policy and star count (conditional on scope)            |
+| `license`         | object  |   yes    | Upstream SPDX license expression                              |
+| `verification`    | object  |   yes    | Verification status, check time, identity and smoke test      |
+| `provenance`      | object  |   yes    | Public Discussion/comment URLs or `null`                      |
+
+### `schemaVersion`
+
+Constant `1`. Identifies public schema version 1; any other value is invalid.
+
+### `id`
+
+String matching `^[a-z0-9]+(?:-[a-z0-9]+)*$` — lowercase kebab-case, no leading/trailing or
+double hyphens. Per [CONTRIBUTING.md](../CONTRIBUTING.md), the entry file must be named
+`catalog/plugins/<id>.yaml` with the identical value.
+
+### `name`
+
+Free-form display name, `minLength: 1`, `maxLength: 120`.
+
+### `description`
+
+Object with exactly two required properties (no others allowed):
+
+| Property       | Type   | Rules                                                                 |
+| -------------- | ------ | --------------------------------------------------------------------- |
+| `en`           | string | English summary, 20–320 characters                                    |
+| `evidencePath` | string | Relative repo path pattern; no leading `/`, no backslashes, no `.`/`..` segments |
+
+The English summary must be curated from the file at `evidencePath` as it exists at
+`source.commit` — not copied from another catalog.
+
+### `unofficial`
+
+Constant `true`. Machine-readable marker that the listing is unofficial.
+
+### `kind`
+
+The **only** artifact-type discriminator (no second integration-kind field exists). One of:
+
+`plugin` · `plugin-family` · `skin-theme` · `skill` · `preset-profile` · `client-interface` ·
+`bridge-adapter` · `ecosystem-project`
+
+Meanings and ranking consequences are defined in [docs/CATEGORIES.md](CATEGORIES.md).
+
+### `primaryCategory`
+
+One of the thirteen capability categories:
+
+`user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
+`browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
+`security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
+`messaging-notifications` · `data-external-services` · `entertainment-customization`
+
+Display labels and selection guidance are in [docs/CATEGORIES.md](CATEGORIES.md).
+
+### `tags`
+
+Array of unique strings, each matching `^[a-z0-9]+(?:-[a-z0-9]+)*$` (lowercase kebab-case).
+No minimum count is imposed by the schema.
+
+### `source`
+
+Object with exactly four required properties:
+
+| Property           | Type           | Rules                                                                  |
+| ------------------ | -------------- | ---------------------------------------------------------------------- |
+| `repository`       | string         | `https://github.com/<owner>/<repo>` URL; owner follows GitHub username rules, repo name 1–100 chars, may not be `.`/`..` or end in `.git` |
+| `repositoryNodeId` | string         | Immutable GitHub repository node ID, non-empty                         |
+| `subpath`          | string or null | Plugin subpath inside the repository (same safe relative-path pattern as `evidencePath`), or `null` for a repository-root plugin |
+| `commit`           | string         | Full 40-character hexadecimal commit OID                               |
+
+Catalog validation must resolve `repositoryNodeId` and reject a repository URL mismatch — that
+resolution is a maintainer-side gate, not part of the local structural check.
+
+### `creator`
+
+Object with a single required property:
+
+| Property | Type   | Rules                                             |
+| -------- | ------ | ------------------------------------------------- |
+| `github` | string | GitHub username (1–39 chars, GitHub handle rules) |
+
+The public profile URL is always derived as `https://github.com/<handle>`; no second profile
+field is stored, so the two can never diverge.
+
+### `package`
+
+The canonical install descriptor. It is data, never a shell command, and takes exactly one of
+two shapes (`oneOf`):
+
+**npm package** — required `ecosystem`, `name`, `version`; optional `integrity`:
+
+| Property    | Type  | Rules                                                                      |
+| ----------- | ----- | -------------------------------------------------------------------------- |
+| `ecosystem` | const | `npm`                                                                      |
+| `name`      | string | npm package name shape (optionally scoped), max 214 chars                 |
+| `version`   | string | Exact `x.y.z` version shape (optional prerelease/build); ranges rejected. Semantic layer additionally requires a parseable, exact SemVer |
+| `integrity` | string | Optional `sha512-…` SRI shape, 8–256 chars. Semantic layer must parse it as valid SHA-512 SRI |
+
+**source install** — required `ecosystem` only:
+
+| Property    | Type  | Rules    |
+| ----------- | ----- | -------- |
+| `ecosystem` | const | `source` |
+
+A source descriptor deliberately stores nothing else: the repository, commit and subpath are
+derived from `source`, so mutable values are never duplicated.
+
+### `dsh`
+
+Native DSH integration evidence:
+
+| Property       | Type   | Rules                                                          |
+| -------------- | ------ | -------------------------------------------------------------- |
+| `profiles`     | array  | At least one unique profile name matching `^[A-Za-z0-9][A-Za-z0-9._-]*$` |
+| `evidencePath` | string | Safe relative path to the DSH integration evidence at `source.commit` |
+
+### `repositoryScope`
+
+Either `dedicated` (repository stars belong to this exact plugin) or `monorepo` (the plugin is
+a subpath or package inside a broader project). This value drives the conditional popularity
+rules below.
+
+### `popularity`
+
+| Property     | Type            | Rules                                                |
+| ------------ | --------------- | ---------------------------------------------------- |
+| `starsPolicy`| enum            | `exact-repository` or `undefined-parent-repository`  |
+| `stars`      | integer or null | Non-negative integer, or `null`                      |
+
+Conditional rules (enforced by the schema's `allOf` blocks):
+
+- `repositoryScope: monorepo` **forces** `starsPolicy: undefined-parent-repository` and
+  `stars: null`. Parent-project stars are never attributed to a monorepo plugin.
+- `repositoryScope: dedicated` **forces** `starsPolicy: exact-repository` and an integer
+  `stars >= 0`.
+
+See [docs/RANKING.md](RANKING.md) for how these values feed the ranking predicate.
+
+### `license`
+
+| Property | Type   | Rules                                                          |
+| -------- | ------ | -------------------------------------------------------------- |
+| `spdx`   | string | SPDX expression shape, 2–256 chars, no leading hyphen          |
+
+The schema enforces only a safe character shape; catalog validation must parse and normalize
+the value with a real SPDX expression parser. Record the complete upstream expression evidenced
+at the pinned commit (for example `Apache-2.0` or `MIT OR GPL-3.0-only`).
+
+### `verification`
+
+Verification applies to `source.commit`. Object with four required properties:
+
+| Property             | Type           | Rules                                                  |
+| -------------------- | -------------- | ------------------------------------------------------ |
+| `status`             | enum           | `eligible` · `verified` · `stale` · `unavailable` · `archived` · `quarantined` |
+| `checkedAt`          | string         | `date-time` formatted timestamp of the check           |
+| `repositoryIdentity` | const          | Must be `resolved`                                     |
+| `smokeTest`          | object or null | Smoke-test record, or `null` when no qualifying test exists |
+
+When present, `smokeTest` requires:
+
+| Property        | Type   | Rules                                                             |
+| --------------- | ------ | ----------------------------------------------------------------- |
+| `installTarget` | const  | `canonical-install-descriptor` — references `package` or the pinned source without duplicating mutable values |
+| `check`         | object | Required `name` (package-name shape) and `version` (exact version shape) |
+| `result`        | const  | `passed` — a failed smoke test is not recorded as a smoke test    |
+
+Conditional rule: `status: verified` **requires** a non-null `smokeTest` object. Entries
+without reviewable smoke evidence use `status: eligible` and `smokeTest: null`. No status is an
+endorsement or security certification — see [docs/RANKING.md](RANKING.md).
+
+### `provenance`
+
+Public provenance links, each a URI or `null`:
+
+| Property     | Type          | Rules                                            |
+| ------------ | ------------- | ------------------------------------------------ |
+| `discussion` | string or null | Public Discussion URL when one exists            |
+| `comment`    | string or null | Public comment URL when one exists               |
+
+## What the schema does not check
+
+The schema is intentionally local and structural. It does **not** verify that the repository
+exists, that the node ID matches the URL, that evidence paths exist at the pinned commit, that
+the star count is accurate, or that the creator owns the source. Those checks belong to the
+maintainer review gates described in [CONTRIBUTING.md](../CONTRIBUTING.md) and
+[docs/GOVERNANCE.md](GOVERNANCE.md).


### PR DESCRIPTION
Expands the public documentation set, OmniRoute-style, with zero changes to the catalog contract:

- README: at-a-glance table, CLI usage for the published 0.1.0, entry anatomy with a schema-validated example, creator-first flow summary, full documentation map. All machine-checked anchors preserved (unofficial notice, catalog count, canonical npx command).
- docs/SCHEMA.md: field-by-field reference of schemas/plugin.schema.yaml (required fields, conditional rules, package oneOf, verification states).
- docs/CLI.md: command reference for @diegosouza.pw/dsh-plugins@0.1.0 as it actually behaves (flags and exit codes verified against the binary).
- docs/GOVERNANCE.md: how the catalog is governed — creator-first precedence, the catalog-validation check scope (local structural gate vs maintainer provenance gates), claim/correction/removal flows, branch rules.

Validated: catalog validate / docs-check / github-forms-check all exit 0; catalog remains at exactly zero entries; POLICY_MARKERS untouched; independent boundary sweep confirms no private-side terms or concepts.