### PR TITLE
catalog: add dsh-doublecheck (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/dsh-doublecheck.yaml
+++ b/catalog/plugins/dsh-doublecheck.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-doublecheck
+name: dsh-doublecheck
+description:
+  en: "Delivery quality gate for DeepSeek Harness: grill the requirements, test the implementation, prove the delivery, and gate the handoff with a deliverable/rework decision."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - engineering-discipline
+  - requirements
+  - guard
+  - skill
+  - quality-gate
+  - delivery-gate
+  - delivery
+  - quality
+  - gate
+  - grill
+  - test
+  - implementation
+  - prove
+source:
+  repository: https://github.com/PerryLink/dsh-doublecheck
+  repositoryNodeId: R_kgDOT397Fg
+  subpath: null
+  commit: ef7870e78f5fac3e0004086371e3e5be21e7e6b0
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-doublecheck
+  version: 0.7.1
+  integrity: sha512-pYGXU3gF0iohvOdRDIKOM51J/hSLh+Qt3EYMGQGXx0TviDSKxNiMIvD5K91YVXi/wEMSn0q0FbQxIKg9Gf4H5g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:43.968Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-doublecheck`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-doublecheck
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@PerryLink — this entry was curated from your public repository (https://github.com/PerryLink/dsh-doublecheck). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.