### PR TITLE
catalog: add dsh-update-checker (community curation, created by @Airmetro)

### DIFF
--- a/catalog/plugins/dsh-update-checker.yaml
+++ b/catalog/plugins/dsh-update-checker.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: dsh-update-checker
+name: dsh-update-checker
+description:
+  en: Auto-check DeepSeek Harness and third-party plugin updates, notify in the Web GUI, one-click update with backup/rollback and restart watchdog.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - update
+  - notify
+  - auto
+  - check
+  - third
+  - party
+  - updates
+  - click
+  - backup
+  - rollback
+  - restart
+  - watchdog
+source:
+  repository: https://github.com/Airmetro/dsh-update-checker
+  repositoryNodeId: R_kgDOT4_9hw
+  subpath: null
+  commit: bea57c020bb8a32889079b8f3a04182bc94e4982
+creator:
+  github: Airmetro
+package:
+  ecosystem: npm
+  name: dsh-update-checker
+  version: 1.4.8
+  integrity: sha512-qR0ztvI4zVqwtAydAlH4e//F/oppQITVIAReO1vQOH9g9l0w5pVvEknbcKjafdYQnbmK4psbi/TSZmdSjJ4x0w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:27.814Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-update-checker`
- Submission type: community curation
- Created by `Airmetro` — https://github.com/Airmetro
- Original source repository: https://github.com/Airmetro/dsh-update-checker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Airmetro — this entry was curated from your public repository (https://github.com/Airmetro/dsh-update-checker). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.