### PR TITLE
catalog: add dsh-plugin (community curation, created by @ralf0131)

### DIFF
--- a/catalog/plugins/dsh-plugin.yaml
+++ b/catalog/plugins/dsh-plugin.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: dsh-plugin
+name: "@loongsuite/dsh-plugin"
+description:
+  en: Standalone OpenTelemetry GenAI observability plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - opentelemetry
+  - otel
+  - otlp
+  - genai
+  - observability
+  - loongsuite
+  - standalone
+source:
+  repository: https://github.com/loongsuite/dsh-plugin
+  repositoryNodeId: R_kgDOT49nog
+  subpath: null
+  commit: 5e893af6172beb703a98b56ccc5e443495287732
+creator:
+  github: ralf0131
+package:
+  ecosystem: npm
+  name: "@loongsuite/dsh-plugin"
+  version: 0.1.1
+  integrity: sha512-wQmSzOzyjp0rd3XKFmcK+vXRETqVr0V7xL5qh8El2RujteV4Gkc1vz1OxTG12lQZrjKVWV5ixRRJU1HDlBafog==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:00.510Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 14
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin`
- Submission type: community curation
- Created by `ralf0131` — https://github.com/ralf0131
- Original source repository: https://github.com/loongsuite/dsh-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@ralf0131 — this entry was curated from your public repository (https://github.com/loongsuite/dsh-plugin). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.