### PR TITLE
docs(readme): refresh the Top 10 for 86 entries and replace the broken mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ repository, pinned at the exact commit the catalog validated.
 
 | #   | Plugin | Creator | ★ | Category | What it does |
 | --- | ------ | ------- | --- | -------- | ------------ |
-| 1 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | [@Nagi-ovo](https://github.com/Nagi-ovo) | 180 | UI & dashboards | Inline visualization: the model renders interactive charts and diagrams inside the session |
-| 2 | [dsh-pet-remielle](https://github.com/Gin-7/dsh-pet-remielle) | [@Gin-7](https://github.com/Gin-7) | 20 | Entertainment | Hot-pluggable transparent desktop pet (Remielle, Zenless Zone Zero) for the DSH web GUI |
-| 3 | [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) | [@Sutera-Diffusus](https://github.com/Sutera-Diffusus) | 19 | Entertainment | Animated whale-girl Kanban Musume mascot that reacts to dashboard activity |
-| 4 | [deepseek-harness-tui](https://github.com/gxinxing/deepseek-harness-tui) | [@gxinxing](https://github.com/gxinxing) | 7 | UI & dashboards | Full-screen curses-style terminal chat client for driving dsh sessions |
-| 5 | [dsh-tui](https://github.com/turtle1999/turtle-ui) | [@turtle1999](https://github.com/turtle1999) | 7 | UI & dashboards | Interactive pi-tui terminal front door: session picker, streaming chat, keybindings |
-| 6 | [dsh-tavily-workspace](https://github.com/moguiyu/dsh-tavily) | [@moguiyu](https://github.com/moguiyu) | 3 | Search & research | Opt-in Tavily advanced search tool with multi-key management and a usage gauge |
-| 7 | [dsh-bili-widget](https://github.com/pyf2818/dsh-bili-widget) | [@pyf2818](https://github.com/pyf2818) | 2 | Entertainment | Floating bilibili video widget: recommendations, trending, rankings and search |
-| 8 | [dsh-themes](https://github.com/MangMax/dsh-themes) | [@MangMax](https://github.com/MangMax) | 1 | Entertainment | Appearance plugin: built-in palettes, light/dark/system mode, VS Code themes |
-| 9 | [dsh-arknights](https://github.com/DocJlm/dsh-arknights) | [@DocJlm](https://github.com/DocJlm) | — | Entertainment | Non-commercial Arknights astral-garden skin featuring Pramanix and Eyjafjalla |
-| 10 | [dsh-bridge-browser](https://github.com/Lum1104/dsh-browser) | [@Lum1104](https://github.com/Lum1104) | — | Browser automation | Token-authenticated WebSocket bridge for the companion browser extension |
+| 1 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | [@ysr666](https://github.com/ysr666) | 843 | Vision & multimodal | Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools… |
+| 2 | [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | [@taekchef](https://github.com/taekchef) | 249 | UI & dashboards | GenUI for DeepSeek Harness: interactive UI components rendered inline in assistant replies via the dsh-ui… |
+| 3 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | [@huiliyi37](https://github.com/huiliyi37) | 220 | UI & dashboards | dsh-tianshu-tui: an interactive terminal UI plugin for the official DeepSeek Harness — streaming… |
+| 4 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | [@Nagi-ovo](https://github.com/Nagi-ovo) | 180 | UI & dashboards | Inline visualization for DeepSeek Harness: a visualize tool plus bundled skill let the model render… |
+| 5 | [anime-find](https://github.com/cocofhu/anime-find) | [@cocofhu00](https://github.com/cocofhu00) | 152 | Search & research | An anime search plugin for DeepSeek Harness: an anime_find_search tool aggregates Mikan, AniBT and… |
+| 6 | [dsh-undo-savepoint](https://github.com/lire1131/dsh-undo-savepoint) | [@lire1131](https://github.com/lire1131) | 96 | UI & dashboards | DSH undo/rollback system: snapshot config files on change, undo/redo the last action from the WebUI or by… |
+| 7 | [workflow](https://github.com/omdsh-dev/dsh_workflow) | [@icetomoyo](https://github.com/icetomoyo) | 88 | Coding & dev tools | KodaX-parity dynamic workflow harness for DeepSeek Harness |
+| 8 | [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | [@taekchef](https://github.com/taekchef) | 79 | UI & dashboards | DSH Web selection-annotation plugin: select assistant text, annotate (optional), and press Enter to send the… |
+| 9 | [dsh-vision](https://github.com/oil-oil/dsh-vision) | [@oil-oil](https://github.com/oil-oil) | 70 | Vision & multimodal | Near-native image understanding for text-only DeepSeek Harness models |
+| 10 | [dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) | [@Mars-Sea](https://github.com/Mars-Sea) | 69 | Models & routing | Unofficial DeepSeek Harness LLM provider plugin for Command Code, ported from pi-commandcode-provider (MIT… |
 
 <div align="center">
 
@@ -120,7 +120,7 @@ catalog data, schema and policies they consume.
 
 ## Catalog status
 
-**10 plugins merged.** Every plugin enters through an individually reviewed pull request, one at
+**86 plugins merged.** Every plugin enters through an individually reviewed pull request, one at
 a time, from the original creator repository, with a pinned source commit and explicit
 attribution.
 
@@ -167,16 +167,8 @@ WSL. Read-only and dry-run commands work everywhere.
 
 ## 🔍 How a plugin enters the catalog
 
-```mermaid
-flowchart LR
-    A["Creator repository<br/>(pinned commit)"] --> B["One branch,<br/>one PR,<br/>one YAML entry"]
-    B --> C["catalog-validation CI<br/>(schema + local semantics)"]
-    C --> D["Maintainer gates<br/>(identity, creator binding,<br/>pinned evidence)"]
-    D --> E["catalog/plugins/*.yaml<br/>merged"]
-    E --> F["Website"]
-    E --> G["CLI"]
-    E --> H["catalog.json feeds"]
-```
+![How a plugin enters the catalog](./docs/diagrams/catalog-flow-dark.svg#gh-dark-mode-only)
+![How a plugin enters the catalog](./docs/diagrams/catalog-flow-light.svg#gh-light-mode-only)
 
 1. **One plugin, one branch, one pull request.** The PR adds or changes exactly one YAML file
    under `catalog/plugins/`.

--- a/docs/diagrams/catalog-flow-dark.svg
+++ b/docs/diagrams/catalog-flow-dark.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 806" role="img" aria-roledescription="flowchart" aria-labelledby="dg-title" aria-describedby="dg-desc">
+<title id="dg-title">How a plugin enters the catalog animated diagram</title>
+<desc id="dg-desc">Top-down flow diagram; dashed connectors animate in the direction of flow and dots ride the main paths. All information is also conveyed by the static layout.</desc>
+<style>:root{--bg:#030a1c;--grid:#0f1b33;--panel:#0b1226;--panel2:#060d20;--line:#1e293b;--ink:#e2e8f0;--soft:#94a3b8;--muted:#64748b;--dim:#475569;--bnd-region:#fbbf24;--bnd-subnet:#fb7185;--f-frontend:rgba(8,51,68,0.45);--f-backend:rgba(6,78,59,0.45);--f-database:rgba(76,29,149,0.45);--f-cloud:rgba(120,53,15,0.35);--f-security:rgba(136,19,55,0.45);--f-bus:rgba(154,52,18,0.35);--f-external:rgba(30,41,59,0.5)}.ink{fill:var(--ink)}.soft{fill:var(--soft)}.muted{fill:var(--muted)}.dim{fill:var(--dim)}.panel{fill:var(--panel)}.f-frontend{fill:var(--f-frontend)}.f-backend{fill:var(--f-backend)}.f-database{fill:var(--f-database)}.f-cloud{fill:var(--f-cloud)}.f-security{fill:var(--f-security)}.f-bus{fill:var(--f-bus)}.f-external{fill:var(--f-external)}.bg{fill:var(--bg);stroke:var(--line)}.panel2{fill:var(--panel2);stroke:var(--line)}.grid{stroke:var(--grid)}.bnd-region{stroke:var(--bnd-region)}.bnd-subnet{stroke:var(--bnd-subnet)}.bnd-region-t{fill:var(--bnd-region)}.bnd-subnet-t{fill:var(--bnd-subnet)}@media (prefers-reduced-motion: reduce){.dot{display:none}}</style>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" class="grid" stroke-width="0.5"/></pattern></defs>
+<rect width="760" height="806" rx="12" class="bg"/>
+<rect width="760" height="806" rx="12" fill="url(#grid)"/>
+<g font-family="Consolas, 'Courier New', monospace">
+<circle cx="39" cy="30" r="5" fill="#34d399"><animate attributeName="opacity" values="1;0.4;1" dur="2s" repeatCount="indefinite"/></circle>
+<text x="54" y="35" class="ink" font-size="18" font-weight="600">How a plugin enters the catalog</text>
+<text x="54" y="56" class="muted" font-size="11">Creator-first curation: one plugin, one branch, one pull request</text>
+</g>
+<g fill="none">
+<path d="M380 176 V228" stroke="#10b981" stroke-width="1.5" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 290 V342" stroke="#10b981" stroke-width="1.5" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 404 V456" stroke="#10b981" stroke-width="1.5" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 518 V570" stroke="#10b981" stroke-width="1.5" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 632 V660 H214.5 V684" stroke="#10b981" stroke-width="1" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 632 V660 H354.5 V684" stroke="#10b981" stroke-width="1" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 632 V660 H520 V684" stroke="#10b981" stroke-width="1" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+</g>
+<g>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_0" dur="0.6s" begin="0s;j0_4.end+0.6s" fill="freeze" path="M380 176 V228"/></circle>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_1" dur="0.6s" begin="j0_0.end+0.3s" fill="freeze" path="M380 290 V342"/></circle>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_2" dur="0.6s" begin="j0_1.end+0.3s" fill="freeze" path="M380 404 V456"/></circle>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_3" dur="0.6s" begin="j0_2.end+0.3s" fill="freeze" path="M380 518 V570"/></circle>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_4" dur="1.4s" begin="j0_3.end+0.3s" fill="freeze" path="M380 632 V660 H214.5 V684"/></circle>
+<circle r="3.5" class="dot" fill="#a78bfa"><animateMotion id="j1_0" dur="0.6s" begin="0s;j1_0.end+0.6s" fill="freeze" path="M380 632 V660 H354.5 V684"/></circle>
+<circle r="3.5" class="dot" fill="#f472b6"><animateMotion id="j2_0" dur="1.3s" begin="0s;j2_0.end+0.6s" fill="freeze" path="M380 632 V660 H520 V684"/></circle>
+</g>
+<g font-family="Consolas, 'Courier New', monospace" text-anchor="middle">
+<rect x="298" y="118" width="164" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="144" class="ink" font-size="13" font-weight="500"><tspan x="380">Creator repository</tspan><tspan x="380" dy="15">(pinned commit)</tspan></text>
+<rect x="298" y="232" width="164" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="258" class="ink" font-size="13" font-weight="500"><tspan x="380">One branch, one</tspan><tspan x="380" dy="15">PR, one YAML entry</tspan></text>
+<rect x="267.5" y="346" width="225" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="372" class="ink" font-size="13" font-weight="500"><tspan x="380">catalog-validation CI</tspan><tspan x="380" dy="15">(schema + local semantics)</tspan></text>
+<rect x="245.5" y="460" width="269" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="486" class="ink" font-size="13" font-weight="500"><tspan x="380">Maintainer gates (identity,</tspan><tspan x="380" dy="15">creator binding, pinned evidence)</tspan></text>
+<rect x="283.5" y="574" width="193" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="600" class="ink" font-size="13" font-weight="500"><tspan x="380">catalog/plugins/*.yaml</tspan><tspan x="380" dy="15">merged</tspan></text>
+<rect x="159.5" y="688" width="110" height="44" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="214.5" y="714" class="ink" font-size="13" font-weight="500">Website</text>
+<rect x="299.5" y="688" width="110" height="44" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="354.5" y="714" class="ink" font-size="13" font-weight="500">CLI</text>
+<rect x="439.5" y="688" width="161" height="44" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="520" y="714" class="ink" font-size="13" font-weight="500">catalog.json feeds</text>
+</g>
+<g font-family="Consolas, 'Courier New', monospace">
+<text x="34" y="794" class="dim" font-size="10">Community-maintained and unofficial. Not affiliated with, endorsed by, or sponsored by DeepSeek.</text>
+</g>
+</svg>

--- a/docs/diagrams/catalog-flow-light.svg
+++ b/docs/diagrams/catalog-flow-light.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 806" role="img" aria-roledescription="flowchart" aria-labelledby="dg-title" aria-describedby="dg-desc">
+<title id="dg-title">How a plugin enters the catalog animated diagram</title>
+<desc id="dg-desc">Top-down flow diagram; dashed connectors animate in the direction of flow and dots ride the main paths. All information is also conveyed by the static layout.</desc>
+<style>:root{--bg:#f8fafc;--grid:#e2e8f0;--panel:#ffffff;--panel2:#f1f5f9;--line:#cbd5e1;--ink:#0f172a;--soft:#334155;--muted:#475569;--dim:#64748b;--bnd-region:#b45309;--bnd-subnet:#be123c;--f-frontend:rgba(34,211,238,0.14);--f-backend:rgba(52,211,153,0.14);--f-database:rgba(167,139,250,0.16);--f-cloud:rgba(251,191,36,0.18);--f-security:rgba(251,113,133,0.14);--f-bus:rgba(251,146,60,0.18);--f-external:rgba(148,163,184,0.22)}.ink{fill:var(--ink)}.soft{fill:var(--soft)}.muted{fill:var(--muted)}.dim{fill:var(--dim)}.panel{fill:var(--panel)}.f-frontend{fill:var(--f-frontend)}.f-backend{fill:var(--f-backend)}.f-database{fill:var(--f-database)}.f-cloud{fill:var(--f-cloud)}.f-security{fill:var(--f-security)}.f-bus{fill:var(--f-bus)}.f-external{fill:var(--f-external)}.bg{fill:var(--bg);stroke:var(--line)}.panel2{fill:var(--panel2);stroke:var(--line)}.grid{stroke:var(--grid)}.bnd-region{stroke:var(--bnd-region)}.bnd-subnet{stroke:var(--bnd-subnet)}.bnd-region-t{fill:var(--bnd-region)}.bnd-subnet-t{fill:var(--bnd-subnet)}@media (prefers-reduced-motion: reduce){.dot{display:none}}</style>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" class="grid" stroke-width="0.5"/></pattern></defs>
+<rect width="760" height="806" rx="12" class="bg"/>
+<rect width="760" height="806" rx="12" fill="url(#grid)"/>
+<g font-family="Consolas, 'Courier New', monospace">
+<circle cx="39" cy="30" r="5" fill="#34d399"><animate attributeName="opacity" values="1;0.4;1" dur="2s" repeatCount="indefinite"/></circle>
+<text x="54" y="35" class="ink" font-size="18" font-weight="600">How a plugin enters the catalog</text>
+<text x="54" y="56" class="muted" font-size="11">Creator-first curation: one plugin, one branch, one pull request</text>
+</g>
+<g fill="none">
+<path d="M380 176 V228" stroke="#10b981" stroke-width="1.5" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 290 V342" stroke="#10b981" stroke-width="1.5" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 404 V456" stroke="#10b981" stroke-width="1.5" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 518 V570" stroke="#10b981" stroke-width="1.5" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 632 V660 H214.5 V684" stroke="#10b981" stroke-width="1" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 632 V660 H354.5 V684" stroke="#10b981" stroke-width="1" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+<path d="M380 632 V660 H520 V684" stroke="#10b981" stroke-width="1" opacity="0.85" stroke-dasharray="5 5" marker-end="url(#arrow)"><animate attributeName="stroke-dashoffset" values="0;-10" dur="0.75s" repeatCount="indefinite"/></path>
+</g>
+<g>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_0" dur="0.6s" begin="0s;j0_4.end+0.6s" fill="freeze" path="M380 176 V228"/></circle>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_1" dur="0.6s" begin="j0_0.end+0.3s" fill="freeze" path="M380 290 V342"/></circle>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_2" dur="0.6s" begin="j0_1.end+0.3s" fill="freeze" path="M380 404 V456"/></circle>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_3" dur="0.6s" begin="j0_2.end+0.3s" fill="freeze" path="M380 518 V570"/></circle>
+<circle r="3.5" class="dot" fill="#22d3ee"><animateMotion id="j0_4" dur="1.4s" begin="j0_3.end+0.3s" fill="freeze" path="M380 632 V660 H214.5 V684"/></circle>
+<circle r="3.5" class="dot" fill="#a78bfa"><animateMotion id="j1_0" dur="0.6s" begin="0s;j1_0.end+0.6s" fill="freeze" path="M380 632 V660 H354.5 V684"/></circle>
+<circle r="3.5" class="dot" fill="#f472b6"><animateMotion id="j2_0" dur="1.3s" begin="0s;j2_0.end+0.6s" fill="freeze" path="M380 632 V660 H520 V684"/></circle>
+</g>
+<g font-family="Consolas, 'Courier New', monospace" text-anchor="middle">
+<rect x="298" y="118" width="164" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="144" class="ink" font-size="13" font-weight="500"><tspan x="380">Creator repository</tspan><tspan x="380" dy="15">(pinned commit)</tspan></text>
+<rect x="298" y="232" width="164" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="258" class="ink" font-size="13" font-weight="500"><tspan x="380">One branch, one</tspan><tspan x="380" dy="15">PR, one YAML entry</tspan></text>
+<rect x="267.5" y="346" width="225" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="372" class="ink" font-size="13" font-weight="500"><tspan x="380">catalog-validation CI</tspan><tspan x="380" dy="15">(schema + local semantics)</tspan></text>
+<rect x="245.5" y="460" width="269" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="486" class="ink" font-size="13" font-weight="500"><tspan x="380">Maintainer gates (identity,</tspan><tspan x="380" dy="15">creator binding, pinned evidence)</tspan></text>
+<rect x="283.5" y="574" width="193" height="58" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="380" y="600" class="ink" font-size="13" font-weight="500"><tspan x="380">catalog/plugins/*.yaml</tspan><tspan x="380" dy="15">merged</tspan></text>
+<rect x="159.5" y="688" width="110" height="44" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="214.5" y="714" class="ink" font-size="13" font-weight="500">Website</text>
+<rect x="299.5" y="688" width="110" height="44" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="354.5" y="714" class="ink" font-size="13" font-weight="500">CLI</text>
+<rect x="439.5" y="688" width="161" height="44" rx="8" fill="rgba(16,185,129,0.04)" stroke="#10b981"/>
+<text x="520" y="714" class="ink" font-size="13" font-weight="500">catalog.json feeds</text>
+</g>
+<g font-family="Consolas, 'Courier New', monospace">
+<text x="34" y="794" class="dim" font-size="10">Community-maintained and unofficial. Not affiliated with, endorsed by, or sponsored by DeepSeek.</text>
+</g>
+</svg>


### PR DESCRIPTION
## 1. Ranking refreshed

76 curated entries were merged, so the catalog now holds **86** and the Top 10 was stale.

The table and the count are **regenerated from the merged YAML files**, not edited by hand:

- Ranked by **exact-repository stars**, keeping the documented predicate intact — the 8 monorepo
  entries carry `stars: null` and stay *out* of the ranking rather than inheriting a parent
  project's stars.
- Descriptions are each entry's own `description.en`, shortened at a word boundary to fit one
  table row. **Never reworded** — the text stays the creator's and traceable to the validated entry.
- `catalog docs-check` enforces that the printed count matches the number of entries, so the
  number is *verified*, not asserted.

New #1 is `dsh-vision-router` (843★); `modlens`/`dsh-better-sidebar` are **not** here because they
were never approved into the catalog — only merged entries are ranked.

## 2. Broken mermaid diagram replaced

The `mermaid` block did not render on GitHub — readers saw:

> Unable to render rich display · Cannot read properties of undefined (reading 'render')

Replaced with a pair of **self-contained animated SVGs** (no script, no external references) using
the `#gh-dark-mode-only` / `#gh-light-mode-only` pair, so the diagram follows the reader's **GitHub
theme toggle**, including in the iOS app.

**Fidelity:** topology and labels come from the mermaid source — 8 nodes, 7 edges, checked
mechanically rather than by eye. Only geometry is recomputed (top-down instead of left-right), and
a travelling dot now traces the path a plugin actually takes. The `<br/>` line breaks became
spaces; that is the only textual difference from the original labels.

## Verification

| gate | result |
|---|---|
| `catalog validate` | 86 entries valid |
| `catalog docs-check` | passed for 86 entries |
| `catalog github-forms-check` | 3 forms valid |
| SVG embed-sandbox validator | pass, 0 warnings (both themes) |
| diagram structure checker | 0 violations (both themes) |
| label/edge fidelity vs mermaid source | PASS (nodes=8 edges=7 paths=7) |
| animation | both themes rendered and reviewed as images at several timestamps; dots move between frames |

No catalog entry was touched — only `README.md` and the two new SVGs under `docs/diagrams/`.