### PR TITLE
catalog: add godot-bridge (community curation, created by @Smalldy)

### DIFF
--- a/catalog/plugins/godot-bridge.yaml
+++ b/catalog/plugins/godot-bridge.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: godot-bridge
+name: godot-bridge
+description:
+  en: "DSH (DeepSeek Harness) plugin: launch and drive a running Godot 4.x game through its in-game TCP interaction server — replaces the godot-mcp MCP server with native agent tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - godot
+  - godot-engine
+  - godot-plugin
+  - mcp
+  - game-development
+  - ai-agent
+  - launch
+  - drive
+  - running
+  - game
+  - through
+  - interaction
+  - server
+source:
+  repository: https://github.com/Smalldy/godot-bridge
+  repositoryNodeId: R_kgDOT4fcwA
+  subpath: null
+  commit: e586db3fdd29bfa367caa9b46ac6daee2d9ac287
+creator:
+  github: Smalldy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:18.989Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `godot-bridge`
- Submission type: community curation
- Created by `Smalldy` — https://github.com/Smalldy
- Original source repository: https://github.com/Smalldy/godot-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Smalldy — this entry was curated from your public repository (https://github.com/Smalldy/godot-bridge). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.