### PR TITLE
catalog: add dsh-gauge (community curation, created by @noone89A)

### DIFF
--- a/catalog/plugins/dsh-gauge.yaml
+++ b/catalog/plugins/dsh-gauge.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-gauge
+name: dsh-gauge
+description:
+  en: "Accurate cache-hit rate, token usage, and cost estimates for the DeepSeek Harness Web UI: one-decimal hit rate, bucket breakdown, peak/off-peak pricing with auto price-switch, and a session usage panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cache-hit
+  - token-usage
+  - accurate
+  - cache
+  - rate
+  - token
+  - usage
+  - cost
+  - estimates
+  - decimal
+  - bucket
+  - breakdown
+  - peak
+source:
+  repository: https://github.com/noone89A/dsh-gauge
+  repositoryNodeId: R_kgDOT4abKA
+  subpath: null
+  commit: ca176d7658661c91bdea666102a51692fc3d88d6
+creator:
+  github: noone89A
+package:
+  ecosystem: npm
+  name: dsh-gauge
+  version: 0.1.1
+  integrity: sha512-Kd14hSOUxomqnN6LjfJlUtfvMGQPCRGh+hOeKijdkwwkunMYwt8fd2j+k7trhSlxLTKYrl5tOqao6k6avjX+jg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:42.529Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-gauge`
- Submission type: community curation
- Created by `noone89A` — https://github.com/noone89A
- Original source repository: https://github.com/noone89A/dsh-gauge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@noone89A — this entry was curated from your public repository (https://github.com/noone89A/dsh-gauge). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.