### PR TITLE
catalog: add deepseek-harness-wallet (community curation, created by @feibi-mochi)

### DIFF
--- a/catalog/plugins/deepseek-harness-wallet.yaml
+++ b/catalog/plugins/deepseek-harness-wallet.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: deepseek-harness-wallet
+name: deepseek-harness-wallet
+description:
+  en: Local-first account monitoring, usage accounting, official recharge, completion reminders, flexible layout, host-gated session controls, and multi-account management with hot account switching for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - balance-monitor
+  - recharge
+  - token-tracking
+  - cost-tracking
+  - wallet
+  - multi-account
+  - account-switching
+  - llm
+  - agentic-ai
+  - local
+  - first
+  - account
+  - monitoring
+  - usage
+  - accounting
+source:
+  repository: https://github.com/feibi-mochi/deepseek-harness-control-center
+  repositoryNodeId: R_kgDOT4RiEA
+  subpath: null
+  commit: 79d2ea3ff7050326adaa7f13f8455e61967e3f8b
+creator:
+  github: feibi-mochi
+package:
+  ecosystem: npm
+  name: deepseek-harness-wallet
+  version: 0.2.0
+  integrity: sha512-5x/Dyvd7kTfCEQ8UAdp9Tl1MT7F5fV/VnlJzsZ1woyLmVD4oZtc/9NJ5s9VIvNofSSEhcqInBsrG/NdQazqTmQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:01.475Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 54
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `deepseek-harness-wallet`
- Submission type: community curation
- Created by `feibi-mochi` — https://github.com/feibi-mochi
- Original source repository: https://github.com/feibi-mochi/deepseek-harness-control-center
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@feibi-mochi — this entry was curated from your public repository (https://github.com/feibi-mochi/deepseek-harness-control-center). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.