### PR TITLE
catalog: add dsh-task-dag (community curation, created by @LeemanCheung)

### DIFF
--- a/catalog/plugins/dsh-task-dag.yaml
+++ b/catalog/plugins/dsh-task-dag.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: dsh-task-dag
+name: dsh-task-dag
+description:
+  en: Persistent live DAG visualization for DeepSeek Harness subagents and workflows
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - dag
+  - subagent
+  - workflow
+  - visualization
+  - persistent
+  - live
+  - subagents
+  - workflows
+source:
+  repository: https://github.com/LeemanCheung/dsh-task-dag
+  repositoryNodeId: R_kgDOT4VT4g
+  subpath: null
+  commit: 256cfdab272e35b1e72dd11f948a74d2dcfc4ee0
+creator:
+  github: LeemanCheung
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:44:58.478Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-task-dag`
- Submission type: community curation
- Created by `LeemanCheung` — https://github.com/LeemanCheung
- Original source repository: https://github.com/LeemanCheung/dsh-task-dag
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@LeemanCheung — this entry was curated from your public repository (https://github.com/LeemanCheung/dsh-task-dag). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.