### PR TITLE
catalog: add dsh-ui-appearance (community curation, created by @TQSY114514)

### DIFF
--- a/catalog/plugins/dsh-ui-appearance.yaml
+++ b/catalog/plugins/dsh-ui-appearance.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-ui-appearance
+name: dsh-ui-appearance
+description:
+  en: "Appearance customization plugin for DeepSeek Harness WebUI: theme palette, background image, transparency and blur over the --dsw- token system"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - appearance
+  - customization
+  - webui
+  - theme
+  - palette
+  - background
+  - image
+  - transparency
+  - blur
+  - over
+  - token
+  - system
+  - dsh
+source:
+  repository: https://github.com/TQSY114514/dsh-ui-appearance
+  repositoryNodeId: R_kgDOT4ATYA
+  subpath: null
+  commit: e9605869ddb38dd79d88ff7de191fea21da1db52
+creator:
+  github: TQSY114514
+package:
+  ecosystem: npm
+  name: dsh-ui-appearance
+  version: 0.1.3
+  integrity: sha512-TBAt78M6A1n6Zk/MM8Numl7wgAtDHqsM4U5seBjCzAOPtuFsv5IqEtOP2RgC/FjsOHbOkpNc2XzeDjUn0LkYTQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:47.872Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-ui-appearance`
- Submission type: community curation
- Created by `TQSY114514` — https://github.com/TQSY114514
- Original source repository: https://github.com/TQSY114514/dsh-ui-appearance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@TQSY114514 — this entry was curated from your public repository (https://github.com/TQSY114514/dsh-ui-appearance). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.