### PR TITLE
catalog: add dsh-pet-remielle (community curation, created by @Gin-7)

### DIFF
--- a/catalog/plugins/dsh-pet-remielle.yaml
+++ b/catalog/plugins/dsh-pet-remielle.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: dsh-pet-remielle
+name: dsh-pet-remielle
+description:
+  en: 'Hot-pluggable desktop pet for the DSH web GUI: a transparent floating Remielle companion (Zenless Zone Zero) that switches animated moods while the agent works.'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+- desktop-pet
+- companion
+- web-ui
+- animation
+- fun
+source:
+  repository: https://github.com/Gin-7/dsh-pet-remielle
+  repositoryNodeId: R_kgDOT5B6oA
+  subpath: null
+  commit: 897fc30b275c794cf3d6d88319915a61f2f16ee8
+creator:
+  github: Gin-7
+package:
+  ecosystem: source
+dsh:
+  profiles:
+  - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19 03:42:12.470000+00:00
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 20
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->
<!-- creator-first:source-bound-git-identity -->

## Plugin scope and source

- Plugin ID: `dsh-pet-remielle`
- Dedicated branch: `catalog/dsh-pet-remielle`
- Submission type (`creator`, `owning organization`, `creator-approved`, or `community curation`): community curation
- Created by `Gin-7`
- Creator profile (`https://github.com/<handle>`): https://github.com/Gin-7
- Original source repository: https://github.com/Gin-7/dsh-pet-remielle
- Repository node ID: `R_kgDOT5B6oA`
- Source commit (40-character OID): `897fc30b275c794cf3d6d88319915a61f2f16ee8`
- Plugin subpath (`null` only for a repository-root plugin): `None`
- Artifact kind, primary category and tags: `plugin` · `entertainment-customization` · desktop-pet, companion, web-ui, animation, fun
- Curated English description evidence path: `README.md` at the pinned commit
- SPDX license evidence at the pinned commit: `MIT` (LICENSE file at source commit)
- Canonical exact-version package or pinned-source descriptor: pinned-source (ecosystem: source)
- Native DSH integration evidence at the pinned commit: `cordis.patch.yml`
- Existing smoke evidence for the exact pin, or `not run`: not run (`verification.status: eligible`, `smokeTest: null`)
- Repository scope and star evidence (`null` policy for monorepos): `dedicated`, stars: 20
- Existing entry/open-PR collision search result: no existing entry, open PR, canonical key, ID or package collision (catalog is empty at base `c5eb6c6`)
- Original repository link and one respectful creator mention (curated PRs only): @Gin-7 — this entry was curated from your public repository (https://github.com/Gin-7/dsh-pet-remielle). If anything is wrong, or you prefer to own the listing, a direct PR from you supersedes this one.

## Checklist

- [x] I used one dedicated branch and this PR changes exactly one plugin entry.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] The creator handle/profile, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] Smoke evidence is linked, or the entry uses `eligible` with `smokeTest: null` for `not run`.
- [x] I did not execute plugin or package lifecycle code to prepare this contribution.
- [x] Dedicated stars are verifiable, or monorepo stars are `null` with `undefined-parent-repository`.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] I understand that a direct creator PR supersedes an open curated or automation PR.
- [x] Creator Git authorship is source-bound and verified, or curator authorship keeps visible creator credit.
- [x] The entry is explicitly unofficial.
- [x] This PR contains no credentials, private contact details or other secrets.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.