### PR TITLE
catalog: add dsh-plugin-notify (community curation, created by @huguangyu666)

### DIFF
--- a/catalog/plugins/dsh-plugin-notify.yaml
+++ b/catalog/plugins/dsh-plugin-notify.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: dsh-plugin-notify
+name: dsh-plugin-notify
+description:
+  en: DeepSeek Harness 插件：通知出口——agent 通过桌面通知 / 中文语音播报 / 提示音主动联系用户（长任务完成、出错、呼叫用户回来）。Windows 本机零依赖。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - notify
+  - notification
+  - tts
+  - voice
+  - alert
+  - agent
+  - windows
+source:
+  repository: https://github.com/huguangyu666/dsh-plugin-notify
+  repositoryNodeId: R_kgDOT4Y5Lg
+  subpath: null
+  commit: df39977781cdd3166d38eef04aae0e5bf4bf0ba2
+creator:
+  github: huguangyu666
+package:
+  ecosystem: npm
+  name: dsh-plugin-notify
+  version: 0.1.1
+  integrity: sha512-PsJrRD3Ov0K3uYf3kqm5S0BzMTfDeyFKtv3X+PQ2vwMiFWN9lwez4hcBSa6k1C+imUZe2+dCBee+Gl8ZAa83BQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:25.022Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-notify`
- Submission type: community curation
- Created by `huguangyu666` — https://github.com/huguangyu666
- Original source repository: https://github.com/huguangyu666/dsh-plugin-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@huguangyu666 — this entry was curated from your public repository (https://github.com/huguangyu666/dsh-plugin-notify). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.