### PR TITLE
catalog: add dsh-store (community curation, created by @huguangyu666)

### DIFF
--- a/catalog/plugins/dsh-store.yaml
+++ b/catalog/plugins/dsh-store.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: dsh-store
+name: dsh-store
+description:
+  en: DeepSeek Harness 插件商店：npm 权威源 + awesome 精选 + 自动雷达（550+ 插件、11 分类、运行级验证），官方 dsh plugin add/remove 一键安装卸载，dsh 原生 UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - store
+  - marketplace
+  - plugin-manager
+  - awesome
+  - remove
+source:
+  repository: https://github.com/huguangyu666/dsh-store
+  repositoryNodeId: R_kgDOT4fvkg
+  subpath: null
+  commit: 1f7c63c4e16804717f0faa734adf613324999919
+creator:
+  github: huguangyu666
+package:
+  ecosystem: npm
+  name: dsh-store
+  version: 0.5.2
+  integrity: sha512-hag43sNlFmXts0jwWlO5UYlMDY9CIuAVTggQKkFVjDQe/HSd+keCkztoAGaAHfsrQOfHGQwwXQscZpaEC/+iOw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:26.376Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-store`
- Submission type: community curation
- Created by `huguangyu666` — https://github.com/huguangyu666
- Original source repository: https://github.com/huguangyu666/dsh-store
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@huguangyu666 — this entry was curated from your public repository (https://github.com/huguangyu666/dsh-store). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.