### PR TITLE
catalog: add dsh-claude-cli (community curation, created by @katsos)

### DIFF
--- a/catalog/plugins/dsh-claude-cli.yaml
+++ b/catalog/plugins/dsh-claude-cli.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-claude-cli
+name: dsh-claude-cli
+description:
+  en: Use the locally installed Claude Code CLI as a DeepSeek Harness LLM provider — no API key, native tool calls through an MCP bridge
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - llm-provider
+  - claude-code
+  - locally
+  - installed
+  - claude
+  - code
+  - provider
+  - native
+  - tool
+  - calls
+  - through
+  - bridge
+  - dsh
+source:
+  repository: https://github.com/katsos/dsh-claude-cli
+  repositoryNodeId: R_kgDOT5T9Yw
+  subpath: null
+  commit: 3a3a57f22a3e748c9720a1b96ce64e015f0f9643
+creator:
+  github: katsos
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:32.353Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-claude-cli`
- Submission type: community curation
- Created by `katsos` — https://github.com/katsos
- Original source repository: https://github.com/katsos/dsh-claude-cli
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@katsos — this entry was curated from your public repository (https://github.com/katsos/dsh-claude-cli). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.