### PR TITLE
catalog: add dsh-web-lan-access (community curation, created by @AcidGr)

### DIFF
--- a/catalog/plugins/dsh-web-lan-access.yaml
+++ b/catalog/plugins/dsh-web-lan-access.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: dsh-web-lan-access
+name: dsh-web-lan-access
+description:
+  en: "LAN / remote access support for the DeepSeek Harness Web UI: self-contained 0.0.0.0 binding + crypto.randomUUID polyfill on plain-HTTP origins."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - lan
+  - remote-access
+  - polyfill
+  - remote
+  - access
+  - self
+  - contained
+  - binding
+  - crypto
+  - randomuuid
+  - plain
+  - origins
+source:
+  repository: https://github.com/AcidGr/dsh-web-lan-access
+  repositoryNodeId: R_kgDOT4ceuA
+  subpath: null
+  commit: e27e909f2f079d2213c13823f56fe9ade4726f80
+creator:
+  github: AcidGr
+package:
+  ecosystem: npm
+  name: dsh-web-lan-access
+  version: 1.1.0
+  integrity: sha512-sX1cedrKDpXmh2k1E15aOz4Pm3c1kSE8nEr3jwLtAhGHAxAwkfp82zERxSvVUqOJqkFaAD8qRbiNzz3YIytjCw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:32.995Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 22
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-web-lan-access.yaml
+++ b/catalog/plugins/dsh-web-lan-access.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: models-providers-routing
+primaryCategory: coding-developer-tools
 tags:
   - deepseek-harness
   - dsh


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-web-lan-access`
- Submission type: community curation
- Created by `AcidGr` — https://github.com/AcidGr
- Original source repository: https://github.com/AcidGr/dsh-web-lan-access
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@AcidGr — this entry was curated from your public repository (https://github.com/AcidGr/dsh-web-lan-access). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.