### PR TITLE
catalog: add dsh-lark (community curation, created by @sugarforever)

### DIFF
--- a/catalog/plugins/dsh-lark.yaml
+++ b/catalog/plugins/dsh-lark.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: dsh-lark
+name: "@sugarforever/dsh-lark"
+description:
+  en: Feishu/Lark WebSocket channel plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - feishu
+  - lark
+  - websocket
+  - channel
+  - dsh
+source:
+  repository: https://github.com/sugarforever/dsh-lark
+  repositoryNodeId: R_kgDOT5WU-Q
+  subpath: null
+  commit: ee639df50fc7c004ac4e3ea90fa523a4d366729c
+creator:
+  github: sugarforever
+package:
+  ecosystem: npm
+  name: "@sugarforever/dsh-lark"
+  version: 0.2.2
+  integrity: sha512-jKBEqTd3yRvnEmvmyrFo+B6abKNn/UoAKOZdlMNB6Dkfb/EgTKo/spUxEvqbRahITY7r4ZIGsqe/z2hjFNlc5A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:25.201Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 20
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-lark`
- Submission type: community curation
- Created by `sugarforever` — https://github.com/sugarforever
- Original source repository: https://github.com/sugarforever/dsh-lark
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@sugarforever — this entry was curated from your public repository (https://github.com/sugarforever/dsh-lark). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.