### PR TITLE
catalog: add dsh-navbar (community curation, created by @vlln)

### DIFF
--- a/catalog/plugins/dsh-navbar.yaml
+++ b/catalog/plugins/dsh-navbar.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-navbar
 name: "@vlln/dsh-navbar"
 description:
-  en: 对话节点导航条——user 消息快速跳转（自渲染 DOM，官方 client 通道）
+  en: "A conversation navigation rail for DeepSeek Harness: one node per user message along the right edge of the chat, hover preview cards, click and scroll-wheel jumping, a sliding window past 11 nodes, and a pin button that marks a chosen assistant reply."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: coding-developer-tools
+primaryCategory: user-interface-dashboards
 tags:
   - user
   - client

--- a/catalog/plugins/dsh-navbar.yaml
+++ b/catalog/plugins/dsh-navbar.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: dsh-navbar
+name: "@vlln/dsh-navbar"
+description:
+  en: 对话节点导航条——user 消息快速跳转（自渲染 DOM，官方 client 通道）
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - user
+  - client
+  - dsh
+source:
+  repository: https://github.com/vlln/dsh-navbar
+  repositoryNodeId: R_kgDOT0bTDw
+  subpath: null
+  commit: 08c1acf164c779a09584b7199cced1f0d59399ce
+creator:
+  github: vlln
+package:
+  ecosystem: npm
+  name: "@vlln/dsh-navbar"
+  version: 0.3.0
+  integrity: sha512-dMynNNnKuePm1HgNOCe2tEe86OecPn7KJEUWAQunf/d0TPQV6yyQ+prPle7ztvpyHFXsqACErzyqP2tn75l1EQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:17.974Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 46
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-navbar`
- Submission type: community curation
- Created by `vlln` — https://github.com/vlln
- Original source repository: https://github.com/vlln/dsh-navbar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@vlln — this entry was curated from your public repository (https://github.com/vlln/dsh-navbar). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.