### PR TITLE
catalog: add dsh-session-audit (community curation, created by @bwndlct)

### DIFF
--- a/catalog/plugins/dsh-session-audit.yaml
+++ b/catalog/plugins/dsh-session-audit.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-session-audit
+name: dsh-session-audit
+description:
+  en: "Session execution analytics and audit reports for DeepSeek Harness. Understand how your agent actually worked: steps, tool calls, failures, repeated actions, token usage and verification signals."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent
+  - agent-observability
+  - session
+  - audit
+  - analytics
+  - execution
+  - reports
+  - understand
+  - actually
+  - worked
+  - steps
+  - tool
+  - calls
+source:
+  repository: https://github.com/bwndlct/dsh-session-audit
+  repositoryNodeId: R_kgDOT4RX5w
+  subpath: null
+  commit: 7f1d90e70fc628e602bc5cff531183a37ef6cae2
+creator:
+  github: bwndlct
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:19.295Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-session-audit`
- Submission type: community curation
- Created by `bwndlct` — https://github.com/bwndlct
- Original source repository: https://github.com/bwndlct/dsh-session-audit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@bwndlct — this entry was curated from your public repository (https://github.com/bwndlct/dsh-session-audit). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.