### PR TITLE
docs: 10 plugins merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ catalog data, schema and policies they consume.
 
 ## Catalog status
 
-**9 plugins merged.** Every plugin enters through an individually reviewed pull request.
+**10 plugins merged.** Every plugin enters through an individually reviewed pull request.
 
 The catalog intentionally starts empty. Entries are added one at a time from the original
 creator repository, with a pinned source commit and explicit attribution.


### PR DESCRIPTION
Count bump after #8 (dsh-tavily-workspace) merged. Catalog now lists 10 curated plugins.