### PR TITLE
catalog: add dsh-browser (community curation, created by @anweat)

### DIFF
--- a/catalog/plugins/dsh-browser.yaml
+++ b/catalog/plugins/dsh-browser.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-browser
+name: "@anweat/dsh-browser"
+description:
+  en: Self-contained browser runtime plugin for DeepSeek Harness (scoped @anweat) — bundles Playwright (chromium) and OpenCLI as plugin-local dependencies (with global-reuse fallback), exposes a browser service and interactive browser tools.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - browser
+  - playwright
+  - opencli
+  - self
+  - contained
+  - runtime
+  - scoped
+  - anweat
+  - bundles
+  - chromium
+  - local
+  - dependencies
+  - global
+  - reuse
+source:
+  repository: https://github.com/anweat/dsh-browser
+  repositoryNodeId: R_kgDOT36ugg
+  subpath: null
+  commit: 570ac8b54bd152b3f1be26cc0cc068f1a4eeb001
+creator:
+  github: anweat
+package:
+  ecosystem: npm
+  name: "@anweat/dsh-browser"
+  version: 0.1.3
+  integrity: sha512-YDNcR7xRw2cUSCn2xCTNRRtb2dpSsStAt9zXWUx+GLiUze93DyWnxSKCeJFiufyA4vzQZi9Z0R3mbTe9CzFsSg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:57.804Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-browser`
- Submission type: community curation
- Created by `anweat` — https://github.com/anweat
- Original source repository: https://github.com/anweat/dsh-browser
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@anweat — this entry was curated from your public repository (https://github.com/anweat/dsh-browser). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.