### PR TITLE
catalog: add dsh-web-search-exa (community curation, created by @TonyDua)

### DIFF
--- a/catalog/plugins/dsh-web-search-exa.yaml
+++ b/catalog/plugins/dsh-web-search-exa.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-web-search-exa
+name: "@tonydua/dsh-web-search-exa"
+description:
+  en: "Zero-config Exa web search provider for DeepSeek Harness (dsh): keyless anonymous MCP fallback (mcp.exa.ai/mcp) plus keyed REST search — a drop-in WebSearchProvider for the ctx.web seam, no API key required."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - exa
+  - exa-search
+  - web-search
+  - websearch
+  - search-provider
+  - mcp
+  - mcp-server
+  - anonymous
+  - zero-config
+  - no-api-key
+  - llm
+  - agent
+  - zero
+source:
+  repository: https://github.com/TonyDua/dsh-web-search-exa
+  repositoryNodeId: R_kgDOT4BUDg
+  subpath: null
+  commit: 083706bae60af8e1f3776b02448f17c140c3f571
+creator:
+  github: TonyDua
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:44:42.181Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-web-search-exa`
- Submission type: community curation
- Created by `TonyDua` — https://github.com/TonyDua
- Original source repository: https://github.com/TonyDua/dsh-web-search-exa
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@TonyDua — this entry was curated from your public repository (https://github.com/TonyDua/dsh-web-search-exa). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.