### PR TITLE
fix: canonicalize dsh-tavily-workspace verification.checkedAt

### DIFF
--- a/catalog/plugins/dsh-tavily-workspace.yaml
+++ b/catalog/plugins/dsh-tavily-workspace.yaml
@@ -31,7 +31,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-19 03:47:37.594000+00:00
+  checkedAt: "2026-08-19T03:47:37.594Z"
   repositoryIdentity: resolved
   smokeTest: null
 popularity:


### PR DESCRIPTION
The entry merged in #8 predates the checkedAt canonicalization from #14, so its timestamp kept the non-canonical serialized form (`2026-08-19 03:47:37.594000+00:00`). Same surgical one-line fix as #14: exact ISO-8601 string. No other field changes.