### PR TITLE
catalog: add dsh-computer-use (community curation, created by @Anionex)

### DIFF
--- a/catalog/plugins/dsh-computer-use.yaml
+++ b/catalog/plugins/dsh-computer-use.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-computer-use
+name: "@anionex/dsh-computer-use"
+description:
+  en: Accessibility-first macOS Computer Use capability for DeepSeek Harness with stale-observation protection, app leases, confirmations, screenshots, and Web diagnostics
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - computer-use
+  - macos
+  - accessibility
+  - desktop-automation
+  - first
+  - computer
+  - capability
+  - stale
+  - observation
+  - protection
+  - leases
+  - confirmations
+  - screenshots
+  - diagnostics
+  - dsh
+source:
+  repository: https://github.com/Anionex/dsh-computer-use
+  repositoryNodeId: R_kgDOT3W-ow
+  subpath: null
+  commit: 76bfe8607f61945c1cbb84e73976e601100c13a2
+creator:
+  github: Anionex
+package:
+  ecosystem: npm
+  name: "@anionex/dsh-computer-use"
+  version: 0.1.0
+  integrity: sha512-3Fm5ZKGbPD3HoWS145IsSWzuLl8CqbPwHOHTRgzbVPnJHb7TZIx1wAezU8J5TdciZFas6nwEVAx3L5Q59dt21Q==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:09:36.062Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 24
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-computer-use`
- Submission type: community curation
- Created by `Anionex` — https://github.com/Anionex
- Original source repository: https://github.com/Anionex/dsh-computer-use
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Anionex — this entry was curated from your public repository (https://github.com/Anionex/dsh-computer-use). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.