### PR TITLE
catalog: add dsh-balance-plugin (community curation, created by @stevenx65)

### DIFF
--- a/catalog/plugins/dsh-balance-plugin.yaml
+++ b/catalog/plugins/dsh-balance-plugin.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: dsh-balance-plugin
+name: dsh-balance-plugin
+description:
+  en: DeepSeek API balance and token usage monitor for the dsh web sidebar
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - balance
+  - usage
+  - dsh-plugin
+  - token
+  - monitor
+  - sidebar
+source:
+  repository: https://github.com/stevenx65/dsh-balance-plugin
+  repositoryNodeId: R_kgDOT4S86g
+  subpath: null
+  commit: 9067ed33ac83f986b54096bcd21c2c1db0583bb4
+creator:
+  github: stevenx65
+package:
+  ecosystem: npm
+  name: dsh-balance-plugin
+  version: 0.1.0
+  integrity: sha512-9+zp19FHXdVJVUktJn9R7G9RZtoYpU3z8rSFp71QQ8PvX3lJ4imO8idIGwrVx544YcvE2zpAT7Brvf1inwWCJQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:51.388Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-balance-plugin`
- Submission type: community curation
- Created by `stevenx65` — https://github.com/stevenx65
- Original source repository: https://github.com/stevenx65/dsh-balance-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@stevenx65 — this entry was curated from your public repository (https://github.com/stevenx65/dsh-balance-plugin). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.