### PR TITLE
catalog: add dsh-recommend (community curation, created by @zp-home)

### DIFF
--- a/catalog/plugins/dsh-recommend.yaml
+++ b/catalog/plugins/dsh-recommend.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-recommend
 name: dsh-recommend
 description:
-  en: DSH 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态 + 公开评分模型 + rank/recommend/search 工具 + 设置页排行标签
+  en: "A plugin leaderboard and recommendation source for DeepSeek Harness: a scheduled pipeline re-scans the GitHub dsh-plugin topic every 5 hours and scores it with a published model, surfaced as rank/recommend/search tools, a settings-page ranking tab and a static leaderboard site."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/dsh-recommend.yaml
+++ b/catalog/plugins/dsh-recommend.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: dsh-recommend
+name: dsh-recommend
+description:
+  en: DSH 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态 + 公开评分模型 + rank/recommend/search 工具 + 设置页排行标签
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - deepseek-harness
+  - ranking
+  - leaderboard
+  - recommendation
+  - rank
+  - recommend
+  - search
+source:
+  repository: https://github.com/zp-home/dsh-recommend
+  repositoryNodeId: R_kgDOT3ykeQ
+  subpath: null
+  commit: 269afff5d277fb0e2c37e3bbda78c55b43c51159
+creator:
+  github: zp-home
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:45.490Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 17
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-recommend`
- Submission type: community curation
- Created by `zp-home` — https://github.com/zp-home
- Original source repository: https://github.com/zp-home/dsh-recommend
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@zp-home — this entry was curated from your public repository (https://github.com/zp-home/dsh-recommend). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.