### PR TITLE
catalog: add dsh-auto-collapse (community curation, created by @a179302)

### DIFF
--- a/catalog/plugins/dsh-auto-collapse.yaml
+++ b/catalog/plugins/dsh-auto-collapse.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-auto-collapse
 name: dsh-auto-collapse
 description:
-  en: DeepSeek Harness Web 客户端插件：把会话里的工具卡片与 Think 推理块折叠成一行，折叠态实时显示当前正在进行的工作（工具名 + 正在执行的命令/参数、或思考内容），运行中带流光动画；点击展开/收起。让界面只保留模型说的话。
+  en: "A front-end plugin for the DeepSeek Harness Web chat that collapses the working process: tool cards and Think blocks fold into one-line summaries per turn and expand level by level, styled with native DSH icons and tokens, and every collapsed node is restored when the plugin is removed."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: coding-developer-tools
+primaryCategory: user-interface-dashboards
 tags:
   - dsh
   - deepseek-harness

--- a/catalog/plugins/dsh-auto-collapse.yaml
+++ b/catalog/plugins/dsh-auto-collapse.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: dsh-auto-collapse
+name: dsh-auto-collapse
+description:
+  en: DeepSeek Harness Web 客户端插件：把会话里的工具卡片与 Think 推理块折叠成一行，折叠态实时显示当前正在进行的工作（工具名 + 正在执行的命令/参数、或思考内容），运行中带流光动画；点击展开/收起。让界面只保留模型说的话。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - client-plugin
+  - ui
+  - collapse
+  - auto-collapse
+  - chat
+  - think
+source:
+  repository: https://github.com/a179-sanae/dsh-auto-collapse
+  repositoryNodeId: R_kgDOT4nMEg
+  subpath: null
+  commit: 9d02fb02e8dd2fb56c5e82fcc5d68b5a5b62efcd
+creator:
+  github: a179302
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:20.916Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 30
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-auto-collapse`
- Submission type: community curation
- Created by `a179302` — https://github.com/a179302
- Original source repository: https://github.com/a179-sanae/dsh-auto-collapse
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@a179302 — this entry was curated from your public repository (https://github.com/a179-sanae/dsh-auto-collapse). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.