### PR TITLE
catalog: add dsh-task-planner (community curation, created by @leon)

### DIFF
--- a/catalog/plugins/dsh-task-planner.yaml
+++ b/catalog/plugins/dsh-task-planner.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dsh-task-planner
+name: dsh-task-planner
+description:
+  en: "Task planning with experience muscle-memory for DeepSeek Harness: condition-reflex recall of past solutions + LLM-driven capability matching + auto-persisted lessons. Zero keys, zero hard-coded paths."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - planning
+  - memory
+  - experience
+  - task
+  - muscle
+  - condition
+  - reflex
+  - recall
+  - past
+  - solutions
+  - driven
+  - capability
+  - matching
+source:
+  repository: https://github.com/ztl34245881-commits/dsh-task-planner
+  repositoryNodeId: R_kgDOT4aFIw
+  subpath: null
+  commit: 7326670e4131d54d8a4a5602c45fc0f3628bc413
+creator:
+  github: leon
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-20T00:45:51.724Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-task-planner`
- Submission type: community curation
- Created by `leon` — https://github.com/leon
- Original source repository: https://github.com/ztl34245881-commits/dsh-task-planner
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.
- [x] No credentials, private contact details or other secrets.

@leon — this entry was curated from your public repository (https://github.com/ztl34245881-commits/dsh-task-planner). If anything is wrong,
or you prefer to own the listing yourself, a direct PR from you supersedes this one.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored
> by DeepSeek. DeepSeek names and marks belong to their respective owner.