### PR TITLE
catalog: add model-catalog (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/model-catalog.yaml
+++ b/catalog/plugins/model-catalog.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: model-catalog
 name: model-catalog
 description:
-  en: dsh 插件：模型目录自动发现 —— 从 OpenAI 兼容 API 主机自动拉取模型列表、定价与能力，归一化后生成可直接使用的配置。
+  en: "Model-catalog auto-discovery for DeepSeek Harness: probes a configured OpenAI-compatible host (official API, relay gateway, Ollama, vLLM), pulls model listings, pricing and capability flags, normalizes units and provenance, and writes ready-to-use model configuration."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/model-catalog.yaml
+++ b/catalog/plugins/model-catalog.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: model-catalog
+name: model-catalog
+description:
+  en: dsh 插件：模型目录自动发现 —— 从 OpenAI 兼容 API 主机自动拉取模型列表、定价与能力，归一化后生成可直接使用的配置。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - model
+  - catalog
+  - pricing
+  - llm
+  - openai
+source:
+  repository: https://github.com/JohnXu22786/model-catalog
+  repositoryNodeId: R_kgDOT59RnQ
+  subpath: null
+  commit: f9ec6c7810e32686719c192679d7a27d4cfaf1ac
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:37:00.331Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `model-catalog`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/model-catalog
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@JohnXu22786 — this entry was curated from your public repository (https://github.com/JohnXu22786/model-catalog). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.