### PR TITLE
catalog: add dsh-bash-terminal (community curation, created by @MAXeaglet)

### DIFF
--- a/catalog/plugins/dsh-bash-terminal.yaml
+++ b/catalog/plugins/dsh-bash-terminal.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-bash-terminal
+name: dsh-bash-terminal
+description:
+  en: "DSH plugin: one shell tool that runs commands through PowerShell, Git Bash, or WSL on Windows, with a user-chosen default terminal in the Web UI settings."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - terminal
+  - shell
+  - powershell
+  - git-bash
+  - wsl
+  - windows
+  - tool
+  - runs
+  - commands
+  - through
+  - bash
+  - user
+  - chosen
+  - default
+source:
+  repository: https://github.com/MAXeaglet/dsh-bash-terminal
+  repositoryNodeId: R_kgDOT3kaNQ
+  subpath: null
+  commit: 6894913d71098f2ea24120d3a1afd5771f9ccd4a
+creator:
+  github: MAXeaglet
+package:
+  ecosystem: npm
+  name: dsh-bash-terminal
+  version: 0.3.14
+  integrity: sha512-DXzhDuaGzDPbjn2r6RoFWQ6d8fo6zPQnlxkc6quxYVLdAcuiDWPniHiKf5k1Bs+0UiRI3UK1HsFADbmj0tbTeQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:56.074Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-bash-terminal`
- Submission type: community curation
- Created by `MAXeaglet` — https://github.com/MAXeaglet
- Original source repository: https://github.com/MAXeaglet/dsh-bash-terminal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@MAXeaglet — this entry was curated from your public repository (https://github.com/MAXeaglet/dsh-bash-terminal). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.