### PR TITLE
catalog: add chatnode-wechat (community curation, created by @jesse)

### DIFF
--- a/catalog/plugins/chatnode-wechat.yaml
+++ b/catalog/plugins/chatnode-wechat.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: chatnode-wechat
+name: "@dsh-cowork/chatnode-wechat"
+description:
+  en: Chat with, monitor, and approve your DSH agents from WeChat — an iLink gateway + conversation node bundle for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - wechat
+  - weixin
+  - ilink
+  - conversation-node
+  - chat
+  - monitor
+  - approve
+  - agents
+  - gateway
+  - conversation
+  - node
+  - bundle
+source:
+  repository: https://github.com/Jesse-njx/dsh-chatnode-wechat
+  repositoryNodeId: R_kgDOT3khgw
+  subpath: null
+  commit: a724da34b5c78a9b9ab4a5de79f5d2a05fac1745
+creator:
+  github: jesse
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:11:19.618Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chatnode-wechat`
- Submission type: community curation
- Created by `jesse` — https://github.com/jesse
- Original source repository: https://github.com/Jesse-njx/dsh-chatnode-wechat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@jesse — this entry was curated from your public repository (https://github.com/Jesse-njx/dsh-chatnode-wechat). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.