### PR TITLE
catalog: add dsh-enhance (community curation, created by @jiangnanquan)

### DIFF
--- a/catalog/plugins/dsh-enhance.yaml
+++ b/catalog/plugins/dsh-enhance.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: dsh-enhance
+name: dsh-enhance
+description:
+  en: "A web UI experience kit for DeepSeek Harness: a Solarized light theme with a Maple Mono stack, a wider and more compact message column, thinking blocks and tool chains folded into capsules that rewrap with the column, and a footer with account balance, per-turn token cost and 30-day usage."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - theme
+  - generative-ui
+  - solarized
+  - maple
+  - mono
+source:
+  repository: https://github.com/jiangnanquan/dsh-ux
+  repositoryNodeId: R_kgDOT4EZaw
+  subpath: null
+  commit: 9a2a16c57e05b051fc05ceea26cbcef90af60546
+creator:
+  github: jiangnanquan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:43.547Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-enhance`
- Submission type: community curation
- Created by `jiangnanquan` — https://github.com/jiangnanquan
- Original source repository: https://github.com/jiangnanquan/dsh-ux
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@jiangnanquan — this entry was curated from your public repository (https://github.com/jiangnanquan/dsh-ux). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.