### PR TITLE
catalog: add dsh-spend (community curation, created by @Zihengwind)

### DIFF
--- a/catalog/plugins/dsh-spend.yaml
+++ b/catalog/plugins/dsh-spend.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-spend
+name: dsh-spend
+description:
+  en: Token usage, multi-dimensional statistics, auto-detected billing plans (Code/Token) and estimated spend for the dsh web UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - token
+  - usage
+  - tokens
+  - billing
+  - cost
+  - spend
+  - monitoring
+  - codex
+  - opencode
+  - multi
+  - dimensional
+  - statistics
+  - auto
+  - detected
+source:
+  repository: https://github.com/nonewind/dsh-spend
+  repositoryNodeId: R_kgDOT3-uiw
+  subpath: null
+  commit: 43fb7b08b2b38d3da9f09c0ac085720a4144e61f
+creator:
+  github: Zihengwind
+package:
+  ecosystem: npm
+  name: dsh-spend
+  version: 0.4.6
+  integrity: sha512-s8qRoTW5TWgfdp3J/qpQtL8awwZQwehdM4gD9rv08QjH+Yl6BPimH28nfdKsDX2Z7QhD9dxi/wsbqqkKjJcilw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:31:06.868Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-spend`
- Submission type: community curation
- Created by `Zihengwind` — https://github.com/Zihengwind
- Original source repository: https://github.com/nonewind/dsh-spend
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Zihengwind — this entry was curated from your public repository (https://github.com/nonewind/dsh-spend). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.