### PR TITLE
catalog: add dsh-chat-import (community curation, created by @Nwflower)

### DIFF
--- a/catalog/plugins/dsh-chat-import.yaml
+++ b/catalog/plugins/dsh-chat-import.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-chat-import
+name: dsh-chat-import
+description:
+  en: Import Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / Pi Coding Agent / opencode / ZCode / Grok Build / OpenClaw / Hermes / Kimi CLI / Qoder CLI conversation histories as resumable DeepSeek Harness sessions
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh
+  - claude-code
+  - codex
+  - chatgpt
+  - cursor
+  - gemini
+  - reasonix
+  - pi-coding-agent
+  - opencode
+  - zcode
+  - grokbuild
+  - openclaw
+  - hermes
+  - kimi
+source:
+  repository: https://github.com/Nwflower/dsh-chat-import
+  repositoryNodeId: R_kgDOT3cGVA
+  subpath: null
+  commit: 2a29395619ef89fe191bfc04d29b3140c820402a
+creator:
+  github: Nwflower
+package:
+  ecosystem: npm
+  name: dsh-chat-import
+  version: 0.6.2
+  integrity: sha512-8TBQzK3UqTpNO1zTa/vPPHgySU6wBFvOHIbIT9YwbfFSI69c2C1y4XincrkFIK01oatrLlQla8MAM+qRP+AaCA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:28:52.211Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 76
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-chat-import`
- Submission type: community curation
- Created by `Nwflower` — https://github.com/Nwflower
- Original source repository: https://github.com/Nwflower/dsh-chat-import
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Nwflower — this entry was curated from your public repository (https://github.com/Nwflower/dsh-chat-import). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.