### PR TITLE
catalog: add dsh-opencode-zen (community curation, created by @xiaozhe7772222)

### DIFF
--- a/catalog/plugins/dsh-opencode-zen.yaml
+++ b/catalog/plugins/dsh-opencode-zen.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: dsh-opencode-zen
+name: dsh-opencode-zen
+description:
+  en: "OpenCode Zen free-tier models for DeepSeek Harness: zero-config public-key provider with quota-aware pacing."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - opencode
+  - zen
+  - free
+  - llm
+  - provider
+  - tier
+  - models
+  - zero
+  - config
+  - public
+  - quota
+  - aware
+  - pacing
+source:
+  repository: https://github.com/xiaozhe7772222/dsh-opencode-zen
+  repositoryNodeId: R_kgDOT6cL2A
+  subpath: null
+  commit: e569f42e2ef245fe1edf779af6caab2280ce5add
+creator:
+  github: xiaozhe7772222
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:48.206Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-opencode-zen`
- Submission type: community curation
- Created by `xiaozhe7772222` — https://github.com/xiaozhe7772222
- Original source repository: https://github.com/xiaozhe7772222/dsh-opencode-zen
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@xiaozhe7772222 — this entry was curated from your public repository (https://github.com/xiaozhe7772222/dsh-opencode-zen). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.