### PR TITLE
catalog: add dsh-hud (community curation, created by @a903067276-rgb)

### DIFF
--- a/catalog/plugins/dsh-hud.yaml
+++ b/catalog/plugins/dsh-hud.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-hud
+name: dsh-hud
+description:
+  en: "A HUD status panel for DSH web: git status, MCP servers, skills, model and token usage in a floating side panel"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - hud
+  - git
+  - git-status
+  - mcp
+  - web-ui
+  - status
+  - panel
+  - servers
+  - skills
+  - model
+  - token
+  - usage
+  - floating
+  - side
+source:
+  repository: https://github.com/a903067276-rgb/dsh-hud
+  repositoryNodeId: R_kgDOT4GnHg
+  subpath: null
+  commit: c1ae452f7ffeff6122a0897ad71a813b1a9897b1
+creator:
+  github: a903067276-rgb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:16.341Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-hud`
- Submission type: community curation
- Created by `a903067276-rgb` — https://github.com/a903067276-rgb
- Original source repository: https://github.com/a903067276-rgb/dsh-hud
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@a903067276-rgb — this entry was curated from your public repository (https://github.com/a903067276-rgb/dsh-hud). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.