### PR TITLE
catalog: add dsh-im-gateway (community curation, created by @lijian-ui)

### DIFF
--- a/catalog/plugins/dsh-im-gateway.yaml
+++ b/catalog/plugins/dsh-im-gateway.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dsh-im-gateway
+name: "@lijian-ui/dsh-im-gateway"
+description:
+  en: "Multi-channel IM gateway plugin for DeepSeek Harness (dsh): DingTalk / QQ / WeChat(iLink) with QR-scan binding, streaming replies, and a unified ctx.imGateway service. 为 DeepSeek Harness 提供钉钉/QQ/个人微信多 IM 通道接入。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - im-gateway
+  - dingtalk
+  - qq
+  - wechat
+  - weixin
+  - cordis
+  - multi
+  - channel
+  - gateway
+  - ilink
+  - scan
+  - binding
+  - streaming
+source:
+  repository: https://github.com/lijian-ui/dsh-im-gateway
+  repositoryNodeId: R_kgDOT5qajw
+  subpath: null
+  commit: 00a9eeac1bd76369f112f63a4b904ec8129c2e73
+creator:
+  github: lijian-ui
+package:
+  ecosystem: npm
+  name: "@lijian-ui/dsh-im-gateway"
+  version: 0.1.1
+  integrity: sha512-GbkjySHozO20nGsBW2zVSaR4xG8FzBsNxz2XvYT+cRT/Vg5iR6/U+/eNFDs4OsdyztfK7EidS4kECkkW58lhGA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:36.926Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-im-gateway`
- Submission type: community curation
- Created by `lijian-ui` — https://github.com/lijian-ui
- Original source repository: https://github.com/lijian-ui/dsh-im-gateway
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@lijian-ui — this entry was curated from your public repository (https://github.com/lijian-ui/dsh-im-gateway). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.