### PR TITLE
catalog: add dsh-skill-manager-ytxue (community curation, created by @YTxue)

### DIFF
--- a/catalog/plugins/dsh-skill-manager-ytxue.yaml
+++ b/catalog/plugins/dsh-skill-manager-ytxue.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-skill-manager-ytxue
+name: dsh-skill-manager-ytxue
+description:
+  en: "DSH web plugin: skill pool manager in the Settings sidebar. Audits skills against the DSH skill spec (kebab-case names, required description, boolean fields) with state-driven one-click check and auto-fix; folder-picker single/batch import with rename-conflict prompts; enable/disable between skill-pool and skills."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skill
+  - skill-manager-ytxue
+  - cordis
+  - pool
+  - manager
+  - settings
+  - sidebar
+  - audits
+  - skills
+  - against
+  - spec
+  - kebab
+  - case
+source:
+  repository: https://github.com/YTxue/dsh-skill-manager-ytxue
+  repositoryNodeId: R_kgDOT4WZbg
+  subpath: null
+  commit: f254f3005a446062e312144f27ed0820d38d4654
+creator:
+  github: YTxue
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:14.915Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-skill-manager-ytxue`
- Submission type: community curation
- Created by `YTxue` — https://github.com/YTxue
- Original source repository: https://github.com/YTxue/dsh-skill-manager-ytxue
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@YTxue — this entry was curated from your public repository (https://github.com/YTxue/dsh-skill-manager-ytxue). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.