### PR TITLE
catalog: add dsh-ding (community curation, created by @CAOGGL)

### DIFF
--- a/catalog/plugins/dsh-ding.yaml
+++ b/catalog/plugins/dsh-ding.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: dsh-ding
+name: dsh-ding
+description:
+  en: DSH 插件：对话完成时播放提示音 + Windows 通知，WebUI 铃铛按钮可调开关/音量/音效
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - notification
+  - windows
+  - toast
+  - dsh-plugin
+  - webui
+source:
+  repository: https://github.com/CAOGGL/dsh-ding
+  repositoryNodeId: R_kgDOT3m0Fg
+  subpath: null
+  commit: c92bfda6618ee52e52f147d5b626de396bfd6bbe
+creator:
+  github: CAOGGL
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:20.807Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-ding`
- Submission type: community curation
- Created by `CAOGGL` — https://github.com/CAOGGL
- Original source repository: https://github.com/CAOGGL/dsh-ding
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@CAOGGL — this entry was curated from your public repository (https://github.com/CAOGGL/dsh-ding). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.