### PR TITLE
catalog: add dsh-updater-ui (community curation, created by @xingyingyuzhui)

### DIFF
--- a/catalog/plugins/dsh-updater-ui.yaml
+++ b/catalog/plugins/dsh-updater-ui.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: dsh-updater-ui
+name: dsh-updater-ui
+description:
+  en: "An official-update checker for DeepSeek Harness: the settings page compares the local checkout against deepseek-ai/deepseek-harness, shows the version delta and the latest official commits, and fast-forwards with `git pull --ff-only` — refusing safely when the clone has unpushed commits or has diverged."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - updater
+  - pull
+  - only
+source:
+  repository: https://github.com/xingyingyuzhui/dsh-updater-ui
+  repositoryNodeId: R_kgDOT38cWg
+  subpath: null
+  commit: 354a5825f1852198b8c65220d3c8668cd7ebf9cc
+creator:
+  github: xingyingyuzhui
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:31:18.546Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-updater-ui`
- Submission type: community curation
- Created by `xingyingyuzhui` — https://github.com/xingyingyuzhui
- Original source repository: https://github.com/xingyingyuzhui/dsh-updater-ui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@xingyingyuzhui — this entry was curated from your public repository (https://github.com/xingyingyuzhui/dsh-updater-ui). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.