### PR TITLE
catalog: add dsh-models-config-plugin (community curation, created by @MarvekG)

### DIFF
--- a/catalog/plugins/dsh-models-config-plugin.yaml
+++ b/catalog/plugins/dsh-models-config-plugin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: dsh-models-config-plugin
+name: dsh-models-config-plugin
+description:
+  en: Advanced per-model reasoning and capacity settings for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - advanced
+  - model
+  - reasoning
+  - capacity
+  - settings
+  - dsh
+source:
+  repository: https://github.com/MarvekG/deepseek-harness-model-config
+  repositoryNodeId: R_kgDOT4d6cg
+  subpath: null
+  commit: c7f99da1f40b7e7c35fc83d8a49910655475169d
+creator:
+  github: MarvekG
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:16.110Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 24
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-models-config-plugin`
- Submission type: community curation
- Created by `MarvekG` — https://github.com/MarvekG
- Original source repository: https://github.com/MarvekG/deepseek-harness-model-config
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@MarvekG — this entry was curated from your public repository (https://github.com/MarvekG/deepseek-harness-model-config). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.