### PR TITLE
catalog: add dsh-board (community curation, created by @dfkai)

### DIFF
--- a/catalog/plugins/dsh-board.yaml
+++ b/catalog/plugins/dsh-board.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-board
+name: dsh-board
+description:
+  en: "dsh client bundle: a sidebar usage & cost dashboard — token stats, peak/off-peak aware per-model pricing, membership ladder, achievements and a daily heatmap."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - dashboard
+  - usage
+  - cost
+  - billing
+  - pricing
+  - tokens
+  - sidebar
+  - ui
+  - client
+  - bundle
+  - token
+  - stats
+  - peak
+source:
+  repository: https://github.com/dfkai/dsh-board
+  repositoryNodeId: R_kgDOT485gg
+  subpath: null
+  commit: 8f5b96279e3cb776a62e098be1c89de360a9d938
+creator:
+  github: dfkai
+package:
+  ecosystem: npm
+  name: dsh-board
+  version: 0.2.6
+  integrity: sha512-HCpqLoHiPw6m/026wAThgvNygzYGoOsCZYSci/gFLO16/Vc7OBZi/SX0OdlOPLDLcJUj+chGb/Z4xGW9j2qgfw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:10.624Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-board`
- Submission type: community curation
- Created by `dfkai` — https://github.com/dfkai
- Original source repository: https://github.com/dfkai/dsh-board
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@dfkai — this entry was curated from your public repository (https://github.com/dfkai/dsh-board). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.