### PR TITLE
catalog: add dsh-visual-plugin (community curation, created by @jyh20030112)

### DIFF
--- a/catalog/plugins/dsh-visual-plugin.yaml
+++ b/catalog/plugins/dsh-visual-plugin.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-visual-plugin
+name: dsh-visual-plugin
+description:
+  en: "Vision bridge plugin for DeepSeek Harness: when the main model has no vision, forward user images to a configurable OpenAI-compatible vision model and show results in a Web UI right panel. Host tool + browser half, distributed as a dsh bundle."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - vision
+  - bridge
+  - main
+  - model
+  - forward
+  - user
+  - images
+  - configurable
+  - openai
+  - compatible
+  - show
+  - results
+  - right
+  - panel
+  - host
+  - tool
+source:
+  repository: https://github.com/jyh20030112/dsh-visual-plugin
+  repositoryNodeId: R_kgDOT3-N4g
+  subpath: null
+  commit: 21d67581f14f0d977feeca1cf93fed3be7737a2f
+creator:
+  github: jyh20030112
+package:
+  ecosystem: npm
+  name: dsh-visual-plugin
+  version: 0.2.7
+  integrity: sha512-ImpIWWAYFfzSZ+NMQ6NdFlhIQLfm6ksOpGMmsWFDbSh4MnUnvt8XSkOAI8nrlPun4uWWYiKkDObqaqHLmsEI3Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:34.369Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-visual-plugin`
- Submission type: community curation
- Created by `jyh20030112` — https://github.com/jyh20030112
- Original source repository: https://github.com/jyh20030112/dsh-visual-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@jyh20030112 — this entry was curated from your public repository (https://github.com/jyh20030112/dsh-visual-plugin). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.