### PR TITLE
catalog: add deepseek-harness-acp (community curation, created by @hrhrng)

### DIFF
--- a/catalog/plugins/deepseek-harness-acp.yaml
+++ b/catalog/plugins/deepseek-harness-acp.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: deepseek-harness-acp
+name: "@openma/deepseek-harness-acp"
+description:
+  en: Agent Client Protocol (ACP) adapter for DeepSeek Harness — use DeepSeek Harness from ACP clients such as Zed.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - agent
+  - client
+  - protocol
+  - adapter
+  - clients
+  - such
+  - dsh
+source:
+  repository: https://github.com/openma-ai/deepseek-harness-acp
+  repositoryNodeId: R_kgDOT3dkDQ
+  subpath: null
+  commit: 0cf5797d2a42418417410072edbceb38773c8adc
+creator:
+  github: hrhrng
+package:
+  ecosystem: npm
+  name: "@openma/deepseek-harness-acp"
+  version: 0.4.14
+  integrity: sha512-FeswCQo0VpgADjS9/BCkfL1Zq1odTk83pWUisqOnyqXOMDxPJ9Lp4aVchn3KlrzU1reOYpG+qC3JjrmjB/3DCw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:57.574Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `deepseek-harness-acp`
- Submission type: community curation
- Created by `hrhrng` — https://github.com/hrhrng
- Original source repository: https://github.com/openma-ai/deepseek-harness-acp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@hrhrng — this entry was curated from your public repository (https://github.com/openma-ai/deepseek-harness-acp). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.