### PR TITLE
catalog: add dsh-movein (community curation, created by @sjh9714)

### DIFF
--- a/catalog/plugins/dsh-movein.yaml
+++ b/catalog/plugins/dsh-movein.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-movein
 name: dsh-movein
 description:
-  en: Migrate your whole Claude Code or Codex setup into DeepSeek Harness (DSH) with one command - import skills, slash commands, MCP servers, hooks, subagents, permission rules. 一键迁移导入，从 Claude Code 拎包入住 DSH。
+  en: "A setup migration tool for DeepSeek Harness: moves a Claude Code or Codex configuration over in one command, converting skills, slash commands, subagents, MCP servers, hooks and permission rules, with a dry run by default, a movein_from_claude_code tool, a doctor check and a reverse mode."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/dsh-movein.yaml
+++ b/catalog/plugins/dsh-movein.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-movein
+name: dsh-movein
+description:
+  en: Migrate your whole Claude Code or Codex setup into DeepSeek Harness (DSH) with one command - import skills, slash commands, MCP servers, hooks, subagents, permission rules. 一键迁移导入，从 Claude Code 拎包入住 DSH。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - claude-code
+  - migration
+  - mcp
+  - skills
+  - migrate
+  - whole
+  - claude
+  - code
+  - codex
+  - setup
+  - command
+  - import
+  - slash
+source:
+  repository: https://github.com/sjh9714/dsh-movein
+  repositoryNodeId: R_kgDOT469Vg
+  subpath: null
+  commit: d305b89a08b8ed0901aac398bb1abfdc374055c3
+creator:
+  github: sjh9714
+package:
+  ecosystem: npm
+  name: dsh-movein
+  version: 0.6.0
+  integrity: sha512-X4ZnCRG+kkUagzB6I4stRiqLt7i2UWCLNrcaZ8dFwXq8xgsNfwRv5MOA3CuIlgUxXW5RQlNB6U7Q/rWdwPiOfw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:57.629Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-movein`
- Submission type: community curation
- Created by `sjh9714` — https://github.com/sjh9714
- Original source repository: https://github.com/sjh9714/dsh-movein
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@sjh9714 — this entry was curated from your public repository (https://github.com/sjh9714/dsh-movein). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.