### PR TITLE
catalog: add task-passport (community curation, created by @dongsheng123132)

### DIFF
--- a/catalog/plugins/task-passport.yaml
+++ b/catalog/plugins/task-passport.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: task-passport
+name: task-passport
+description:
+  en: "TaskPack: an open, offline task-handoff container. Task Passport is the durable state; TaskPack is the box it travels in."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - ai-agent
+  - task-state
+  - handoff
+  - taskpack
+  - a2a
+  - task-handoff
+  - open
+  - offline
+  - task
+  - container
+  - passport
+  - durable
+  - state
+  - travels
+source:
+  repository: https://github.com/dongsheng123132/task-passport
+  repositoryNodeId: R_kgDOT3iqVg
+  subpath: null
+  commit: da741767ee01e9cb764e6120707b6ba9352047d9
+creator:
+  github: dongsheng123132
+package:
+  ecosystem: npm
+  name: task-passport
+  version: 0.3.0
+  integrity: sha512-hyz+FjhTrl7TIxjo1vywLFjLA5deRd1fYgLupPP+JhSbAtDs923KAPr6hjQXKzaGOl8Ajq6FCfcymmn+LLP8XQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-19T21:30:17.848Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `task-passport`
- Submission type: community curation
- Created by `dongsheng123132` — https://github.com/dongsheng123132
- Original source repository: https://github.com/dongsheng123132/task-passport
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] `description.en` is English, checked against the README at the pinned commit.
- [x] No credentials, private contact details or other secrets.

@dongsheng123132 — this entry was curated from your public repository (https://github.com/dongsheng123132/task-passport). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.