### PR TITLE
catalog: add dsh-ai4scholar (community curation, created by @literaf)

### DIFF
--- a/catalog/plugins/dsh-ai4scholar.yaml
+++ b/catalog/plugins/dsh-ai4scholar.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-ai4scholar
+name: dsh-ai4scholar
+description:
+  en: "AI4Scholar for DeepSeek Harness (dsh): 38 native academic tools — Semantic Scholar, PubMed, Google Scholar, arXiv, bioRxiv/medRxiv, DOI resolution, PDF full text, auto-cite, scientific figures, credit balance — with an API-key card in the Web UI settings. Powered by ai4scholar.net."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - ai4scholar
+  - academic
+  - literature
+  - paper-search
+  - semantic-scholar
+  - pubmed
+  - google-scholar
+  - arxiv
+  - biorxiv
+  - medrxiv
+  - doi
+  - auto-cite
+  - scientific-figures
+source:
+  repository: https://github.com/literaf/dsh-ai4scholar
+  repositoryNodeId: R_kgDOT5zjkw
+  subpath: null
+  commit: 500e49d004715908122b76fef90e1db05db7c7f4
+creator:
+  github: literaf
+package:
+  ecosystem: npm
+  name: dsh-ai4scholar
+  version: 0.3.3
+  integrity: sha512-HEIBBCi2S8uf13gFN4PLbeyDS1JZPDZn51BPVOlVXCLgCrITfYPxx/o03DDg77hXE9TL/Xwzzr9pq76f6m7NEg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:21.868Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-ai4scholar`
- Submission type: community curation
- Created by `literaf` — https://github.com/literaf
- Original source repository: https://github.com/literaf/dsh-ai4scholar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@literaf — this entry was curated from your public repository (https://github.com/literaf/dsh-ai4scholar). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.