### PR TITLE
catalog: add dsh-web-search-pro (community curation, created by @anweat)

### DIFF
--- a/catalog/plugins/dsh-web-search-pro.yaml
+++ b/catalog/plugins/dsh-web-search-pro.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-web-search-pro
+name: dsh-web-search-pro
+description:
+  en: Enhanced, persistent web search plugin for DeepSeek Harness — multi-engine routing (DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/Twitter/Reddit/RSS), SQLite+LRU cache, userscript-style extraction, and Playwright rendering.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - deepseek-harness
+  - web-search
+  - search
+  - enhanced
+  - persistent
+  - multi
+  - engine
+  - routing
+  - bing
+  - jina
+  - youtube
+  - v2ex
+  - twitter
+  - reddit
+  - sqlite
+source:
+  repository: https://github.com/anweat/dsh-web-search-pro
+  repositoryNodeId: R_kgDOT3jZcQ
+  subpath: null
+  commit: f8f388c75d11a5fbee673a4ab010c166098a989b
+creator:
+  github: anweat
+package:
+  ecosystem: npm
+  name: dsh-web-search-pro
+  version: 0.1.2
+  integrity: sha512-fBY6ObydoWrB6LVsPt7AwBd9I4S1WYpdOcXyUAUBFs+23weSeFAk8G1Yt6ybyu/j7p8no74m6HQauoiJRLWmqw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:29:10.396Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 26
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-web-search-pro`
- Submission type: community curation
- Created by `anweat` — https://github.com/anweat
- Original source repository: https://github.com/anweat/dsh-web-search-pro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@anweat — this entry was curated from your public repository (https://github.com/anweat/dsh-web-search-pro). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.