### PR TITLE
catalog: add dsh-plugin-claude-bridge (community curation, created by @YYTbit)

### DIFF
--- a/catalog/plugins/dsh-plugin-claude-bridge.yaml
+++ b/catalog/plugins/dsh-plugin-claude-bridge.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: dsh-plugin-claude-bridge
+name: dsh-plugin-claude-bridge
+description:
+  en: Bridge Claude Code's memory, skills, and configuration into DeepSeek Harness — zero migration, full compatibility
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - claude-code
+  - memory
+  - skills
+  - migration
+  - bridge
+  - claude
+  - code
+  - configuration
+  - zero
+  - full
+  - compatibility
+  - dsh
+source:
+  repository: https://github.com/YYTbit/dsh-plugin-claude-bridge
+  repositoryNodeId: R_kgDOT3a4KQ
+  subpath: null
+  commit: 895431fa8d2b1635334bb71efe1387ba0122df1b
+creator:
+  github: YYTbit
+package:
+  ecosystem: npm
+  name: dsh-plugin-claude-bridge
+  version: 0.1.1
+  integrity: sha512-71AYNQVKNeZFVzOPxk6RpZxTjA8uRgInYMynyTZ9B8siqRtvAeb5opFLC1TFSK4uJkTV0TCm7ELtCW6c1ZWleA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:38.700Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-claude-bridge`
- Submission type: community curation
- Created by `YYTbit` — https://github.com/YYTbit
- Original source repository: https://github.com/YYTbit/dsh-plugin-claude-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@YYTbit — this entry was curated from your public repository (https://github.com/YYTbit/dsh-plugin-claude-bridge). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.