### PR TITLE
catalog: add dsh-user-experience (community curation, created by @cursoragent)

### DIFF
--- a/catalog/plugins/dsh-user-experience.yaml
+++ b/catalog/plugins/dsh-user-experience.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-user-experience
+name: dsh-user-experience
+description:
+  en: "DeepSeek Harness UX walkthrough plugin: persona-driven source-code UX review for React (TypeScript/JavaScript) and Vue 3 projects, with change-triggered automatic walkthroughs"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - ux
+  - code-review
+  - persona
+  - accessibility
+  - walkthrough
+  - driven
+  - source
+  - code
+  - review
+  - react
+  - typescript
+  - javascript
+  - projects
+  - change
+source:
+  repository: https://github.com/DietCokewithSugar/dsh-user-experience
+  repositoryNodeId: R_kgDOT38ljw
+  subpath: null
+  commit: bba21e6a634844b448b34aae4e7c8af1d8bbd9d4
+creator:
+  github: cursoragent
+package:
+  ecosystem: npm
+  name: dsh-user-experience
+  version: 0.4.2
+  integrity: sha512-AbGIN6zJF9gEyGSe+AaPl6HFNEY1IretiaT0ZwoYWU3IaZSulRZrWHlo5V6neKnmIdE0tH6AkKBqx0mCbs8EnA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:26.588Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 19
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-user-experience`
- Submission type: community curation
- Created by `cursoragent` — https://github.com/cursoragent
- Original source repository: https://github.com/DietCokewithSugar/dsh-user-experience
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@cursoragent — this entry was curated from your public repository (https://github.com/DietCokewithSugar/dsh-user-experience). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.