### PR TITLE
catalog: add dsh-lark-bridge (community curation, created by @imetn)

### DIFF
--- a/catalog/plugins/dsh-lark-bridge.yaml
+++ b/catalog/plugins/dsh-lark-bridge.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: dsh-lark-bridge
+name: dsh-lark-bridge
+description:
+  en: Bidirectional Lark/Feishu control bridge for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - feishu
+  - lark
+  - agent
+  - bot
+  - bidirectional
+  - control
+  - bridge
+  - dsh
+source:
+  repository: https://github.com/imetn/dsh-lark-bridge
+  repositoryNodeId: R_kgDOT3hT6A
+  subpath: null
+  commit: f1e544cce5108873e238313bf7c5ccf092827e2a
+creator:
+  github: imetn
+package:
+  ecosystem: npm
+  name: dsh-lark-bridge
+  version: 0.1.0
+  integrity: sha512-qaFvR01FXjIEDd6kfSTwWEgyDkiyJAzxMN0UgJ91diHpGk9kCTTyGoeIauscRkF/99Ne+B8IZsiYij7q1ZF1vw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:42.160Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-lark-bridge`
- Submission type: community curation
- Created by `imetn` — https://github.com/imetn
- Original source repository: https://github.com/imetn/dsh-lark-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@imetn — this entry was curated from your public repository (https://github.com/imetn/dsh-lark-bridge). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.