### PR TITLE
docs(readme): atualiza o Top 10 e a contagem para 160 entradas

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -1,11 +1,12 @@
 name: validate-catalog
 
+# Runs on EVERY pull request, not only the ones touching catalog paths. A path filter and a
+# required status check cannot coexist: GitHub never reports a check that a filter skipped, so a
+# documentation-only pull request would wait forever for a run that will never start. Validating
+# an unchanged catalog costs seconds, and it is what lets this be a required check instead of an
+# advisory one — a catalog pull request could merge red until now.
 on:
   pull_request:
-    paths:
-      - "catalog/plugins/**"
-      - "schemas/**"
-      - ".github/workflows/validate-catalog.yml"
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ repository, pinned at the exact commit the catalog validated.
 
 | #   | Plugin | Creator | ★ | Category | What it does |
 | --- | ------ | ------- | --- | -------- | ------------ |
-| 1 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | [@ysr666](https://github.com/ysr666) | 843 | Vision & multimodal | Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools… |
-| 2 | [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | [@taekchef](https://github.com/taekchef) | 249 | UI & dashboards | GenUI for DeepSeek Harness: interactive UI components rendered inline in assistant replies via the dsh-ui… |
-| 3 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | [@huiliyi37](https://github.com/huiliyi37) | 220 | UI & dashboards | dsh-tianshu-tui: an interactive terminal UI plugin for the official DeepSeek Harness — streaming… |
-| 4 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | [@Nagi-ovo](https://github.com/Nagi-ovo) | 180 | UI & dashboards | Inline visualization for DeepSeek Harness: a visualize tool plus bundled skill let the model render… |
-| 5 | [anime-find](https://github.com/cocofhu/anime-find) | [@cocofhu00](https://github.com/cocofhu00) | 152 | Search & research | An anime search plugin for DeepSeek Harness: an anime_find_search tool aggregates Mikan, AniBT and… |
-| 6 | [dsh-undo-savepoint](https://github.com/lire1131/dsh-undo-savepoint) | [@lire1131](https://github.com/lire1131) | 96 | UI & dashboards | DSH undo/rollback system: snapshot config files on change, undo/redo the last action from the WebUI or by… |
-| 7 | [workflow](https://github.com/omdsh-dev/dsh_workflow) | [@icetomoyo](https://github.com/icetomoyo) | 88 | Coding & dev tools | KodaX-parity dynamic workflow harness for DeepSeek Harness |
-| 8 | [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | [@taekchef](https://github.com/taekchef) | 79 | UI & dashboards | DSH Web selection-annotation plugin: select assistant text, annotate (optional), and press Enter to send the… |
-| 9 | [dsh-vision](https://github.com/oil-oil/dsh-vision) | [@oil-oil](https://github.com/oil-oil) | 70 | Vision & multimodal | Near-native image understanding for text-only DeepSeek Harness models |
-| 10 | [dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) | [@Mars-Sea](https://github.com/Mars-Sea) | 69 | Models & routing | Unofficial DeepSeek Harness LLM provider plugin for Command Code, ported from pi-commandcode-provider (MIT… |
+| 1 | [modlens](https://github.com/liustack/modlens) | [@liustack](https://github.com/liustack) | 3270 | Vision & multimodal | Plug-in vision for text-only LLMs, powered by the free Antigravity CLI |
+| 2 | [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | [@Menghuan1918](https://github.com/Menghuan1918) | 2330 | Coding & dev tools | DSH web plugin: a VSCode-like right sidebar (explorer / editor / terminal / git / browser), isolated per… |
+| 3 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | [@ysr666](https://github.com/ysr666) | 843 | Vision & multimodal | Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools… |
+| 4 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | [@Anionex](https://github.com/Anionex) | 750 | Vision & multimodal | DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration,… |
+| 5 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | [@Nagi-ovo](https://github.com/Nagi-ovo) | 511 | Entertainment | DSH ad-infestation plugin: localized Chinese portal ads and English scam-ad parody, with fake pop-ups, a… |
+| 6 | [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | [@taekchef](https://github.com/taekchef) | 249 | UI & dashboards | GenUI for DeepSeek Harness: interactive UI components rendered inline in assistant replies via the dsh-ui… |
+| 7 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | [@huiliyi37](https://github.com/huiliyi37) | 220 | UI & dashboards | dsh-tianshu-tui: an interactive terminal UI plugin for the official DeepSeek Harness — streaming… |
+| 8 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | [@Nagi-ovo](https://github.com/Nagi-ovo) | 180 | UI & dashboards | Inline visualization for DeepSeek Harness: a visualize tool plus bundled skill let the model render… |
+| 9 | [anime-find](https://github.com/cocofhu/anime-find) | [@cocofhu00](https://github.com/cocofhu00) | 152 | Search & research | An anime search plugin for DeepSeek Harness: an anime_find_search tool aggregates Mikan, AniBT and… |
+| 10 | [dsh-undo-savepoint](https://github.com/lire1131/dsh-undo-savepoint) | [@lire1131](https://github.com/lire1131) | 96 | Sessions & productivity | DSH undo/rollback system: snapshot config files on change, undo/redo the last action from the WebUI or by… |
 
 <div align="center">
 
@@ -120,7 +120,7 @@ catalog data, schema and policies they consume.
 
 ## Catalog status
 
-**86 plugins merged.** Every plugin enters through an individually reviewed pull request, one at
+**160 plugins merged.** Every plugin enters through an individually reviewed pull request, one at
 a time, from the original creator repository, with a pinned source commit and explicit
 attribution.
 


### PR DESCRIPTION
O catálogo foi de 86 para 160 e a tabela é **mantida à mão**, então já estava errada. Quatro entradas que estavam no Top 10 saíram, e quatro novas passaram por cima de tudo:

| # | Entrada | ★ |
|---|---|---:|
| 1 | `modlens` | 3270 |
| 2 | `dsh-better-sidebar` | 2330 |
| 4 | `dsh-vision-toolkit` | 750 |
| 5 | `dsh-ads` | 511 |

Recomputado com o predicado documentado — `kind: plugin`, `repositoryScope: dedicated`, `verification.status` em `eligible|verified`, e estrelas que pertencem ao repositório do próprio plugin — sobre as **147 entradas que qualificam** das 160. A contagem no corpo também saiu de 86 para 160.

## Esta PR é também o teste do check obrigatório

Ela **não toca em `catalog/` nem em `schemas/`**. Antes do #172 o `catalog-validation` seria pulado pelo filtro de path e, com o check agora obrigatório no ruleset, a branch ficaria immergeável para sempre. Se o check rodar e passar aqui, a correção está provada no caso exato que a motivou.

## Débito que isto expõe

O Top 10 do README **não tem gerador** — é escrito à mão e envelhece a cada merge de catálogo. Enquanto for manual, vai voltar a divergir. O certo é gerar e travar com um check, como o pin do catálogo.