### PR TITLE
catalog: add workflow (community curation, created by @icetomoyo)

### DIFF
--- a/catalog/plugins/workflow.yaml
+++ b/catalog/plugins/workflow.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: models-providers-routing
+primaryCategory: coding-developer-tools
 tags:
   - dsh
   - deepseek-harness

--- a/catalog/plugins/workflow.yaml
+++ b/catalog/plugins/workflow.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: workflow
+name: "@dsh-external/workflow"
+description:
+  en: KodaX-parity dynamic workflow harness for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - workflow
+  - dshtopic
+  - multi-agent
+  - agent-orchestration
+  - kodax
+  - parity
+  - dynamic
+source:
+  repository: https://github.com/omdsh-dev/dsh_workflow
+  repositoryNodeId: R_kgDOT2hsPA
+  subpath: null
+  commit: 44b83c182aa02d1be8a0803e8446cb495f93cd8f
+creator:
+  github: icetomoyo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:00.794Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 88
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `workflow`
- Submission type: community curation
- Created by `icetomoyo` — https://github.com/icetomoyo
- Original source repository: https://github.com/omdsh-dev/dsh_workflow
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@icetomoyo — this entry was curated from your public repository (https://github.com/omdsh-dev/dsh_workflow). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.