### PR TITLE
catalog: add dsh-vision-insights-plugin (community curation, created by @fmlin0429712024)

### DIFF
--- a/catalog/plugins/dsh-vision-insights-plugin.yaml
+++ b/catalog/plugins/dsh-vision-insights-plugin.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-vision-insights-plugin
+name: dsh-vision-insights-plugin
+description:
+  en: "LinkHealth Vision Insights for DeepSeek Harness: DSH-side access point for vision insights. The OpenVINO visual app (Intelligent Queue Management kit) is a separate application with its own insight storage (SQLite behind a thin read API); this plugin's query vision events tool reads that data source via a baseUrl confi"
+  evidencePath: plugins/dsh-vision-insights-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - bundle
+  - vision
+  - insights
+  - edge
+  - queue-management
+  - linkhealth
+  - side
+  - access
+  - point
+  - openvino
+  - visual
+  - intelligent
+  - queue
+source:
+  repository: https://github.com/fmlin0429712024/linkhealth-dsh-platform
+  repositoryNodeId: R_kgDOT6mwFA
+  subpath: plugins/dsh-vision-insights-plugin
+  commit: ac726ea9dcef9e8e6f90a8dcf512d09b4572a7d1
+creator:
+  github: fmlin0429712024
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: plugins/dsh-vision-insights-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T19:35:23.901Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-vision-insights-plugin`
- Submission type: community curation
- Created by `fmlin0429712024` — https://github.com/fmlin0429712024
- Original source repository: https://github.com/fmlin0429712024/linkhealth-dsh-platform
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@fmlin0429712024 — this entry was curated from your public repository (https://github.com/fmlin0429712024/linkhealth-dsh-platform). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.