### PR TITLE
catalog: add dsh-feishu-bridge (community curation, created by @wz-heng)

### DIFF
--- a/catalog/plugins/dsh-feishu-bridge.yaml
+++ b/catalog/plugins/dsh-feishu-bridge.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-feishu-bridge
+name: dsh-feishu-bridge
+description:
+  en: "DSH plugin shell for dsh-feishu-bridge: spawns and supervises the Feishu (Lark) channel bridge's Python process as a managed child of the DSH Host. The bridge itself is unchanged Python — this package only adds the dsh.bundle install path."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - feishu
+  - lark
+  - bridge
+  - agent
+  - shell
+  - spawns
+  - supervises
+  - channel
+  - python
+  - process
+  - managed
+  - child
+  - host
+source:
+  repository: https://github.com/wz-heng/dsh-feishu-bridge
+  repositoryNodeId: R_kgDOT4Q3_A
+  subpath: null
+  commit: 7cb392ee508ecd5e74d3a57c60fc06e9ca6cdb01
+creator:
+  github: wz-heng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:54.714Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-feishu-bridge`
- Submission type: community curation
- Created by `wz-heng` — https://github.com/wz-heng
- Original source repository: https://github.com/wz-heng/dsh-feishu-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@wz-heng — this entry was curated from your public repository (https://github.com/wz-heng/dsh-feishu-bridge). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.