### PR TITLE
fix: canonicalize verification.checkedAt in the nine entries

### DIFF
--- a/catalog/plugins/deepseek-harness-tui.yaml
+++ b/catalog/plugins/deepseek-harness-tui.yaml
@@ -30,7 +30,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:42:45.768000+00:00
+  checkedAt: "2026-08-19T03:42:45.768Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/dsh-arknights.yaml
+++ b/catalog/plugins/dsh-arknights.yaml
@@ -31,7 +31,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:46:25.822000+00:00
+  checkedAt: "2026-08-19T03:46:25.822Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/dsh-bili-widget.yaml
+++ b/catalog/plugins/dsh-bili-widget.yaml
@@ -31,7 +31,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:44:38.783000+00:00
+  checkedAt: "2026-08-19T03:44:38.783Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/dsh-bridge-browser.yaml
+++ b/catalog/plugins/dsh-bridge-browser.yaml
@@ -31,7 +31,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:47:34.929000+00:00
+  checkedAt: "2026-08-19T03:47:34.929Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/dsh-pet-remielle.yaml
+++ b/catalog/plugins/dsh-pet-remielle.yaml
@@ -31,7 +31,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:42:12.470000+00:00
+  checkedAt: "2026-08-19T03:42:12.470Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/dsh-themes.yaml
+++ b/catalog/plugins/dsh-themes.yaml
@@ -31,7 +31,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:45:10.555000+00:00
+  checkedAt: "2026-08-19T03:45:10.555Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/dsh-tui.yaml
+++ b/catalog/plugins/dsh-tui.yaml
@@ -30,7 +30,7 @@ license:
   spdx: BSD-3-Clause
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:42:52.261000+00:00
+  checkedAt: "2026-08-19T03:42:52.261Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/dsh-visualize.yaml
+++ b/catalog/plugins/dsh-visualize.yaml
@@ -32,7 +32,7 @@ license:
   spdx: BSD-3-Clause
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:41:52.040000+00:00
+  checkedAt: "2026-08-19T03:41:52.040Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/dsh-whale-musume.yaml
+++ b/catalog/plugins/dsh-whale-musume.yaml
@@ -31,7 +31,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:42:13.693000+00:00
+  checkedAt: "2026-08-19T03:42:13.693Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:


### PR DESCRIPTION
Mechanical normalization: checkedAt must be the exact `toISOString()` form for the site snapshot builder; the entries carried re-serialized YAML timestamps. No semantic change — same instants, canonical strings. Follow-up of today's authorized merges.