### PR TITLE
catalog: add dsh-file-mentions (community curation, created by @a903067276-rgb)

### DIFF
--- a/catalog/plugins/dsh-file-mentions.yaml
+++ b/catalog/plugins/dsh-file-mentions.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-file-mentions
+name: dsh-file-mentions
+description:
+  en: "Clickable file paths in DSH replies: open files/directories from inline paths (Codex-style), with a mentioned-files chip list as fallback"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - file-mentions
+  - clickable-paths
+  - codex
+  - web-ui
+  - clickable
+  - file
+  - paths
+  - replies
+  - open
+  - files
+  - directories
+  - inline
+  - style
+  - mentioned
+source:
+  repository: https://github.com/a903067276-rgb/dsh-file-mentions
+  repositoryNodeId: R_kgDOT4KeyQ
+  subpath: null
+  commit: 4bd43b55d9ea3f9630036e95ba3c481981ac6f63
+creator:
+  github: a903067276-rgb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:00.675Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-file-mentions`
- Submission type: community curation
- Created by `a903067276-rgb` — https://github.com/a903067276-rgb
- Original source repository: https://github.com/a903067276-rgb/dsh-file-mentions
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@a903067276-rgb — this entry was curated from your public repository (https://github.com/a903067276-rgb/dsh-file-mentions). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.