### PR TITLE
catalog: add dsh-cdi-plugin (community curation, created by @fmlin0429712024)

### DIFF
--- a/catalog/plugins/dsh-cdi-plugin.yaml
+++ b/catalog/plugins/dsh-cdi-plugin.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-cdi-plugin
+name: dsh-cdi-plugin
+description:
+  en: "Synthetic CDI (clinical documentation integrity) auditing plugin for DeepSeek Harness — Step 1: pure host plugin, AS-IS GUI. Bundles the deterministic SOP-rule evaluation tools, the SQLite SOP stores, the synthetic gold sets, the audit rules, and a packaged copy of the CDI skills."
+  evidencePath: plugins/dsh-cdi-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - synthetic
+  - clinical
+  - documentation
+  - integrity
+  - auditing
+  - step
+  - pure
+  - host
+  - bundles
+  - deterministic
+  - rule
+  - evaluation
+  - tools
+  - sqlite
+  - stores
+  - gold
+source:
+  repository: https://github.com/fmlin0429712024/linkhealth-dsh-platform
+  repositoryNodeId: R_kgDOT6mwFA
+  subpath: plugins/dsh-cdi-plugin
+  commit: ac726ea9dcef9e8e6f90a8dcf512d09b4572a7d1
+creator:
+  github: fmlin0429712024
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-cdi-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:35:23.901Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-cdi-plugin`
- Submission type: community curation
- Created by `fmlin0429712024` — https://github.com/fmlin0429712024
- Original source repository: https://github.com/fmlin0429712024/linkhealth-dsh-platform
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@fmlin0429712024 — this entry was curated from your public repository (https://github.com/fmlin0429712024/linkhealth-dsh-platform). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.