### PR TITLE
catalog: add minecraft-dev (community curation, created by @sikadi233-hub)

### DIFF
--- a/catalog/plugins/minecraft-dev.yaml
+++ b/catalog/plugins/minecraft-dev.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: minecraft-dev
+name: minecraft-dev
+description:
+  en: "Minecraft development skills and tools for DeepSeek Harness: Paper/Spigot server plugins (modern and legacy lines), Fabric, Forge and NeoForge mods, MC 1.7.10 through 26.x, plus the mc gradle Gradle runner, modern major-mod references (Create/Botania/AE2/Mekanism/Ars Nouveau/Farmer's Delight/Curios/JEI/REI/Patchouli), "
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - minecraft
+  - development
+  - skills
+  - tools
+  - paper
+  - spigot
+  - server
+  - modern
+  - legacy
+  - lines
+  - fabric
+  - forge
+  - neoforge
+  - mods
+  - through
+  - plus
+source:
+  repository: https://github.com/sikadi233-hub/minecraft-dev
+  repositoryNodeId: R_kgDOT6Kx4g
+  subpath: null
+  commit: ff5458c52358b2e945018c8b8a140d56f01b1008
+creator:
+  github: sikadi233-hub
+package:
+  ecosystem: npm
+  name: minecraft-dev
+  version: 0.6.1
+  integrity: sha512-p25IvprHay/fDd7qoqXS/eGieXserrJsk2Tj8RhHDWRGE+TthQaZ6EnZt936oADQ4fakqOgfnvsM5UtLRQCENQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:21.344Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/minecraft-dev.yaml
+++ b/catalog/plugins/minecraft-dev.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: sessions-productivity
+primaryCategory: coding-developer-tools
 tags:
   - minecraft
   - development


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `minecraft-dev`
- Submission type: community curation
- Created by `sikadi233-hub` — https://github.com/sikadi233-hub
- Original source repository: https://github.com/sikadi233-hub/minecraft-dev
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@sikadi233-hub — this entry was curated from your public repository (https://github.com/sikadi233-hub/minecraft-dev). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.