### PR TITLE
catalog: add dsh-chat-outline (community curation, created by @liliuCourier)

### DIFF
--- a/catalog/plugins/dsh-chat-outline.yaml
+++ b/catalog/plugins/dsh-chat-outline.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: dsh-chat-outline
+name: dsh-chat-outline
+description:
+  en: 对话栏左侧常驻大纲：快速定位每次 user 提问与最后一条 assistant 回复（DeepSeek Harness 插件）。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - chat-outline
+  - user
+  - assistant
+source:
+  repository: https://github.com/liliuCourier/dsh-chat-outline
+  repositoryNodeId: R_kgDOT3uOCg
+  subpath: null
+  commit: be56f36e4d51b7da3a618dbe5abc47c010a444ed
+creator:
+  github: liliuCourier
+package:
+  ecosystem: npm
+  name: dsh-chat-outline
+  version: 0.1.10
+  integrity: sha512-D+OaWvbVjXud5/B4lI+6L6Z9r/VuTTsbhHsPDxXSVJX5U6CGFNrqiLFPT7RycnXX94m+GrLnHha5trS9phpNrw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:44:59.839Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-chat-outline`
- Submission type: community curation
- Created by `liliuCourier` — https://github.com/liliuCourier
- Original source repository: https://github.com/liliuCourier/dsh-chat-outline
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@liliuCourier — this entry was curated from your public repository (https://github.com/liliuCourier/dsh-chat-outline). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.