### PR TITLE
catalog: add dsh-annotation (community curation, created by @taekchef)

### DIFF
--- a/catalog/plugins/dsh-annotation.yaml
+++ b/catalog/plugins/dsh-annotation.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: messaging-notifications
+primaryCategory: user-interface-dashboards
 tags:
   - selection
   - annotation

--- a/catalog/plugins/dsh-annotation.yaml
+++ b/catalog/plugins/dsh-annotation.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-annotation
+name: "@omdsh-dev/dsh-annotation"
+description:
+  en: "DSH Web selection-annotation plugin: select assistant text, annotate (optional), and press Enter to send the annotation block with your message — the model replies to each annotation by number, with hoverable chips in the reply."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - selection
+  - annotation
+  - select
+  - assistant
+  - text
+  - annotate
+  - optional
+  - press
+  - enter
+  - send
+  - block
+  - message
+  - model
+  - replies
+  - each
+  - number
+source:
+  repository: https://github.com/omdsh-dev/dsh-annotation
+  repositoryNodeId: R_kgDOT0ePZw
+  subpath: null
+  commit: cd356724cb5cab2c1cc3cdb64c50a7ce807bbb84
+creator:
+  github: taekchef
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:03.650Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 79
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-annotation`
- Submission type: community curation
- Created by `taekchef` — https://github.com/taekchef
- Original source repository: https://github.com/omdsh-dev/dsh-annotation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@taekchef — this entry was curated from your public repository (https://github.com/omdsh-dev/dsh-annotation). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.