### PR TITLE
catalog: add dsh-quant (community curation, created by @pengpengyi92)

### DIFF
--- a/catalog/plugins/dsh-quant.yaml
+++ b/catalog/plugins/dsh-quant.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-quant
+name: dsh-quant
+description:
+  en: "🐳 The Everything-Plugin Quant OS — AI-native & DSH-native: 46 tools, 6 pluggable domains (data/alpha/ML/risk/execution), one end-to-end PDAT→PET pipeline. Methods open, secrets internal."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - quant
+  - trading
+  - technical-analysis
+  - indicators
+  - backtest
+  - everything
+  - native
+  - tools
+  - pluggable
+  - domains
+  - data
+  - alpha
+  - risk
+source:
+  repository: https://github.com/pengpengyi92/dsh-quant
+  repositoryNodeId: R_kgDOT51x8w
+  subpath: null
+  commit: c80854f1e158c98ca154330cc521a95b45a4079e
+creator:
+  github: pengpengyi92
+package:
+  ecosystem: npm
+  name: dsh-quant
+  version: 0.50.0
+  integrity: sha512-qlhS/F9voBqhYPzZ/l8b5vDij620uEY+VAfJrpMDbh8LfyU6aAWCqFttwVe9eUSQjcZab2lGFGz4PIS1SEXxPg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:57.511Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 17
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-quant.yaml
+++ b/catalog/plugins/dsh-quant.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: security-permissions-approvals
+primaryCategory: data-external-services
 tags:
   - dsh
   - dsh-plugin


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-quant`
- Submission type: community curation
- Created by `pengpengyi92` — https://github.com/pengpengyi92
- Original source repository: https://github.com/pengpengyi92/dsh-quant
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@pengpengyi92 — this entry was curated from your public repository (https://github.com/pengpengyi92/dsh-quant). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.