### PR TITLE
catalog: add dsh-plugin-knowledge-graph (community curation, created by @Luke-Yong)

### DIFF
--- a/catalog/plugins/dsh-plugin-knowledge-graph.yaml
+++ b/catalog/plugins/dsh-plugin-knowledge-graph.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-plugin-knowledge-graph
+name: dsh-plugin-knowledge-graph
+description:
+  en: "DeepSeek Harness plugin: a read graph tool backed by a codebase knowledge graph (CONTAINS / EXPORTS / IMPORTS / IMPORTS SYMBOL)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - knowledge-graph
+  - code-graph
+  - read-graph
+  - read
+  - graph
+  - tool
+  - backed
+  - codebase
+  - knowledge
+  - contains
+  - exports
+  - imports
+  - symbol
+  - dsh
+source:
+  repository: https://github.com/Luke-Yong/dsh-plugin-knowledge-graph
+  repositoryNodeId: R_kgDOT3-7iA
+  subpath: null
+  commit: 30bb1305027bcba773dc241834935f290d7336f0
+creator:
+  github: Luke-Yong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:39.772Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-knowledge-graph`
- Submission type: community curation
- Created by `Luke-Yong` — https://github.com/Luke-Yong
- Original source repository: https://github.com/Luke-Yong/dsh-plugin-knowledge-graph
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@Luke-Yong — this entry was curated from your public repository (https://github.com/Luke-Yong/dsh-plugin-knowledge-graph). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.