### PR TITLE
catalog: add candidate-v011-baseline (community curation, created by @timwhitez)

### DIFF
--- a/catalog/plugins/candidate-v011-baseline.yaml
+++ b/catalog/plugins/candidate-v011-baseline.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: candidate-v011-baseline
+name: "@dsh-self-evolving/candidate-v011-baseline"
+description:
+  en: v0.1.1 migration baseline
+  evidencePath: packages/candidate-v011-baseline/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - migration
+  - baseline
+  - dsh
+source:
+  repository: https://github.com/timwhitez/dsh-self-evolving
+  repositoryNodeId: R_kgDOT5BH8A
+  subpath: packages/candidate-v011-baseline
+  commit: 4eb3bb4058dce4330ecbfc2b96e9c2bdabb71677
+creator:
+  github: timwhitez
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/candidate-v011-baseline/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:39:18.043Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `candidate-v011-baseline`
- Submission type: community curation
- Created by `timwhitez` — https://github.com/timwhitez
- Original source repository: https://github.com/timwhitez/dsh-self-evolving
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@timwhitez — this entry was curated from your public repository (https://github.com/timwhitez/dsh-self-evolving). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.