### PR TITLE
catalog: add dsh-webui-market-plugin (community curation, created by @Sanqi-normal)

### DIFF
--- a/catalog/plugins/dsh-webui-market-plugin.yaml
+++ b/catalog/plugins/dsh-webui-market-plugin.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: dsh-webui-market-plugin
+name: "@sanqi-normal/dsh-webui-market-plugin"
+description:
+  en: "In-harness community plugin market for the dsh web GUI: browse awesome-dsh-plugin.com, install and uninstall plugins into a profile"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - agent-harness
+  - market
+  - web
+  - ui
+  - community
+  - browse
+  - awesome
+  - install
+  - uninstall
+  - profile
+source:
+  repository: https://github.com/Sanqi-normal/dsh-webui-market-plugin
+  repositoryNodeId: R_kgDOT3rL4A
+  subpath: null
+  commit: 44cd1ababaeeda11519042ab876c598f5961774d
+creator:
+  github: Sanqi-normal
+package:
+  ecosystem: npm
+  name: "@sanqi-normal/dsh-webui-market-plugin"
+  version: 0.5.5
+  integrity: sha512-pGHgU3YyfX7OatsUh3pgd+iDQEbwCET+/f1xu3QAQAPNarbhWbhCUuBFklzaCbia7HtoEzVn4yStD2tjuWUlMA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:28:46.283Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 90
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-webui-market-plugin`
- Submission type: community curation
- Created by `Sanqi-normal` — https://github.com/Sanqi-normal
- Original source repository: https://github.com/Sanqi-normal/dsh-webui-market-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@Sanqi-normal — this entry was curated from your public repository (https://github.com/Sanqi-normal/dsh-webui-market-plugin). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.