### PR TITLE
catalog: add dsh-codex (community curation, created by @Yan-Zero)

### DIFF
--- a/catalog/plugins/dsh-codex.yaml
+++ b/catalog/plugins/dsh-codex.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: dsh-codex
+name: dsh-codex
+description:
+  en: ChatGPT OAuth, Codex models, search, read image URL support, and gpt-image-2 generation for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - chatgpt
+  - oauth
+  - codex
+  - models
+  - search
+  - read
+  - image
+  - generation
+  - dsh
+source:
+  repository: https://github.com/Yan-Zero/dsh-codex
+  repositoryNodeId: R_kgDOT3mUmA
+  subpath: null
+  commit: f1682136472fde06e8f1a82107d221227bb5b7fc
+creator:
+  github: Yan-Zero
+package:
+  ecosystem: npm
+  name: dsh-codex
+  version: 0.2.4
+  integrity: sha512-q+tLsrQHCYicqqAFrhkz34wxDmvAUjsm6t0KkjIedAYJ9IWotDVIhXjZCAiV+Vt+SlC6t/faLyQD0c/lpF40NA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:19.491Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 35
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-codex`
- Submission type: community curation
- Created by `Yan-Zero` — https://github.com/Yan-Zero
- Original source repository: https://github.com/Yan-Zero/dsh-codex
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Yan-Zero — this entry was curated from your public repository (https://github.com/Yan-Zero/dsh-codex). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.