### PR TITLE
catalog: add dsh-agent-skills (community curation, created by @kuweiMaster)

### DIFF
--- a/catalog/plugins/dsh-agent-skills.yaml
+++ b/catalog/plugins/dsh-agent-skills.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: dsh-agent-skills
+name: dsh-agent-skills
+description:
+  en: Discover and manage Claude Code, Codex, Gemini CLI, and other Agent Skills inside DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-skills
+  - skills
+  - codex
+  - claude-code
+  - discover
+  - manage
+  - claude
+  - code
+  - gemini
+  - other
+  - agent
+  - inside
+  - dsh
+source:
+  repository: https://github.com/minivv/dsh-agent-skills
+  repositoryNodeId: R_kgDOT6rOBw
+  subpath: null
+  commit: fcc914b5189b6882ce24fa245022a32eb907326f
+creator:
+  github: kuweiMaster
+package:
+  ecosystem: npm
+  name: dsh-agent-skills
+  version: 0.1.7
+  integrity: sha512-w+rZVJVVQ15MpBqrJmGuFyig//lnT68OcI43Lo6ZOrNPJQxrh0JhbMi9ASdOLP8l5NtbsqsBvEVBDLgZl5fQ0Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:31:05.243Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-agent-skills`
- Submission type: community curation
- Created by `kuweiMaster` — https://github.com/kuweiMaster
- Original source repository: https://github.com/minivv/dsh-agent-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@kuweiMaster — this entry was curated from your public repository (https://github.com/minivv/dsh-agent-skills). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.