### PR TITLE
catalog: add dsh-mcp-lens (community curation, created by @sluckyli2023)

### DIFF
--- a/catalog/plugins/dsh-mcp-lens.yaml
+++ b/catalog/plugins/dsh-mcp-lens.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-mcp-lens
+name: dsh-mcp-lens
+description:
+  en: Cut MCP context and API cost in DeepSeek Harness with two model-facing tools, lazy discovery, and exact-schema calls
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - mcp-gateway
+  - model-context-protocol
+  - progressive-disclosure
+  - context-optimization
+  - cost-optimization
+  - tool-discovery
+  - tool-routing
+  - context
+  - cost
+  - model
+  - facing
+  - tools
+source:
+  repository: https://github.com/labmimors/dsh-mcp-lens
+  repositoryNodeId: R_kgDOT4aglQ
+  subpath: null
+  commit: d6ff88b976ad2898786049bbeb1f29f85ee492e3
+creator:
+  github: sluckyli2023
+package:
+  ecosystem: npm
+  name: dsh-mcp-lens
+  version: 0.1.0-rc.9
+  integrity: sha512-P4GwpIf8s4bo97BnGiQUHsYrQSz9K1RFto3GExrW2lZjwEcXq9dmwkHKLgDadlWd8BUWUO9Su41N/UEpmIrH8A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:28:39.479Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-mcp-lens`
- Submission type: community curation
- Created by `sluckyli2023` — https://github.com/sluckyli2023
- Original source repository: https://github.com/labmimors/dsh-mcp-lens
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@sluckyli2023 — this entry was curated from your public repository (https://github.com/labmimors/dsh-mcp-lens). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.