### PR TITLE
catalog: add dsh-requirements-alignment (community curation, created by @jiezeng2004-design)

### DIFF
--- a/catalog/plugins/dsh-requirements-alignment.yaml
+++ b/catalog/plugins/dsh-requirements-alignment.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-requirements-alignment
+name: dsh-requirements-alignment
+description:
+  en: Runtime requirement drift guard for DeepSeek Harness — keeps long-running agents aligned with user intent while they work.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - requirement-alignment
+  - agent
+  - ai-agent
+  - runtime
+  - requirement
+  - drift
+  - guard
+  - keeps
+  - long
+  - running
+  - agents
+  - aligned
+  - user
+source:
+  repository: https://github.com/jiezeng2004-design/dsh-requirements-alignment
+  repositoryNodeId: R_kgDOT4fI1w
+  subpath: null
+  commit: 9ae177cb9e40dd71cf9f6b4636c9e9dc3cab54dd
+creator:
+  github: jiezeng2004-design
+package:
+  ecosystem: npm
+  name: dsh-requirements-alignment
+  version: 0.2.2
+  integrity: sha512-Ad6a7ljiz0J2/lGSNJy1eC72zV/KWI3jVD0yJ2EFZ9/yqGmP1nMYxgdjn+TG8TzSsS2JCfhM7wxJ2kekyPnmzw==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:45.003Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-requirements-alignment`
- Submission type: community curation
- Created by `jiezeng2004-design` — https://github.com/jiezeng2004-design
- Original source repository: https://github.com/jiezeng2004-design/dsh-requirements-alignment
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@jiezeng2004-design — this entry was curated from your public repository (https://github.com/jiezeng2004-design/dsh-requirements-alignment). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.