### PR TITLE
catalog: add dsh-themes (community curation, created by @MangMax)

### DIFF
--- a/catalog/plugins/dsh-themes.yaml
+++ b/catalog/plugins/dsh-themes.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: dsh-themes
+name: dsh-themes
+description:
+  en: 'Appearance and themes plugin for DeepSeek Harness: built-in palettes, light/dark/system mode and VS Code theme import for the web GUI.'
+  evidencePath: README.md
+unofficial: true
+kind: skin-theme
+primaryCategory: entertainment-customization
+tags:
+- themes
+- appearance
+- dark-mode
+- vscode-themes
+- web-ui
+source:
+  repository: https://github.com/MangMax/dsh-themes
+  repositoryNodeId: R_kgDOT35ZdQ
+  subpath: null
+  commit: 85fe103cc2792da5eec2d57b045509256a5206d1
+creator:
+  github: MangMax
+package:
+  ecosystem: source
+dsh:
+  profiles:
+  - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19 03:45:10.555000+00:00
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->
<!-- creator-first:source-bound-git-identity -->

## Plugin scope and source

- Plugin ID: `dsh-themes`
- Dedicated branch: `catalog/dsh-themes`
- Submission type (`creator`, `owning organization`, `creator-approved`, or `community curation`): community curation
- Created by `MangMax`
- Creator profile (`https://github.com/<handle>`): https://github.com/MangMax
- Original source repository: https://github.com/MangMax/dsh-themes
- Repository node ID: `R_kgDOT35ZdQ`
- Source commit (40-character OID): `85fe103cc2792da5eec2d57b045509256a5206d1`
- Plugin subpath (`null` only for a repository-root plugin): `None`
- Artifact kind, primary category and tags: `skin-theme` · `entertainment-customization` · themes, appearance, dark-mode, vscode-themes, web-ui
- Curated English description evidence path: `README.md` at the pinned commit
- SPDX license evidence at the pinned commit: `MIT` (LICENSE file at source commit)
- Canonical exact-version package or pinned-source descriptor: pinned-source (ecosystem: source)
- Native DSH integration evidence at the pinned commit: `cordis.patch.yml`
- Existing smoke evidence for the exact pin, or `not run`: not run (`verification.status: eligible`, `smokeTest: null`)
- Repository scope and star evidence (`null` policy for monorepos): `dedicated`, stars: 1
- Existing entry/open-PR collision search result: no existing entry, open PR, canonical key, ID or package collision (catalog is empty at base `c5eb6c6`)
- Original repository link and one respectful creator mention (curated PRs only): @MangMax — this entry was curated from your public repository (https://github.com/MangMax/dsh-themes). If anything is wrong, or you prefer to own the listing, a direct PR from you supersedes this one.

## Checklist

- [x] I used one dedicated branch and this PR changes exactly one plugin entry.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] The creator handle/profile, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] Smoke evidence is linked, or the entry uses `eligible` with `smokeTest: null` for `not run`.
- [x] I did not execute plugin or package lifecycle code to prepare this contribution.
- [x] Dedicated stars are verifiable, or monorepo stars are `null` with `undefined-parent-repository`.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] I understand that a direct creator PR supersedes an open curated or automation PR.
- [x] Creator Git authorship is source-bound and verified, or curator authorship keeps visible creator credit.
- [x] The entry is explicitly unofficial.
- [x] This PR contains no credentials, private contact details or other secrets.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.