### PR TITLE
catalog: add dsh-reef (community curation, created by @huey1in)

### DIFF
--- a/catalog/plugins/dsh-reef.yaml
+++ b/catalog/plugins/dsh-reef.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-reef
+name: dsh-reef
+description:
+  en: "DSH 插件全家桶:浏览器自动化 + MCP Server + GitHub/GitLab 自动评审 + 原生嵌入面板。One install, five modules for DeepSeek Harness: browser automation, an MCP server exposing your agents to any MCP client, GitHub & GitLab automation, and a native in-app panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - browser
+  - playwright
+  - mcp
+  - gitlab
+  - agent
+  - server
+  - install
+  - five
+  - modules
+  - automation
+  - exposing
+  - agents
+  - client
+source:
+  repository: https://github.com/huey1in/reef
+  repositoryNodeId: R_kgDOT4DgtA
+  subpath: null
+  commit: 5d5ade9af01e134a3f64dc9619eb1881993d4a76
+creator:
+  github: huey1in
+package:
+  ecosystem: npm
+  name: dsh-reef
+  version: 1.5.2
+  integrity: sha512-QHnauPJYizjWXfUyXXTnJrxwzwzerSslIM08e2/JicvRTT1waRHWCVfs7BZSKnsYtjpQySvk9HBVO7AaCJSUjw==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:42.640Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 15
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-reef`
- Submission type: community curation
- Created by `huey1in` — https://github.com/huey1in
- Original source repository: https://github.com/huey1in/reef
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@huey1in — this entry was curated from your public repository (https://github.com/huey1in/reef). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.