### PR TITLE
catalog: add dsh-blue-whale (community curation, created by @starslittle)

### DIFF
--- a/catalog/plugins/dsh-blue-whale.yaml
+++ b/catalog/plugins/dsh-blue-whale.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-blue-whale
+name: dsh-blue-whale
+description:
+  en: A DeepSeek Chat-style blue-whale color skin. Light and dark follow the built-in appearance.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+  - blue-whale
+  - chat
+  - style
+  - blue
+  - whale
+  - color
+  - light
+  - dark
+  - follow
+  - built
+  - appearance
+source:
+  repository: https://github.com/starslittle/dsh-blue-whale
+  repositoryNodeId: R_kgDOT4mb6g
+  subpath: null
+  commit: e18aa1e27e98df98c478b8d24076a94e64d43ed5
+creator:
+  github: starslittle
+package:
+  ecosystem: npm
+  name: dsh-blue-whale
+  version: 0.1.0
+  integrity: sha512-fQRkkY86lygqGKCjbW1qMQGU+sso854vJM8WiG36G6f+izejnT48y0qWqshMAIleZatRzcEYPJFZrziRtuxJdA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:22.805Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-blue-whale`
- Submission type: community curation
- Created by `starslittle` — https://github.com/starslittle
- Original source repository: https://github.com/starslittle/dsh-blue-whale
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@starslittle — this entry was curated from your public repository (https://github.com/starslittle/dsh-blue-whale). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.