### PR TITLE
catalog: add dsh-deepseek-vision (community curation, created by @siegfly)

### DIFF
--- a/catalog/plugins/dsh-deepseek-vision.yaml
+++ b/catalog/plugins/dsh-deepseek-vision.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-deepseek-vision
+name: dsh-deepseek-vision
+description:
+  en: "Out-of-tree dsh provider plugin: a DeepSeek gateway route that claims image input and transparently describes pasted images through a configured vision-language model (e.g. Qwen-VL) before the text-only DeepSeek wire sees them."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - vision
+  - vision-language
+  - multimodal
+  - qwen-vl
+  - provider
+  - llm-gateway
+  - coding-agent
+  - tree
+  - gateway
+  - route
+  - claims
+  - image
+  - input
+  - transparently
+source:
+  repository: https://github.com/siegfly/dsh-deepseek-vision
+  repositoryNodeId: R_kgDOT491Vw
+  subpath: null
+  commit: 00ebf579ed6bb0214f7b6e7ecf01bd1eaca0958e
+creator:
+  github: siegfly
+package:
+  ecosystem: npm
+  name: dsh-deepseek-vision
+  version: 0.1.5
+  integrity: sha512-w8qT1LGOPsQZf06o2qenX8WbAEQxd5gzjpMXATjBsKRPhmF9vj/LSWvN6P1vQy5HVzoXrAxSV1+zvPLClwRfzA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:19.911Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-deepseek-vision`
- Submission type: community curation
- Created by `siegfly` — https://github.com/siegfly
- Original source repository: https://github.com/siegfly/dsh-deepseek-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@siegfly — this entry was curated from your public repository (https://github.com/siegfly/dsh-deepseek-vision). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.