### PR TITLE
catalog: add dsh-science (community curation, created by @biociao)

### DIFF
--- a/catalog/plugins/dsh-science.yaml
+++ b/catalog/plugins/dsh-science.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: models-providers-routing
+primaryCategory: search-research
 tags:
   - dsh
   - dsh-plugin

--- a/catalog/plugins/dsh-science.yaml
+++ b/catalog/plugins/dsh-science.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-science
+name: dsh-science
+description:
+  en: "Claude Science-style research workbench for DeepSeek Harness: ReAct research-loop engine (research tools), versioned artifacts with provenance (artifact tools), SSH remote-compute engine for long bioinformatics jobs on workstations/HPC (remote tools), and 11 science skills for genomics / pathogens / bioinformatics. Shi"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - science
+  - research
+  - react-loop
+  - artifact
+  - provenance
+  - reproducibility
+  - genomics
+  - pathogen
+  - bioinformatics
+  - remote-compute
+  - ssh
+  - hpc
+  - slurm
+  - claude
+source:
+  repository: https://github.com/biociao/dsh-science
+  repositoryNodeId: R_kgDOT382Zw
+  subpath: null
+  commit: 23767ab2f8d7bcf84a0820daa4c6ae79549da000
+creator:
+  github: biociao
+package:
+  ecosystem: npm
+  name: dsh-science
+  version: 0.2.0
+  integrity: sha512-7On5CDZKd2Jwm4hpbPwpeI0beSNJdpK1tAuWFzUs4vTlP4reSNHgz6kbwnO7b0Za3Q1Jm7Qzb51h9HORq0PDLw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:35.207Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 21
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-science`
- Submission type: community curation
- Created by `biociao` — https://github.com/biociao
- Original source repository: https://github.com/biociao/dsh-science
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@biociao — this entry was curated from your public repository (https://github.com/biociao/dsh-science). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.