### PR TITLE
catalog: add dsh-ads (community curation, created by @Nagi-ovo)

### DIFF
--- a/catalog/plugins/dsh-ads.yaml
+++ b/catalog/plugins/dsh-ads.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: dsh-ads
+name: "@dsh-external/dsh-ads"
+description:
+  en: "DSH ad-infestation plugin: localized Chinese portal ads and English scam-ad parody, with fake pop-ups, a jackpot wheel, rewarded inference ads, and fake-game animation."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - infestation
+  - localized
+  - chinese
+  - portal
+  - english
+  - scam
+  - parody
+  - fake
+  - jackpot
+  - wheel
+  - rewarded
+  - inference
+  - game
+  - animation
+  - dsh
+source:
+  repository: https://github.com/Nagi-ovo/dsh-ads
+  repositoryNodeId: R_kgDOTzipNQ
+  subpath: null
+  commit: 3a2ba704bc383099c686d3288ff6e0d61fc391e5
+creator:
+  github: Nagi-ovo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:28:37.419Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 511
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-ads`
- Submission type: community curation
- Created by `Nagi-ovo` — https://github.com/Nagi-ovo
- Original source repository: https://github.com/Nagi-ovo/dsh-ads
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Nagi-ovo — this entry was curated from your public repository (https://github.com/Nagi-ovo/dsh-ads). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.