### PR TITLE
catalog: add dsh-message-rail (community curation, created by @wx-yss)

### DIFF
--- a/catalog/plugins/dsh-message-rail.yaml
+++ b/catalog/plugins/dsh-message-rail.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-message-rail
 name: dsh-message-rail
 description:
-  en: Codex 风格左侧消息导航轨道：等距刻度 + 悬停波纹 + 预览浮层 + 点击跳转用户消息
+  en: "A left-side message navigation rail for the DeepSeek Harness Web UI: one evenly spaced tick per user message, hover previews showing index, relative time and text, click-to-jump with highlight, background indexing of the whole session history, and virtualized rendering."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: messaging-notifications
+primaryCategory: user-interface-dashboards
 tags:
   - dsh
   - dsh-plugin

--- a/catalog/plugins/dsh-message-rail.yaml
+++ b/catalog/plugins/dsh-message-rail.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: dsh-message-rail
+name: dsh-message-rail
+description:
+  en: Codex 风格左侧消息导航轨道：等距刻度 + 悬停波纹 + 预览浮层 + 点击跳转用户消息
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - message-rail
+  - navigation
+  - codex
+source:
+  repository: https://github.com/wx-yss/dsh-message-rail
+  repositoryNodeId: R_kgDOT5KJdA
+  subpath: null
+  commit: 2efb1ded515d5f2a490c2057790d4eb1655b6f8c
+creator:
+  github: wx-yss
+package:
+  ecosystem: npm
+  name: dsh-message-rail
+  version: 0.1.3
+  integrity: sha512-m86PHr7G0qQ1h/zl4MNUXCR5GvwEk8CRM66022TrBn57Qk8fFwZLpdK6TH/8USJbVApzpAeeU4wRKsIM9wAXtg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:03.285Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-message-rail`
- Submission type: community curation
- Created by `wx-yss` — https://github.com/wx-yss
- Original source repository: https://github.com/wx-yss/dsh-message-rail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@wx-yss — this entry was curated from your public repository (https://github.com/wx-yss/dsh-message-rail). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.