### PR TITLE
catalog: add dsh-encrypt (community curation, created by @yauntyour)

### DIFF
--- a/catalog/plugins/dsh-encrypt.yaml
+++ b/catalog/plugins/dsh-encrypt.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: dsh-encrypt
+name: dsh-encrypt
+description:
+  en: "WebUI-managed encrypted credentials for DeepSeek Harness: one file, plaintext until a password is set, then AES-256-GCM ciphertext under an Argon2id-derived key with SHA3-256 fingerprints; per-request decryption, unlock lockout, leak-guard output redaction, and shipped-code integrity self-checks."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - aes-256-gcm
+  - argon2id
+  - credentials
+  - dsh
+  - encryption
+  - leak-guard
+  - password
+  - prompt-injection
+  - sha3-256
+  - webui
+  - managed
+  - encrypted
+  - file
+  - plaintext
+  - until
+  - ciphertext
+source:
+  repository: https://github.com/yauntyour/DSH-Encrypt
+  repositoryNodeId: R_kgDOT5aeZg
+  subpath: null
+  commit: 00e114472919218a36ff8656d8a201e005d67a4d
+creator:
+  github: yauntyour
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:31:20.059Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-encrypt`
- Submission type: community curation
- Created by `yauntyour` — https://github.com/yauntyour
- Original source repository: https://github.com/yauntyour/DSH-Encrypt
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@yauntyour — this entry was curated from your public repository (https://github.com/yauntyour/DSH-Encrypt). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.