### PR TITLE
catalog: add dsh-mmx-bridge (community curation, created by @welsione)

### DIFF
--- a/catalog/plugins/dsh-mmx-bridge.yaml
+++ b/catalog/plugins/dsh-mmx-bridge.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-mmx-bridge
+name: dsh-mmx-bridge
+description:
+  en: MiniMax multimodal bridge for DeepSeek Harness (DSH). One mmx bridge tool covers describe/image/video/speech/music/cover/search/quota; optional web search/read image takeover; built-in client enhancement renders inline players/previews plus a settings-page management card in the Web GUI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - minimax
+  - mmx-cli
+  - multimodal
+  - ai-agent
+  - bridge
+  - tool
+  - covers
+  - describe
+  - image
+  - video
+  - speech
+  - music
+  - cover
+  - search
+source:
+  repository: https://github.com/welsione/dsh-mmx-bridge
+  repositoryNodeId: R_kgDOT4L_7w
+  subpath: null
+  commit: bab6c71fb3abbf8963cb68f087323aa033821599
+creator:
+  github: welsione
+package:
+  ecosystem: npm
+  name: dsh-mmx-bridge
+  version: 1.0.6
+  integrity: sha512-dwdk9D99MptFoCDUasROWso3Q84a7qm3dO8CSONlpENzF2+284N88Hk5VUBJ2QQJlqbutH/0SRB2uyw6oKPWGg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:25.691Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-mmx-bridge`
- Submission type: community curation
- Created by `welsione` — https://github.com/welsione
- Original source repository: https://github.com/welsione/dsh-mmx-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@welsione — this entry was curated from your public repository (https://github.com/welsione/dsh-mmx-bridge). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.