### PR TITLE
catalog: add dsh-github-intelligence (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/dsh-github-intelligence.yaml
+++ b/catalog/plugins/dsh-github-intelligence.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-github-intelligence
+name: dsh-github-intelligence
+description:
+  en: "The most comprehensive developer-intelligence integration for DeepSeek Harness: 195+ read-only tools across GitHub, GitLab, Gitee, npm, PyPI, crates.io, Docker Hub, Hugging Face, Hacker News, Stack Overflow, Reddit, dev.to, RubyGems, NuGet, and the Go module proxy — with rate-limit-friendly caching."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - integration
+  - releases
+  - issues
+  - pull-requests
+  - agent
+  - most
+  - comprehensive
+  - developer
+  - intelligence
+  - read
+  - only
+  - tools
+  - across
+  - gitlab
+source:
+  repository: https://github.com/zoahdev/dsh-github-intelligence
+  repositoryNodeId: R_kgDOT46Gwg
+  subpath: null
+  commit: d69702fa0afd88ec5ae46c56f157641a03840e69
+creator:
+  github: zoahdev
+package:
+  ecosystem: npm
+  name: dsh-github-intelligence
+  version: 2.9.0
+  integrity: sha512-J32765Oa/3ygrPSwByTNVuG3Jvg9djxnrNt65nNYKF6g35kLnGOaAIBpq7noFn4edM9vqWyB/3F6NSVwqDx7FQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:32.082Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-github-intelligence`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-github-intelligence
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@zoahdev — this entry was curated from your public repository (https://github.com/zoahdev/dsh-github-intelligence). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.