### PR TITLE
catalog: add dsh-portable-desktop-bridge (community curation, created by @SR043)

### DIFF
--- a/catalog/plugins/dsh-portable-desktop-bridge.yaml
+++ b/catalog/plugins/dsh-portable-desktop-bridge.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: dsh-portable-desktop-bridge
+name: "@wsl043/dsh-portable-desktop-bridge"
+description:
+  en: <p align="center" <img src="assets/DSH-Portable.svg" width="96" alt="DeepSeek Harness" </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - align
+  - center
+  - assets
+  - portable
+  - width
+  - dsh
+source:
+  repository: https://github.com/WSL043/DSH-Portable
+  repositoryNodeId: R_kgDOT3z_RQ
+  subpath: desktop-bridge
+  commit: 9e6f1afea2a65feaa3aa2f818574f7c003ab1deb
+creator:
+  github: SR043
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: desktop-bridge/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:40:06.777Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-portable-desktop-bridge`
- Submission type: community curation
- Created by `SR043` — https://github.com/SR043
- Original source repository: https://github.com/WSL043/DSH-Portable
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@SR043 — this entry was curated from your public repository (https://github.com/WSL043/DSH-Portable). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.