### PR TITLE
catalog: add dsh-tianshu-tui (community curation, created by @huiliyi37)

### DIFF
--- a/catalog/plugins/dsh-tianshu-tui.yaml
+++ b/catalog/plugins/dsh-tianshu-tui.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-tianshu-tui
+name: "@huiliyi37/dsh-tianshu-tui"
+description:
+  en: "dsh-tianshu-tui: an interactive terminal UI plugin for the official DeepSeek Harness — streaming markdown/tool cards, 16+ themes, slash commands, session tabs, LSP diagnostics, cost tracking, self-update ( dsh plugin --profile tui add @huiliyi37/dsh-tianshu-tui )"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - agent-harness
+  - terminal
+  - tui
+  - cli
+  - tianshu
+  - interactive
+  - official
+  - streaming
+  - markdown
+  - tool
+  - cards
+  - themes
+  - slash
+  - commands
+  - session
+source:
+  repository: https://github.com/huiliyi37/dsh-tianshu-tui
+  repositoryNodeId: R_kgDOT29GJw
+  subpath: null
+  commit: 8993e5c9ea756fa9ebe37d1a68ac08fe69d8eb5d
+creator:
+  github: huiliyi37
+package:
+  ecosystem: npm
+  name: "@huiliyi37/dsh-tianshu-tui"
+  version: 0.1.2-rc.10
+  integrity: sha512-s+iNcwiQY0WKI5NqOZH+a0UNFYyrBqGV/9a2M9QWW75xGmP9ofZrzBrtfaqSOKd6Gvpn9gx7cyylnqDNA9pHvA==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:25:54.539Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 220
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-tianshu-tui`
- Submission type: community curation
- Created by `huiliyi37` — https://github.com/huiliyi37
- Original source repository: https://github.com/huiliyi37/dsh-tianshu-tui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@huiliyi37 — this entry was curated from your public repository (https://github.com/huiliyi37/dsh-tianshu-tui). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.