### PR TITLE
catalog: add dsh-windows-ocr (community curation, created by @maxwell-feng)

### DIFF
--- a/catalog/plugins/dsh-windows-ocr.yaml
+++ b/catalog/plugins/dsh-windows-ocr.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-windows-ocr
+name: "@maxwell-feng/dsh-windows-ocr"
+description:
+  en: "dsh plugin: recognize attached images with the built-in Windows OCR engine (Windows.Media.Ocr) and send only the recognized text to the model. Text models never receive image bytes; vision passthrough is opt-in."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ocr
+  - windows
+  - privacy
+  - recognize
+  - attached
+  - images
+  - built
+  - engine
+  - media
+  - send
+  - only
+  - recognized
+  - text
+source:
+  repository: https://github.com/maxwell-feng/dsh-windows-ocr
+  repositoryNodeId: R_kgDOT5FbXQ
+  subpath: null
+  commit: 14f16066bfa83be8d9a971536bfc583c05c22446
+creator:
+  github: maxwell-feng
+package:
+  ecosystem: npm
+  name: "@maxwell-feng/dsh-windows-ocr"
+  version: 0.2.3
+  integrity: sha512-ACgt47/kMesU+x0Oa9tto6+iVzx7WguVCTz+HNNLj79TdihozOL0vd7/l61UIZVP3PUS895CK4U82/gB8Oe8QA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:12.209Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-windows-ocr`
- Submission type: community curation
- Created by `maxwell-feng` — https://github.com/maxwell-feng
- Original source repository: https://github.com/maxwell-feng/dsh-windows-ocr
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@maxwell-feng — this entry was curated from your public repository (https://github.com/maxwell-feng/dsh-windows-ocr). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.