### PR TITLE
catalog: add dsh-meme (community curation, created by @yyh-001)

### DIFF
--- a/catalog/plugins/dsh-meme.yaml
+++ b/catalog/plugins/dsh-meme.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: dsh-meme
+name: dsh-meme
+description:
+  en: "A sticker plugin for DeepSeek Harness: the chat shows the image while the model only receives a `[meme: description]` text token, so no image-input capability is required. A learn_meme tool files the user's last attachment and classifies it, and an emoji panel in the composer sends directly."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh-plugin
+  - dsh-meme
+  - deepseek-harness
+  - meme
+  - emoticon
+  - sticker
+  - send
+  - dsh
+source:
+  repository: https://github.com/yyh-001/dsh-meme
+  repositoryNodeId: R_kgDOT3eD3g
+  subpath: null
+  commit: 5c83b91fe2942279b677ae537850e77504e26c7c
+creator:
+  github: yyh-001
+package:
+  ecosystem: npm
+  name: dsh-meme
+  version: 0.1.38
+  integrity: sha512-YFHhmgD72hW3M2WL9elvBta2SGoAB4K0dSCcEeIkXjPHkXsukar1cfiCfSY6cV+Q5YpXAhB0eb2Tb2ov9sEtmQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:31:21.465Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-meme`
- Submission type: community curation
- Created by `yyh-001` — https://github.com/yyh-001
- Original source repository: https://github.com/yyh-001/dsh-meme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@yyh-001 — this entry was curated from your public repository (https://github.com/yyh-001/dsh-meme). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.