### PR TITLE
catalog: add dsh-win32 (community curation, created by @sjh9714)

### DIFF
--- a/catalog/plugins/dsh-win32.yaml
+++ b/catalog/plugins/dsh-win32.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-win32
 name: dsh-win32
 description:
-  en: "在 Windows 上把 DSH 用起来。一行装好极简模式的持久 shell，沙箱内也能用 Get DSH working on Windows: persistent shell for Minimal mode, sandbox included"
+  en: "A Windows compatibility bundle for DeepSeek Harness: swaps in a win32-aware subprocess runtime so persistent PTY shells work, ships the minimal-windows and sandboxed busybox presets, decodes GBK and UTF-16 file reads, and adds dsh-win32 setup and doctor commands."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: security-permissions-approvals
+primaryCategory: coding-developer-tools
 tags:
   - dsh
   - dsh-plugin

--- a/catalog/plugins/dsh-win32.yaml
+++ b/catalog/plugins/dsh-win32.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-win32
+name: dsh-win32
+description:
+  en: "在 Windows 上把 DSH 用起来。一行装好极简模式的持久 shell，沙箱内也能用 Get DSH working on Windows: persistent shell for Minimal mode, sandbox included"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - dsh-plugins
+  - deepseek-harness
+  - windows
+  - win32
+  - git-bash
+  - persistent-shell
+  - minimal-mode
+  - shell
+  - working
+  - persistent
+  - minimal
+  - mode
+  - sandbox
+  - included
+source:
+  repository: https://github.com/sjh9714/dsh-win32
+  repositoryNodeId: R_kgDOT5Ca-w
+  subpath: null
+  commit: 1e3e54cbf34853ad9ca22084d515932903c2535f
+creator:
+  github: sjh9714
+package:
+  ecosystem: npm
+  name: dsh-win32
+  version: 0.14.0
+  integrity: sha512-Fwo8/GaUx6tlVqZ+IsGLS7yXqTEBfUdIBLYk2hUkWg8N0USDwyI6UOR3jTN8GNLLy9c17jnuDk7PQmazclC9xg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:17.515Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-win32`
- Submission type: community curation
- Created by `sjh9714` — https://github.com/sjh9714
- Original source repository: https://github.com/sjh9714/dsh-win32
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@sjh9714 — this entry was curated from your public repository (https://github.com/sjh9714/dsh-win32). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.