### PR TITLE
catalog: add dsh-stock-watch (community curation, created by @Awu12277)

### DIFF
--- a/catalog/plugins/dsh-stock-watch.yaml
+++ b/catalog/plugins/dsh-stock-watch.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-stock-watch
 name: dsh-stock-watch
 description:
-  en: A股自选股实时行情盯盘插件 - DeepSeek Harness Web 右上角可折叠弹窗（分时/K线/目标价/主题切换/可拖动/添加股票分组）
+  en: "A watchlist ticker panel for the DeepSeek Harness Web UI: a draggable, edge-snapping pill in the top-right corner tracks Chinese A-share quotes on a 10-second refresh, with grouped lists, intraday and candlestick charts, editable target prices, and buttons that open a new DSH session for analysis."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: search-research
+primaryCategory: data-external-services
 tags:
   - dsh
   - deepseek-harness

--- a/catalog/plugins/dsh-stock-watch.yaml
+++ b/catalog/plugins/dsh-stock-watch.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: dsh-stock-watch
+name: dsh-stock-watch
+description:
+  en: A股自选股实时行情盯盘插件 - DeepSeek Harness Web 右上角可折叠弹窗（分时/K线/目标价/主题切换/可拖动/添加股票分组）
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - stock
+  - a-share
+source:
+  repository: https://github.com/Awu12277/dsh-stock-watch
+  repositoryNodeId: R_kgDOT4Qxwg
+  subpath: null
+  commit: 0bd76f3f72b647249b2168fc50ae4955c6c86575
+creator:
+  github: Awu12277
+package:
+  ecosystem: npm
+  name: dsh-stock-watch
+  version: 1.0.8
+  integrity: sha512-71ubIr7uI1z25yzTS7Wf4z6kPFfS0UUS9L28m7XD0X3gM6egGH2+/omH0JAeb2WIJf+qUcYuO2wPjBvwTDJUxg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:13.399Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 56
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-stock-watch`
- Submission type: community curation
- Created by `Awu12277` — https://github.com/Awu12277
- Original source repository: https://github.com/Awu12277/dsh-stock-watch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Awu12277 — this entry was curated from your public repository (https://github.com/Awu12277/dsh-stock-watch). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.