### PR TITLE
catalog: add dsh-calculator (community curation, created by @bobcat848)

### DIFF
--- a/catalog/plugins/dsh-calculator.yaml
+++ b/catalog/plugins/dsh-calculator.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-calculator
+name: dsh-calculator
+description:
+  en: "DeepSeek Harness web plugin: DeepSeek API spend (per session / all sessions) and account balance in a top-right overlay card. Only deepseek-official routes are billed; third-party models are reported as unbilled."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - cost
+  - spend
+  - balance
+  - session
+  - sessions
+  - account
+  - right
+  - overlay
+  - card
+  - only
+  - official
+  - routes
+  - billed
+source:
+  repository: https://github.com/bobcat848/dsh-calculator
+  repositoryNodeId: R_kgDOT4Ed9A
+  subpath: null
+  commit: 1f4b17db702a6742490ec9410daba86910a59a7a
+creator:
+  github: bobcat848
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:17.805Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-calculator`
- Submission type: community curation
- Created by `bobcat848` — https://github.com/bobcat848
- Original source repository: https://github.com/bobcat848/dsh-calculator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@bobcat848 — this entry was curated from your public repository (https://github.com/bobcat848/dsh-calculator). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.