### PR TITLE
catalog: add dsh-commandcode-provider (community curation, created by @Mars-Sea)

### DIFF
--- a/catalog/plugins/dsh-commandcode-provider.yaml
+++ b/catalog/plugins/dsh-commandcode-provider.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-commandcode-provider
+name: "@mars-sea/dsh-commandcode-provider"
+description:
+  en: Unofficial DeepSeek Harness LLM provider plugin for Command Code, ported from pi-commandcode-provider (MIT). Registers the 'commandcode' provider route with a Models-page card and live model catalog.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - commandcode
+  - command-code
+  - llm
+  - adapter
+  - provider
+  - bundle
+  - unofficial
+  - command
+  - code
+  - ported
+  - registers
+  - route
+  - models
+  - page
+source:
+  repository: https://github.com/Mars-Sea/dsh-commandcode-provider
+  repositoryNodeId: R_kgDOT4UInw
+  subpath: null
+  commit: c2d14917cf38c2f625989a4204f8d9489be9743e
+creator:
+  github: Mars-Sea
+package:
+  ecosystem: npm
+  name: "@mars-sea/dsh-commandcode-provider"
+  version: 0.5.0
+  integrity: sha512-dddmfAJEmOgKuklXf33UFOvdpjWZK9foaui4QUOsI3guQt4ZjVtnT3C0KGUp7kdZkFJvgD9BjnJiJEJeuqb0aQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:08.311Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 69
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-commandcode-provider`
- Submission type: community curation
- Created by `Mars-Sea` — https://github.com/Mars-Sea
- Original source repository: https://github.com/Mars-Sea/dsh-commandcode-provider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Mars-Sea — this entry was curated from your public repository (https://github.com/Mars-Sea/dsh-commandcode-provider). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.