### PR TITLE
catalog: add dsh-plugin-doctor (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/dsh-plugin-doctor.yaml
+++ b/catalog/plugins/dsh-plugin-doctor.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-plugin-doctor
+name: dsh-plugin-doctor
+description:
+  en: "Health checks for DeepSeek Harness: manifest/patch/entry/build/pack/install verification, model-callable plugin check, profile host-shadowing + manifest-BOM detection, environment diagnostics, supply-chain poison preflight, and broken tool-call-sequence detection ( 2334)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - doctor
+  - health-check
+  - cli
+  - security
+  - supply-chain
+  - health
+  - checks
+  - manifest
+  - patch
+  - entry
+  - build
+  - pack
+  - install
+  - verification
+source:
+  repository: https://github.com/zoahdev/dsh-plugin-doctor
+  repositoryNodeId: R_kgDOT48tCw
+  subpath: null
+  commit: 7a8eb59a0fddade56200d1a4c42c4a6311a6e5d2
+creator:
+  github: zoahdev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:49.771Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-doctor`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-plugin-doctor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@zoahdev — this entry was curated from your public repository (https://github.com/zoahdev/dsh-plugin-doctor). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.