### PR TITLE
catalog: add dsh-codex-subscription (community curation, created by @SR043)

### DIFF
--- a/catalog/plugins/dsh-codex-subscription.yaml
+++ b/catalog/plugins/dsh-codex-subscription.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: coding-developer-tools
+primaryCategory: models-providers-routing
 tags:
   - dsh-plugin
   - deepseek-harness

--- a/catalog/plugins/dsh-codex-subscription.yaml
+++ b/catalog/plugins/dsh-codex-subscription.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-codex-subscription
+name: dsh-codex-subscription
+description:
+  en: ChatGPT and Codex subscriptions for DeepSeek Harness with OAuth login, image generation, quota, and subscription web search
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - openai-codex
+  - codex-cli
+  - chatgpt
+  - chatgpt-plus
+  - subscription
+  - quota
+  - usage
+  - oauth
+  - web-search
+  - image-generation
+  - codex
+  - subscriptions
+  - login
+source:
+  repository: https://github.com/WSL043/dsh-codex-subscription
+  repositoryNodeId: R_kgDOT3wJGQ
+  subpath: null
+  commit: b5d19ee0fafdfe3a9e15fc7cf635754ede623676
+creator:
+  github: SR043
+package:
+  ecosystem: npm
+  name: dsh-codex-subscription
+  version: 1.0.0
+  integrity: sha512-+r85ajBOuPs92CvN2FUwzEPA96zl9j1VI5nwYyZR+sCyXpzCqznoTY35prBCVnuRlw+BxnjIk9MVVUHj82Z9jQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:54.594Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 16
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-codex-subscription`
- Submission type: community curation
- Created by `SR043` — https://github.com/SR043
- Original source repository: https://github.com/WSL043/dsh-codex-subscription
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@SR043 — this entry was curated from your public repository (https://github.com/WSL043/dsh-codex-subscription). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.