### PR TITLE
catalog: add dsh-evolve-modes (community curation, created by @GraySilver)

### DIFF
--- a/catalog/plugins/dsh-evolve-modes.yaml
+++ b/catalog/plugins/dsh-evolve-modes.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-evolve-modes
+name: "@graysilver/dsh-evolve-modes"
+description:
+  en: Composable working, reasoning, quality, and human-reviewed self-evolution controls for DeepSeek Harness Web.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ai-agents
+  - prompt-engineering
+  - agent-review
+  - plan-mode
+  - acceptance-review
+  - composable
+  - working
+  - reasoning
+  - quality
+  - human
+  - reviewed
+  - self
+  - evolution
+source:
+  repository: https://github.com/GraySilver/dsh-evolve-modes
+  repositoryNodeId: R_kgDOT5_geA
+  subpath: null
+  commit: d1f717c8e7e6deae21e6f8e22c728c8572999cc9
+creator:
+  github: GraySilver
+package:
+  ecosystem: npm
+  name: "@graysilver/dsh-evolve-modes"
+  version: 0.3.1
+  integrity: sha512-uklsf/Hd/JC7efwvkScFK+sIByMxHFcsH/bhwFbt9remTkCo5TJBvWUxEQBYUTwN0JRq3qmc+oZeJT0WZT8y2A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:51.596Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 21
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-evolve-modes`
- Submission type: community curation
- Created by `GraySilver` — https://github.com/GraySilver
- Original source repository: https://github.com/GraySilver/dsh-evolve-modes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@GraySilver — this entry was curated from your public repository (https://github.com/GraySilver/dsh-evolve-modes). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.