### PR TITLE
catalog: add dsh-message-preview (community curation, created by @asukasec)

### DIFF
--- a/catalog/plugins/dsh-message-preview.yaml
+++ b/catalog/plugins/dsh-message-preview.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-message-preview
+name: dsh-message-preview
+description:
+  en: "Sidebar message-history preview for DeepSeek Harness web UI: lists the current session's sent messages with previews; click to jump the chat to that message."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - conversation
+  - navigation
+  - sidebar
+  - message
+  - history
+  - preview
+  - lists
+  - current
+  - session
+  - sent
+  - messages
+  - previews
+  - click
+  - jump
+source:
+  repository: https://github.com/asukasec/dsh-message-preview
+  repositoryNodeId: R_kgDOT4J75g
+  subpath: null
+  commit: dfdb543e3982ed5d3f5612b3b0b2e2f6be0f0ed7
+creator:
+  github: asukasec
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:44:53.842Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-message-preview`
- Submission type: community curation
- Created by `asukasec` — https://github.com/asukasec
- Original source repository: https://github.com/asukasec/dsh-message-preview
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@asukasec — this entry was curated from your public repository (https://github.com/asukasec/dsh-message-preview). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.