### PR TITLE
catalog: add dsh-usage-stats (community curation, created by @Grivn)

### DIFF
--- a/catalog/plugins/dsh-usage-stats.yaml
+++ b/catalog/plugins/dsh-usage-stats.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dsh-usage-stats
+name: dsh-usage-stats
+description:
+  en: Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - token-usage
+  - token
+  - usage
+  - heatmap
+  - provider
+  - balances
+  - subscription
+  - quotas
+source:
+  repository: https://github.com/Ychris12138/dsh-usage-stats
+  repositoryNodeId: R_kgDOT35uZw
+  subpath: null
+  commit: f22d415f2ff042b57601a1445df329dcfec5653b
+creator:
+  github: Grivn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:28:49.267Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 87
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-usage-stats`
- Submission type: community curation
- Created by `Grivn` — https://github.com/Grivn
- Original source repository: https://github.com/Ychris12138/dsh-usage-stats
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Grivn — this entry was curated from your public repository (https://github.com/Ychris12138/dsh-usage-stats). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.