### PR TITLE
catalog: add dsh-vision-router (community curation, created by @ysr666)

### DIFF
--- a/catalog/plugins/dsh-vision-router.yaml
+++ b/catalog/plugins/dsh-vision-router.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: dsh-vision-router
+name: dsh-vision-router
+description:
+  en: "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - vision
+  - vision-tools
+  - multimodal
+  - openrouter
+  - image
+  - ocr
+  - screenshot
+  - eyes
+  - text
+  - only
+  - agents
+  - built
+  - free
+  - chain
+source:
+  repository: https://github.com/ysr666/dsh-vision-router
+  repositoryNodeId: R_kgDOT3rG5g
+  subpath: null
+  commit: b8620bc65047aaba315a3cb39ebc44e0e78e58a3
+creator:
+  github: ysr666
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:25:48.481Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 843
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-vision-router`
- Submission type: community curation
- Created by `ysr666` — https://github.com/ysr666
- Original source repository: https://github.com/ysr666/dsh-vision-router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@ysr666 — this entry was curated from your public repository (https://github.com/ysr666/dsh-vision-router). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.