### PR TITLE
catalog: add dsh-change-review (community curation, created by @cirelir)

### DIFF
--- a/catalog/plugins/dsh-change-review.yaml
+++ b/catalog/plugins/dsh-change-review.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: dsh-change-review
+name: dsh-change-review
+description:
+  en: DeepSeek Harness 会话修改审查：追踪会话内 write/edit 工具调用，以可自定义颜色的 diff 对比展示；会话隔离、子代理聚合、SSE 实时推送。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - diff
+  - review
+  - write
+  - edit
+source:
+  repository: https://github.com/cirelir/dsh-change-review
+  repositoryNodeId: R_kgDOT5QGIA
+  subpath: null
+  commit: 1f2de55b3f95dd1c513e713fe56664648ca2e447
+creator:
+  github: cirelir
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:09.167Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-change-review.yaml
+++ b/catalog/plugins/dsh-change-review.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-change-review
 name: dsh-change-review
 description:
-  en: DeepSeek Harness 会话修改审查：追踪会话内 write/edit 工具调用，以可自定义颜色的 diff 对比展示；会话隔离、子代理聚合、SSE 实时推送。
+  en: "A session change-review panel for DeepSeek Harness: tracks write and edit tool calls per session, renders line-level diffs with configurable colors, aggregates subagent changes into the parent session, pushes updates over SSE, and reverts a single change or a whole file."
   evidencePath: README.md
 unofficial: true
 kind: plugin


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-change-review`
- Submission type: community curation
- Created by `cirelir` — https://github.com/cirelir
- Original source repository: https://github.com/cirelir/dsh-change-review
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@cirelir — this entry was curated from your public repository (https://github.com/cirelir/dsh-change-review). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.