### PR TITLE
catalog: add dsh-plugin-genui (community curation, created by @pengyue-polaron)

### DIFF
--- a/catalog/plugins/dsh-plugin-genui.yaml
+++ b/catalog/plugins/dsh-plugin-genui.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: dsh-plugin-genui
+name: dsh-plugin-genui
+description:
+  en: Task-specific React apps for DeepSeek Harness with state carried into the next Agent turn
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - generative-ui
+  - genui
+  - mcp
+  - react
+  - task
+  - specific
+  - apps
+  - state
+  - carried
+  - next
+  - agent
+  - turn
+  - dsh
+source:
+  repository: https://github.com/pengyue-polaron/deepseek-harness-genui
+  repositoryNodeId: R_kgDOT4uuiA
+  subpath: null
+  commit: 59fa47b01281bf34dd1234f153ae60d2dc30a759
+creator:
+  github: pengyue-polaron
+package:
+  ecosystem: npm
+  name: dsh-plugin-genui
+  version: 0.13.1
+  integrity: sha512-CS6w286p3PJfSFHvfijhgRUG7fgJ/fGofmqiy4NmYMDgq91E0nxhoO05GCalcDFzjXEY5zt/MZJuuJy9S/8Nkw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:16.543Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 49
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-plugin-genui.yaml
+++ b/catalog/plugins/dsh-plugin-genui.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: sessions-productivity
+primaryCategory: user-interface-dashboards
 tags:
   - deepseek-harness
   - dsh-plugin


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-genui`
- Submission type: community curation
- Created by `pengyue-polaron` — https://github.com/pengyue-polaron
- Original source repository: https://github.com/pengyue-polaron/deepseek-harness-genui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@pengyue-polaron — this entry was curated from your public repository (https://github.com/pengyue-polaron/deepseek-harness-genui). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.