### PR TITLE
docs(cli): documenta o discover, o único comando que a referência não tinha

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -95,6 +95,29 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
 npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 ```
 
+### `discover` — find plugins beyond the catalog
+
+```text
+dsh-plugins discover [options] <query...>
+```
+
+> **Not in the published `0.1.0`.** `discover` ships in `1.0.0`; every other command on this page
+> works with the version currently on npm. Running it against `@0.1.0` fails with an unknown
+> command.
+
+Searches the curated catalog first, then — unless `--offline` is given — the live GitHub
+`dsh-plugin` topic, so a plugin that has not been submitted yet is still findable. Catalog results
+carry the evidence the catalog holds (pinned commit, creator, license); community results carry
+none of it and are labelled as such, because nothing about them has been reviewed.
+
+`--limit <n>` caps results per tier (default `8`). `--json` emits the stable machine shape, which
+is never localized.
+
+```bash
+npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
+npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+```
+
 ### `info` — show one public catalog entry
 
 ```text


### PR DESCRIPTION
A CLI entrega **dez** comandos e esta página documentava **nove**. Faltava justamente o `discover` — uma das duas features principais da 1.0.0 — e o leitor não tinha como saber que ele existe.

## Honestidade sobre disponibilidade

A seção diz explicitamente que **o `discover` não está na 0.1.0 publicada**, porque não está: rodá-lo contra a versão que está hoje no npm falha com comando desconhecido. Documentar como disponível descreveria um pacote que ninguém consegue instalar. A nota sai quando a 1.0.0 for publicada.

## O que a seção deixa claro

Os dois níveis provam coisas diferentes, e isso precisa estar escrito:

- resultados do **catálogo** carregam o commit fixado, o criador e a licença que o catálogo verificou;
- resultados da **comunidade** não carregam nada disso, e vêm rotulados como tal — nada sobre eles foi revisado.

Confere com a superfície real do comando (`--limit`, `--offline`, `--catalog`, `--revision`, `--json`), lida do `--help` do binário construído, não de memória.