### PR TITLE
catalog: add dsh-usage-chart (community curation, created by @Max-Samson)

### DIFF
--- a/catalog/plugins/dsh-usage-chart.yaml
+++ b/catalog/plugins/dsh-usage-chart.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-usage-chart
 name: dsh-usage-chart
 description:
-  en: DeepSeek 用量 / 成本 / 余额仪表盘 for DSH Web：输入框下方实时指标指示器 + 零依赖 SVG 用量可视化图表（含每轮成本视角、耗时叠加、异常标记、成本徽章、上下文压力条），token 数据来自官方 adapter 上报，成本按官方刊例价 + 用户覆盖 pricing.json 解析，余额来自官方 /user/balance 接口。
+  en: "A usage, cost and balance dashboard for the DeepSeek Harness Web UI: a live indicator under the composer plus a zero-dependency SVG panel with per-turn token and cost views, peak and off-peak CNY/USD list pricing, a context-pressure bar, and the official /user/balance query."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: models-providers-routing
+primaryCategory: diagnostics-observability
 tags:
   - dsh
   - dsh-plugin

--- a/catalog/plugins/dsh-usage-chart.yaml
+++ b/catalog/plugins/dsh-usage-chart.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: dsh-usage-chart
+name: dsh-usage-chart
+description:
+  en: DeepSeek 用量 / 成本 / 余额仪表盘 for DSH Web：输入框下方实时指标指示器 + 零依赖 SVG 用量可视化图表（含每轮成本视角、耗时叠加、异常标记、成本徽章、上下文压力条），token 数据来自官方 adapter 上报，成本按官方刊例价 + 用户覆盖 pricing.json 解析，余额来自官方 /user/balance 接口。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - usage
+  - tokens
+  - cost
+  - balance
+  - dashboard
+  - charts
+  - visualization
+  - token
+  - adapter
+  - pricing
+  - json
+  - user
+source:
+  repository: https://github.com/Max-Samson/dsh-usage-chart
+  repositoryNodeId: R_kgDOT3rZaQ
+  subpath: null
+  commit: 8efd6ec4bd2f1662fd95b51e8a4bb9653e1ef84f
+creator:
+  github: Max-Samson
+package:
+  ecosystem: npm
+  name: dsh-usage-chart
+  version: 1.0.1
+  integrity: sha512-Ew1B4djwBT/GYUzbqj3vxGq+bEYyljAjG+d/a5yK9RbJU0pwTeRHomYUfQy0X25JLVRbZ1OfUMnxn9ShC/Vsvg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:27:55.954Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-usage-chart`
- Submission type: community curation
- Created by `Max-Samson` — https://github.com/Max-Samson
- Original source repository: https://github.com/Max-Samson/dsh-usage-chart
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Max-Samson — this entry was curated from your public repository (https://github.com/Max-Samson/dsh-usage-chart). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.