### PR TITLE
catalog: add dsh-continual-evolve (community curation, created by @ZK-Andy)

### DIFF
--- a/catalog/plugins/dsh-continual-evolve.yaml
+++ b/catalog/plugins/dsh-continual-evolve.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-continual-evolve
+name: dsh-continual-evolve
+description:
+  en: "Continual self-evolution plugin for DeepSeek Harness: versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - continual
+  - self
+  - evolution
+  - versioned
+  - auditable
+  - rollback
+  - safe
+  - state
+  - prompt
+  - notes
+  - memories
+  - skills
+  - subagent
+  - specs
+  - refined
+  - session
+source:
+  repository: https://github.com/ZK-Andy/dsh-continual-evolve
+  repositoryNodeId: R_kgDOT3vuZA
+  subpath: null
+  commit: a86f38b691762e81a9d8a6be1c9f47d322684810
+creator:
+  github: ZK-Andy
+package:
+  ecosystem: npm
+  name: dsh-continual-evolve
+  version: 0.3.0
+  integrity: sha512-G0S9r+O6tGG7A82rjwzS02J0yqR+/n3kMLyx8/QC8Hu1eojhYETrsaGDVWAZQBVMOSkyyKb6lb9GVmqBUomypg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:50.277Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 14
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-continual-evolve`
- Submission type: community curation
- Created by `ZK-Andy` — https://github.com/ZK-Andy
- Original source repository: https://github.com/ZK-Andy/dsh-continual-evolve
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@ZK-Andy — this entry was curated from your public repository (https://github.com/ZK-Andy/dsh-continual-evolve). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.