### PR TITLE
catalog: add dsh-undo-savepoint (community curation, created by @lire1131)

### DIFF
--- a/catalog/plugins/dsh-undo-savepoint.yaml
+++ b/catalog/plugins/dsh-undo-savepoint.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-undo-savepoint
+name: dsh-undo-savepoint
+description:
+  en: "DSH undo/rollback system: snapshot config files on change, undo/redo the last action from the WebUI or by chat, and roll back broken plugin trees without reinstalling. Works even when DSH fails to boot (offline CLI + GUI)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - undo
+  - redo
+  - rollback
+  - snapshot
+  - backup
+  - crash-recovery
+  - safe-mode
+  - windows
+  - powershell
+  - system
+  - config
+  - files
+  - change
+  - last
+source:
+  repository: https://github.com/lire1131/dsh-undo-savepoint
+  repositoryNodeId: R_kgDOT4Bt6g
+  subpath: null
+  commit: ecd9eb837ebddfa29488bd56812ecf2d4a9ea80a
+creator:
+  github: lire1131
+package:
+  ecosystem: npm
+  name: dsh-undo-savepoint
+  version: 0.3.5
+  integrity: sha512-ZOkmFUnJ27fJ3JYjwsK5SUp0THn7NlDMQdLsqQm538xJ+ktJZRXi3sKvdydGSRSdjoPRYXXjpqryQ8iup/oQ4w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:09:00.630Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 96
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-undo-savepoint`
- Submission type: community curation
- Created by `lire1131` — https://github.com/lire1131
- Original source repository: https://github.com/lire1131/dsh-undo-savepoint
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@lire1131 — this entry was curated from your public repository (https://github.com/lire1131/dsh-undo-savepoint). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.