### PR TITLE
catalog: add dsh-vision-proxy (community curation, created by @Flyvhidbwo)

### DIFF
--- a/catalog/plugins/dsh-vision-proxy.yaml
+++ b/catalog/plugins/dsh-vision-proxy.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-vision-proxy
+name: dsh-vision-proxy
+description:
+  en: "DeepSeek brain + automatic image transcription for DeepSeek Harness: a deepseek-vision provider route that transcribes attached images to text via any OpenAI-compatible VLM before delegating to the text-only DeepSeek adapter. Paid fast path with a key (DashScope/Zhipu/OpenRouter...), zero-config local Ollama auto-detec"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - vision
+  - multimodal
+  - image
+  - image-understanding
+  - ocr
+  - vlm
+  - qwen
+  - dashscope
+  - brain
+  - automatic
+  - transcription
+  - provider
+  - route
+source:
+  repository: https://github.com/Flyvhidbwo/dsh-vision-proxy
+  repositoryNodeId: R_kgDOT3bpkw
+  subpath: null
+  commit: 0108d1a5c2e07e607be81b136516fc947d479cd9
+creator:
+  github: Flyvhidbwo
+package:
+  ecosystem: npm
+  name: dsh-vision-proxy
+  version: 0.2.5
+  integrity: sha512-KlHr7xqfLcCBRQMh7W8DZieA0TgDqwOOO+/IEaPx/IwVsPK5t/8bd1DtjibmlQrf5F15UfxI+SxCrOxo255NCw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:14.452Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-vision-proxy`
- Submission type: community curation
- Created by `Flyvhidbwo` — https://github.com/Flyvhidbwo
- Original source repository: https://github.com/Flyvhidbwo/dsh-vision-proxy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Flyvhidbwo — this entry was curated from your public repository (https://github.com/Flyvhidbwo/dsh-vision-proxy). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.