### PR TITLE
catalog: add dsh-compact-activity (community curation, created by @wallpap)

### DIFF
--- a/catalog/plugins/dsh-compact-activity.yaml
+++ b/catalog/plugins/dsh-compact-activity.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: dsh-compact-activity
+name: dsh-compact-activity
+description:
+  en: Codex-style one-line disclosures for DeepSeek Harness reasoning and tool activity
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - codex
+  - style
+  - line
+  - disclosures
+  - reasoning
+  - tool
+  - activity
+  - dsh
+source:
+  repository: https://github.com/wallpap/dsh-compact-activity
+  repositoryNodeId: R_kgDOT5RoBQ
+  subpath: null
+  commit: 9cdedd6a5f41cd3778cf2037abffb75041c37c8f
+creator:
+  github: wallpap
+package:
+  ecosystem: npm
+  name: dsh-compact-activity
+  version: 1.2.2
+  integrity: sha512-UiKPy4nUxMKtleoNEjNnWgKEeHDE5Ll2bbYVCF0yvo0v1rG5JeP71omUKn2DMnldfeYvu2vs4S1WKbd8WFUc2Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:10.258Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-compact-activity`
- Submission type: community curation
- Created by `wallpap` — https://github.com/wallpap
- Original source repository: https://github.com/wallpap/dsh-compact-activity
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@wallpap — this entry was curated from your public repository (https://github.com/wallpap/dsh-compact-activity). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.