### PR TITLE
catalog: add ds-vision-plugin (community curation, created by @Sorwcyra)

### DIFF
--- a/catalog/plugins/ds-vision-plugin.yaml
+++ b/catalog/plugins/ds-vision-plugin.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: ds-vision-plugin
+name: ds-vision-plugin
+description:
+  en: Automatic Web image-to-text bridge plus vision and OCR tools for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - deepseek-vision
+  - dsh-plugin
+  - vision
+  - vlm
+  - ocr
+  - multimodal
+  - image-to-text
+  - web-composer
+  - typescript
+  - automatic
+  - image
+  - text
+  - bridge
+  - plus
+  - tools
+source:
+  repository: https://github.com/Sorwcyra/ds-vision-plugin
+  repositoryNodeId: R_kgDOT37aUQ
+  subpath: null
+  commit: 55967fad750f86d0826068cb9cd228be03c943ba
+creator:
+  github: Sorwcyra
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:45.386Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ds-vision-plugin`
- Submission type: community curation
- Created by `Sorwcyra` — https://github.com/Sorwcyra
- Original source repository: https://github.com/Sorwcyra/ds-vision-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Sorwcyra — this entry was curated from your public repository (https://github.com/Sorwcyra/ds-vision-plugin). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.