### PR TITLE
catalog: add deepseek-harness-wecom (community curation, created by @sliverp)

### DIFF
--- a/catalog/plugins/deepseek-harness-wecom.yaml
+++ b/catalog/plugins/deepseek-harness-wecom.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: deepseek-harness-wecom
+name: deepseek-harness-wecom
+description:
+  en: WeCom AI Bot text, image, and file channel bridge for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - wecom
+  - wework
+  - cordis
+  - text
+  - image
+  - file
+  - channel
+  - bridge
+  - dsh
+source:
+  repository: https://github.com/sliverp/DeepSeek-harness-wecom
+  repositoryNodeId: R_kgDOT3kizA
+  subpath: null
+  commit: e241355f081c90cddfcc16d0e26020a5db30be25
+creator:
+  github: sliverp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:50.345Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `deepseek-harness-wecom`
- Submission type: community curation
- Created by `sliverp` — https://github.com/sliverp
- Original source repository: https://github.com/sliverp/DeepSeek-harness-wecom
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@sliverp — this entry was curated from your public repository (https://github.com/sliverp/DeepSeek-harness-wecom). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.