### PR TITLE
catalog: add dsh-plugin-manager (community curation, created by @2768651338)

### DIFF
--- a/catalog/plugins/dsh-plugin-manager.yaml
+++ b/catalog/plugins/dsh-plugin-manager.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: dsh-plugin-manager
+name: "@2768651338/dsh-plugin-manager"
+description:
+  en: "Plugin management for DeepSeek Harness under Settings → Plugins: a catalog that gives every plugin a plain-language name and description, one-click enable/disable written to the global cordis.patch.yml and applied live, and notes edited in place."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - cordis
+  - patch
+  - dsh
+source:
+  repository: https://github.com/2768651338/dsh-plugin-manager
+  repositoryNodeId: R_kgDOT4dNhA
+  subpath: null
+  commit: 35827d22724034e3bd53c03429ce10ea1a67a1b1
+creator:
+  github: "2768651338"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:56.506Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-manager`
- Submission type: community curation
- Created by `2768651338` — https://github.com/2768651338
- Original source repository: https://github.com/2768651338/dsh-plugin-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@2768651338 — this entry was curated from your public repository (https://github.com/2768651338/dsh-plugin-manager). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.