### PR TITLE
catalog: add dsh-composer-history (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/dsh-composer-history.yaml
+++ b/catalog/plugins/dsh-composer-history.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-composer-history
+name: dsh-composer-history
+description:
+  en: "Terminal-style input history for the DeepSeek Harness web composer: edge-first arrows with exact draft/caret restore, browser-local persisted history, Ctrl+R reverse search, workspace-scoped recall, and fully configurable keys — plus sliding-context awareness (compaction summaries join recall/search, a compaction notic"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - web-gui
+  - composer
+  - input-history
+  - keyboard-shortcuts
+  - terminal
+  - compaction
+  - sliding-context
+  - context-window
+  - typescript
+  - ui
+  - style
+  - input
+  - history
+source:
+  repository: https://github.com/PerryLink/dsh-composer-history
+  repositoryNodeId: R_kgDOT3r_7g
+  subpath: null
+  commit: 0d53b7022c4ad265883e269ab4e7b1af2c1befe6
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-composer-history
+  version: 0.5.0
+  integrity: sha512-2mE7e2t/xF/O9k0fjxgbhmJ18yMpnRApoJaGiAEFN0hXGekM5K1ElGYv1saM1dQ+5axrqvI2J1/6d+9V3rXmtA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:16.868Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/dsh-composer-history.yaml
+++ b/catalog/plugins/dsh-composer-history.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: search-research
+primaryCategory: user-interface-dashboards
 tags:
   - deepseek-harness
   - dsh


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-composer-history`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-composer-history
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@PerryLink — this entry was curated from your public repository (https://github.com/PerryLink/dsh-composer-history). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.