### PR TITLE
catalog: add dsh-restart (community curation, created by @anweat)

### DIFF
--- a/catalog/plugins/dsh-restart.yaml
+++ b/catalog/plugins/dsh-restart.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dsh-restart
+name: dsh-restart
+description:
+  en: DSH 重启插件：可配置的重启方式（Node 原生 / 旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - restart
+  - watchdog
+  - client-plugin
+  - node
+  - powershell
+source:
+  repository: https://github.com/anweat/dsh-restart
+  repositoryNodeId: R_kgDOT4H3Dw
+  subpath: null
+  commit: 8d9f4947530a08e9a2967a7847ae2f906c2d7b5b
+creator:
+  github: anweat
+package:
+  ecosystem: npm
+  name: dsh-restart
+  version: 0.1.0
+  integrity: sha512-dUAzFC2ld6Kn5V+udWHB0Z1M2g+/ehprTyABKo5yoEd6F7OTKvpzkpaAwjGMQ9tc+Uha0tRrTISpu0xRLr9T9g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:14.567Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-restart`
- Submission type: community curation
- Created by `anweat` — https://github.com/anweat
- Original source repository: https://github.com/anweat/dsh-restart
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@anweat — this entry was curated from your public repository (https://github.com/anweat/dsh-restart). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.