### PR TITLE
catalog: add dsh-surfing-plugin (community curation, created by @cyijun)

### DIFF
--- a/catalog/plugins/dsh-surfing-plugin.yaml
+++ b/catalog/plugins/dsh-surfing-plugin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dsh-surfing-plugin
+name: dsh-surfing-plugin
+description:
+  en: SearXNG search and Crawl4AI fetch providers for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - searxng
+  - crawl4ai
+  - web-search
+  - web-fetch
+  - search
+  - fetch
+  - providers
+source:
+  repository: https://github.com/cyijun/dsh-surfing-plugin
+  repositoryNodeId: R_kgDOT4OZuQ
+  subpath: null
+  commit: 40041327e552157bafcc9bba866925b775c1469d
+creator:
+  github: cyijun
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:54.662Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-surfing-plugin`
- Submission type: community curation
- Created by `cyijun` — https://github.com/cyijun
- Original source repository: https://github.com/cyijun/dsh-surfing-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@cyijun — this entry was curated from your public repository (https://github.com/cyijun/dsh-surfing-plugin). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.