### PR TITLE
catalog: add dsh-vision-toolkit (community curation, created by @Anionex)

### DIFF
--- a/catalog/plugins/dsh-vision-toolkit.yaml
+++ b/catalog/plugins/dsh-vision-toolkit.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-vision-toolkit
+name: "@anionex/dsh-vision-toolkit"
+description:
+  en: "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - agent-vision-toolkit
+  - agent-skills
+  - text-only-llm
+  - vision-language-model
+  - vision-tools
+  - vision-skills
+  - computer-vision
+  - ocr
+  - ui-restoration
+  - screenshot-testing
+  - gui-automation
+  - native
+  - integration
+  - agent
+  - vision
+source:
+  repository: https://github.com/Anionex/dsh-vision-toolkit
+  repositoryNodeId: R_kgDOT3V-Jw
+  subpath: null
+  commit: ebedb91885e56f9fb0ba81de47f3ec58a884eb00
+creator:
+  github: Anionex
+package:
+  ecosystem: npm
+  name: "@anionex/dsh-vision-toolkit"
+  version: 0.1.34
+  integrity: sha512-LdcUJVA1u5WLWhQuAtlfO7eUH4YYGTyfHC6Fp+ojd3NLj/Hq39PmCn7bLq5Tg4WsYCU5bGtyK2N5Ln1a/yXeWA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:28:35.987Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 750
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-vision-toolkit`
- Submission type: community curation
- Created by `Anionex` — https://github.com/Anionex
- Original source repository: https://github.com/Anionex/dsh-vision-toolkit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Anionex — this entry was curated from your public repository (https://github.com/Anionex/dsh-vision-toolkit). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.