### PR TITLE
catalog: add dsh-client-auto-continue (community curation, created by @HsiangNianian)

### DIFF
--- a/catalog/plugins/dsh-client-auto-continue.yaml
+++ b/catalog/plugins/dsh-client-auto-continue.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: dsh-client-auto-continue
+name: dsh-client-auto-continue
+description:
+  en: 'DSH Web UI plugin: automatically sends "继续" (continue) when a request is interrupted by network errors or other non-human causes'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - web-ui
+  - auto-continue
+  - automatically
+  - sends
+  - continue
+  - request
+  - interrupted
+  - network
+  - errors
+  - other
+  - human
+  - causes
+source:
+  repository: https://github.com/HsiangNianian/dsh-auto-continue
+  repositoryNodeId: R_kgDOT389Ig
+  subpath: null
+  commit: 5b7f241e639ec461a2bb471edbcc1aa15f41b37f
+creator:
+  github: HsiangNianian
+package:
+  ecosystem: npm
+  name: dsh-client-auto-continue
+  version: 0.7.1
+  integrity: sha512-QmGunEsf1lz6zaa/KYSkLCIPFRExdje0n7CTHVw+mwYiY36IvPjwMW4UabXrbZDamioCF5bV2NP5N8gepjoQ3w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:08.924Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 30
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-client-auto-continue`
- Submission type: community curation
- Created by `HsiangNianian` — https://github.com/HsiangNianian
- Original source repository: https://github.com/HsiangNianian/dsh-auto-continue
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@HsiangNianian — this entry was curated from your public repository (https://github.com/HsiangNianian/dsh-auto-continue). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.