### PR TITLE
catalog: add dsh-tdai-memory (community curation, created by @Scorp1o117)

### DIFF
--- a/catalog/plugins/dsh-tdai-memory.yaml
+++ b/catalog/plugins/dsh-tdai-memory.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: dsh-tdai-memory
+name: dsh-tdai-memory
+description:
+  en: "A port of TencentDB Agent Memory into DeepSeek Harness: L0 captures every turn, an L1 pipeline extracts facts, preferences and events, L2/L3 build scenes and a user profile, and relevant memories are injected into each prompt automatically. Adds memory and conversation search tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - tencentdb
+  - agent-memory
+  - rag
+  - vector-search
+  - persona
+  - agent
+  - tdai
+source:
+  repository: https://github.com/Scorp1o117/dsh-tdai-memory
+  repositoryNodeId: R_kgDOT3e4Sg
+  subpath: null
+  commit: e6bf395f9b9b35bcc50b2f6827d12b80f4779bd9
+creator:
+  github: Scorp1o117
+package:
+  ecosystem: npm
+  name: dsh-tdai-memory
+  version: 0.2.10
+  integrity: sha512-4PvVWkfu5a+46ZqHjlHWVcAT9U9TmAsZW7YNc3UmfPJOxRFH/1/5cpVuJWvZoyTY8ePJET7pXdDktNPC83Qt5g==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:31:09.778Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-tdai-memory`
- Submission type: community curation
- Created by `Scorp1o117` — https://github.com/Scorp1o117
- Original source repository: https://github.com/Scorp1o117/dsh-tdai-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Scorp1o117 — this entry was curated from your public repository (https://github.com/Scorp1o117/dsh-tdai-memory). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.