### PR TITLE
catalog: reescreve nove descrições que entraram em outra língua

### DIFF
--- a/catalog/plugins/dsh-chat-outline.yaml
+++ b/catalog/plugins/dsh-chat-outline.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-chat-outline
 name: dsh-chat-outline
 description:
-  en: 对话栏左侧常驻大纲：快速定位每次 user 提问与最后一条 assistant 回复（DeepSeek Harness 插件）。
+  en: "A persistent conversation outline down the left of the DeepSeek Harness chat: one row per turn with the question and that turn's last reply, click to jump, Ctrl/Shift-click to land in the trace view. A marker follows what you are reading, and a light mode reads only the already-loaded window at zero cost."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/dsh-deepseek-billing.yaml
+++ b/catalog/plugins/dsh-deepseek-billing.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-deepseek-billing
 name: dsh-deepseek-billing
 description:
-  en: DSH WebUI 插件:侧边栏 DeepSeek 账户余额显示与按会话费用估算
+  en: "A balance card for the DeepSeek Harness web UI: the sidebar shows your DeepSeek account balance and what the current session cost, expanding to token breakdown, cache hit rate and per-rate subtotals. Refreshes every minute; the figures are an estimate, not a bill."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: models-providers-routing
+primaryCategory: data-external-services
 tags:
   - webui
   - dsh

--- a/catalog/plugins/dsh-ding.yaml
+++ b/catalog/plugins/dsh-ding.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-ding
 name: dsh-ding
 description:
-  en: DSH 插件：对话完成时播放提示音 + Windows 通知，WebUI 铃铛按钮可调开关/音量/音效
+  en: "A DSH host plugin that notifies you when a conversation finishes: when the agent completes a turn it plays a sound and shows a native Windows toast, so you never miss the reply while working elsewhere. A bell in the chat header toggles it and picks the sound; clicking the toast opens that session."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: user-interface-dashboards
+primaryCategory: messaging-notifications
 tags:
   - dsh
   - deepseek-harness

--- a/catalog/plugins/dsh-effort-slider.yaml
+++ b/catalog/plugins/dsh-effort-slider.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-effort-slider
 name: dsh-effort-slider
 description:
-  en: 仿 Claude Code 推理等级滑块 DSH 插件：无极拖动、松手吸附、WebGL 火焰跟随、OFF/MAX 刻度、Low/Medium/High/Ultracode 状态；宿主侧通用思考强度供给——任何自定义第三方模型/提供商都能获得真实生效的思考强度调节。
+  en: "A Claude Code-style reasoning-effort slider for DeepSeek Harness: click Effort in the model menu for a panel with an OFF/MAX scale, stepless dragging that snaps on release, and Low/Medium/High/Ultracode shown live. Any third-party model or provider gets working thinking-effort control."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/dsh-plugin-notify.yaml
+++ b/catalog/plugins/dsh-plugin-notify.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-plugin-notify
 name: dsh-plugin-notify
 description:
-  en: DeepSeek Harness 插件：通知出口——agent 通过桌面通知 / 中文语音播报 / 提示音主动联系用户（长任务完成、出错、呼叫用户回来）。Windows 本机零依赖。
+  en: "A notification outlet for DeepSeek Harness so the agent can reach you: desktop toast, spoken announcement and sound, with no native dependency on Windows. It injects a proactive-notification rule into every agent's prompt, exposes a notify_user tool and a /notify command, and still notifies on turn end or error."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/dsh-plugin-session-import.yaml
+++ b/catalog/plugins/dsh-plugin-session-import.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-plugin-session-import
 name: dsh-plugin-session-import
 description:
-  en: DeepSeek Harness 插件：导入 claude-code / codex / reasonix / zcode 的聊天记录为 dsh 会话（含工作区绑定）。
+  en: "Import chat history from claude-code, codex, reasonix and zcode into DeepSeek Harness as real sessions, workspace binding included, and carry on the conversation. Sessions are discovered with title, project and message count, imported in bulk, and their 25+ tools work like any other session's."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: coding-developer-tools
+primaryCategory: sessions-productivity
 tags:
   - dsh
   - dsh-plugin

--- a/catalog/plugins/dsh-plugin-subhub.yaml
+++ b/catalog/plugins/dsh-plugin-subhub.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-plugin-subhub
 name: dsh-plugin-subhub
 description:
-  en: DeepSeek Harness 第三方订阅接入插件:登录第三方订阅账户即可使用订阅内的模型(当前支持 OpenAI / ChatGPT 订阅,更多订阅服务规划中;支持图片理解与对话内图片生成、编辑)
+  en: "Use a third-party subscription's models inside DeepSeek Harness: sign in to the subscription account and its models become available in the model menu, with image understanding and conversation support. OpenAI/ChatGPT subscriptions are supported today and more are planned."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/dsh-restart.yaml
+++ b/catalog/plugins/dsh-restart.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: dsh-restart
 name: dsh-restart
 description:
-  en: DSH 重启插件：可配置的重启方式（Node 原生 / 旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
+  en: "Restart the whole DeepSeek Harness process to reload plugins and configuration: a restart_harness tool the agent can schedule, a /restart command, and a settings card for the restart strategy, the continue prompt and an optional watchdog. The restart endpoint accepts same-origin loopback requests only."
   evidencePath: README.md
 unofficial: true
 kind: plugin

--- a/catalog/plugins/dsh-store.yaml
+++ b/catalog/plugins/dsh-store.yaml
@@ -2,11 +2,11 @@ schemaVersion: 1
 id: dsh-store
 name: dsh-store
 description:
-  en: DeepSeek Harness 插件商店：npm 权威源 + awesome 精选 + 自动雷达（550+ 插件、11 分类、运行级验证），官方 dsh plugin add/remove 一键安装卸载，dsh 原生 UI
+  en: "A plugin store inside DeepSeek Harness built on the npm registry as the authoritative source, plus the awesome list and GitHub stars: entries are verified by their dsh field, categorised and star-ranked, and installed through the official dsh plugin add/remove path, so every listed npm entry actually installs."
   evidencePath: README.md
 unofficial: true
 kind: plugin
-primaryCategory: models-providers-routing
+primaryCategory: coding-developer-tools
 tags:
   - dsh
   - dsh-plugin


### PR DESCRIPTION
O campo se chama `description.en` — o nome é a promessa. Nove entradas mergearam com a redação original em chinês do próprio criador nesse campo; cada uma foi reescrita a partir do README do commit fixado, com a evidência registrada em `curation-overrides-batch5.json`.

Quatro categorias corrigidas enquanto a evidência estava aberta:

| Entrada | Correção | Por quê |
|---|---|---|
| `dsh-deepseek-billing` | `models-providers-routing → data-external-services` | Lê saldo e custo da conta; não roteia modelo |
| `dsh-ding` | `user-interface-dashboards → messaging-notifications` | O produto é a notificação; o sino é o controle |
| `dsh-plugin-session-import` | `coding-developer-tools → sessions-productivity` | Importa e continua **sessões** |
| `dsh-store` | `models-providers-routing → coding-developer-tools` | É loja de **plugins**; nada a ver com provedor |

**Verificação**: `catalog validate` → **160 entries valid**; gate de escrita → **zero descrições não-inglesas** em todo o catálogo; nenhuma acima do teto de 320 caracteres.

Bloqueia a 1.0.0 — um release não sai com um campo `.en` em outra língua.