### PR TITLE
catalog: add dsh-fate-spectrum (community curation, created by @EchoUser005)

### DIFF
--- a/catalog/plugins/dsh-fate-spectrum.yaml
+++ b/catalog/plugins/dsh-fate-spectrum.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dsh-fate-spectrum
+name: dsh-fate-spectrum
+description:
+  en: 四柱八字与紫微斗数排盘 Bundle for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - bazi
+  - ziwei
+  - fate-chart
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/EchoUser005/dsh-fate-spectrum
+  repositoryNodeId: R_kgDOT5RQEA
+  subpath: null
+  commit: b5adfca0fedf27a9ee7ce53cb4d07b634b43b05b
+creator:
+  github: EchoUser005
+package:
+  ecosystem: npm
+  name: dsh-fate-spectrum
+  version: 0.1.0
+  integrity: sha512-v9hN2SyasMJTgh0HjoicFFXcrKQDDcIzknXDknVNu6oUkktT5SUAT83A82bbF4ApIsquSdITSRUqRI+6dNHMTQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:43.605Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-fate-spectrum.yaml
+++ b/catalog/plugins/dsh-fate-spectrum.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-fate-spectrum
 name: dsh-fate-spectrum
 description:
-  en: 四柱八字与紫微斗数排盘 Bundle for DeepSeek Harness.
+  en: "A deterministic Chinese astrology charting plugin for DeepSeek Harness: computes BaZi (Four Pillars) and Zi Wei Dou Shu charts as structured, agent-callable tools, keeps candidate charts when the birth hour is unknown or near a day boundary, and asks for missing details instead of guessing."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: memory-rag
+primaryCategory: entertainment-customization
 tags:
   - deepseek-harness
   - dsh-plugin


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-fate-spectrum`
- Submission type: community curation
- Created by `EchoUser005` — https://github.com/EchoUser005
- Original source repository: https://github.com/EchoUser005/dsh-fate-spectrum
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@EchoUser005 — this entry was curated from your public repository (https://github.com/EchoUser005/dsh-fate-spectrum). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.