### PR TITLE
catalog: add dsh-desktop-bridge (community curation, created by @tsdaer)

### DIFF
--- a/catalog/plugins/dsh-desktop-bridge.yaml
+++ b/catalog/plugins/dsh-desktop-bridge.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: dsh-desktop-bridge
+name: "@deepseek-ai/dsh-desktop-bridge"
+description:
+  en: "Host half of the desktop shell bridge: settings, balance, Explorer, and bounded Search routes"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - host
+  - half
+  - desktop
+  - shell
+  - bridge
+  - settings
+  - balance
+  - explorer
+  - bounded
+  - search
+  - routes
+  - dsh
+source:
+  repository: https://github.com/tsdaer/dsh-desktop
+  repositoryNodeId: R_kgDOT44kBg
+  subpath: apps/desktop/bridge
+  commit: f74dd8a2a4d38452bffb3f398ae933f5364429f7
+creator:
+  github: tsdaer
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: apps/desktop/bridge/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:39:27.106Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-desktop-bridge`
- Submission type: community curation
- Created by `tsdaer` — https://github.com/tsdaer
- Original source repository: https://github.com/tsdaer/dsh-desktop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@tsdaer — this entry was curated from your public repository (https://github.com/tsdaer/dsh-desktop). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.