### PR TITLE
catalog: add dsh-deepseek-billing (community curation, created by @Jolly-J)

### DIFF
--- a/catalog/plugins/dsh-deepseek-billing.yaml
+++ b/catalog/plugins/dsh-deepseek-billing.yaml
@@ -1,0 +1,39 @@
+schemaVersion: 1
+id: dsh-deepseek-billing
+name: dsh-deepseek-billing
+description:
+  en: DSH WebUI 插件:侧边栏 DeepSeek 账户余额显示与按会话费用估算
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - webui
+  - dsh
+source:
+  repository: https://github.com/Jolly-J/dsh-deepseek-billing
+  repositoryNodeId: R_kgDOT4B8YA
+  subpath: null
+  commit: f37e07844ac39c40594e26417c2029325d915202
+creator:
+  github: Jolly-J
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:30.978Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-deepseek-billing`
- Submission type: community curation
- Created by `Jolly-J` — https://github.com/Jolly-J
- Original source repository: https://github.com/Jolly-J/dsh-deepseek-billing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Jolly-J — this entry was curated from your public repository (https://github.com/Jolly-J/dsh-deepseek-billing). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.