### PR TITLE
catalog: add dsh-clawrouter (community curation, created by @VickyXAI)

### DIFF
--- a/catalog/plugins/dsh-clawrouter.yaml
+++ b/catalog/plugins/dsh-clawrouter.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-clawrouter
+name: dsh-clawrouter
+description:
+  en: A second brain for your DeepSeek Harness agent — strong-model review before risky tool calls, plus 67 models from one wallet. No accounts, no API keys.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - blockrun
+  - clawrouter
+  - x402
+  - llm-router
+  - code-review
+  - second
+  - brain
+  - agent
+  - strong
+  - model
+  - review
+  - before
+  - risky
+  - tool
+source:
+  repository: https://github.com/BlockRunAI/dsh-clawrouter
+  repositoryNodeId: R_kgDOT34UjA
+  subpath: null
+  commit: 18fc2466cdea00d3854323b01756b51eec190029
+creator:
+  github: VickyXAI
+package:
+  ecosystem: npm
+  name: dsh-clawrouter
+  version: 0.10.1
+  integrity: sha512-m8Vyhlpl3k42jB7j2cB4ulPh2bMyaA6bSk2QmotdFswQ4x5kvUGezrVYgsYmFlTLS3ydGpE2yetIXM7kcbOXKA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:47.059Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 19
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-clawrouter`
- Submission type: community curation
- Created by `VickyXAI` — https://github.com/VickyXAI
- Original source repository: https://github.com/BlockRunAI/dsh-clawrouter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@VickyXAI — this entry was curated from your public repository (https://github.com/BlockRunAI/dsh-clawrouter). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.