### PR TITLE
catalog: add dsh-chatgpt-bridge (community curation, created by @jiezeng2004-design)

### DIFF
--- a/catalog/plugins/dsh-chatgpt-bridge.yaml
+++ b/catalog/plugins/dsh-chatgpt-bridge.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: security-permissions-approvals
+primaryCategory: data-external-services
 tags:
   - deepseek-harness
   - dsh

--- a/catalog/plugins/dsh-chatgpt-bridge.yaml
+++ b/catalog/plugins/dsh-chatgpt-bridge.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-chatgpt-bridge
+name: dsh-chatgpt-bridge
+description:
+  en: "MCP bridge: lets ChatGPT Web create, view, continue and control DeepSeek Harness (DSH) agent sessions through the official MCP protocol. The bridge only connects; DSH keeps its session, agent, tool, approval and workspace security model."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - mcp
+  - chatgpt
+  - bridge
+  - lets
+  - create
+  - view
+  - continue
+  - control
+  - agent
+  - sessions
+  - through
+  - official
+  - protocol
+  - only
+source:
+  repository: https://github.com/jiezeng2004-design/dsh-chatgpt-bridge
+  repositoryNodeId: R_kgDOT4T3lA
+  subpath: null
+  commit: 53d1d1dda8240bf88b69292c471fd3f4c20b5504
+creator:
+  github: jiezeng2004-design
+package:
+  ecosystem: npm
+  name: dsh-chatgpt-bridge
+  version: 0.3.0
+  integrity: sha512-DxCBLl8WZsv+sQY3O6IuLr6Pcfp7/R18xqvWQuOdbtkYs0mamkLHbBusCWryQ2yFP11EMWBBeQ/82OR2yd2chQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:32.631Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-chatgpt-bridge`
- Submission type: community curation
- Created by `jiezeng2004-design` — https://github.com/jiezeng2004-design
- Original source repository: https://github.com/jiezeng2004-design/dsh-chatgpt-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@jiezeng2004-design — this entry was curated from your public repository (https://github.com/jiezeng2004-design/dsh-chatgpt-bridge). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.