### PR TITLE
catalog: add modlens (community curation, created by @liustack)

### DIFF
--- a/catalog/plugins/modlens.yaml
+++ b/catalog/plugins/modlens.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: modlens
+name: "@liustack/modlens"
+description:
+  en: Plug-in vision for text-only LLMs, powered by the free Antigravity CLI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - cli
+  - vision
+  - ocr
+  - antigravity
+  - agent-skill
+  - claude-code
+  - skill
+  - image-to-text
+  - multimodal
+  - modlens
+  - plug
+  - text
+  - only
+  - llms
+  - powered
+  - free
+source:
+  repository: https://github.com/liustack/modlens
+  repositoryNodeId: R_kgDORV5N0w
+  subpath: null
+  commit: 6e1fb0666a11c8c6c04b0895b0fc3f0d10ba0c96
+creator:
+  github: liustack
+package:
+  ecosystem: npm
+  name: "@liustack/modlens"
+  version: 3.21.1
+  integrity: sha512-/Yb79rhhvFI18qouDqxh8RqmCZx0/OP06AvKEhCsraE4RtgH1PTOdFnJ0N4Wk4dt82fbIcnDMuEjn4eX6mPzhw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:28:26.143Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3270
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `modlens`
- Submission type: community curation
- Created by `liustack` — https://github.com/liustack
- Original source repository: https://github.com/liustack/modlens
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@liustack — this entry was curated from your public repository (https://github.com/liustack/modlens). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.