### PR TITLE
catalog: add dsh-workbench-plugin (community curation, created by @loadingvx)

### DIFF
--- a/catalog/plugins/dsh-workbench-plugin.yaml
+++ b/catalog/plugins/dsh-workbench-plugin.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: dsh-workbench-plugin
+name: dsh-workbench-plugin
+description:
+  en: DeepSeek Harness Web UI 工作台：聊天 / 编辑器（语法高亮） / 文件与 Git、侧边栏、模型工具
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+source:
+  repository: https://github.com/loadingvx/deepseek-harness-workbench-plugin
+  repositoryNodeId: R_kgDOT5Ea5w
+  subpath: null
+  commit: 96bc9be1a8efa946a16eee3d20d2c02f3fab85fe
+creator:
+  github: loadingvx
+package:
+  ecosystem: npm
+  name: dsh-workbench-plugin
+  version: 0.1.21
+  integrity: sha512-wfvVItcKqmaDBIbd9GGLFK5eiEKehvfZQyIyhZmS+qiIv30WrVeLzS33RaOXHcilrAFanIQ/y2NqyO3rH6HbDA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:41.909Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 19
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-workbench-plugin.yaml
+++ b/catalog/plugins/dsh-workbench-plugin.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-workbench-plugin
 name: dsh-workbench-plugin
 description:
-  en: DeepSeek Harness Web UI 工作台：聊天 / 编辑器（语法高亮） / 文件与 Git、侧边栏、模型工具
+  en: "A three-column workbench for the DeepSeek Harness Web UI: chat on the left, a CodeMirror editor and local PTY terminal in the center, and a right dock with the file tree, Git including streamed AI commit messages, a usage and balance panel, and Ultra Slash commands."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: coding-developer-tools
+primaryCategory: user-interface-dashboards
 tags:
   - dsh
 source:


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-workbench-plugin`
- Submission type: community curation
- Created by `loadingvx` — https://github.com/loadingvx
- Original source repository: https://github.com/loadingvx/deepseek-harness-workbench-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@loadingvx — this entry was curated from your public repository (https://github.com/loadingvx/deepseek-harness-workbench-plugin). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.