### PR TITLE
catalog: add dsh-opencode-palette (community curation, created by @FeatherHunter)

### DIFF
--- a/catalog/plugins/dsh-opencode-palette.yaml
+++ b/catalog/plugins/dsh-opencode-palette.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: dsh-opencode-palette
+name: dsh-opencode-palette
+description:
+  en: DSH Web 多主题引擎：完整支持 opencode TUI 全部 34 个主题（33 内置 + system）。数据驱动三层管线：主题 JSON → 颜色解析 → DSH 适配注入。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - opencode
+  - system
+  - json
+  - dsh
+source:
+  repository: https://github.com/FeatherHunter/dsh-opencode-palette
+  repositoryNodeId: R_kgDOT5Qmlw
+  subpath: null
+  commit: 5aeadca70606ceb38f94080694e0c9fe47d4b10f
+creator:
+  github: FeatherHunter
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:10:56.817Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-opencode-palette`
- Submission type: community curation
- Created by `FeatherHunter` — https://github.com/FeatherHunter
- Original source repository: https://github.com/FeatherHunter/dsh-opencode-palette
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@FeatherHunter — this entry was curated from your public repository (https://github.com/FeatherHunter/dsh-opencode-palette). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.