### PR TITLE
catalog: add anime-find (community curation, created by @cocofhu00)

### DIFF
--- a/catalog/plugins/anime-find.yaml
+++ b/catalog/plugins/anime-find.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: anime-find
+name: "@cocofhu/anime-find"
+description:
+  en: DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - anime
+  - mikan
+  - bangumi
+source:
+  repository: https://github.com/cocofhu/anime-find
+  repositoryNodeId: R_kgDOT5RvJA
+  subpath: null
+  commit: 66f21a9836b33709041aa72853a2edadb771a87b
+creator:
+  github: cocofhu00
+package:
+  ecosystem: npm
+  name: "@cocofhu/anime-find"
+  version: 0.1.11
+  integrity: sha512-cJ1IiP0C4nEo09SihwSTlfzDjzBaH3yxtNrlNDDMZtlHrLlwTuIEtdzdEWiJNMzH+W94LbKJucKxwW4Tiy6OKA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:25:57.703Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 152
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/anime-find.yaml
+++ b/catalog/plugins/anime-find.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: anime-find
 name: "@cocofhu/anime-find"
 description:
-  en: DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放
+  en: "An anime search plugin for DeepSeek Harness: an anime_find_search tool aggregates Mikan, AniBT and AnimeGarden into clickable cards in the chat, with per-fansub episode lists, magnet and .torrent links, Bangumi details, and an optional rule-based streaming tab."
   evidencePath: README.md
 unofficial: true
 kind: plugin


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `anime-find`
- Submission type: community curation
- Created by `cocofhu00` — https://github.com/cocofhu00
- Original source repository: https://github.com/cocofhu/anime-find
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@cocofhu00 — this entry was curated from your public repository (https://github.com/cocofhu/anime-find). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.