### PR TITLE
catalog: add dsh-any-background (community curation, created by @Tkingxiao)

### DIFF
--- a/catalog/plugins/dsh-any-background.yaml
+++ b/catalog/plugins/dsh-any-background.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-any-background
+name: dsh-any-background
+description:
+  en: "Appearance plugin for DeepSeek Harness: custom theme color (PS-style color wheel), background wallpaper with opacity/blur controls, and separate main/settings interface opacity."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - wallpaper
+  - web-ui
+  - appearance
+  - custom
+  - color
+  - style
+  - wheel
+  - background
+  - opacity
+  - blur
+  - controls
+  - separate
+source:
+  repository: https://github.com/Tkingxiao/dsh-any-background
+  repositoryNodeId: R_kgDOT4tdOg
+  subpath: null
+  commit: 5e4c0e0c3758c834422a6528ac26821ebf764b29
+creator:
+  github: Tkingxiao
+package:
+  ecosystem: npm
+  name: dsh-any-background
+  version: 0.1.8
+  integrity: sha512-zqUZPBJ2FjAg6zZDbm/PgVC9JlaG8J7Coq7lsBx5zTi3FCl4RFHaDXDULAXeA3p8ixhCy5QoNRnW0NBXWbD1Pw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:11.302Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 14
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-any-background`
- Submission type: community curation
- Created by `Tkingxiao` — https://github.com/Tkingxiao
- Original source repository: https://github.com/Tkingxiao/dsh-any-background
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Tkingxiao — this entry was curated from your public repository (https://github.com/Tkingxiao/dsh-any-background). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.