### PR TITLE
catalog: add dsh-vision (community curation, created by @oil-oil)

### DIFF
--- a/catalog/plugins/dsh-vision.yaml
+++ b/catalog/plugins/dsh-vision.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: dsh-vision
+name: "@oil-oil/dsh-vision"
+description:
+  en: Near-native image understanding for text-only DeepSeek Harness models
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - vision
+  - multimodal
+  - image-understanding
+  - near
+  - native
+  - image
+  - understanding
+  - text
+  - only
+  - models
+  - dsh
+source:
+  repository: https://github.com/oil-oil/dsh-vision
+  repositoryNodeId: R_kgDOT39-NA
+  subpath: null
+  commit: 9446a41dc96bd9fc96a7cc3b3a11365e125c9bd7
+creator:
+  github: oil-oil
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:06.536Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 70
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-vision`
- Submission type: community curation
- Created by `oil-oil` — https://github.com/oil-oil
- Original source repository: https://github.com/oil-oil/dsh-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@oil-oil — this entry was curated from your public repository (https://github.com/oil-oil/dsh-vision). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.