### PR TITLE
catalog: add dsh-effort-slider (community curation, created by @2768651338)

### DIFF
--- a/catalog/plugins/dsh-effort-slider.yaml
+++ b/catalog/plugins/dsh-effort-slider.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: dsh-effort-slider
+name: dsh-effort-slider
+description:
+  en: 仿 Claude Code 推理等级滑块 DSH 插件：无极拖动、松手吸附、WebGL 火焰跟随、OFF/MAX 刻度、Low/Medium/High/Ultracode 状态；宿主侧通用思考强度供给——任何自定义第三方模型/提供商都能获得真实生效的思考强度调节。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - claude
+  - code
+  - webgl
+  - medium
+  - high
+  - ultracode
+  - dsh
+source:
+  repository: https://github.com/2768651338/dsh-effort-slider
+  repositoryNodeId: R_kgDOT54uWA
+  subpath: null
+  commit: b95d997a787ddfc2dfe05e167f59229ccd8bafb2
+creator:
+  github: "2768651338"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:44:51.060Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-effort-slider`
- Submission type: community curation
- Created by `2768651338` — https://github.com/2768651338
- Original source repository: https://github.com/2768651338/dsh-effort-slider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@2768651338 — this entry was curated from your public repository (https://github.com/2768651338/dsh-effort-slider). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.