### PR TITLE
catalog: add dsh-better-sidebar (community curation, created by @Menghuan1918)

### DIFF
--- a/catalog/plugins/dsh-better-sidebar.yaml
+++ b/catalog/plugins/dsh-better-sidebar.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-better-sidebar
+name: dsh-better-sidebar
+description:
+  en: "DSH web plugin: a VSCode-like right sidebar (explorer / editor / terminal / git / browser), isolated per conversation session. Exposes a service for other plugins to register sidebar tabs and file viewers."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - vscode
+  - right
+  - sidebar
+  - explorer
+  - editor
+  - terminal
+  - browser
+  - isolated
+  - conversation
+  - session
+  - exposes
+  - service
+  - other
+  - register
+  - tabs
+  - file
+source:
+  repository: https://github.com/omdsh-dev/DSH-better-sidebar
+  repositoryNodeId: R_kgDOTxbKjg
+  subpath: null
+  commit: 14ef8e4df8ab0ac8054965b68991d187498c8073
+creator:
+  github: Menghuan1918
+package:
+  ecosystem: npm
+  name: dsh-better-sidebar
+  version: 0.13.1
+  integrity: sha512-LCPCJuW8+QHEsBMAL39c6rvnPP0Q83+G4nacmx/KJtNrweiYwM/jOLNVECLviS+7e5DnpcYIYAf397A8RsKRTA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:28:28.721Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2330
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-better-sidebar`
- Submission type: community curation
- Created by `Menghuan1918` — https://github.com/Menghuan1918
- Original source repository: https://github.com/omdsh-dev/DSH-better-sidebar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Menghuan1918 — this entry was curated from your public repository (https://github.com/omdsh-dev/DSH-better-sidebar). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.