### PR TITLE
catalog: add dsh-codex-connect (community curation, created by @Yan-Zero)

### DIFF
--- a/catalog/plugins/dsh-codex-connect.yaml
+++ b/catalog/plugins/dsh-codex-connect.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: coding-developer-tools
+primaryCategory: models-providers-routing
 tags:
   - dsh-plugin
   - deepseek-harness

--- a/catalog/plugins/dsh-codex-connect.yaml
+++ b/catalog/plugins/dsh-codex-connect.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: dsh-codex-connect
+name: dsh-codex-connect
+description:
+  en: ChatGPT OAuth and Codex models for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - openai-codex
+  - chatgpt-oauth
+  - oauth
+  - codex
+  - chatgpt
+  - models
+  - dsh
+source:
+  repository: https://github.com/franksong2702/dsh-codex-connect
+  repositoryNodeId: R_kgDOT33VZQ
+  subpath: null
+  commit: ed7eaf2da664885637033961522b5cb2e6e861ce
+creator:
+  github: Yan-Zero
+package:
+  ecosystem: npm
+  name: dsh-codex-connect
+  version: 0.1.0-alpha.4.10
+  integrity: sha512-Da8WIdhfaXAV0HcBnlCsyLRz/RhNnSxS5+DWXKKmvMULpTfCc/tIKh2YVawA+/k+NU33mHCLK3RcmnriVZWCqA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:25.621Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 29
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-codex-connect`
- Submission type: community curation
- Created by `Yan-Zero` — https://github.com/Yan-Zero
- Original source repository: https://github.com/franksong2702/dsh-codex-connect
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Yan-Zero — this entry was curated from your public repository (https://github.com/franksong2702/dsh-codex-connect). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.