### PR TITLE
catalog: add dsh-plugin-writing-guard (community curation, created by @xmutfyh)

### DIFF
--- a/catalog/plugins/dsh-plugin-writing-guard.yaml
+++ b/catalog/plugins/dsh-plugin-writing-guard.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-plugin-writing-guard
+name: dsh-plugin-writing-guard
+description:
+  en: DeepSeek Harness (DSH) academic writing guard for papers — 论文去AI味 / AI-writing style detection, evidence preservation, journal-fit calibration, manuscript proofreading, writing audit & automatic checks. Local, zero network, zero LLM.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - host-plugin
+  - academic-writing
+  - scientific-writing
+  - paper-writing
+  - paper
+  - manuscript
+  - writing-style
+  - ai-detection
+  - ai-writing
+  - llm-writing
+  - defensive-writing
+  - scientific-integrity
+  - evidence-based-writing
+source:
+  repository: https://github.com/xmutfyh/dsh-plugin-writing-guard
+  repositoryNodeId: R_kgDOT47vgg
+  subpath: null
+  commit: aa037036122d12e6bebf6e9052b16b0425f61a47
+creator:
+  github: xmutfyh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:53.187Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 15
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-writing-guard`
- Submission type: community curation
- Created by `xmutfyh` — https://github.com/xmutfyh
- Original source repository: https://github.com/xmutfyh/dsh-plugin-writing-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@xmutfyh — this entry was curated from your public repository (https://github.com/xmutfyh/dsh-plugin-writing-guard). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.