### PR TITLE
catalog: add dsh-plugin-subhub (community curation, created by @kinoward)

### DIFF
--- a/catalog/plugins/dsh-plugin-subhub.yaml
+++ b/catalog/plugins/dsh-plugin-subhub.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: dsh-plugin-subhub
+name: dsh-plugin-subhub
+description:
+  en: DeepSeek Harness 第三方订阅接入插件:登录第三方订阅账户即可使用订阅内的模型(当前支持 OpenAI / ChatGPT 订阅,更多订阅服务规划中;支持图片理解与对话内图片生成、编辑)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - openai
+  - chatgpt
+  - dsh
+source:
+  repository: https://github.com/kinoward/dsh-plugin-subhub
+  repositoryNodeId: R_kgDOT42Y4g
+  subpath: null
+  commit: 92d578d734806a4a81c53c6baf24a369d292a445
+creator:
+  github: kinoward
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:33.786Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-plugin-subhub`
- Submission type: community curation
- Created by `kinoward` — https://github.com/kinoward
- Original source repository: https://github.com/kinoward/dsh-plugin-subhub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@kinoward — this entry was curated from your public repository (https://github.com/kinoward/dsh-plugin-subhub). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.