### PR TITLE
catalog: add reasoning-slider (community curation, created by @qjcnmd)

### DIFF
--- a/catalog/plugins/reasoning-slider.yaml
+++ b/catalog/plugins/reasoning-slider.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: reasoning-slider
+name: reasoning-slider
+description:
+  en: Codex-style reasoning-effort slider embedded in the DSH model selector
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - reasoning
+  - slider
+  - codex
+  - style
+  - effort
+  - embedded
+  - model
+  - selector
+source:
+  repository: https://github.com/qjcnmd/dsh-reasoning-slider
+  repositoryNodeId: R_kgDOT4WR2A
+  subpath: null
+  commit: dae619c312a061c1c913279d86a79f5d857baa8c
+creator:
+  github: qjcnmd
+package:
+  ecosystem: npm
+  name: reasoning-slider
+  version: 0.0.3
+  integrity: sha512-Al9zF5bmBWqK33hGnFe9WQBXNQUjlOr/sa8Q4GPscak9Sn0e8fJYvoofdVmINOM2uuBtVkhQuzkPxyxihKoWIw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:04.295Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `reasoning-slider`
- Submission type: community curation
- Created by `qjcnmd` — https://github.com/qjcnmd
- Original source repository: https://github.com/qjcnmd/dsh-reasoning-slider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@qjcnmd — this entry was curated from your public repository (https://github.com/qjcnmd/dsh-reasoning-slider). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.