### PR TITLE
catalog: add dsh-catppuccin (community curation, created by @NoNameLeGo)

### DIFF
--- a/catalog/plugins/dsh-catppuccin.yaml
+++ b/catalog/plugins/dsh-catppuccin.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-catppuccin
+name: "@nonamelego/dsh-catppuccin"
+description:
+  en: "Catppuccin themes + a toggleable glassmorphism skin for the DeepSeek Harness web GUI — Latte, Frappé, Macchiato and Mocha registered into the official theme system (Appearance settings), fully remapping the --dsw- token ladder, with adjustable frosted glass for the top bar, sidebar, composer, stats line and trajectory "
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - catppuccin
+  - theme
+  - dsh-plugin
+  - themes
+  - toggleable
+  - glassmorphism
+  - skin
+  - latte
+  - frapp
+  - macchiato
+  - mocha
+  - registered
+  - official
+  - system
+source:
+  repository: https://github.com/NoNameLeGo/dsh-catppuccin-theme
+  repositoryNodeId: R_kgDOT4fijQ
+  subpath: null
+  commit: 46134262e1804f00331554a00c080d311a94e539
+creator:
+  github: NoNameLeGo
+package:
+  ecosystem: npm
+  name: "@nonamelego/dsh-catppuccin"
+  version: 0.2.7
+  integrity: sha512-8Rw5Pu5CnCzfn/sF4oigRAYXIyGA51/XUzxu2aZkivKVR4Mx9exN9bObu2jYD9pQawdkSpLH4poYJV3Ye9v10w==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:03.382Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 14
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-catppuccin`
- Submission type: community curation
- Created by `NoNameLeGo` — https://github.com/NoNameLeGo
- Original source repository: https://github.com/NoNameLeGo/dsh-catppuccin-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@NoNameLeGo — this entry was curated from your public repository (https://github.com/NoNameLeGo/dsh-catppuccin-theme). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.