### PR TITLE
catalog: add dsh-plugin-workshop (community curation, created by @yyyyukari)

### DIFF
--- a/catalog/plugins/dsh-plugin-workshop.yaml
+++ b/catalog/plugins/dsh-plugin-workshop.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-plugin-workshop
+name: "@dsh-external/dsh-plugin-workshop"
+description:
+  en: "Steam Workshop-style plugin browser for the DeepSeek Harness (DSH) web UI: search, hot/newest/trending windows, Chinese keyword mapping, bilingual description & README translation, plugin-signature filtering, one-click install/update/uninstall, and an installed-plugins manager."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - steam
+  - workshop
+  - style
+  - browser
+  - search
+  - newest
+  - trending
+  - windows
+  - chinese
+  - keyword
+  - mapping
+  - bilingual
+  - description
+  - translation
+  - signature
+  - filtering
+source:
+  repository: https://github.com/yyyyukari/dsh-plugin-workshop
+  repositoryNodeId: R_kgDOT3_bsQ
+  subpath: null
+  commit: f53a7e466948a6c5636f2079b2382976a1eea4c8
+creator:
+  github: yyyyukari
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:13.421Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 25
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-workshop`
- Submission type: community curation
- Created by `yyyyukari` — https://github.com/yyyyukari
- Original source repository: https://github.com/yyyyukari/dsh-plugin-workshop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@yyyyukari — this entry was curated from your public repository (https://github.com/yyyyukari/dsh-plugin-workshop). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.