### PR TITLE
catalog: add dsh-lsp-actions (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/dsh-lsp-actions.yaml
+++ b/catalog/plugins/dsh-lsp-actions.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-lsp-actions
+name: dsh-lsp-actions
+description:
+  en: "LSP action surface for DeepSeek Harness: diagnostics, formatting, completion, code actions, symbols, signature help, inlay hints, and rename tools over language servers, plus the editor action protocol (lsp.actions. ) that makes the plugin the IDE integration backend"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - lsp
+  - language-server
+  - diagnostics
+  - formatting
+  - completion
+  - code-action
+  - symbols
+  - signature-help
+  - inlay-hints
+  - rename
+  - refactor
+  - ide
+  - editor
+source:
+  repository: https://github.com/PerryLink/dsh-lsp-actions
+  repositoryNodeId: R_kgDOT3v_gQ
+  subpath: null
+  commit: 07bbcc07e9b02e6a3dde1ec41833c02e0f75dd64
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-lsp-actions
+  version: 0.3.1
+  integrity: sha512-NxP8tmzbP7uSDZ6Kn2plJ8xezq5GuJPX6WKwFWB7Ed6NuMToFQxcoHmRijA/djz6we2uvAU3PfWs6rV+IcvWNg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:45.639Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-lsp-actions`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-lsp-actions
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@PerryLink — this entry was curated from your public repository (https://github.com/PerryLink/dsh-lsp-actions). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.