### PR TITLE
catalog: add dsh-mcp-manager (community curation, created by @Js2Hou)

### DIFF
--- a/catalog/plugins/dsh-mcp-manager.yaml
+++ b/catalog/plugins/dsh-mcp-manager.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: dsh-mcp-manager
+name: "@js2hou/dsh-mcp-manager"
+description:
+  en: "MCP visual manager plugin for DeepSeek Harness: inspect installed/enabled MCP servers, add/remove, enable/disable and view live connection status from the web GUI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - visual
+  - manager
+  - inspect
+  - installed
+  - enabled
+  - servers
+  - remove
+  - enable
+  - disable
+  - view
+  - live
+  - connection
+  - status
+  - dsh
+source:
+  repository: https://github.com/Js2Hou/dsh-mcp-manager
+  repositoryNodeId: R_kgDOT5GiMw
+  subpath: null
+  commit: 72c060e521f62a48b3e674fa5b1dcdb4feec47bd
+creator:
+  github: Js2Hou
+package:
+  ecosystem: npm
+  name: "@js2hou/dsh-mcp-manager"
+  version: 0.1.5
+  integrity: sha512-vP1CEDjdWH2JtAXRAp3iOuRFB1Iww14J7XHLvuca830i832ZUFLa2+g7LIaKVstxBUY2/PJwQe1y/nUJo9Sy7g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:44.992Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-mcp-manager`
- Submission type: community curation
- Created by `Js2Hou` — https://github.com/Js2Hou
- Original source repository: https://github.com/Js2Hou/dsh-mcp-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Js2Hou — this entry was curated from your public repository (https://github.com/Js2Hou/dsh-mcp-manager). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.