### PR TITLE
catalog: add dsh-mcp-panel (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/dsh-mcp-panel.yaml
+++ b/catalog/plugins/dsh-mcp-panel.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-mcp-panel
+name: dsh-mcp-panel
+description:
+  en: "MCP management console for the official DeepSeek Harness MCP client: /mcp command with health diagnostics and pipeline trial calls, a Settings MCP tab with server CRUD (append-only profile-patch fragments, approval-gated writes with automatic backups), a tool trial console over the official tool pipeline, connection st"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - mcp
+  - mcp-client
+  - mcp-console
+  - management
+  - observability
+  - panel
+  - console
+  - official
+  - client
+  - command
+  - health
+  - diagnostics
+source:
+  repository: https://github.com/PerryLink/dsh-mcp-panel
+  repositoryNodeId: R_kgDOT3-v7A
+  subpath: null
+  commit: 2d5f84ff46031914f5d7ce2d47fc8b909da347b9
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-mcp-panel
+  version: 0.4.1
+  integrity: sha512-IsHwXoWbjaWEVsQQjOjcTqky3p9CLMwd9+qQprI/vkie9Xiua+EwauSwoHcBMg4xvX3i3DkrN77nQRCOVzkGWA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:25.004Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-mcp-panel`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-mcp-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@PerryLink — this entry was curated from your public repository (https://github.com/PerryLink/dsh-mcp-panel). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.