### PR TITLE
catalog: add context-vista (community curation, created by @GooodWei)

### DIFF
--- a/catalog/plugins/context-vista.yaml
+++ b/catalog/plugins/context-vista.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: context-vista
+name: context-vista
+description:
+  en: "A live context-window donut for DeepSeek Harness: token usage, compaction savings, and cost at a glance"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - cordis
+  - slash-command
+  - context
+  - tokens
+  - compaction
+  - cost
+  - pricing
+  - live
+  - window
+  - donut
+  - token
+  - usage
+  - savings
+  - glance
+source:
+  repository: https://github.com/GooodWei/context-vista
+  repositoryNodeId: R_kgDOT3eBIw
+  subpath: null
+  commit: a26cd744557d5d537a801bd5f51853658b70971a
+creator:
+  github: GooodWei
+package:
+  ecosystem: npm
+  name: context-vista
+  version: 0.1.0
+  integrity: sha512-oE8xX1j4NZK40MlL9eu7k5a+p1YN2fMFqHep7kzKVo8rQHWEishrN9bEUYRu8nNq+YCw5ynXeAxduDVvC5vGiA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:08.732Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `context-vista`
- Submission type: community curation
- Created by `GooodWei` — https://github.com/GooodWei
- Original source repository: https://github.com/GooodWei/context-vista
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@GooodWei — this entry was curated from your public repository (https://github.com/GooodWei/context-vista). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.