### PR TITLE
catalog: add dsh-webui-auth (community curation, created by @Yuuz12)

### DIFF
--- a/catalog/plugins/dsh-webui-auth.yaml
+++ b/catalog/plugins/dsh-webui-auth.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-webui-auth
+name: dsh-webui-auth
+description:
+  en: "Persistent WebUI authentication plugin for DeepSeek Harness: configure an account/password in Settings, then accessing the WebUI requires login. Zero dependencies."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - auth
+  - login
+  - gate
+  - persistent
+  - webui
+  - authentication
+  - configure
+  - account
+  - password
+  - settings
+  - accessing
+  - requires
+  - zero
+  - dependencies
+source:
+  repository: https://github.com/Yuuz12/dsh-webui-auth
+  repositoryNodeId: R_kgDOT3_dlA
+  subpath: null
+  commit: 8efcd867a2cdeadffcbf80f6b0f0ec3e2bc05f85
+creator:
+  github: Yuuz12
+package:
+  ecosystem: npm
+  name: dsh-webui-auth
+  version: 0.3.0
+  integrity: sha512-d+KMo/u8B7Ata7HdAQAsc3Qhj787tId+qRfey0MExdAmg2GE3vfZMENP8YOnBXIAWQnmI5CQZ+uSuQ/pmySYTg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:54.723Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-webui-auth`
- Submission type: community curation
- Created by `Yuuz12` — https://github.com/Yuuz12
- Original source repository: https://github.com/Yuuz12/dsh-webui-auth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Yuuz12 — this entry was curated from your public repository (https://github.com/Yuuz12/dsh-webui-auth). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.