### PR TITLE
catalog: add deepseek-harness-qqbot (community curation, created by @sliverp)

### DIFF
--- a/catalog/plugins/deepseek-harness-qqbot.yaml
+++ b/catalog/plugins/deepseek-harness-qqbot.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: security-permissions-approvals
+primaryCategory: messaging-notifications
 tags:
   - deepseek-harness
   - qqbot

--- a/catalog/plugins/deepseek-harness-qqbot.yaml
+++ b/catalog/plugins/deepseek-harness-qqbot.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: deepseek-harness-qqbot
+name: deepseek-harness-qqbot
+description:
+  en: QQ Bot channel bridge for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - qqbot
+  - cordis
+  - channel
+  - bridge
+  - dsh
+source:
+  repository: https://github.com/sliverp/DeepSeek-harness-qqbot
+  repositoryNodeId: R_kgDOT3jZHA
+  subpath: null
+  commit: 691af8ca2ffc9a1d67784d49744565b08d936f5e
+creator:
+  github: sliverp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:59.831Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `deepseek-harness-qqbot`
- Submission type: community curation
- Created by `sliverp` — https://github.com/sliverp
- Original source repository: https://github.com/sliverp/DeepSeek-harness-qqbot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@sliverp — this entry was curated from your public repository (https://github.com/sliverp/DeepSeek-harness-qqbot). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.