### PR TITLE
catalog: add dsh-checkpoint-rewind (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/dsh-checkpoint-rewind.yaml
+++ b/catalog/plugins/dsh-checkpoint-rewind.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-checkpoint-rewind
+name: dsh-checkpoint-rewind
+description:
+  en: "Unified DSH checkpoints: session + workspace + config three-state snapshots with one-shot rollback — /checkpoint and /rewind commands, a checkpoint tool, automatic interval snapshots, a Settings page timeline with pairwise diffs, and seed-replay session rollback via the official sessions.create API"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - rewind
+  - checkpoint
+  - snapshot
+  - session-replay
+  - session-fork
+  - config-restore
+  - workspace-safety
+  - undo
+  - cordis-plugin
+  - unified
+  - checkpoints
+  - session
+  - workspace
+source:
+  repository: https://github.com/PerryLink/dsh-checkpoint-rewind
+  repositoryNodeId: R_kgDOT3vfIw
+  subpath: null
+  commit: f070f47a2f2171ebaf5ed33672a3c230256d6e4e
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-checkpoint-rewind
+  version: 0.5.2
+  integrity: sha512-qm0HP5ZFhjhd4oN2bcounkU8h7X9dTRC9krwLjcuPL0s5tXQYdR1o9OKGeChJ/eXB4KRKJgw8VbQpu7/m0S3qQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:46.451Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-checkpoint-rewind`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-checkpoint-rewind
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@PerryLink — this entry was curated from your public repository (https://github.com/PerryLink/dsh-checkpoint-rewind). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.