### PR TITLE
ci: valida o catálogo em toda PR, para o check poder ser obrigatório

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -1,11 +1,12 @@
 name: validate-catalog
 
+# Runs on EVERY pull request, not only the ones touching catalog paths. A path filter and a
+# required status check cannot coexist: GitHub never reports a check that a filter skipped, so a
+# documentation-only pull request would wait forever for a run that will never start. Validating
+# an unchanged catalog costs seconds, and it is what lets this be a required check instead of an
+# advisory one — a catalog pull request could merge red until now.
 on:
   pull_request:
-    paths:
-      - "catalog/plugins/**"
-      - "schemas/**"
-      - ".github/workflows/validate-catalog.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Hoje o `catalog-validation` é **advisory**: o ruleset `protect-main-baseline` exige PR, histórico linear e proíbe force-push, mas **não exige nenhum status check**. Na prática, uma PR de catálogo pode mergear vermelha.

O motivo de nunca ter virado obrigatório está no gatilho: o workflow só roda em PRs que tocam `catalog/plugins/**` ou `schemas/**`. **Filtro de path e required check não convivem** — o GitHub nunca reporta um check que o filtro pulou, então uma PR só de documentação ficaria esperando para sempre por uma execução que jamais começa, e a branch ficaria immergeável.

Validar um catálogo inalterado leva segundos. Tirar o filtro é o que torna seguro marcar o check como obrigatório.

**Depois deste merge**, o passo seguinte é adicionar `catalog-validation` aos required status checks do ruleset — aí sim a validação vira barreira, não aviso.