### PR TITLE
catalog: add dsh-plugin-session-import (community curation, created by @huguangyu666)

### DIFF
--- a/catalog/plugins/dsh-plugin-session-import.yaml
+++ b/catalog/plugins/dsh-plugin-session-import.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: dsh-plugin-session-import
+name: dsh-plugin-session-import
+description:
+  en: DeepSeek Harness 插件：导入 claude-code / codex / reasonix / zcode 的聊天记录为 dsh 会话（含工作区绑定）。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - session
+  - import
+  - claude-code
+  - codex
+  - reasonix
+  - zcode
+  - claude
+  - code
+source:
+  repository: https://github.com/huguangyu666/dsh-plugin-session-import
+  repositoryNodeId: R_kgDOT3zPiA
+  subpath: null
+  commit: 13139abe5820ea07bf5a89cef36801ee17987aa0
+creator:
+  github: huguangyu666
+package:
+  ecosystem: npm
+  name: dsh-plugin-session-import
+  version: 0.1.1
+  integrity: sha512-ZCRx2Ml9dNh1prj6BAK1Be9BdJosPtEh27jqsxMQdVWU9dg8XcDOY0II0/tyoxZkd3Tz+DN5S78xObTGWYdQWg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:44:55.244Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-session-import`
- Submission type: community curation
- Created by `huguangyu666` — https://github.com/huguangyu666
- Original source repository: https://github.com/huguangyu666/dsh-plugin-session-import
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@huguangyu666 — this entry was curated from your public repository (https://github.com/huguangyu666/dsh-plugin-session-import). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.