### PR TITLE
catalog: add dsh-im (community curation, created by @xmanrui)

### DIFF
--- a/catalog/plugins/dsh-im.yaml
+++ b/catalog/plugins/dsh-im.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-im
+name: "@xmanrui/dsh-im"
+description:
+  en: "Connect IM bots to DeepSeek Harness via QR code or bot credentials — nine channels: Feishu, WeChat, DingTalk, WeCom, QQ, Slack, Telegram, Discord and WhatsApp."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ai-agent
+  - im
+  - instant-messaging
+  - chatbot
+  - feishu
+  - lark
+  - wechat
+  - wecom
+  - dingtalk
+  - qq
+  - slack
+  - telegram
+  - discord
+source:
+  repository: https://github.com/xmanrui/dsh-im
+  repositoryNodeId: R_kgDOT4vL9Q
+  subpath: null
+  commit: 443d3b4799a2e751e7666b10de968c05a795978a
+creator:
+  github: xmanrui
+package:
+  ecosystem: npm
+  name: "@xmanrui/dsh-im"
+  version: 0.11.0
+  integrity: sha512-cxwI+6I+5A1sUIKOaqmCMPUuuLu6bqMuKV+cT/1mEGJKwn2AAdtdBf/Kh216P757+o6O1F/dUSckeINS3oU4KA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:28:56.868Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 71
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-im`
- Submission type: community curation
- Created by `xmanrui` — https://github.com/xmanrui
- Original source repository: https://github.com/xmanrui/dsh-im
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@xmanrui — this entry was curated from your public repository (https://github.com/xmanrui/dsh-im). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.