### PR TITLE
catalog: add dsh-imagegen (community curation, created by @dickpy)

### DIFF
--- a/catalog/plugins/dsh-imagegen.yaml
+++ b/catalog/plugins/dsh-imagegen.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-imagegen
 name: "@dickpy/dsh-imagegen"
 description:
-  en: "AI 生图 (image generation) plugin for the dsh web GUI: text-to-image and image-to-image through a configurable OpenAI-compatible endpoint (gpt-image-2 / gpt-image-1 / dall-e-3), with a settings card for api url / api key and a sidebar entry opening a split-pane generation studio."
+  en: "Image generation plugin for the dsh web GUI: text-to-image and image-to-image through a configurable OpenAI-compatible endpoint (gpt-image-2 / gpt-image-1 / dall-e-3), with a settings card for api url / api key and a sidebar entry opening a split-pane generation studio."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/dsh-imagegen.yaml
+++ b/catalog/plugins/dsh-imagegen.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: user-interface-dashboards
+primaryCategory: vision-audio-multimodal
 tags:
   - image
   - generation

--- a/catalog/plugins/dsh-imagegen.yaml
+++ b/catalog/plugins/dsh-imagegen.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-imagegen
+name: "@dickpy/dsh-imagegen"
+description:
+  en: "AI 生图 (image generation) plugin for the dsh web GUI: text-to-image and image-to-image through a configurable OpenAI-compatible endpoint (gpt-image-2 / gpt-image-1 / dall-e-3), with a settings card for api url / api key and a sidebar entry opening a split-pane generation studio."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - image
+  - generation
+  - text
+  - through
+  - configurable
+  - openai
+  - compatible
+  - endpoint
+  - dall
+  - settings
+  - card
+  - sidebar
+  - entry
+  - opening
+  - split
+  - pane
+source:
+  repository: https://github.com/dickpy/dsh-imagegen
+  repositoryNodeId: R_kgDOT5bc5A
+  subpath: null
+  commit: 3cb80565dcd0718b13120f65853f6e89eae46a3d
+creator:
+  github: dickpy
+package:
+  ecosystem: npm
+  name: "@dickpy/dsh-imagegen"
+  version: 1.0.7
+  integrity: sha512-+hkYNt4IREI3DzIhqchZvKHH5Bx5+XRzpAJ14/Qc1vhelNs4TTfku09zy3qiyU0ioZhp3ph7jyrLNmI9lreMcA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:49.377Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-imagegen`
- Submission type: community curation
- Created by `dickpy` — https://github.com/dickpy
- Original source repository: https://github.com/dickpy/dsh-imagegen
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@dickpy — this entry was curated from your public repository (https://github.com/dickpy/dsh-imagegen). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.