### PR TITLE
catalog: add dsh-anchored-standard (community curation, created by @Jungod1121)

### DIFF
--- a/catalog/plugins/dsh-anchored-standard.yaml
+++ b/catalog/plugins/dsh-anchored-standard.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-anchored-standard
+name: dsh-anchored-standard
+description:
+  en: "Task-aware two-phase DeepSeek Harness preset: spec/react/weak first-request anchors (bash+read±edit/write), then the full Standard tool catalog after the first tool call."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - agent-preset
+  - preset
+  - anchored-standard
+  - deepseek-v4-pro
+  - task
+  - aware
+  - phase
+  - spec
+  - react
+  - weak
+  - first
+  - request
+  - anchors
+  - bash
+source:
+  repository: https://github.com/Jungod1121/dsh-anchored-standard
+  repositoryNodeId: R_kgDOT5AkXw
+  subpath: null
+  commit: 560530f0e1af6dba3528ac8962f5e5e63951b1bb
+creator:
+  github: Jungod1121
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:53.024Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 17
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-anchored-standard`
- Submission type: community curation
- Created by `Jungod1121` — https://github.com/Jungod1121
- Original source repository: https://github.com/Jungod1121/dsh-anchored-standard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Jungod1121 — this entry was curated from your public repository (https://github.com/Jungod1121/dsh-anchored-standard). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.