### PR TITLE
catalog: aplica a curadoria da leva 3 em seis entradas que mergearam antes dela

### DIFF
--- a/catalog/plugins/deepseek-harness-wecom.yaml
+++ b/catalog/plugins/deepseek-harness-wecom.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: vision-audio-multimodal
+primaryCategory: messaging-notifications
 tags:
   - deepseek-harness
   - wecom

--- a/catalog/plugins/dsh-client-ui-theme-xp.yaml
+++ b/catalog/plugins/dsh-client-ui-theme-xp.yaml
@@ -5,7 +5,7 @@ description:
   en: "Windows XP Luna desktop theme for the DeepSeek Harness web GUI: floating window manager with taskbar and desktop icons, Explorer-style workspace/session browser, native directory picker, search and the Luna token palette."
   evidencePath: README.md
 unofficial: true
-kind: plugin
+kind: skin-theme
 primaryCategory: entertainment-customization
 tags:
   - dsh

--- a/catalog/plugins/dsh-computer-use.yaml
+++ b/catalog/plugins/dsh-computer-use.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: diagnostics-observability
+primaryCategory: browser-automation
 tags:
   - deepseek-harness
   - computer-use

--- a/catalog/plugins/dsh-github-intelligence.yaml
+++ b/catalog/plugins/dsh-github-intelligence.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: models-providers-routing
+primaryCategory: data-external-services
 tags:
   - deepseek-harness
   - dsh-plugin

--- a/catalog/plugins/dsh-opencode-palette.yaml
+++ b/catalog/plugins/dsh-opencode-palette.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-opencode-palette
 name: dsh-opencode-palette
 description:
-  en: DSH Web 多主题引擎：完整支持 opencode TUI 全部 34 个主题（33 内置 + system）。数据驱动三层管线：主题 JSON → 颜色解析 → DSH 适配注入。
+  en: "Brings the opencode colour schemes to the DeepSeek Harness web UI: all 34 themes (33 built in plus `system`), delivered through the official DSH bundle mechanism — the package ships its own cordis.patch.yml, so `dsh plugin add` and `dsh plugin remove` wire and unwire the theme with no file editing."
   evidencePath: README.md
 unofficial: true
-kind: plugin
-primaryCategory: user-interface-dashboards
+kind: skin-theme
+primaryCategory: entertainment-customization
 tags:
   - opencode
   - system

--- a/catalog/plugins/dsh-undo-savepoint.yaml
+++ b/catalog/plugins/dsh-undo-savepoint.yaml
@@ -6,7 +6,7 @@ description:
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: user-interface-dashboards
+primaryCategory: sessions-productivity
 tags:
   - deepseek-harness
   - dsh


### PR DESCRIPTION
Seis entradas foram mergeadas **com os valores crus do renderizador**, antes da curadoria manual
daquela leva existir. Este PR aplica a curadoria. Cada correção sai do README do commit fixado.

| Entrada | Correção | Por quê |
|---|---|---|
| `dsh-opencode-palette` | `description.en` reescrita · `kind: plugin → skin-theme` · `user-interface-dashboards → entertainment-customization` | **Estava com prosa em chinês num campo que o schema chama de inglês** |
| `dsh-client-ui-theme-xp` | `kind: plugin → skin-theme` | É tema visual, não plugin |
| `dsh-github-intelligence` | `models-providers-routing → data-external-services` | São 195+ ferramentas somente-leitura sobre serviços externos (GitHub, npm, PyPI, crates.io, Docker Hub, Hugging Face…); não roteia modelo nenhum |
| `dsh-computer-use` | `diagnostics-observability → browser-automation` | O rótulo da categoria é "Browser **and automation**"; o plugin automatiza o macOS por acessibilidade. Diagnóstico é efeito colateral |
| `deepseek-harness-wecom` | `vision-audio-multimodal → messaging-notifications` | Texto/imagem/arquivo são tipos de payload do canal WeCom, não capacidade multimodal |
| `dsh-undo-savepoint` | `user-interface-dashboards → sessions-productivity` | O produto é desfazer/refazer e rollback de configuração — funciona até com o DSH sem subir, por CLI offline |

**As duas correções de `kind` não são cosméticas**: `docs/CATEGORIES.md` exclui `skin-theme` do
ranking por estrelas, então um tema arquivado como `plugin` disputa o ranking de plugins.

A descrição reescrita ficou em 299 caracteres — o schema rejeita `description.en` acima de 320,
e a primeira versão batia em 322.

## Verificação

```
npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
86 entries valid
```

Nenhuma outra entrada é tocada. A causa-raiz da descrição em língua errada está sendo corrigida
na origem, no pipeline, para não reincidir.
