### PR TITLE
catalog: add dsh-client-ui-obsidian-memory (community curation, created by @detongz)

### DIFF
--- a/catalog/plugins/dsh-client-ui-obsidian-memory.yaml
+++ b/catalog/plugins/dsh-client-ui-obsidian-memory.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: dsh-client-ui-obsidian-memory
+name: dsh-client-ui-obsidian-memory
+description:
+  en: Obsidian Memory plugin for DeepSeek Harness — persistent memory via local Markdown vault
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - obsidian
+  - memory
+  - codex
+  - dsh-plugin
+  - persistent
+  - local
+  - markdown
+  - vault
+source:
+  repository: https://github.com/detongz/dsh-client-ui-obsidian-memory
+  repositoryNodeId: R_kgDOT58AYg
+  subpath: null
+  commit: 042c7f2596e25c92200dc40a415fe8a084c5dc35
+creator:
+  github: detongz
+package:
+  ecosystem: npm
+  name: dsh-client-ui-obsidian-memory
+  version: 0.3.2
+  integrity: sha512-o571s1GdNPuzoDuARko3OF2IZ1QhJJeUCZFuX3diwr7+lhmx/I07AxIjhYkde9zOaFMak6k2rE5vItjOiNRYHA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:42.140Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-client-ui-obsidian-memory`
- Submission type: community curation
- Created by `detongz` — https://github.com/detongz
- Original source repository: https://github.com/detongz/dsh-client-ui-obsidian-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@detongz — this entry was curated from your public repository (https://github.com/detongz/dsh-client-ui-obsidian-memory). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.