### PR TITLE
catalog: add dsh-milestone (community curation, created by @SnowCrescenter-tech)

### DIFF
--- a/catalog/plugins/dsh-milestone.yaml
+++ b/catalog/plugins/dsh-milestone.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: dsh-milestone
+name: dsh-milestone
+description:
+  en: "Git-style milestone timeline for DeepSeek Harness: one dot per question down the side of the session, hover for the content, click to jump to any message."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - conversation
+  - navigation
+  - style
+  - milestone
+  - timeline
+  - hover
+  - metadata
+  - click
+  - jump
+  - message
+source:
+  repository: https://github.com/SnowCrescenter-tech/dsh-milestone
+  repositoryNodeId: R_kgDOT3lV1A
+  subpath: null
+  commit: c238f8c5d4afe153ede8559e5f7e3d1a652b6327
+creator:
+  github: SnowCrescenter-tech
+package:
+  ecosystem: npm
+  name: dsh-milestone
+  version: 0.6.0
+  integrity: sha512-ShgvR2A9QPmaU7zknYF1wU0+zaXJbK9WR6Bb9wr4i/5NhkFh0Zgl41RWoWbo3ujMCvCjlIbpjxy2L+vtJppUgQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:35.878Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 17
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-milestone`
- Submission type: community curation
- Created by `SnowCrescenter-tech` — https://github.com/SnowCrescenter-tech
- Original source repository: https://github.com/SnowCrescenter-tech/dsh-milestone
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@SnowCrescenter-tech — this entry was curated from your public repository (https://github.com/SnowCrescenter-tech/dsh-milestone). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.