### PR TITLE
catalog: add dsh-side-chat (community curation, created by @heartmove)

### DIFF
--- a/catalog/plugins/dsh-side-chat.yaml
+++ b/catalog/plugins/dsh-side-chat.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-side-chat
+name: dsh-side-chat
+description:
+  en: "侧边聊天 (Side chat) — DSH web plugin: select text in a conversation and ask it in a per-session side chat (hidden ordinary session, own right-side panel, inherits model/effort/permissions, lookup toggle)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - side
+  - chat
+  - select
+  - text
+  - conversation
+  - session
+  - hidden
+  - ordinary
+  - right
+  - panel
+  - inherits
+  - model
+  - effort
+  - permissions
+  - lookup
+  - toggle
+source:
+  repository: https://github.com/heartmove/dsh-side-chat
+  repositoryNodeId: R_kgDOT4GG6A
+  subpath: null
+  commit: 9dda48d72d3b51589096e8b130d3dd83740531f7
+creator:
+  github: heartmove
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:19.407Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-side-chat`
- Submission type: community curation
- Created by `heartmove` — https://github.com/heartmove
- Original source repository: https://github.com/heartmove/dsh-side-chat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@heartmove — this entry was curated from your public repository (https://github.com/heartmove/dsh-side-chat). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.