### PR TITLE
catalog: add dsh-genui (community curation, created by @taekchef)

### DIFF
--- a/catalog/plugins/dsh-genui.yaml
+++ b/catalog/plugins/dsh-genui.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-genui
+name: "@omdsh-dev/dsh-genui"
+description:
+  en: "GenUI for DeepSeek Harness: interactive UI components rendered inline in assistant replies via the dsh-ui fence — layout, charts, plots, forms, quizzes, mermaid, 3D scenes, and an action event loop back to the model. Ships the fence-teaching host plugin, the browser renderer (client half), and the genui skill."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - generative-ui
+  - ui
+  - genui
+  - interactive
+  - components
+  - rendered
+  - inline
+  - assistant
+  - replies
+  - fence
+  - layout
+  - charts
+  - plots
+  - forms
+source:
+  repository: https://github.com/omdsh-dev/dsh-genui
+  repositoryNodeId: R_kgDOT3XuFg
+  subpath: null
+  commit: dab48fae600edb97859591ff6a25feb363d10721
+creator:
+  github: taekchef
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:25:52.904Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 249
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-genui.yaml
+++ b/catalog/plugins/dsh-genui.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: browser-automation
+primaryCategory: user-interface-dashboards
 tags:
   - dsh
   - deepseek-harness


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-genui`
- Submission type: community curation
- Created by `taekchef` — https://github.com/taekchef
- Original source repository: https://github.com/omdsh-dev/dsh-genui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@taekchef — this entry was curated from your public repository (https://github.com/omdsh-dev/dsh-genui). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.