### PR TITLE
catalog: add dsh-web-file-uploader (community curation, created by @Mooling0602)

### DIFF
--- a/catalog/plugins/dsh-web-file-uploader.yaml
+++ b/catalog/plugins/dsh-web-file-uploader.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-web-file-uploader
+name: dsh-web-file-uploader
+description:
+  en: "A DeepSeek-style paperclip attach button in the DSH web composer; uploads files to the DSH host (model-aware: native image blocks for multimodal models, file paths for text-only models)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - web
+  - upload
+  - attachment
+  - style
+  - paperclip
+  - attach
+  - button
+  - composer
+  - uploads
+  - files
+  - host
+  - model
+  - aware
+source:
+  repository: https://github.com/Mooling0602/dsh-web-file-uploader
+  repositoryNodeId: R_kgDOT6UzDg
+  subpath: null
+  commit: 6ee65d1c662b1038196a2c24c800c98da5bc6e4c
+creator:
+  github: Mooling0602
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:23.446Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-web-file-uploader.yaml
+++ b/catalog/plugins/dsh-web-file-uploader.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: vision-audio-multimodal
+primaryCategory: user-interface-dashboards
 tags:
   - dsh
   - deepseek-harness


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-web-file-uploader`
- Submission type: community curation
- Created by `Mooling0602` — https://github.com/Mooling0602
- Original source repository: https://github.com/Mooling0602/dsh-web-file-uploader
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Mooling0602 — this entry was curated from your public repository (https://github.com/Mooling0602/dsh-web-file-uploader). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.