### PR TITLE
catalog: add dsh-archived-sessions (community curation, created by @smackgg)

### DIFF
--- a/catalog/plugins/dsh-archived-sessions.yaml
+++ b/catalog/plugins/dsh-archived-sessions.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dsh-archived-sessions
+name: dsh-archived-sessions
+description:
+  en: View and restore archived DeepSeek Harness sessions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - archived-sessions
+  - view
+  - restore
+  - archived
+  - sessions
+source:
+  repository: https://github.com/smackgg/dsh-archived-sessions
+  repositoryNodeId: R_kgDOT4O1rA
+  subpath: null
+  commit: 7f58de3e5fc1dd6f0262b47c3e0735312b956312
+creator:
+  github: smackgg
+package:
+  ecosystem: npm
+  name: dsh-archived-sessions
+  version: 0.1.0
+  integrity: sha512-C2XvQuRh1FjsZxW54L4soDN7iDYlHeYFmcUVS9Es3r5IhJ6rwOsih6EN24uuYIsxBa7hdJ6IdFaVqzpQWAeYSQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:51.843Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-archived-sessions`
- Submission type: community curation
- Created by `smackgg` — https://github.com/smackgg
- Original source repository: https://github.com/smackgg/dsh-archived-sessions
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@smackgg — this entry was curated from your public repository (https://github.com/smackgg/dsh-archived-sessions). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.