### PR TITLE
catalog: add dsh-client-ui-skin-maid-whale-webui (community curation, created by @yunxiiQwQ)

### DIFF
--- a/catalog/plugins/dsh-client-ui-skin-maid-whale-webui.yaml
+++ b/catalog/plugins/dsh-client-ui-skin-maid-whale-webui.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dsh-client-ui-skin-maid-whale-webui
+name: "@dsh-external/dsh-client-ui-skin-maid-whale-webui"
+description:
+  en: Cloud-paper DeepSeek skin for the DSH web GUI with the deepseek-drool character as a quiet page-edge mascot
+  evidencePath: maid-whale-webui/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - cloud
+  - paper
+  - skin
+  - drool
+  - character
+  - quiet
+  - page
+  - edge
+  - mascot
+  - dsh
+source:
+  repository: https://github.com/yunxiiQwQ/dsh-maid-whale-webUI
+  repositoryNodeId: R_kgDOT49vPA
+  subpath: maid-whale-webui
+  commit: f574f151bdfde7e8569797962eb8ff6aad4b3bf1
+creator:
+  github: yunxiiQwQ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: maid-whale-webui/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:40:40.112Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-client-ui-skin-maid-whale-webui`
- Submission type: community curation
- Created by `yunxiiQwQ` — https://github.com/yunxiiQwQ
- Original source repository: https://github.com/yunxiiQwQ/dsh-maid-whale-webUI
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@yunxiiQwQ — this entry was curated from your public repository (https://github.com/yunxiiQwQ/dsh-maid-whale-webUI). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.