### PR TITLE
catalog: add dsh-background-agents (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/dsh-background-agents.yaml
+++ b/catalog/plugins/dsh-background-agents.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-background-agents
+name: dsh-background-agents
+description:
+  en: "Interactive long-session background agents plus persistent multi-agent team rooms for DeepSeek Harness: durable continuable child agents with progress, steering and interruption, and cross-session team rooms with a message bus, shared task board, approval-gated handoffs and a shared timeline that survive DSH restarts."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - subagent
+  - background-agent
+  - background-agents
+  - agent-dashboard
+  - conversation-steering
+  - team-rooms
+  - multi-agent
+  - message-bus
+  - task-board
+  - collaboration
+  - interactive
+  - long
+  - session
+source:
+  repository: https://github.com/PerryLink/dsh-background-agents
+  repositoryNodeId: R_kgDOT38lTw
+  subpath: null
+  commit: 6be49a39e5a154ac5d79efb2c3990fa55f64882c
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-background-agents
+  version: 0.5.4
+  integrity: sha512-MQvqWlJktgzEb3DtAxcpzp8iMn1mS9wkzAgEjiicfQc8tpe+weXNajWdRLpgjvTcqgxqlUJ4aLQRwxcGmCtGUg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:44.168Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-background-agents`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-background-agents
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@PerryLink — this entry was curated from your public repository (https://github.com/PerryLink/dsh-background-agents). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.