### PR TITLE
catalog: add dsh-answer-pet (community curation, created by @Nanki-nn)

### DIFF
--- a/catalog/plugins/dsh-answer-pet.yaml
+++ b/catalog/plugins/dsh-answer-pet.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: dsh-answer-pet
+name: dsh-answer-pet
+description:
+  en: "A pet-shaped answer-status framework for the DeepSeek Harness web UI: a declarative PetTheme v1 owns the SVG, animation and stage copy while the core tracks session progress, model trajectory and tool calls. One draggable, collapsible card per running session; whale, orange cat and silver tabby ship built in."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - desktop-pet
+  - answer-progress
+  - multi-session
+  - pet-theme
+  - extensible
+source:
+  repository: https://github.com/Nanki-nn/dsh-answer-pet
+  repositoryNodeId: R_kgDOT4LoNA
+  subpath: null
+  commit: a0827d41c3f8f9177622c460a99f1aeeb8034b8d
+creator:
+  github: Nanki-nn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:24.963Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-answer-pet`
- Submission type: community curation
- Created by `Nanki-nn` — https://github.com/Nanki-nn
- Original source repository: https://github.com/Nanki-nn/dsh-answer-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Nanki-nn — this entry was curated from your public repository (https://github.com/Nanki-nn/dsh-answer-pet). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.