### PR TITLE
catalog: add dsh-lan-access (community curation, created by @Leon0555)

### DIFF
--- a/catalog/plugins/dsh-lan-access.yaml
+++ b/catalog/plugins/dsh-lan-access.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-lan-access
+name: dsh-lan-access
+description:
+  en: "DSH plugin: bind the Web GUI to 0.0.0.0 for LAN access and polyfill crypto.randomUUID for non-secure (LAN HTTP) contexts. Trusted networks only."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - lan
+  - remote-access
+  - randomuuid
+  - bind
+  - access
+  - polyfill
+  - crypto
+  - secure
+  - contexts
+  - trusted
+  - networks
+  - only
+source:
+  repository: https://github.com/Leon0555/dsh-lan-access
+  repositoryNodeId: R_kgDOT4Hf2g
+  subpath: null
+  commit: 279efda4ee782099b8f1eed90ed6d824839e0088
+creator:
+  github: Leon0555
+package:
+  ecosystem: npm
+  name: dsh-lan-access
+  version: 0.1.1
+  integrity: sha512-ljkQ6YULCsroIsO32+owxHvVsd4srs5kBnbVY1oZNORheQp+vx0cGtWDGj5w2Ze20C4qQSKlxn+HY669jfoubg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:23.547Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-lan-access`
- Submission type: community curation
- Created by `Leon0555` — https://github.com/Leon0555
- Original source repository: https://github.com/Leon0555/dsh-lan-access
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Leon0555 — this entry was curated from your public repository (https://github.com/Leon0555/dsh-lan-access). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.