### PR TITLE
catalog: add pi2dsh (community curation, created by @weijiafu14)

### DIFF
--- a/catalog/plugins/pi2dsh.yaml
+++ b/catalog/plugins/pi2dsh.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: vision-audio-multimodal
+primaryCategory: data-external-services
 tags:
   - deepseek-harness
   - dsh-plugin

--- a/catalog/plugins/pi2dsh.yaml
+++ b/catalog/plugins/pi2dsh.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: pi2dsh
+name: pi2dsh
+description:
+  en: "Bridge the Pi and DeepSeek Harness ecosystems: a general Pi Host ABI that runs unmodified Pi extensions as native DSH plugins, plus per-package conversion and MCP config translation."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - pi-package
+  - migration
+  - compatibility
+  - bridge
+  - ecosystems
+  - general
+  - host
+  - runs
+  - unmodified
+  - extensions
+  - native
+  - plus
+  - package
+  - conversion
+source:
+  repository: https://github.com/weijiafu14/pi2dsh
+  repositoryNodeId: R_kgDOT3reRg
+  subpath: null
+  commit: 70a79cfb46baa32e1a79d5aab43691bff6d10960
+creator:
+  github: weijiafu14
+package:
+  ecosystem: npm
+  name: pi2dsh
+  version: 0.12.4
+  integrity: sha512-DxF/zHVrdZ84GT9To+LB2GBZZpfaJcpUYZC9EjcwwUtmW+DT4b/y+L89kF28Ey2yu/4IORqyi4fZBiifreNhaw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:28.394Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 25
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pi2dsh`
- Submission type: community curation
- Created by `weijiafu14` — https://github.com/weijiafu14
- Original source repository: https://github.com/weijiafu14/pi2dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@weijiafu14 — this entry was curated from your public repository (https://github.com/weijiafu14/pi2dsh). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.