### PR TITLE
catalog: add dsh-queue-plus (community curation, created by @starslittle)

### DIFF
--- a/catalog/plugins/dsh-queue-plus.yaml
+++ b/catalog/plugins/dsh-queue-plus.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: coding-developer-tools
+primaryCategory: user-interface-dashboards
 tags:
   - deepseek-harness
   - dsh

--- a/catalog/plugins/dsh-queue-plus.yaml
+++ b/catalog/plugins/dsh-queue-plus.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-queue-plus
+name: dsh-queue-plus
+description:
+  en: A calm, unified prompt queue for DeepSeek Harness with smart expansion, persistent confirmations, editing, steering, accessible reordering, and official queue removal.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - queue
+  - prompt-queue
+  - calm
+  - unified
+  - prompt
+  - smart
+  - expansion
+  - persistent
+  - confirmations
+  - editing
+  - steering
+  - accessible
+  - reordering
+source:
+  repository: https://github.com/starslittle/dsh-queue-plus
+  repositoryNodeId: R_kgDOT4rBjw
+  subpath: null
+  commit: ed6448d4828d5fd5c3933dc3c1e08340b9fbc2f9
+creator:
+  github: starslittle
+package:
+  ecosystem: npm
+  name: dsh-queue-plus
+  version: 0.3.0
+  integrity: sha512-Jjlj6OZsArO5JEpQW0B9inMXtMT0DRE77TCLOwHpdqp31IvkP7uT+75MqGpNwQ3RaVkTJgz6pQ0Uivw8QfsMYQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:26:59.023Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 15
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-queue-plus`
- Submission type: community curation
- Created by `starslittle` — https://github.com/starslittle
- Original source repository: https://github.com/starslittle/dsh-queue-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@starslittle — this entry was curated from your public repository (https://github.com/starslittle/dsh-queue-plus). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.