### PR TITLE
catalog: add dsh-sentinel (community curation, created by @fuhefei)

### DIFF
--- a/catalog/plugins/dsh-sentinel.yaml
+++ b/catalog/plugins/dsh-sentinel.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: dsh-sentinel
+name: dsh-sentinel
+description:
+  en: "Condition-driven wakeup for DeepSeek Harness: the agent registers a watch, goes to sleep — even closes the session — and the sentinel wakes it when the condition happens. File, process, port and command sensors probe on a shared heartbeat, and every subscription and fire is a visible session event."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - agent
+  - dsh
+source:
+  repository: https://github.com/fuhefei/dsh-sentinel
+  repositoryNodeId: R_kgDOT3XXlQ
+  subpath: null
+  commit: 0a63241ba0370f516fc951e9d32cc94e874190b0
+creator:
+  github: fuhefei
+package:
+  ecosystem: npm
+  name: dsh-sentinel
+  version: 0.11.0
+  integrity: sha512-zscBPaEim4DOnf1qgpoHNPd0ZlyKzDID/k3x7OBMZ5XR4r79XMxWWd+T2P5PbGPhvchpn0/7uU/T/owM/0muQg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:03.986Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-sentinel`
- Submission type: community curation
- Created by `fuhefei` — https://github.com/fuhefei
- Original source repository: https://github.com/fuhefei/dsh-sentinel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@fuhefei — this entry was curated from your public repository (https://github.com/fuhefei/dsh-sentinel). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.