### PR TITLE
catalog: add dsh-blender (community curation, created by @CheshireJCat)

### DIFF
--- a/catalog/plugins/dsh-blender.yaml
+++ b/catalog/plugins/dsh-blender.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: dsh-blender
+name: dsh-blender
+description:
+  en: DeepSeek Harness Blender production, reconstruction, validation, and export plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - blender
+  - 3d-modeling
+  - agent-skill
+  - production
+  - reconstruction
+  - validation
+  - export
+  - dsh
+source:
+  repository: https://github.com/CheshireJCat/blender
+  repositoryNodeId: R_kgDOT4P7PA
+  subpath: null
+  commit: 3d641dae1c84248f213095f322f6beace0631409
+creator:
+  github: CheshireJCat
+package:
+  ecosystem: npm
+  name: dsh-blender
+  version: 0.2.1
+  integrity: sha512-JtgGGWhYYy/F6tVImmFINYDUzAhqD7tr7uRSFf+bwg37I0gqiB4B0r+CthXhmX7yBBBI6YFhlQSFaT2Xw1Gj0g==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:29.529Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 18
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-blender`
- Submission type: community curation
- Created by `CheshireJCat` — https://github.com/CheshireJCat
- Original source repository: https://github.com/CheshireJCat/blender
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@CheshireJCat — this entry was curated from your public repository (https://github.com/CheshireJCat/blender). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.