### PR TITLE
catalog: add dsh-permission-rules (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/dsh-permission-rules.yaml
+++ b/catalog/plugins/dsh-permission-rules.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-permission-rules
+name: dsh-permission-rules
+description:
+  en: "Declarative Claude Code-style permission rules plus a Codex-style process-level network policy for DeepSeek Harness: ordered allow/deny/ask rules with tool-name, argument (glob/regex), workspace-path, and network-target (domain/ip/port/scheme) matching on the tools/pre-execute waterfall, a built-in local HTTP/CONNECT p"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - permission
+  - policy
+  - allow-deny-ask
+  - approval
+  - safety
+  - network
+  - network-policy
+  - proxy
+  - declarative
+  - claude
+  - code
+  - style
+  - rules
+source:
+  repository: https://github.com/PerryLink/dsh-permission-rules
+  repositoryNodeId: R_kgDOT3vUCw
+  subpath: null
+  commit: 369f146d4a73935005442d1b9350c421111ada04
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-permission-rules
+  version: 0.5.2
+  integrity: sha512-AXcZXomh2HWORFbpeHvEf8GShyXxN8hkSG7Oa4MN/5ewKkjojikmJO/+541OD9FUlQ7XE3Umvz2Ebb1ubC2VtA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:48.542Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 21
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-permission-rules`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-permission-rules
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@PerryLink — this entry was curated from your public repository (https://github.com/PerryLink/dsh-permission-rules). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.