### PR TITLE
catalog: add dsh-bili-widget (community curation, created by @pyf2818)

### DIFF
--- a/catalog/plugins/dsh-bili-widget.yaml
+++ b/catalog/plugins/dsh-bili-widget.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: dsh-bili-widget
+name: '@dsh-external/dsh-bili-widget'
+description:
+  en: 'Floating bilibili video widget for the DSH web GUI: recommendations, trending, rankings, subscriptions and search with history persistence, autoplay and a mini focus mode.'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+- bilibili
+- video
+- floating-window
+- web-ui
+- entertainment
+source:
+  repository: https://github.com/pyf2818/dsh-bili-widget
+  repositoryNodeId: R_kgDOT5Nvmg
+  subpath: null
+  commit: 7d564f5f134389a905b5f39485469d602eee2b4a
+creator:
+  github: pyf2818
+package:
+  ecosystem: source
+dsh:
+  profiles:
+  - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19 03:44:38.783000+00:00
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->
<!-- creator-first:source-bound-git-identity -->

## Plugin scope and source

- Plugin ID: `dsh-bili-widget`
- Dedicated branch: `catalog/dsh-bili-widget`
- Submission type (`creator`, `owning organization`, `creator-approved`, or `community curation`): community curation
- Created by `pyf2818`
- Creator profile (`https://github.com/<handle>`): https://github.com/pyf2818
- Original source repository: https://github.com/pyf2818/dsh-bili-widget
- Repository node ID: `R_kgDOT5Nvmg`
- Source commit (40-character OID): `7d564f5f134389a905b5f39485469d602eee2b4a`
- Plugin subpath (`null` only for a repository-root plugin): `None`
- Artifact kind, primary category and tags: `plugin` · `entertainment-customization` · bilibili, video, floating-window, web-ui, entertainment
- Curated English description evidence path: `README.md` at the pinned commit
- SPDX license evidence at the pinned commit: `MIT` (LICENSE file at source commit)
- Canonical exact-version package or pinned-source descriptor: pinned-source (ecosystem: source)
- Native DSH integration evidence at the pinned commit: `cordis.patch.yml`
- Existing smoke evidence for the exact pin, or `not run`: not run (`verification.status: eligible`, `smokeTest: null`)
- Repository scope and star evidence (`null` policy for monorepos): `dedicated`, stars: 2
- Existing entry/open-PR collision search result: no existing entry, open PR, canonical key, ID or package collision (catalog is empty at base `c5eb6c6`)
- Original repository link and one respectful creator mention (curated PRs only): @pyf2818 — this entry was curated from your public repository (https://github.com/pyf2818/dsh-bili-widget). If anything is wrong, or you prefer to own the listing, a direct PR from you supersedes this one.

## Checklist

- [x] I used one dedicated branch and this PR changes exactly one plugin entry.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] The creator handle/profile, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] Smoke evidence is linked, or the entry uses `eligible` with `smokeTest: null` for `not run`.
- [x] I did not execute plugin or package lifecycle code to prepare this contribution.
- [x] Dedicated stars are verifiable, or monorepo stars are `null` with `undefined-parent-repository`.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] I understand that a direct creator PR supersedes an open curated or automation PR.
- [x] Creator Git authorship is source-bound and verified, or curator authorship keeps visible creator credit.
- [x] The entry is explicitly unofficial.
- [x] This PR contains no credentials, private contact details or other secrets.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.