### PR TITLE
catalog: add dsh-remote (community curation, created by @xgone)

### DIFF
--- a/catalog/plugins/dsh-remote.yaml
+++ b/catalog/plugins/dsh-remote.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: dsh-remote
+name: "@xgone/dsh-remote"
+description:
+  en: "Remote access & authentication for the DeepSeek Harness web UI: login gate, MFA (TOTP), signed session cookies, role-based access, in-browser directory picker, account management settings. Fully localized (zh/en)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - auth
+  - authentication
+  - mfa
+  - totp
+  - 2fa
+  - security
+  - remote-access
+  - gateway
+  - login
+  - remote
+  - access
+  - gate
+  - signed
+  - session
+source:
+  repository: https://github.com/xgone/dsh-remote
+  repositoryNodeId: R_kgDOT53uWg
+  subpath: null
+  commit: 7f63759737673b89a1276e0070c92360f4513834
+creator:
+  github: xgone
+package:
+  ecosystem: npm
+  name: "@xgone/dsh-remote"
+  version: 0.1.8
+  integrity: sha512-uobYPPqdoInx3n9/ifejv+mC+KYqFp4A8ZTQTb4hjb7AbJqrJWx0OqseQ1ggysfQ9/hQCwn4pfFWbEeqvifbfA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:13.094Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-remote`
- Submission type: community curation
- Created by `xgone` — https://github.com/xgone
- Original source repository: https://github.com/xgone/dsh-remote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@xgone — this entry was curated from your public repository (https://github.com/xgone/dsh-remote). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.