### PR TITLE
cli: the installer lives beside the catalog it reads

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,57 @@
+# Build and test the CLI on every change that can affect it. The catalog itself is validated by
+# validate-catalog.yml; this job answers the other question — does the client that reads the
+# catalog still work.
+name: cli
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: cli-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cli:
+    name: cli
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      # The published binary must answer with the version in its own manifest. Running
+      # --version without reading the output is exactly what let a build whose embedded
+      # version literal had drifted reach a release gate unnoticed.
+      - name: The built binary reports its own version
+        run: |
+          set -eu
+          EXPECTED="$(node -p "require('./package.json').version")"
+          REPORTED="$(node dist/bin.js --version)"
+          if [ "$REPORTED" != "$EXPECTED" ]; then
+            echo "Built binary reports $REPORTED but package.json says $EXPECTED" >&2
+            exit 1
+          fi
+          node dist/bin.js --help > /dev/null

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,115 @@
+# npm release via trusted publishing. Owner-dispatched only; fails closed until the trusted
+# publisher is configured on npmjs.com for this repository and this workflow. No npm token
+# exists anywhere in this repository — authentication is the OIDC exchange itself.
+name: release-npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version being released (must equal cli/package.json)"
+        required: true
+
+permissions:
+  contents: read
+  id-token: write # OIDC for npm trusted publishing AND provenance attestation
+
+concurrency:
+  group: release-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-release
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      # Owner dispatch can target any ref; a release may only ever come from main so a hostile
+      # or stale branch cannot reach the OIDC publish step.
+      - name: Enforce the release ref
+        working-directory: .
+        run: |
+          case "$GITHUB_REF" in
+            refs/heads/main) : ;;
+            *) echo "release-npm may only run from main (got $GITHUB_REF)" >&2; exit 1 ;;
+          esac
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - name: Guard the requested version
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$REQUESTED_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Requested $REQUESTED_VERSION but cli/package.json says $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+          if [ "$PACKAGE_VERSION" = "0.1.0" ]; then
+            echo "0.1.0 is the immutable bootstrap release and must never be republished" >&2
+            exit 1
+          fi
+
+      - run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build the publishable artifact
+        run: npm run build
+
+      # Exact-manifest verification: the tarball must contain precisely these four files —
+      # a prefix allowlist would let anything under dist/ ride along unseen.
+      - name: Verify the artifact set
+        run: |
+          set -eu
+          npm pack --json > /tmp/pack.json
+          node -e "
+            const report = require('/tmp/pack.json')[0];
+            const files = report.files.map((f) => f.path).sort();
+            const expected = ['LICENSE', 'README.md', 'dist/bin.js', 'package.json'];
+            if (JSON.stringify(files) !== JSON.stringify(expected)) {
+              console.error('Tarball must contain exactly', expected, 'but has', files);
+              process.exit(1);
+            }
+            require('node:fs').writeFileSync('/tmp/tarball-name', report.filename);
+          "
+
+      # The artifact that smokes is the artifact that ships: install the packed tarball into a
+      # scratch prefix and prove the published entrypoint actually runs — and that it answers
+      # with the version being released. Running --version without reading it is what once let a
+      # build reach the release gate still calling itself by the previous version; npm versions
+      # are immutable, so this must fail here or never.
+      - name: Smoke the packed tarball
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          TARBALL="$(cat /tmp/tarball-name)"
+          SCRATCH="$(mktemp -d)"
+          npm install --prefix "$SCRATCH" --no-save --ignore-scripts "./$TARBALL"
+          REPORTED="$("$SCRATCH/node_modules/.bin/dsh-plugins" --version)"
+          if [ "$REPORTED" != "$REQUESTED_VERSION" ]; then
+            echo "Packed binary reports $REPORTED but this release is $REQUESTED_VERSION" >&2
+            exit 1
+          fi
+          "$SCRATCH/node_modules/.bin/dsh-plugins" --help > /dev/null
+
+      # Trusted publishing: npm exchanges the workflow's OIDC token for a scoped credential.
+      # --provenance is possible here and was not in the previous home: attestation requires a
+      # public source repository, so moving the CLI beside the catalog is what lets an installer
+      # trace this binary back to the commit and workflow run that built it.
+      - name: Publish
+        run: |
+          set -eu
+          npm publish "./$(cat /tmp/tarball-name)" --access public --provenance

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tgz

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Diego Souza
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,148 @@
+# @diegosouza.pw/dsh-plugins
+
+> **Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.**
+> DeepSeek names and marks belong to their respective owner.
+
+`@diegosouza.pw/dsh-plugins` is a thin catalog client and safety boundary for public DeepSeek
+Harness (DSH) plugin entries. Its canonical invocation is:
+
+```bash
+npx @diegosouza.pw/dsh-plugins --help
+```
+
+The npm artifact is MIT-licensed executable JavaScript built from the sources in
+[`cli/`](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/tree/main/cli) of this
+repository, published with npm provenance attestation — so the binary you install can be traced
+back to the commit and workflow run that produced it. It carries no credentials and no source
+maps, and the curation engine that assembles the catalog is a separate, private system that
+never ships here.
+
+## Requirements
+
+- Node.js 20 or newer.
+- The official `dsh` executable on `PATH` for add, update and remove operations.
+- A public catalog snapshot for discovery. Version `1.0.0` defaults to catalog revision
+  `f01d1d2d22b80222c121db6dfc0fd4035c24b390` (160 entries); `--revision` overrides it and stays
+  the trust anchor, because a fetched snapshot whose declared revision differs is rejected.
+
+## Discover and validate
+
+```bash
+npx @diegosouza.pw/dsh-plugins search vision
+npx @diegosouza.pw/dsh-plugins info example-plugin
+npx @diegosouza.pw/dsh-plugins catalog validate --catalog ./awesome-omni-dsh-plugins
+npx @diegosouza.pw/dsh-plugins catalog validate \
+  --catalog ./awesome-omni-dsh-plugins \
+  --revision <40-character-commit>
+npx @diegosouza.pw/dsh-plugins catalog docs-check ./awesome-omni-dsh-plugins
+npx @diegosouza.pw/dsh-plugins catalog github-forms-check ./awesome-omni-dsh-plugins
+```
+
+An empty catalog is valid and reports `0 entries valid; catalog is empty`. `catalog validate`
+performs local structural and semantic validation: safe YAML, the public schema, SPDX, exact
+SemVer, SHA-512 SRI and duplicate identity checks.
+It does not prove repository identity or pinned-source evidence. Those remain a separate
+maintainer provenance gate. The revision is a declared local pin because the public layout has no
+signed snapshot manifest.
+
+## Safe installation boundary
+
+Preview an operation without downloads, file changes or subprocesses:
+
+```bash
+npx @diegosouza.pw/dsh-plugins add example-plugin --profile web --dry-run
+```
+
+Dry-run is strictly syntactic. It does not load a local or remote catalog and does not read or
+write install state, profiles, cache files, locks or subprocesses. No network request is made.
+
+The official DSH command delegates plugin management to pnpm. Package lifecycle or prepare code
+may execute during that delegated step. The CLI therefore refuses mutation unless you provide
+explicit consent:
+
+```bash
+npx @diegosouza.pw/dsh-plugins add example-plugin \
+  --profile web \
+  --allow-code-execution
+npx @diegosouza.pw/dsh-plugins update example-plugin \
+  --profile web \
+  --allow-code-execution
+npx @diegosouza.pw/dsh-plugins remove example-plugin \
+  --profile web \
+  --allow-code-execution
+```
+
+Native Windows policy for v0.1.0: code-executing `add`, `update`, and `remove` are disabled
+before any profile, state, cache, or subprocess access because complete descendant containment
+cannot be proven. Use WSL for mutations. `--dry-run` and the read-only catalog, `search`, `info`,
+`list`, and `doctor` commands remain available. A native Windows recovery marker is never
+auto-cleared; `doctor` reports that documented manual recovery is required.
+
+Before delegation, the CLI:
+
+- accepts only catalog entries in `eligible` or `verified` state for installation;
+- blocks unavailable, archived, stale and quarantined entries;
+- requires an exact npm version with matching SHA-512 integrity, or an allowlisted GitHub source
+  repository with a full 40-character commit pin;
+- stages content under a canonical private cache using temporary paths and atomic rename;
+- rejects path traversal and symlink escapes;
+- reads package metadata without loading or executing plugin code;
+- snapshots the complete DSH profile and restores it if DSH returns a failure;
+- serializes every profile behind one canonical DSH-home mutation lease and global fencing lock;
+- stores catalog-managed install state atomically with generation and fencing-token CAS;
+- records old and intended install-state fingerprints before spawn, then makes a durable
+  roll-forward decision only after DSH success and an active-profile fingerprint;
+- invokes `dsh plugin --profile <name> ...` with a literal argument array and `shell: false`.
+
+Add and update use a private per-transaction artifact lease and an immutable bounded loopback byte
+channel. A normal or fully reaped POSIX child releases that lease only after close. If the POSIX
+process group cannot be reaped, the CLI retains the profile backup, journal, private artifact and
+global mutation lock; the durable pre-spawn barrier blocks every later mutation. Native Windows
+code-executing mutations are disabled rather than claiming unproven descendant containment.
+Explicit POSIX recovery is available with:
+
+```bash
+npx @diegosouza.pw/dsh-plugins recover
+```
+
+Recovery does not load the catalog. Before durable DSH success it rolls back; after durable DSH
+success it verifies the active profile and rolls the intended state forward. Profile finalization,
+artifact release, and marker removal are separate idempotent phases, and the marker is removed
+last. Native Windows markers remain fail-closed for documented manual recovery. `doctor` reports
+the boundary and never performs recovery itself.
+
+Add and update converge on the catalog pin and are idempotent. Removing an entry that is not
+catalog-managed is also a successful no-op.
+
+## Inspect the local environment
+
+```bash
+npx @diegosouza.pw/dsh-plugins list --profile web
+npx @diegosouza.pw/dsh-plugins doctor
+```
+
+These commands are read-only. Output never intentionally includes tokens, credentials, stack
+traces or absolute DSH-home paths.
+
+## Security scope
+
+A catalog listing is not an endorsement, certification or guarantee. `eligible` means structural
+and integration checks passed. Only `verified` means an installation smoke test passed for the
+pinned artifact. Review the original repository, commit, license and package behavior before
+granting `--allow-code-execution`.
+
+## Pinned catalog snapshots
+
+`--catalog` accepts a local catalog directory, a local
+`omni-dsh-catalog-snapshot-v1` JSON file, or one of two allowlisted HTTPS URLs: the stable
+site-hosted snapshot `https://dsh-plugins.omniroute.online/catalog.snapshot.json` (the
+operational remote source) or the raw GitHub form embedding the revision in its path.
+Remote snapshots require `--revision <40-character-commit-sha>` and the snapshot document must
+declare exactly that SHA. Redirects, alternate hosts, traversal, symlinks, oversized inputs,
+and revision mismatches are rejected before catalog validation.
+
+```bash
+npx @diegosouza.pw/dsh-plugins search tui \
+  --catalog https://dsh-plugins.omniroute.online/catalog.snapshot.json \
+  --revision <published-catalog-revision>
+```

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,2367 @@
+{
+  "name": "@diegosouza.pw/dsh-plugins",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@diegosouza.pw/dsh-plugins",
+      "version": "1.0.0",
+      "license": "MIT",
+      "bin": {
+        "dsh-plugins": "dist/bin.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "@types/semver": "^7.8.0",
+        "@types/spdx-expression-parse": "^4.0.0",
+        "@types/ssri": "^7.1.5",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "commander": "^14.0.0",
+        "esbuild": "^0.25.9",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^5.0.0",
+        "ssri": "^14.0.0",
+        "typescript": "^5.9.2",
+        "vitest": "^3.2.4",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.5.tgz",
+      "integrity": "sha512-jfkGfTwhQpsiSckPF8r9bU3pn3vyd72NlWaO+TgEO6WPSDnUhXzrNYCHBMOYj0ACaUgjm6eERLF+XV9a6RstoA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.5.tgz",
+      "integrity": "sha512-oGVqyQlxnrz9/ty89oHpU857VUHEl5/Xu4R2lS+aivCTrNnSsbiENzTnNaBsjxH0CNWGPhzHArOLFwo+oKXveA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.5.tgz",
+      "integrity": "sha512-bW7B8xMEq8n99Q3ieEcPRGuphurdZAaFzQc9Efyyw3FL6DZO6pMy9xhdN+kBoD7Sy05xNXSr4OyPPnpkYriS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.5.tgz",
+      "integrity": "sha512-YSwBS86QeHOGlrxJ1PSOIZSkzRL/JmKeunhc+lV6M1a6En8QuVCD/T/qIA0J4Gd2Y86RIOBYrLcOUtqGh9+/1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.5.tgz",
+      "integrity": "sha512-2fST8lILgl7cKbme/1KDdPCmbXbG+gqoV3bHp19L0ypX/3akYMBVdOunPleRCwonoLnXOZ/0F+Mt/v8POFmfcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.5.tgz",
+      "integrity": "sha512-cpIxQCP9J+EVad0a6LO1kY3ZGODlk80VlI+2I96B8xMcdHZ4pLVhfQ49JFpYqjPF91FFkQWftf57YlDcTiw9yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.5.tgz",
+      "integrity": "sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.5.tgz",
+      "integrity": "sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.5.tgz",
+      "integrity": "sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.5.tgz",
+      "integrity": "sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.5.tgz",
+      "integrity": "sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.5.tgz",
+      "integrity": "sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.5.tgz",
+      "integrity": "sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.5.tgz",
+      "integrity": "sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.5.tgz",
+      "integrity": "sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.5.tgz",
+      "integrity": "sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.5.tgz",
+      "integrity": "sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.5.tgz",
+      "integrity": "sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.5.tgz",
+      "integrity": "sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.5.tgz",
+      "integrity": "sha512-e7hD+sl3s+mcLQDZ8pbudBVsdG6r5yN4w3LqG2TJ8sQHDpblWj5lrJs/3m01Cvlxbt4x13zu5thLjgypgtkYzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.5.tgz",
+      "integrity": "sha512-GiyJaCf+WpMub/17aPcKk27QMl5W6f+KhdPTjlFOn5akH5Wa/DCM9Stdx5cDfmasyKB08MqpVQ1uJE2RkkpbXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.5.tgz",
+      "integrity": "sha512-+OQ8U2DdoEfXl8T4Fb18AjmEwbXMerKDKCL8yCPAYhKCEEKoul7rkbeGCBFCbAlaGaa7pmtRTpkAJM2LE/i5FA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.5.tgz",
+      "integrity": "sha512-KanvAZrPKbDBFwrgiU9yEVpQoox9QPV1WZOXX7HudJQY+eSlu82CtWxDU8WtuRRvtN5EGkLczkd6Y6DTcvm9wA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.5.tgz",
+      "integrity": "sha512-1aC3UEWTtRl3RK3VpDJ/Tqk1XI4SLTmXIthAq6wRWo8XiSXJNd+VprJM4/1P4+i6HIaFEFlVi9sTTziniD2tOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.5.tgz",
+      "integrity": "sha512-/gDJaRs4gl0NPIwqCz+6PkpmhhjRAD2j6P4rSNHBzUkO3naEx2mIU0pRle1vUNRQ7mE/+8OOeXLTv/J56FKiQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-odQzy87phelGS4inXOzjmusx4hoCVD0IbxUANxHzVkmTzMRTNnUPoq1urIl7S1qf09KcDWKLFIftPmLtgbsAHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ssri": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.5.tgz",
+      "integrity": "sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.5.tgz",
+      "integrity": "sha512-/tqMfgP7GPA3PHhCmuiS4vIjrSVhHLgY++i+dhbG462euyAj7FpM4D9uq1X3BgjlqRdpcOrYhcQtfiQLNc8tqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.5",
+        "@rollup/rollup-android-arm64": "4.62.5",
+        "@rollup/rollup-darwin-arm64": "4.62.5",
+        "@rollup/rollup-darwin-x64": "4.62.5",
+        "@rollup/rollup-freebsd-arm64": "4.62.5",
+        "@rollup/rollup-freebsd-x64": "4.62.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.5",
+        "@rollup/rollup-linux-arm64-musl": "4.62.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.5",
+        "@rollup/rollup-linux-loong64-musl": "4.62.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.5",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.5",
+        "@rollup/rollup-linux-x64-gnu": "4.62.5",
+        "@rollup/rollup-linux-x64-musl": "4.62.5",
+        "@rollup/rollup-openbsd-x64": "4.62.5",
+        "@rollup/rollup-openharmony-arm64": "4.62.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.5",
+        "@rollup/rollup-win32-x64-gnu": "4.62.5",
+        "@rollup/rollup-win32-x64-msvc": "4.62.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
+      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/ssri": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-14.0.0.tgz",
+      "integrity": "sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@diegosouza.pw/dsh-plugins",
+  "version": "1.0.0",
+  "description": "Unofficial catalog and safe installer for DeepSeek Harness plugins",
+  "type": "module",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "bin": {
+    "dsh-plugins": "dist/bin.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "rm -rf dist && esbuild src/bin.ts --bundle --platform=node --target=node20 --format=esm --banner:js='import { createRequire as __dshCreateRequire } from \"node:module\"; const require = __dshCreateRequire(import.meta.url);' --outfile=dist/bin.js && chmod +x dist/bin.js",
+    "test": "vitest run tests",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "@types/semver": "^7.8.0",
+    "@types/spdx-expression-parse": "^4.0.0",
+    "@types/ssri": "^7.1.5",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
+    "commander": "^14.0.0",
+    "esbuild": "^0.25.9",
+    "semver": "^7.8.5",
+    "spdx-expression-parse": "^5.0.0",
+    "ssri": "^14.0.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4",
+    "yaml": "^2.8.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diegosouzapw/awesome-omni-dsh-plugins.git",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/diegosouzapw/awesome-omni-dsh-plugins/tree/main/cli",
+  "bugs": {
+    "url": "https://github.com/diegosouzapw/awesome-omni-dsh-plugins/issues"
+  }
+}

--- a/cli/src/app.ts
+++ b/cli/src/app.ts
@@ -1,0 +1,260 @@
+import { readFileSync } from "node:fs";
+
+import { Command, CommanderError } from "commander";
+
+import { loadDefaultCatalog } from "./catalogSource.js";
+import { sanitizedErrorMessage } from "./errors.js";
+import {
+  docsCheckCommand,
+  githubFormsCheckCommand,
+  validateCatalogCommand,
+} from "./commands/catalog.js";
+import { addCommand } from "./commands/add.js";
+import { doctorCommand, type DoctorRuntimeDependencies } from "./commands/doctor.js";
+import { infoCommand } from "./commands/info.js";
+import { listCommand, type ListCommandDependencies } from "./commands/list.js";
+import { removeCommand } from "./commands/remove.js";
+import { searchCommand } from "./commands/search.js";
+import { createCommunitySearch, discoverCommand } from "./commands/discover.js";
+import { updateCommand } from "./commands/update.js";
+import {
+  recoverPluginMutation,
+  type MutationDependencies,
+} from "./commands/mutate.js";
+import type { CatalogSelection, CatalogSnapshot } from "./model.js";
+
+export interface CliDependencies {
+  loadCatalog(selection?: CatalogSelection): Promise<CatalogSnapshot>;
+  stdout(value: string): void;
+  stderr(value: string): void;
+  readonly mutationDependencies?: Partial<MutationDependencies>;
+  readonly listDependencies?: Partial<ListCommandDependencies>;
+  readonly doctorRuntime?: Partial<DoctorRuntimeDependencies>;
+}
+
+const defaultDependencies: CliDependencies = {
+  loadCatalog: loadDefaultCatalog,
+  stdout: (value) => process.stdout.write(value),
+  stderr: (value) => process.stderr.write(value),
+};
+
+interface CatalogOptions {
+  catalog?: string;
+  revision?: string;
+  json?: boolean;
+}
+
+interface MutationOptions extends CatalogOptions {
+  profile: string;
+  dryRun?: boolean;
+  allowCodeExecution?: boolean;
+}
+
+function selection(options: CatalogOptions): CatalogSelection | undefined {
+  if (options.catalog === undefined && options.revision === undefined) {
+    return undefined;
+  }
+  return {
+    ...(options.catalog === undefined ? {} : { root: options.catalog }),
+    ...(options.revision === undefined ? {} : { revision: options.revision }),
+  };
+}
+
+function addCatalogOptions(command: Command): Command {
+  return command
+    .option(
+      "--catalog <path-or-url>",
+      "local catalog directory, snapshot file, or pinned public snapshot URL",
+    )
+    .option("--revision <sha>", "exact 40-character snapshot revision")
+    .option("--json", "emit stable JSON output");
+}
+
+function addMutationOptions(command: Command): Command {
+  return addCatalogOptions(command)
+    .requiredOption("--profile <name>", "DSH profile to mutate")
+    .option("--dry-run", "show the verified plan without files or subprocesses")
+    .option(
+      "--allow-code-execution",
+      "consent to DSH/pnpm lifecycle code (native Windows disabled; use WSL)",
+    );
+}
+
+// The package manifest is the only place the released version exists. Restating it in source
+// let 1.0.0 ship a binary that still announced itself as 0.1.0, and npm versions are immutable:
+// such a release can never be corrected, only superseded. Both the bundled entrypoint
+// (dist/bin.js) and this module sit exactly one directory below the package root, so the same
+// relative path resolves in the published artifact and under the test runner.
+function publishedVersion(): string {
+  const manifest = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as { version: string };
+  return manifest.version;
+}
+
+export async function runCli(
+  argv: readonly string[],
+  dependencies: CliDependencies = defaultDependencies,
+): Promise<number> {
+  let result = 0;
+  const program = new Command()
+    .name("dsh-plugins")
+    .version(publishedVersion())
+    .description("Unofficial catalog and safe installer for DeepSeek Harness plugins.")
+    .addHelpText(
+      "after",
+      "\nUnofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.\n" +
+        "Native Windows add/update/remove with code execution are disabled; use WSL.\n" +
+        "Dry-run and read-only catalog/search/info/list/doctor commands remain available.\n" +
+        "Native Windows recovery markers require documented manual recovery.\n",
+    )
+    .configureOutput({
+      writeOut: dependencies.stdout,
+      writeErr: dependencies.stderr,
+      outputError: (value, write) => write(value),
+    })
+    .exitOverride();
+
+  const catalog = program.command("catalog").description("validate the public catalog surfaces");
+  addCatalogOptions(catalog.command("validate").description("validate catalog YAML and semantics"))
+    .action(async (options: CatalogOptions) => {
+      result = await validateCatalogCommand(dependencies, selection(options), options.json === true);
+    });
+  catalog.command("docs-check")
+    .description("check required public catalog documentation")
+    .argument("[root]", "public repository root", ".")
+    .action(async (root: string) => {
+      result = await docsCheckCommand(dependencies, root);
+    });
+  catalog.command("github-forms-check")
+    .description("check structured public GitHub issue forms")
+    .argument("[root]", "public repository root", ".")
+    .action(async (root: string) => {
+      result = await githubFormsCheckCommand(dependencies, root);
+    });
+
+  addCatalogOptions(program.command("search").description("search public catalog fields locally")
+    .argument("<query...>", "search terms"))
+    .action(async (query: string[], options: CatalogOptions) => {
+      result = await searchCommand(dependencies, query.join(" "), selection(options), options.json === true);
+    });
+
+  addCatalogOptions(program.command("discover")
+    .description("find plugins: curated catalog first, then a live dsh-plugin topic search")
+    .argument("<query...>", "capability keywords")
+    .option("--limit <n>", "max results per tier", "8")
+    .option("--offline", "skip the live community tier"))
+    .action(async (query: string[], options: CatalogOptions & { limit?: string; offline?: boolean }) => {
+      const limit = Math.max(1, Math.min(Number(options.limit ?? 8) || 8, 20));
+      const selected = selection(options);
+      result = await discoverCommand(dependencies, query.join(" "), {
+        community: createCommunitySearch(),
+        json: options.json === true,
+        limit,
+        offline: options.offline === true,
+        ...(selected === undefined ? {} : { selection: selected }),
+      });
+    });
+
+  addCatalogOptions(program.command("info").description("show one public catalog entry")
+    .argument("<id>", "canonical plugin ID"))
+    .action(async (id: string, options: CatalogOptions) => {
+      result = await infoCommand(dependencies, id, selection(options), options.json === true);
+    });
+
+  for (const operation of ["add", "update"] as const) {
+    addMutationOptions(program.command(operation)
+      .description(`${operation} one catalog plugin through official DSH delegation`)
+      .argument("<id>", "canonical plugin ID"))
+      .action(async (id: string, options: MutationOptions) => {
+        const snapshot = await dependencies.loadCatalog(selection(options));
+        const entry = snapshot.entries.find((candidate) => candidate.id === id);
+        if (entry === undefined) {
+          dependencies.stderr(`Plugin not found: ${id}\n`);
+          result = 1;
+          return;
+        }
+        const command = operation === "add" ? addCommand : updateCommand;
+        result = await command(
+          entry,
+          options.profile,
+          options.dryRun === true,
+          options.allowCodeExecution === true,
+          {
+            stdout: dependencies.stdout,
+            stderr: dependencies.stderr,
+            ...dependencies.mutationDependencies,
+          },
+        );
+      });
+  }
+
+  addMutationOptions(program.command("remove")
+    .description("remove one catalog-managed plugin through official DSH delegation")
+    .argument("<id>", "canonical plugin ID"))
+    .action(async (id: string, options: MutationOptions) => {
+      const snapshot = await dependencies.loadCatalog(selection(options));
+      const entry = snapshot.entries.find((candidate) => candidate.id === id);
+      result = await removeCommand(
+        id,
+        entry,
+        options.profile,
+        options.dryRun === true,
+        options.allowCodeExecution === true,
+        {
+          stdout: dependencies.stdout,
+          stderr: dependencies.stderr,
+          ...dependencies.mutationDependencies,
+        },
+      );
+    });
+
+  program.command("recover")
+    .description("recover a retained POSIX mutation; native Windows recovery remains manual")
+    .action(async () => {
+      result = await recoverPluginMutation({
+        stdout: dependencies.stdout,
+        stderr: dependencies.stderr,
+        ...dependencies.mutationDependencies,
+      });
+    });
+
+  program.command("list")
+    .description("list catalog-managed installs without modifying profiles")
+    .option("--profile <name>", "filter by DSH profile")
+    .option("--json", "emit stable JSON output")
+    .action(async (options: { profile?: string; json?: boolean }) => {
+      result = await listCommand(
+        options.profile,
+        options.json === true,
+        {
+          stdout: dependencies.stdout,
+          stderr: dependencies.stderr,
+          ...dependencies.listDependencies,
+        },
+      );
+    });
+
+  addCatalogOptions(program.command("doctor")
+    .description("run read-only Node, DSH, native Windows policy and catalog diagnostics"))
+    .action(async (options: CatalogOptions) => {
+      result = await doctorCommand(
+        dependencies,
+        selection(options),
+        options.json === true,
+        dependencies.doctorRuntime,
+      );
+    });
+
+  try {
+    await program.parseAsync(["node", "dsh-plugins", ...argv]);
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      return error.exitCode;
+    }
+    dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+    dependencies.stderr("Command failed safely; no changes were made.\n");
+    return 1;
+  }
+  return result;
+}

--- a/cli/src/bin.ts
+++ b/cli/src/bin.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runCli } from "./app.js";
+
+process.exitCode = await runCli(process.argv.slice(2));

--- a/cli/src/catalog/bundleMarker.ts
+++ b/cli/src/catalog/bundleMarker.ts
@@ -1,0 +1,53 @@
+/**
+ * What marks a native DSH bundle on disk.
+ *
+ * Every runtime-validated plugin — and every entry in this catalog — ships its cordis static
+ * patch as `cordis.patch.yml`; `cordis.patch.yaml` is the accepted spelling variant. Anything
+ * that keys off a different name will disagree with the catalog about what a plugin even is,
+ * so these two names are the whole answer.
+ */
+export const DSH_BUNDLE_MARKER_FILENAMES = [
+  "cordis.patch.yml",
+  "cordis.patch.yaml",
+] as const;
+
+/**
+ * Fixture-era patch companion. No real repository ever used it; it is kept
+ * only so existing fixture snapshots remain readable. Never emit it in new
+ * fixtures — model them on the real `cordis.patch.yml` layout instead.
+ */
+export const LEGACY_DSH_PATCH_FILENAME = "dsh.patch";
+
+/**
+ * Every filename accepted as the bundle patch companion, in precedence order:
+ * the real markers first, the legacy fixture companion last.
+ */
+export const DSH_BUNDLE_PATCH_CANDIDATE_FILENAMES = [
+  ...DSH_BUNDLE_MARKER_FILENAMES,
+  LEGACY_DSH_PATCH_FILENAME,
+] as const;
+
+const markerBasenames: ReadonlySet<string> = new Set<string>(DSH_BUNDLE_MARKER_FILENAMES);
+
+function basenameOf(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1).toLowerCase();
+}
+
+/**
+ * Whether a repository-relative path is a native DSH bundle marker
+ * (`cordis.patch.yml` / `cordis.patch.yaml`, case-insensitive, at the root or
+ * in any subdirectory). This is the predicate the live pipeline keys off.
+ */
+export function isDshBundleMarkerPath(path: string): boolean {
+  return markerBasenames.has(basenameOf(path));
+}
+
+/**
+ * Repository-relative candidate paths for the bundle patch companion of a
+ * bundle rooted at `directory` (`""` or `"."` meaning the repository root),
+ * in precedence order.
+ */
+export function dshBundlePatchCandidatePaths(directory: string): readonly string[] {
+  const base = directory === "" || directory === "." ? "" : `${directory}/`;
+  return DSH_BUNDLE_PATCH_CANDIDATE_FILENAMES.map((name) => `${base}${name}`);
+}

--- a/cli/src/catalog/canonical.ts
+++ b/cli/src/catalog/canonical.ts
@@ -1,0 +1,139 @@
+import { types as utilTypes } from "node:util";
+
+/**
+ * Canonical serialization — deterministic, sorted-key JSON.
+ *
+ * Two families with deliberately different semantics live here under distinct names, and they
+ * must never be merged: their output feeds digests that are already recorded elsewhere, so a
+ * change in either would invalidate comparisons against data that already exists.
+ *
+ * 1. `canonicalSerialize` — undefined-THROWS. Rejects `undefined` property values, non-finite
+ *    numbers and unsupported types outright, because silently dropping a key would let two
+ *    different inputs collide on one digest.
+ * 2. `canonicalJsonDroppingUndefined` — undefined-DROPS. Silently omits `undefined`-valued keys,
+ *    mirroring `JSON.stringify`, for digests that were minted with that behavior.
+ */
+
+/**
+ * Undefined-THROWS canonical serializer: deterministic, sorted-key JSON with
+ * hard rejection of `undefined` values, non-finite numbers and unsupported
+ * types. Output is byte-stable and safe to digest.
+ */
+export function canonicalSerialize(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("canonical serialization rejects non-finite numbers");
+    }
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalSerialize(entry)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    const keys = Object.keys(object).sort();
+    return `{${keys.map((key) => {
+      if (object[key] === undefined) {
+        throw new Error("canonical serialization rejects undefined values");
+      }
+      return `${JSON.stringify(key)}:${canonicalSerialize(object[key])}`;
+    }).join(",")}}`;
+  }
+  throw new Error("canonical serialization rejects unsupported values");
+}
+
+function canonicalValueDroppingUndefined(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalValueDroppingUndefined);
+  if (value !== null && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      if (source[key] !== undefined) {
+        result[key] = canonicalValueDroppingUndefined(source[key]);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Undefined-DROPS canonical serializer: sorted-key `JSON.stringify` that
+ * silently omits `undefined`-valued keys. Kept as a SEPARATE family from
+ * `canonicalSerialize` on purpose — see the module doc comment.
+ */
+export function canonicalJsonDroppingUndefined(value: unknown): string {
+  return JSON.stringify(canonicalValueDroppingUndefined(value));
+}
+
+/**
+ * Asserts `value` is a non-Proxy plain object (prototype `Object.prototype`
+ * or `null`) and returns it typed as a record.
+ */
+export function plainRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && utilTypes.isProxy(value)) {
+    throw new Error(`${label} must not be a Proxy`);
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be a plain object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Asserts `value` is a plain object whose own keys are EXACTLY `expected`
+ * (order-insensitive), every property is a data property with a defined
+ * value, and — when `allowedSymbol` is provided — at most that one
+ * non-enumerable, non-writable, non-configurable `true`-valued symbol brand
+ * is present. Any other symbol key is rejected.
+ */
+export function assertExactKeys(
+  value: unknown,
+  expected: readonly string[],
+  label: string,
+  allowedSymbol?: symbol,
+): void {
+  const record = plainRecord(value, label);
+  const ownKeys = Reflect.ownKeys(record);
+  const actual: string[] = [];
+  for (const key of ownKeys) {
+    if (typeof key === "string") {
+      actual.push(key);
+    } else if (key !== allowedSymbol) {
+      throw new Error(`${label} has an invalid runtime shape`);
+    }
+  }
+  actual.sort();
+  const canonicalExpected = [...expected].sort();
+  if (
+    actual.length !== canonicalExpected.length ||
+    actual.some((key, index) => key !== canonicalExpected[index])
+  ) {
+    throw new Error(`${label} has an invalid runtime shape`);
+  }
+  for (const key of ownKeys) {
+    const descriptor = Object.getOwnPropertyDescriptor(record, key);
+    if (descriptor === undefined || !("value" in descriptor)) {
+      throw new Error(`${label} contains an accessor instead of a data property`);
+    }
+    if (typeof key === "symbol") {
+      if (
+        descriptor.value !== true ||
+        descriptor.enumerable ||
+        descriptor.configurable ||
+        descriptor.writable
+      ) {
+        throw new Error(`${label} has an invalid verification brand`);
+      }
+    } else if (descriptor.value === undefined) {
+      throw new Error(`${label}.${key} cannot be undefined`);
+    }
+  }
+}

--- a/cli/src/catalog/index.ts
+++ b/cli/src/catalog/index.ts
@@ -1,0 +1,24 @@
+/**
+ * The slice of catalog contract the CLI needs to read and validate entries.
+ *
+ * These modules were vendored from the private engine when the CLI moved into this repository:
+ * the CLI is a consumer of the public catalog, so the code that defines what a catalog entry IS
+ * belongs beside it. Curation logic — deciding which repository is a
+ * copy of another, ranking duplicates, tracking a sweep's position — stayed private and is
+ * intentionally absent; none of it was ever reachable from the published binary.
+ */
+export { isDshBundleMarkerPath, DSH_BUNDLE_MARKER_FILENAMES } from "./bundleMarker.js";
+export { canonicalPluginKey, canonicalPublicId, publicEntryPath } from "./types.js";
+export type { CanonicalPluginKey } from "./types.js";
+export { loadCatalog } from "./loadCatalog.js";
+export type {
+  CatalogDiagnostic,
+  CatalogDiagnosticCode,
+  CatalogDirectoryInput,
+  CatalogLoadInput,
+  CatalogSnapshot,
+  CatalogSnapshotSource,
+  PinnedCatalogInput,
+} from "./loadCatalog.js";
+export type { PublicCatalogEntry } from "./publicSchema.js";
+export { parseExactSemver, parseSha512Integrity, parseSpdx } from "./publicCatalogValidator.js";

--- a/cli/src/catalog/loadCatalog.ts
+++ b/cli/src/catalog/loadCatalog.ts
@@ -1,0 +1,375 @@
+import type { Dirent } from "node:fs";
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import {
+  createPublicEntryValidator,
+  parseSafeYamlData,
+  PublicSchemaError,
+} from "./publicSchema.js";
+import type {
+  PublicCatalogEntry,
+  PublicEntryValidationCode,
+} from "./publicSchema.js";
+import { canonicalPluginKey } from "./types.js";
+import type { CanonicalPluginKey } from "./types.js";
+
+const SCHEMA_FILE = "schemas/plugin.schema.yaml";
+const ENTRY_DIRECTORY = "catalog/plugins";
+const EXACT_COMMIT = /^[0-9a-f]{40}$/iu;
+
+export interface CatalogDirectoryInput {
+  readonly kind: "directory";
+  readonly root: string;
+}
+
+export interface PinnedCatalogInput {
+  readonly kind: "snapshot";
+  readonly root: string;
+  readonly revision: string;
+}
+
+export type CatalogLoadInput = string | CatalogDirectoryInput | PinnedCatalogInput;
+
+export type CatalogDiagnosticCode =
+  | PublicEntryValidationCode
+  | "duplicate-canonical-key"
+  | "duplicate-id"
+  | "invalid-canonical-key"
+  | "invalid-catalog-root"
+  | "invalid-entry-directory"
+  | "invalid-snapshot-revision"
+  | "invalid-yaml"
+  | "invalid-public-schema"
+  | "unsafe-entry-path"
+  | "unsafe-schema-path"
+  | "unsafe-schema-ref"
+  | "unreadable-entry";
+
+export interface CatalogDiagnostic {
+  readonly file: string;
+  readonly code: CatalogDiagnosticCode;
+  readonly message: string;
+}
+
+export type CatalogSnapshotSource =
+  | { readonly kind: "directory" }
+  | {
+      readonly kind: "snapshot";
+      readonly declaredRevision: string;
+      readonly pinStatus: "declared-local";
+    };
+
+export interface CatalogSnapshot {
+  readonly source: CatalogSnapshotSource;
+  readonly entries: readonly PublicCatalogEntry[];
+  readonly diagnostics: readonly CatalogDiagnostic[];
+}
+
+interface NormalizedInput {
+  readonly root: string;
+  readonly source: CatalogSnapshotSource;
+}
+
+interface CandidateEntry {
+  readonly canonicalKey: CanonicalPluginKey;
+  readonly entry: PublicCatalogEntry;
+  readonly file: string;
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareDiagnostics(left: CatalogDiagnostic, right: CatalogDiagnostic): number {
+  return compareText(
+    `${left.file}\0${left.code}\0${left.message}`,
+    `${right.file}\0${right.code}\0${right.message}`,
+  );
+}
+
+function sortDiagnostics(diagnostics: CatalogDiagnostic[]): readonly CatalogDiagnostic[] {
+  return diagnostics.sort(compareDiagnostics);
+}
+
+function isContained(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === "" ||
+    (!isAbsolute(pathFromRoot) && pathFromRoot !== ".." && !pathFromRoot.startsWith(`..${sep}`))
+  );
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+function safeEntryLabel(fileName: string): string {
+  const safeName = fileName.replaceAll(/[^A-Za-z0-9._-]/gu, "_");
+  return `${ENTRY_DIRECTORY}/${safeName || "invalid-entry"}`;
+}
+
+function normalizeInput(input: CatalogLoadInput): NormalizedInput {
+  if (typeof input === "string") {
+    return { root: input, source: { kind: "directory" } };
+  }
+  if (input.kind === "directory") {
+    return { root: input.root, source: { kind: "directory" } };
+  }
+  return {
+    root: input.root,
+    source: {
+      kind: "snapshot",
+      declaredRevision: input.revision,
+      pinStatus: "declared-local",
+    },
+  };
+}
+
+function snapshotResult(
+  source: CatalogSnapshotSource,
+  entries: readonly PublicCatalogEntry[],
+  diagnostics: CatalogDiagnostic[],
+): CatalogSnapshot {
+  return { source, entries, diagnostics: sortDiagnostics(diagnostics) };
+}
+
+function duplicateDiagnostics(
+  candidates: readonly CandidateEntry[],
+  property: "id" | "canonicalKey",
+  code: "duplicate-id" | "duplicate-canonical-key",
+  message: string,
+): { readonly diagnostics: CatalogDiagnostic[]; readonly rejectedFiles: Set<string> } {
+  const groups = new Map<string, CandidateEntry[]>();
+  for (const candidate of candidates) {
+    const value = property === "id" ? candidate.entry.id : candidate.canonicalKey;
+    const group = groups.get(value) ?? [];
+    group.push(candidate);
+    groups.set(value, group);
+  }
+
+  const diagnostics: CatalogDiagnostic[] = [];
+  const rejectedFiles = new Set<string>();
+  for (const group of groups.values()) {
+    if (group.length < 2) {
+      continue;
+    }
+    for (const candidate of group) {
+      rejectedFiles.add(candidate.file);
+      diagnostics.push({ file: candidate.file, code, message });
+    }
+  }
+  return { diagnostics, rejectedFiles };
+}
+
+async function containedRealPath(root: string, requestedPath: string): Promise<string | null> {
+  const candidate = await realpath(requestedPath);
+  return isContained(root, candidate) ? candidate : null;
+}
+
+export async function loadCatalog(input: CatalogLoadInput): Promise<CatalogSnapshot> {
+  const normalized = normalizeInput(input);
+  const diagnostics: CatalogDiagnostic[] = [];
+
+  if (
+    normalized.source.kind === "snapshot" &&
+    !EXACT_COMMIT.test(normalized.source.declaredRevision)
+  ) {
+    diagnostics.push({
+      file: ".",
+      code: "invalid-snapshot-revision",
+      message: "snapshot revision must be an exact 40-character hexadecimal commit",
+    });
+    return snapshotResult(normalized.source, [], diagnostics);
+  }
+  if (
+    typeof normalized.root !== "string" ||
+    normalized.root.trim() === "" ||
+    normalized.root.includes("\0")
+  ) {
+    diagnostics.push({
+      file: ".",
+      code: "invalid-catalog-root",
+      message: "catalog root must be a readable local directory",
+    });
+    return snapshotResult(normalized.source, [], diagnostics);
+  }
+
+  let root: string;
+  try {
+    root = await realpath(resolve(normalized.root));
+    if (!(await stat(root)).isDirectory()) {
+      throw new Error("not-directory");
+    }
+  } catch {
+    diagnostics.push({
+      file: ".",
+      code: "invalid-catalog-root",
+      message: "catalog root must be a readable local directory",
+    });
+    return snapshotResult(normalized.source, [], diagnostics);
+  }
+
+  let validateEntry: Awaited<ReturnType<typeof createPublicEntryValidator>>;
+  try {
+    validateEntry = await createPublicEntryValidator(root, resolve(root, SCHEMA_FILE));
+  } catch (error) {
+    const code =
+      error instanceof PublicSchemaError
+        ? error.code
+        : ("invalid-public-schema" as const);
+    const message =
+      code === "unsafe-schema-ref"
+        ? "public schema contains an unsafe local reference"
+        : code === "unsafe-schema-path"
+          ? "public schema resolves outside the local catalog root"
+          : "public catalog schema is missing or invalid";
+    diagnostics.push({ file: SCHEMA_FILE, code, message });
+    return snapshotResult(normalized.source, [], diagnostics);
+  }
+
+  const requestedEntryDirectory = resolve(root, ENTRY_DIRECTORY);
+  let entryDirectory: string;
+  try {
+    entryDirectory = await containedRealPath(root, requestedEntryDirectory) ?? "";
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT")) {
+      return snapshotResult(normalized.source, [], diagnostics);
+    }
+    diagnostics.push({
+      file: ENTRY_DIRECTORY,
+      code: "invalid-entry-directory",
+      message: "catalog entry directory is not readable",
+    });
+    return snapshotResult(normalized.source, [], diagnostics);
+  }
+  if (entryDirectory === "") {
+    diagnostics.push({
+      file: ENTRY_DIRECTORY,
+      code: "invalid-entry-directory",
+      message: "catalog entry directory resolves outside the local catalog root",
+    });
+    return snapshotResult(normalized.source, [], diagnostics);
+  }
+  try {
+    if (!(await stat(entryDirectory)).isDirectory()) {
+      throw new Error("not-directory");
+    }
+  } catch {
+    diagnostics.push({
+      file: ENTRY_DIRECTORY,
+      code: "invalid-entry-directory",
+      message: "catalog entry directory is not readable",
+    });
+    return snapshotResult(normalized.source, [], diagnostics);
+  }
+
+  let directoryEntries: Dirent<string>[];
+  try {
+    directoryEntries = await readdir(entryDirectory, { withFileTypes: true });
+  } catch {
+    diagnostics.push({
+      file: ENTRY_DIRECTORY,
+      code: "invalid-entry-directory",
+      message: "catalog entry directory is not readable",
+    });
+    return snapshotResult(normalized.source, [], diagnostics);
+  }
+
+  const candidates: CandidateEntry[] = [];
+  const yamlFiles = directoryEntries
+    .filter((entry) => entry.name.toLowerCase().endsWith(".yaml"))
+    .sort((left, right) => compareText(left.name, right.name));
+
+  for (const directoryEntry of yamlFiles) {
+    const file = safeEntryLabel(directoryEntry.name);
+    const requestedPath = resolve(entryDirectory, directoryEntry.name);
+    let entryPath: string;
+    try {
+      entryPath = await containedRealPath(root, requestedPath) ?? "";
+      if (entryPath === "" || !(await stat(entryPath)).isFile()) {
+        diagnostics.push({
+          file,
+          code: "unsafe-entry-path",
+          message:
+            entryPath === ""
+              ? "catalog entry resolves outside the local catalog root"
+              : "catalog entry path is not a regular file",
+        });
+        continue;
+      }
+    } catch {
+      diagnostics.push({
+        file,
+        code: "unreadable-entry",
+        message: "catalog entry is not readable",
+      });
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = parseSafeYamlData(await readFile(entryPath, "utf8"));
+    } catch {
+      diagnostics.push({
+        file,
+        code: "invalid-yaml",
+        message: "catalog entry is not valid safe YAML",
+      });
+      continue;
+    }
+
+    const validationIssues = validateEntry(parsed);
+    if (validationIssues.length > 0) {
+      for (const issue of validationIssues) {
+        diagnostics.push({ file, code: issue.code, message: issue.message });
+      }
+      continue;
+    }
+
+    const entry = parsed as PublicCatalogEntry;
+    try {
+      candidates.push({
+        canonicalKey: canonicalPluginKey(entry.source.repositoryNodeId, entry.source.subpath),
+        entry,
+        file,
+      });
+    } catch {
+      diagnostics.push({
+        file,
+        code: "invalid-canonical-key",
+        message: "catalog entry does not produce a safe canonical key",
+      });
+    }
+  }
+
+  const duplicateIds = duplicateDiagnostics(
+    candidates,
+    "id",
+    "duplicate-id",
+    "public ID is declared by multiple catalog files",
+  );
+  const duplicateKeys = duplicateDiagnostics(
+    candidates,
+    "canonicalKey",
+    "duplicate-canonical-key",
+    "canonical plugin key is declared by multiple catalog files",
+  );
+  diagnostics.push(...duplicateIds.diagnostics, ...duplicateKeys.diagnostics);
+
+  const rejectedFiles = new Set([
+    ...duplicateIds.rejectedFiles,
+    ...duplicateKeys.rejectedFiles,
+  ]);
+  const entries = candidates
+    .filter((candidate) => !rejectedFiles.has(candidate.file))
+    .map((candidate) => candidate.entry)
+    .sort((left, right) => compareText(left.id, right.id));
+
+  return snapshotResult(normalized.source, entries, diagnostics);
+}

--- a/cli/src/catalog/publicCatalogValidator.ts
+++ b/cli/src/catalog/publicCatalogValidator.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from "node:fs";
+
+import type { ErrorObject } from "ajv";
+import Ajv2020Module from "ajv/dist/2020.js";
+import addFormatsModule from "ajv-formats";
+import semver from "semver";
+import parseSpdxExpression from "spdx-expression-parse";
+import ssri from "ssri";
+import { parse as parseYaml } from "yaml";
+
+export interface RepositoryIdentityResolver {
+  resolveNodeId(repositoryUrl: string): string | null;
+}
+
+export interface CatalogValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+interface PublicEntryShape {
+  source?: { repository?: unknown; repositoryNodeId?: unknown };
+  package?: { ecosystem?: unknown; version?: unknown; integrity?: unknown };
+  license?: { spdx?: unknown };
+  verification?: {
+    status?: unknown;
+    smokeTest?: { check?: { version?: unknown } } | null;
+  };
+}
+
+export function parseSpdx(value: string): ReturnType<typeof parseSpdxExpression> {
+  try {
+    return parseSpdxExpression(value);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`invalid SPDX expression: ${detail}`);
+  }
+}
+
+export function parseExactSemver(value: string): string {
+  const normalized = semver.valid(value, { loose: false });
+  if (normalized === null || normalized !== value) {
+    throw new Error("invalid exact SemVer");
+  }
+  return normalized;
+}
+
+export function parseSha512Integrity(value: string): Uint8Array {
+  let parsed: ssri.Hash;
+  try {
+    parsed = ssri.parse(value, { single: true }) as ssri.Hash;
+  } catch {
+    throw new Error("invalid SHA-512 SRI");
+  }
+  if (parsed.algorithm !== "sha512") {
+    throw new Error("integrity must contain exactly one SHA-512 SRI");
+  }
+  const digest = parsed.digest;
+  if (digest === undefined) {
+    throw new Error("invalid SHA-512 SRI");
+  }
+  const bytes = Buffer.from(digest, "base64");
+  if (bytes.length !== 64 || bytes.toString("base64") !== digest) {
+    throw new Error("invalid SHA-512 digest length or encoding");
+  }
+  return bytes;
+}
+
+export function createPublicCatalogValidator(
+  schemaPath: string,
+  repositoryIdentity: RepositoryIdentityResolver,
+): (entry: unknown) => CatalogValidationResult {
+  const schema = parseYaml(readFileSync(schemaPath, "utf8")) as object;
+  const ajv = new Ajv2020Module.default({ strict: true, allErrors: true, validateFormats: true });
+  addFormatsModule.default(ajv);
+  const validateShape = ajv.compile(schema);
+
+  return (entry: unknown): CatalogValidationResult => {
+    if (!validateShape(entry)) {
+      return {
+        valid: false,
+        errors: (validateShape.errors ?? []).map(
+          (error: ErrorObject) => `${error.instancePath || "/"} ${error.message ?? "is invalid"}`,
+        ),
+      };
+    }
+
+    const value = entry as PublicEntryShape;
+    const errors: string[] = [];
+    try {
+      parseSpdx(String(value.license?.spdx));
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : "invalid SPDX expression");
+    }
+
+    if (value.package?.ecosystem === "npm") {
+      try {
+        parseExactSemver(String(value.package.version));
+      } catch {
+        errors.push("invalid exact SemVer");
+      }
+      if (typeof value.package.integrity === "string") {
+        try {
+          parseSha512Integrity(value.package.integrity);
+        } catch {
+          errors.push("invalid SHA-512 SRI");
+        }
+      }
+    }
+
+    if (value.verification?.status === "verified" && value.verification.smokeTest !== null) {
+      try {
+        parseExactSemver(String(value.verification.smokeTest?.check?.version));
+      } catch {
+        errors.push("invalid smoke-test SemVer");
+      }
+    }
+
+    const repository = String(value.source?.repository);
+    const declaredNodeId = String(value.source?.repositoryNodeId);
+    const resolvedNodeId = repositoryIdentity.resolveNodeId(repository);
+    if (resolvedNodeId === null || resolvedNodeId !== declaredNodeId) {
+      errors.push("repository URL does not resolve to the declared repositoryNodeId");
+    }
+
+    return { valid: errors.length === 0, errors };
+  };
+}

--- a/cli/src/catalog/publicSchema.ts
+++ b/cli/src/catalog/publicSchema.ts
@@ -1,0 +1,353 @@
+import { readFile, realpath } from "node:fs/promises";
+import { dirname, extname, isAbsolute, relative, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { ErrorObject, ValidateFunction } from "ajv";
+import Ajv2020Module from "ajv/dist/2020.js";
+import addFormatsModule from "ajv-formats";
+import { parseDocument } from "yaml";
+
+import { parseExactSemver, parseSha512Integrity, parseSpdx } from "./publicCatalogValidator.js";
+import type {
+  ArtifactKind,
+  CanonicalPluginKey,
+  RepositoryScope,
+  StarsPolicy,
+  VerificationStatus,
+} from "./types.js";
+
+export interface PublicCatalogEntry {
+  readonly schemaVersion: 1;
+  readonly id: string;
+  readonly name: string;
+  readonly description: {
+    readonly en: string;
+    readonly evidencePath: string;
+  };
+  readonly unofficial: true;
+  readonly kind: ArtifactKind;
+  readonly primaryCategory: string;
+  readonly tags: readonly string[];
+  readonly source: {
+    readonly repository: string;
+    readonly repositoryNodeId: string;
+    readonly subpath: string | null;
+    readonly commit: string;
+  };
+  readonly creator: {
+    readonly github: string;
+  };
+  readonly package:
+    | {
+        readonly ecosystem: "npm";
+        readonly name: string;
+        readonly version: string;
+        readonly integrity?: string;
+      }
+    | {
+        readonly ecosystem: "source";
+      };
+  readonly dsh: {
+    readonly profiles: readonly string[];
+    readonly evidencePath: string;
+  };
+  readonly repositoryScope: RepositoryScope;
+  readonly popularity: {
+    readonly starsPolicy: StarsPolicy;
+    readonly stars: number | null;
+  };
+  readonly license: {
+    readonly spdx: string;
+  };
+  readonly verification: {
+    readonly status: VerificationStatus;
+    readonly checkedAt: string;
+    readonly repositoryIdentity: "resolved";
+    readonly smokeTest: null | {
+      readonly installTarget: "canonical-install-descriptor";
+      readonly check: {
+        readonly name: string;
+        readonly version: string;
+      };
+      readonly result: "passed";
+    };
+  };
+  readonly provenance: {
+    readonly discussion: string | null;
+    readonly comment: string | null;
+  };
+}
+
+export type PublicEntryValidationCode =
+  | "schema-validation"
+  | "invalid-spdx"
+  | "invalid-semver"
+  | "invalid-sri";
+
+export interface PublicEntryValidationIssue {
+  readonly code: PublicEntryValidationCode;
+  readonly message: string;
+}
+
+export interface ValidatedPublicCatalogEntry {
+  readonly canonicalKey: CanonicalPluginKey;
+  readonly entry: PublicCatalogEntry;
+}
+
+export type PublicSchemaErrorCode =
+  | "invalid-public-schema"
+  | "unsafe-schema-path"
+  | "unsafe-schema-ref";
+
+export class PublicSchemaError extends Error {
+  readonly code: PublicSchemaErrorCode;
+
+  constructor(code: PublicSchemaErrorCode) {
+    super(code);
+    this.name = "PublicSchemaError";
+    this.code = code;
+  }
+}
+
+type SchemaObject = Record<string, unknown>;
+
+interface LoadedSchemaDocument {
+  readonly schema: SchemaObject;
+  readonly uri: string;
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isContained(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === "" ||
+    (!isAbsolute(pathFromRoot) && pathFromRoot !== ".." && !pathFromRoot.startsWith(`..${sep}`))
+  );
+}
+
+export function parseSafeYamlData(source: string): unknown {
+  const document = parseDocument(source, {
+    prettyErrors: false,
+    schema: "core",
+    uniqueKeys: true,
+  });
+  if (document.errors.length > 0 || document.warnings.length > 0) {
+    throw new Error("invalid-safe-yaml");
+  }
+  return document.toJS({ maxAliasCount: 100 });
+}
+
+function collectSchemaRefs(schema: SchemaObject): string[] {
+  const references: string[] = [];
+  const visited = new WeakSet<object>();
+
+  const visit = (value: unknown): void => {
+    if (typeof value !== "object" || value === null || visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
+      }
+      return;
+    }
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (key === "$id") {
+        throw new PublicSchemaError("invalid-public-schema");
+      }
+      if (key === "$ref" || key === "$dynamicRef") {
+        if (typeof nestedValue !== "string") {
+          throw new PublicSchemaError("invalid-public-schema");
+        }
+        references.push(nestedValue);
+      }
+      visit(nestedValue);
+    }
+  };
+
+  visit(schema);
+  return references.sort(compareText);
+}
+
+function localRefPath(reference: string): string | null {
+  if (reference.startsWith("#")) {
+    return null;
+  }
+  const hashIndex = reference.indexOf("#");
+  const pathPart = hashIndex === -1 ? reference : reference.slice(0, hashIndex);
+  if (
+    pathPart === "" ||
+    pathPart.includes("\0") ||
+    pathPart.includes("\\") ||
+    pathPart.includes("%") ||
+    pathPart.includes("?") ||
+    isAbsolute(pathPart) ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/u.test(pathPart) ||
+    pathPart.split("/").some((segment) => segment === "..")
+  ) {
+    throw new PublicSchemaError("unsafe-schema-ref");
+  }
+  const extension = extname(pathPart).toLowerCase();
+  if (extension !== ".json" && extension !== ".yaml" && extension !== ".yml") {
+    throw new PublicSchemaError("unsafe-schema-ref");
+  }
+  return pathPart;
+}
+
+async function loadSchemaDocument(
+  catalogRoot: string,
+  requestedPath: string,
+  documents: Map<string, LoadedSchemaDocument>,
+): Promise<void> {
+  const uri = pathToFileURL(requestedPath).href;
+  if (documents.has(uri)) {
+    return;
+  }
+
+  let resolvedRealPath: string;
+  try {
+    resolvedRealPath = await realpath(requestedPath);
+  } catch {
+    throw new PublicSchemaError("invalid-public-schema");
+  }
+  if (!isContained(catalogRoot, resolvedRealPath)) {
+    throw new PublicSchemaError("unsafe-schema-ref");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseSafeYamlData(await readFile(resolvedRealPath, "utf8"));
+  } catch (error) {
+    if (error instanceof PublicSchemaError) {
+      throw error;
+    }
+    throw new PublicSchemaError("invalid-public-schema");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new PublicSchemaError("invalid-public-schema");
+  }
+
+  const schemaWithoutId = parsed as SchemaObject;
+  const references = collectSchemaRefs(schemaWithoutId);
+  const schema: SchemaObject = { ...schemaWithoutId, $id: uri };
+  documents.set(uri, { schema, uri });
+
+  for (const reference of references) {
+    const pathPart = localRefPath(reference);
+    if (pathPart === null) {
+      continue;
+    }
+    const referencedPath = resolve(dirname(requestedPath), pathPart);
+    await loadSchemaDocument(catalogRoot, referencedPath, documents);
+  }
+}
+
+function ajvIssue(error: ErrorObject): PublicEntryValidationIssue {
+  const location = error.instancePath === "" ? "/" : error.instancePath;
+  return {
+    code: "schema-validation",
+    message: `${location} ${error.message ?? "is invalid"}`,
+  };
+}
+
+function semanticIssues(entry: PublicCatalogEntry): PublicEntryValidationIssue[] {
+  const issues: PublicEntryValidationIssue[] = [];
+  try {
+    parseSpdx(entry.license.spdx);
+  } catch {
+    issues.push({ code: "invalid-spdx", message: "license.spdx must be a valid SPDX expression" });
+  }
+
+  if (entry.package.ecosystem === "npm") {
+    try {
+      parseExactSemver(entry.package.version);
+    } catch {
+      issues.push({
+        code: "invalid-semver",
+        message: "package.version must be an exact SemVer",
+      });
+    }
+    if (entry.package.integrity !== undefined) {
+      try {
+        parseSha512Integrity(entry.package.integrity);
+      } catch {
+        issues.push({
+          code: "invalid-sri",
+          message: "package.integrity must be a valid SHA-512 SRI",
+        });
+      }
+    }
+  }
+
+  if (entry.verification.smokeTest !== null) {
+    try {
+      parseExactSemver(entry.verification.smokeTest.check.version);
+    } catch {
+      issues.push({
+        code: "invalid-semver",
+        message: "verification.smokeTest.check.version must be an exact SemVer",
+      });
+    }
+  }
+
+  return issues;
+}
+
+export async function createPublicEntryValidator(
+  catalogRoot: string,
+  schemaPath: string,
+): Promise<(entry: unknown) => readonly PublicEntryValidationIssue[]> {
+  let schemaRealPath: string;
+  try {
+    schemaRealPath = await realpath(schemaPath);
+  } catch {
+    throw new PublicSchemaError("invalid-public-schema");
+  }
+  if (!isContained(catalogRoot, schemaRealPath)) {
+    throw new PublicSchemaError("unsafe-schema-path");
+  }
+
+  const documents = new Map<string, LoadedSchemaDocument>();
+  await loadSchemaDocument(catalogRoot, schemaRealPath, documents);
+  const rootUri = pathToFileURL(schemaRealPath).href;
+  const rootDocument = documents.get(rootUri);
+  if (rootDocument === undefined) {
+    throw new PublicSchemaError("invalid-public-schema");
+  }
+
+  let validate: ValidateFunction<PublicCatalogEntry>;
+  try {
+    const ajv = new Ajv2020Module.default({
+      allErrors: true,
+      strict: true,
+      validateFormats: true,
+    });
+    addFormatsModule.default(ajv);
+    for (const document of documents.values()) {
+      if (document.uri !== rootUri) {
+        ajv.addSchema(document.schema, document.uri);
+      }
+    }
+    validate = ajv.compile<PublicCatalogEntry>(rootDocument.schema);
+  } catch {
+    throw new PublicSchemaError("invalid-public-schema");
+  }
+
+  return (entry: unknown): readonly PublicEntryValidationIssue[] => {
+    if (!validate(entry)) {
+      return (validate.errors ?? [])
+        .map(ajvIssue)
+        .sort((left, right) =>
+          compareText(`${left.code}\0${left.message}`, `${right.code}\0${right.message}`),
+        );
+    }
+    return semanticIssues(entry).sort((left, right) =>
+      compareText(`${left.code}\0${left.message}`, `${right.code}\0${right.message}`),
+    );
+  };
+}

--- a/cli/src/catalog/types.ts
+++ b/cli/src/catalog/types.ts
@@ -1,0 +1,216 @@
+export type DiscoveryKind =
+  | "discussion"
+  | "comment"
+  | "reply"
+  | "external-open-pr"
+  | "external-merged-pr"
+  | "external-closed-pr"
+  | "external-issue"
+  | "external-commit"
+  | "github-topic"
+  | "npm-search"
+  | "direct-pr";
+
+export interface DiscoveryOrigin {
+  kind: DiscoveryKind;
+  url: string;
+  nodeId: string;
+  authorLogin: string | null;
+  privateOnly: true;
+}
+
+export type CandidateState =
+  | "discovered"
+  | "normalized"
+  | "needs_review"
+  | "rejected"
+  | "qualified"
+  | "collision_check"
+  | "creator_pr_exists"
+  | "community_pr_exists"
+  | "bot_pr_ready"
+  | "pr_open"
+  | "superseded"
+  | "changes_requested"
+  | "merged"
+  | "closed"
+  | "monitored";
+
+export type CanonicalPluginKey = `${string}:${string}`;
+
+export type ArtifactKind =
+  | "plugin"
+  | "plugin-family"
+  | "skin-theme"
+  | "skill"
+  | "preset-profile"
+  | "client-interface"
+  | "bridge-adapter"
+  | "ecosystem-project";
+
+export type RepositoryScope = "dedicated" | "monorepo";
+export type StarsPolicy = "exact-repository" | "undefined-parent-repository";
+export type VerificationStatus =
+  | "eligible"
+  | "verified"
+  | "stale"
+  | "unavailable"
+  | "archived"
+  | "quarantined";
+
+export interface Candidate {
+  key: CanonicalPluginKey;
+  repositoryNodeId: string;
+  repositoryUrl: string;
+  subpath: string | null;
+  packageName: string | null;
+  state: CandidateState;
+  origins: readonly DiscoveryOrigin[];
+}
+
+export interface QualifiedCandidate extends Candidate {
+  id: string;
+  name: string;
+  kind: ArtifactKind;
+  primaryCategory: string;
+  tags: readonly string[];
+  description: {
+    en: string;
+    evidencePath: string;
+  };
+  commit: string;
+  creator: {
+    github: string;
+    profile: string;
+  };
+  package:
+    | {
+        ecosystem: "npm";
+        name: string;
+        version: string;
+        integrity?: string;
+      }
+    | {
+        ecosystem: "source";
+        name: null;
+      };
+  dsh: {
+    integration: "native-bundle" | "adapter";
+    profiles: readonly string[];
+    installSource: string;
+    evidencePath: string;
+  };
+  repositoryScope: RepositoryScope;
+  license: {
+    spdx: string;
+    status: "detected" | "missing" | "unknown";
+  };
+  verification: {
+    status: VerificationStatus;
+    checkedCommit: string;
+    checkedAt: string;
+    repositoryIdentity: "resolved";
+    smokeTest: null | {
+      installTarget: "canonical-install-descriptor";
+      check: { name: string; version: string };
+      result: "passed";
+    };
+  };
+  popularity: {
+    starsPolicy: StarsPolicy;
+    stars: number | null;
+  };
+  fieldEvidence: Readonly<Record<string, readonly string[]>>;
+}
+
+function normalizePluginSubpath(subpath: string | null): string {
+  if (subpath === null || subpath.trim() === "") {
+    return ".";
+  }
+
+  const slashNormalized = subpath.trim().replaceAll("\\", "/");
+  if (slashNormalized.includes("\0")) {
+    throw new Error("plugin subpath must be a safe relative path");
+  }
+
+  const segments = slashNormalized.split("/").filter((segment) => segment !== "" && segment !== ".");
+  if (segments.some((segment) => segment === "..")) {
+    throw new Error("plugin subpath must be a safe relative path");
+  }
+
+  return segments.join("/") || ".";
+}
+
+export function canonicalPluginKey(
+  repositoryNodeId: string,
+  subpath: string | null,
+): CanonicalPluginKey {
+  const nodeId = repositoryNodeId.trim();
+  if (nodeId === "" || nodeId.includes(":")) {
+    throw new Error("repository node ID must be non-empty and must not contain ':'");
+  }
+
+  return `${nodeId}:${normalizePluginSubpath(subpath)}`;
+}
+
+const PUBLIC_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+export function canonicalPublicId(id: string): string {
+  if (!PUBLIC_ID.test(id)) {
+    throw new Error("canonical public plugin ID must be lowercase kebab-case and path-safe");
+  }
+  return id;
+}
+
+export function publicEntryPath(id: string): `catalog/plugins/${string}.yaml` {
+  return `catalog/plugins/${canonicalPublicId(id)}.yaml`;
+}
+
+export interface PublicNamespaceOccupancy {
+  readonly canonicalKeys: Set<CanonicalPluginKey>;
+  readonly ids: Set<string>;
+  readonly paths: Set<string>;
+  readonly packages: Set<string>;
+}
+
+export interface PublicNamespaceRequest {
+  readonly canonicalKey: CanonicalPluginKey;
+  readonly id: string;
+  readonly packageName: string | null;
+}
+
+export interface PublicNamespaceReservation extends PublicNamespaceRequest {
+  readonly path: `catalog/plugins/${string}.yaml`;
+}
+
+export function reservePublicNamespace(
+  occupied: PublicNamespaceOccupancy,
+  request: PublicNamespaceRequest,
+): PublicNamespaceReservation {
+  const id = canonicalPublicId(request.id);
+  const path = publicEntryPath(id);
+  const packageName = request.packageName?.trim().toLowerCase() ?? null;
+  if (request.packageName !== null && packageName !== request.packageName) {
+    throw new Error("public package name must already be canonical");
+  }
+  if (occupied.canonicalKeys.has(request.canonicalKey)) {
+    throw new Error("public canonical key collision");
+  }
+  if (occupied.ids.has(id)) {
+    throw new Error("public ID collision");
+  }
+  if (occupied.paths.has(path)) {
+    throw new Error("public output path collision");
+  }
+  if (packageName !== null && occupied.packages.has(packageName)) {
+    throw new Error("public package collision");
+  }
+
+  occupied.canonicalKeys.add(request.canonicalKey);
+  occupied.ids.add(id);
+  occupied.paths.add(path);
+  if (packageName !== null) {
+    occupied.packages.add(packageName);
+  }
+  return { ...request, id, packageName, path };
+}

--- a/cli/src/catalogSnapshot.ts
+++ b/cli/src/catalogSnapshot.ts
@@ -1,0 +1,1026 @@
+import { constants } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  opendir,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { TextDecoder } from "node:util";
+
+import {
+  runSupervisedChild,
+  type ChildSpawn,
+  type ProcessGroupSignaler,
+} from "./dsh/childSupervisor.js";
+import { CliSafetyError } from "./errors.js";
+
+export const CATALOG_SNAPSHOT_FORMAT_V1 = "omni-dsh-catalog-snapshot-v1" as const;
+export const PUBLIC_CATALOG_RAW_ORIGIN =
+  "https://raw.githubusercontent.com/diegosouzapw/awesome-omni-dsh-plugins";
+// A snapshot committed to the catalog repository can never declare its own commit, so the
+// raw.githubusercontent form is unreachable in practice (REV-44). The site publishes the
+// generated snapshot at this stable URL instead; the user-supplied --revision stays the trust
+// anchor because parseSnapshot rejects any envelope whose declared revision differs from it.
+export const PUBLIC_SNAPSHOT_SITE_URL =
+  "https://dsh-plugins.omniroute.online/catalog.snapshot.json";
+
+export const CATALOG_SNAPSHOT_LIMITS = Object.freeze({
+  snapshotBytes: 10 * 1024 * 1024,
+  totalFileBytes: 8 * 1024 * 1024,
+  fileBytes: 1024 * 1024,
+  files: 2_048,
+  directoryEntries: 4_096,
+  pathBytes: 512,
+  redirects: 3,
+  gitOutputBytes: 64 * 1024,
+  gitTreeBytes: 2 * 1024 * 1024,
+  pathDepth: 16,
+});
+
+export const CATALOG_DEADLINE_DEFAULTS = Object.freeze({
+  fetchTimeoutMs: 10_000,
+  gitTimeoutMs: 5_000,
+  gitKillGraceMs: 250,
+  gitReapTimeoutMs: 500,
+  maximumTimeoutMs: 5 * 60_000,
+});
+
+const SHA40 = /^[0-9a-f]{40}$/;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+
+export interface CatalogSnapshotV1 {
+  readonly format: typeof CATALOG_SNAPSHOT_FORMAT_V1;
+  readonly revision: string;
+  readonly files: Readonly<Record<string, string>>;
+}
+
+export type CatalogMaterializationSelection =
+  | {
+      readonly kind: "directory";
+      readonly root: string;
+      readonly revision?: string;
+    }
+  | {
+      readonly kind: "snapshot-file";
+      readonly path: string;
+      readonly revision?: string;
+    }
+  | {
+      readonly kind: "snapshot-url";
+      readonly url: string;
+      readonly revision: string;
+    };
+
+export interface MaterializedDirectoryCatalog {
+  readonly kind: "directory";
+  readonly root: string;
+  cleanup(): Promise<void>;
+}
+
+export interface MaterializedSnapshotCatalog {
+  readonly kind: "snapshot";
+  readonly root: string;
+  readonly revision: string;
+  cleanup(): Promise<void>;
+}
+
+export type MaterializedCatalog = MaterializedDirectoryCatalog | MaterializedSnapshotCatalog;
+
+export type CatalogSnapshotFetch = (url: string, init: RequestInit) => Promise<Response>;
+
+export type CatalogGitSpawn = ChildSpawn;
+
+export interface CatalogMaterializationDependencies {
+  readonly fetch?: CatalogSnapshotFetch;
+  readonly fetchTimeoutMs?: number;
+  readonly gitTimeoutMs?: number;
+  readonly gitKillGraceMs?: number;
+  readonly gitReapTimeoutMs?: number;
+  readonly signal?: AbortSignal;
+  readonly gitExecutable?: string;
+  readonly gitArgumentPrefix?: readonly string[];
+  readonly spawnGit?: ChildSpawn;
+  readonly signalProcessGroup?: ProcessGroupSignaler;
+}
+
+interface ParsedSnapshot {
+  readonly revision: string;
+  readonly files: ReadonlyArray<readonly [string, string]>;
+}
+
+interface DirectoryBudget {
+  entries: number;
+  files: number;
+  bytes: number;
+}
+
+interface LocalSnapshotContents {
+  readonly canonicalPath: string;
+  readonly text: string;
+}
+
+interface OperationDeadline {
+  readonly signal: AbortSignal;
+  dispose(): void;
+}
+
+interface GitTreeEntry {
+  readonly mode: string;
+  readonly type: string;
+  readonly oid: string;
+  readonly size: number | null;
+  readonly path: string;
+}
+
+interface LocalGitPin {
+  readonly topLevel: string;
+}
+
+function safety(message: string): CliSafetyError {
+  return new CliSafetyError(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertRevision(revision: string): void {
+  if (!SHA40.test(revision)) {
+    throw safety("catalog revision must be a lowercase SHA40 commit");
+  }
+}
+
+function configuredTimeout(value: number | undefined, fallback: number): number {
+  const timeout = value ?? fallback;
+  if (
+    !Number.isSafeInteger(timeout) ||
+    timeout < 1 ||
+    timeout > CATALOG_DEADLINE_DEFAULTS.maximumTimeoutMs
+  ) {
+    throw safety("catalog operation deadline is invalid");
+  }
+  return timeout;
+}
+
+function createDeadline(timeoutMs: number, parent?: AbortSignal): OperationDeadline {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  const timer = setTimeout(abort, timeoutMs);
+  timer.unref();
+
+  if (parent?.aborted === true) {
+    abort();
+  } else {
+    parent?.addEventListener("abort", abort, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timer);
+      parent?.removeEventListener("abort", abort);
+    },
+  };
+}
+
+function waitForAbortable<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(safety("catalog operation deadline was exceeded"));
+  }
+  return new Promise<T>((resolvePromise, rejectPromise) => {
+    const aborted = () => {
+      rejectPromise(safety("catalog operation deadline was exceeded"));
+    };
+    signal.addEventListener("abort", aborted, { once: true });
+    operation.then(
+      (value) => {
+        signal.removeEventListener("abort", aborted);
+        resolvePromise(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", aborted);
+        rejectPromise(error);
+      },
+    );
+  });
+}
+
+function isContained(root: string, candidate: string): boolean {
+  const child = relative(root, candidate);
+  return child === "" || (!isAbsolute(child) && child !== ".." && !child.startsWith(`..${sep}`));
+}
+
+function assertSafePublicPath(path: string): void {
+  const pathSegments = path.split("/");
+  const isPublicSchema = pathSegments[0] === "schemas" && pathSegments.length >= 2;
+  const isPublicPlugin =
+    pathSegments[0] === "catalog" &&
+    pathSegments[1] === "plugins" &&
+    pathSegments.length >= 3;
+
+  if (
+    path.length === 0 ||
+    Buffer.byteLength(path) > CATALOG_SNAPSHOT_LIMITS.pathBytes ||
+    isAbsolute(path) ||
+    path.includes("\\") ||
+    path.includes("%") ||
+    path.includes("\0") ||
+    /[\x00-\x1f\x7f]/.test(path) ||
+    pathSegments.length > CATALOG_SNAPSHOT_LIMITS.pathDepth ||
+    pathSegments.some(
+      (segment) =>
+        segment.length === 0 ||
+        segment === "." ||
+        segment === ".." ||
+        Buffer.byteLength(segment) > 255,
+    ) ||
+    (!isPublicSchema && !isPublicPlugin)
+  ) {
+    throw safety("catalog snapshot contains an unsafe public file path");
+  }
+}
+
+function decodeUtf8(bytes: Uint8Array): string {
+  try {
+    return UTF8_DECODER.decode(bytes);
+  } catch {
+    throw safety("catalog snapshot is not valid UTF-8");
+  }
+}
+
+function parseSnapshot(text: string, requestedRevision?: string): ParsedSnapshot {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    throw safety("catalog snapshot is not valid JSON");
+  }
+
+  if (!isRecord(value)) {
+    throw safety("catalog snapshot has an invalid v1 envelope");
+  }
+  const keys = Object.keys(value).sort();
+  if (
+    keys.length !== 3 ||
+    keys[0] !== "files" ||
+    keys[1] !== "format" ||
+    keys[2] !== "revision" ||
+    value.format !== CATALOG_SNAPSHOT_FORMAT_V1 ||
+    typeof value.revision !== "string" ||
+    !isRecord(value.files)
+  ) {
+    throw safety("catalog snapshot has an invalid v1 envelope");
+  }
+
+  assertRevision(value.revision);
+  if (requestedRevision !== undefined) {
+    assertRevision(requestedRevision);
+    if (value.revision !== requestedRevision) {
+      throw safety("catalog snapshot revision does not match the requested commit");
+    }
+  }
+
+  const entries = Object.entries(value.files);
+  if (entries.length > CATALOG_SNAPSHOT_LIMITS.files) {
+    throw safety("catalog snapshot exceeds the public file count limit");
+  }
+
+  const caseInsensitivePaths = new Set<string>();
+  const allPaths = new Set(entries.map(([path]) => path));
+  let totalBytes = 0;
+  for (const [path, content] of entries) {
+    assertSafePublicPath(path);
+    if (typeof content !== "string") {
+      throw safety("catalog snapshot public files must contain UTF-8 text");
+    }
+
+    const foldedPath = path.toLowerCase();
+    if (caseInsensitivePaths.has(foldedPath)) {
+      throw safety("catalog snapshot contains colliding public file paths");
+    }
+    caseInsensitivePaths.add(foldedPath);
+
+    const pathSegments = path.split("/");
+    for (let index = 1; index < pathSegments.length; index += 1) {
+      if (allPaths.has(pathSegments.slice(0, index).join("/"))) {
+        throw safety("catalog snapshot contains a conflicting public file layout");
+      }
+    }
+
+    const fileBytes = Buffer.byteLength(content);
+    if (fileBytes > CATALOG_SNAPSHOT_LIMITS.fileBytes) {
+      throw safety("catalog snapshot contains an oversized public file");
+    }
+    totalBytes += fileBytes;
+    if (totalBytes > CATALOG_SNAPSHOT_LIMITS.totalFileBytes) {
+      throw safety("catalog snapshot exceeds the public file byte limit");
+    }
+  }
+
+  return {
+    revision: value.revision,
+    files: entries as ReadonlyArray<readonly [string, string]>,
+  };
+}
+
+async function readLocalSnapshot(path: string): Promise<LocalSnapshotContents> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    const before = await lstat(path);
+    if (
+      before.isSymbolicLink() ||
+      !before.isFile() ||
+      before.size > CATALOG_SNAPSHOT_LIMITS.snapshotBytes
+    ) {
+      throw safety("local catalog snapshot is not a safe bounded file");
+    }
+
+    const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+    handle = await open(path, constants.O_RDONLY | noFollow);
+    const opened = await handle.stat();
+    if (
+      !opened.isFile() ||
+      opened.size > CATALOG_SNAPSHOT_LIMITS.snapshotBytes ||
+      opened.dev !== before.dev ||
+      opened.ino !== before.ino
+    ) {
+      throw safety("local catalog snapshot changed during safe opening");
+    }
+
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let position = 0;
+    while (true) {
+      const remainingProbe = CATALOG_SNAPSHOT_LIMITS.snapshotBytes + 1 - totalBytes;
+      const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, remainingProbe));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) break;
+      totalBytes += bytesRead;
+      position += bytesRead;
+      if (totalBytes > CATALOG_SNAPSHOT_LIMITS.snapshotBytes) {
+        throw safety("local catalog snapshot exceeds the byte limit");
+      }
+      chunks.push(buffer.subarray(0, bytesRead));
+    }
+    const canonicalPath = await realpath(path);
+    return {
+      canonicalPath,
+      text: decodeUtf8(Buffer.concat(chunks, totalBytes)),
+    };
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw safety("local catalog snapshot could not be read safely");
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+function validatePublicSnapshotUrl(rawUrl: string, revision: string): URL {
+  assertRevision(revision);
+  if (rawUrl.includes("\\") || rawUrl.includes("%")) {
+    throw safety("catalog snapshot URL is outside the public allowlist");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw safety("catalog snapshot URL is invalid");
+  }
+
+  const expected = `${PUBLIC_CATALOG_RAW_ORIGIN}/${revision}/catalog.snapshot.json`;
+  if (
+    url.protocol !== "https:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.port !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    (url.href !== expected && url.href !== PUBLIC_SNAPSHOT_SITE_URL)
+  ) {
+    throw safety("catalog snapshot URL is outside the public allowlist");
+  }
+  return url;
+}
+
+async function readResponseBody(response: Response, signal: AbortSignal): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^(0|[1-9][0-9]*)$/.test(declaredLength)) {
+      throw safety("catalog snapshot response has an invalid content length");
+    }
+    const parsedLength = Number(declaredLength);
+    if (
+      !Number.isSafeInteger(parsedLength) ||
+      parsedLength > CATALOG_SNAPSHOT_LIMITS.snapshotBytes
+    ) {
+      throw safety("catalog snapshot response exceeds the byte limit");
+    }
+  }
+
+  if (response.body === null) {
+    throw safety("catalog snapshot response has no body");
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await waitForAbortable(reader.read(), signal);
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > CATALOG_SNAPSHOT_LIMITS.snapshotBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw safety("catalog snapshot response exceeds the byte limit");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    if (error instanceof CliSafetyError) throw error;
+    throw safety("catalog snapshot response could not be read safely");
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Cancellation can settle a pending read after the lock is released.
+    }
+  }
+  return decodeUtf8(Buffer.concat(chunks, totalBytes));
+}
+
+async function downloadSnapshot(
+  rawUrl: string,
+  revision: string,
+  dependencies: CatalogMaterializationDependencies,
+): Promise<string> {
+  const timeoutMs = configuredTimeout(
+    dependencies.fetchTimeoutMs,
+    CATALOG_DEADLINE_DEFAULTS.fetchTimeoutMs,
+  );
+  const deadline = createDeadline(timeoutMs, dependencies.signal);
+  const fetchSnapshot: CatalogSnapshotFetch =
+    dependencies.fetch ?? ((url, init) => globalThis.fetch(url, init));
+  let current = validatePublicSnapshotUrl(rawUrl, revision);
+  try {
+    for (
+      let redirectCount = 0;
+      redirectCount <= CATALOG_SNAPSHOT_LIMITS.redirects;
+      redirectCount += 1
+    ) {
+      let response: Response;
+      try {
+        response = await waitForAbortable(
+          fetchSnapshot(current.href, {
+            redirect: "manual",
+            credentials: "omit",
+            referrerPolicy: "no-referrer",
+            headers: { accept: "application/json" },
+            signal: deadline.signal,
+          }),
+          deadline.signal,
+        );
+      } catch (error) {
+        if (error instanceof CliSafetyError) throw error;
+        throw safety("catalog snapshot download failed safely");
+      }
+
+      if (REDIRECT_STATUSES.has(response.status)) {
+        await response.body?.cancel().catch(() => undefined);
+        const location = response.headers.get("location");
+        if (location === null || redirectCount === CATALOG_SNAPSHOT_LIMITS.redirects) {
+          throw safety("catalog snapshot redirect was rejected");
+        }
+        let redirected: URL;
+        try {
+          redirected = new URL(location, current);
+        } catch {
+          throw safety("catalog snapshot redirect was rejected");
+        }
+        current = validatePublicSnapshotUrl(redirected.href, revision);
+        continue;
+      }
+
+      if (!response.ok) {
+        await response.body?.cancel().catch(() => undefined);
+        throw safety("catalog snapshot download returned an unsuccessful status");
+      }
+      return await readResponseBody(response, deadline.signal);
+    }
+    throw safety("catalog snapshot redirect limit was exceeded");
+  } finally {
+    deadline.dispose();
+  }
+}
+
+function gitEnvironment(): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_OPTIONAL_LOCKS: "0",
+    GIT_PAGER: "cat",
+    GIT_TERMINAL_PROMPT: "0",
+    LC_ALL: "C",
+  };
+  for (const name of ["PATH", "SystemRoot", "SYSTEMROOT", "ComSpec", "PATHEXT", "TMPDIR", "TEMP", "TMP"]) {
+    const value = process.env[name];
+    if (value !== undefined) environment[name] = value;
+  }
+  return environment;
+}
+
+async function runGitBytes(
+  args: readonly string[],
+  cwd: string,
+  dependencies: CatalogMaterializationDependencies,
+  maxOutputBytes = CATALOG_SNAPSHOT_LIMITS.gitOutputBytes,
+): Promise<Buffer> {
+  const timeoutMs = configuredTimeout(
+    dependencies.gitTimeoutMs,
+    CATALOG_DEADLINE_DEFAULTS.gitTimeoutMs,
+  );
+  const killGraceMs = configuredTimeout(
+    dependencies.gitKillGraceMs,
+    CATALOG_DEADLINE_DEFAULTS.gitKillGraceMs,
+  );
+  const reapTimeoutMs = configuredTimeout(
+    dependencies.gitReapTimeoutMs,
+    CATALOG_DEADLINE_DEFAULTS.gitReapTimeoutMs,
+  );
+  const executable = dependencies.gitExecutable ?? "git";
+  if (executable.length === 0 || executable.includes("\0")) {
+    throw safety("local Git executable is invalid");
+  }
+  const result = await runSupervisedChild(
+    {
+      command: executable,
+      args: [
+        ...(dependencies.gitArgumentPrefix ?? []),
+        "-c",
+        "core.fsmonitor=false",
+        ...args,
+      ],
+      cwd,
+      env: gitEnvironment(),
+      timeoutMs,
+      termGraceMs: killGraceMs,
+      reapTimeoutMs,
+      maxOutputBytes,
+      processGroup: true,
+      ...(dependencies.signal === undefined ? {} : { signal: dependencies.signal }),
+    },
+    {
+      ...(dependencies.spawnGit === undefined ? {} : { spawn: dependencies.spawnGit }),
+      ...(dependencies.signalProcessGroup === undefined
+        ? {}
+        : { signalProcessGroup: dependencies.signalProcessGroup }),
+    },
+  );
+  if (!result.reaped) {
+    throw safety("local Git process could not be reaped safely");
+  }
+  if (result.reason !== "exit" || result.exitCode !== 0) {
+    throw safety("local Git proof failed safely");
+  }
+  return result.stdout;
+}
+
+async function runGit(
+  args: readonly string[],
+  cwd: string,
+  dependencies: CatalogMaterializationDependencies,
+  maxOutputBytes = CATALOG_SNAPSHOT_LIMITS.gitOutputBytes,
+): Promise<string> {
+  return decodeUtf8(await runGitBytes(args, cwd, dependencies, maxOutputBytes));
+}
+
+function singleGitLine(output: string): string {
+  const value = output.replace(/\r?\n$/, "");
+  if (value.length === 0 || value.includes("\n") || value.includes("\r") || value.includes("\0")) {
+    throw safety("local Git proof returned an invalid value");
+  }
+  return value;
+}
+
+async function proveLocalGitRevision(
+  input: { readonly kind: "directory" | "snapshot-file"; readonly path: string },
+  revision: string,
+  dependencies: CatalogMaterializationDependencies,
+): Promise<LocalGitPin> {
+  assertRevision(revision);
+  const probeDirectory = input.kind === "directory" ? input.path : dirname(input.path);
+  const topLevelOutput = await runGit(["rev-parse", "--show-toplevel"], probeDirectory, dependencies);
+  let topLevel: string;
+  try {
+    topLevel = await realpath(singleGitLine(topLevelOutput));
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw safety("local Git top-level could not be canonicalized");
+  }
+
+  if (input.kind === "directory") {
+    if (topLevel !== input.path) {
+      throw safety("pinned local catalog must be the Git top-level");
+    }
+  } else {
+    if (!isContained(topLevel, input.path)) {
+      throw safety("pinned local snapshot is outside the Git top-level");
+    }
+    const snapshotRelativePath = relative(topLevel, input.path);
+    if (snapshotRelativePath === ".git" || snapshotRelativePath.startsWith(`.git${sep}`)) {
+      throw safety("pinned local snapshot is inside Git metadata");
+    }
+  }
+
+  await runGit(["cat-file", "-e", `${revision}^{commit}`], topLevel, dependencies);
+  return { topLevel };
+}
+
+function assertSafeGitRelativePath(path: string): void {
+  const segments = path.split("/");
+  if (
+    path.length === 0 ||
+    Buffer.byteLength(path) > CATALOG_SNAPSHOT_LIMITS.pathBytes ||
+    isAbsolute(path) ||
+    path.includes("\\") ||
+    path.includes("%") ||
+    /[\x00-\x1f\x7f]/.test(path) ||
+    segments.length > CATALOG_SNAPSHOT_LIMITS.pathDepth ||
+    segments.some(
+      (segment) =>
+        segment.length === 0 ||
+        segment === "." ||
+        segment === ".." ||
+        Buffer.byteLength(segment) > 255,
+    )
+  ) {
+    throw safety("local Git tree contains an unsafe path");
+  }
+}
+
+function parseGitTree(bytes: Buffer): GitTreeEntry[] {
+  if (bytes.byteLength === 0) return [];
+  const text = decodeUtf8(bytes);
+  if (!text.endsWith("\0")) {
+    throw safety("local Git tree inventory is truncated");
+  }
+
+  return text.slice(0, -1).split("\0").map((record) => {
+    const separator = record.indexOf("\t");
+    if (separator < 1) {
+      throw safety("local Git tree inventory is invalid");
+    }
+    const metadata = record.slice(0, separator);
+    const path = record.slice(separator + 1);
+    const match = /^([0-9]{6}) ([^ ]+) ([0-9a-f]{40}) +([0-9]+|-)$/.exec(metadata);
+    if (match === null) {
+      throw safety("local Git tree inventory is invalid");
+    }
+    const sizeText = match[4];
+    const size = sizeText === "-" || sizeText === undefined ? null : Number(sizeText);
+    if (size !== null && (!Number.isSafeInteger(size) || size < 0)) {
+      throw safety("local Git tree contains an invalid blob size");
+    }
+    return {
+      mode: match[1] ?? "",
+      type: match[2] ?? "",
+      oid: match[3] ?? "",
+      size,
+      path,
+    };
+  });
+}
+
+function assertRegularGitBlob(entry: GitTreeEntry): asserts entry is GitTreeEntry & { size: number } {
+  if (
+    entry.type !== "blob" ||
+    (entry.mode !== "100644" && entry.mode !== "100755") ||
+    entry.size === null
+  ) {
+    throw safety("local Git tree contains a non-regular catalog entry");
+  }
+}
+
+function validatePublicGitTree(entries: readonly GitTreeEntry[]): void {
+  if (entries.length > CATALOG_SNAPSHOT_LIMITS.files) {
+    throw safety("local Git tree exceeds the public file count limit");
+  }
+  const paths = new Set(entries.map((entry) => entry.path));
+  const foldedPaths = new Set<string>();
+  let totalBytes = 0;
+  for (const entry of entries) {
+    assertSafePublicPath(entry.path);
+    assertRegularGitBlob(entry);
+    if (entry.size > CATALOG_SNAPSHOT_LIMITS.fileBytes) {
+      throw safety("local Git tree contains an oversized public file");
+    }
+    totalBytes += entry.size;
+    if (totalBytes > CATALOG_SNAPSHOT_LIMITS.totalFileBytes) {
+      throw safety("local Git tree exceeds the public file byte limit");
+    }
+
+    const foldedPath = entry.path.toLowerCase();
+    if (foldedPaths.has(foldedPath)) {
+      throw safety("local Git tree contains colliding public file paths");
+    }
+    foldedPaths.add(foldedPath);
+
+    const segments = entry.path.split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      if (paths.has(segments.slice(0, index).join("/"))) {
+        throw safety("local Git tree contains a conflicting public file layout");
+      }
+    }
+  }
+}
+
+async function readGitBlob(
+  entry: GitTreeEntry & { readonly size: number },
+  topLevel: string,
+  dependencies: CatalogMaterializationDependencies,
+): Promise<Buffer> {
+  const bytes = await runGitBytes(
+    ["cat-file", "blob", entry.oid],
+    topLevel,
+    dependencies,
+    entry.size + 1,
+  );
+  if (bytes.byteLength !== entry.size) {
+    throw safety("local Git blob size does not match its tree entry");
+  }
+  return bytes;
+}
+
+async function readPinnedDirectory(
+  topLevel: string,
+  revision: string,
+  dependencies: CatalogMaterializationDependencies,
+): Promise<ParsedSnapshot> {
+  const treeBytes = await runGitBytes(
+    [
+      "--literal-pathspecs",
+      "ls-tree",
+      "-rz",
+      "-l",
+      "--full-tree",
+      revision,
+      "--",
+      "schemas",
+      "catalog/plugins",
+    ],
+    topLevel,
+    dependencies,
+    CATALOG_SNAPSHOT_LIMITS.gitTreeBytes,
+  );
+  const entries = parseGitTree(treeBytes);
+  validatePublicGitTree(entries);
+
+  const files: Array<readonly [string, string]> = [];
+  for (const entry of [...entries].sort((left, right) => left.path.localeCompare(right.path))) {
+    assertRegularGitBlob(entry);
+    files.push([entry.path, decodeUtf8(await readGitBlob(entry, topLevel, dependencies))]);
+  }
+  return { revision, files };
+}
+
+async function readPinnedSnapshotFile(
+  topLevel: string,
+  absolutePath: string,
+  revision: string,
+  dependencies: CatalogMaterializationDependencies,
+): Promise<string> {
+  const snapshotPath = relative(topLevel, absolutePath).split(sep).join("/");
+  assertSafeGitRelativePath(snapshotPath);
+  const treeBytes = await runGitBytes(
+    [
+      "--literal-pathspecs",
+      "ls-tree",
+      "-z",
+      "-l",
+      "--full-tree",
+      revision,
+      "--",
+      snapshotPath,
+    ],
+    topLevel,
+    dependencies,
+    CATALOG_SNAPSHOT_LIMITS.gitTreeBytes,
+  );
+  const entries = parseGitTree(treeBytes);
+  if (entries.length !== 1 || entries[0]?.path !== snapshotPath) {
+    throw safety("pinned local snapshot is not tracked by the selected commit");
+  }
+  const entry = entries[0];
+  assertRegularGitBlob(entry);
+  if (entry.size > CATALOG_SNAPSHOT_LIMITS.snapshotBytes) {
+    throw safety("pinned local snapshot exceeds the byte limit");
+  }
+  return decodeUtf8(await readGitBlob(entry, topLevel, dependencies));
+}
+
+function ownedCleanup(root: string): () => Promise<void> {
+  let cleanupPromise: Promise<void> | undefined;
+  return () => {
+    cleanupPromise ??= rm(root, { recursive: true, force: true }).catch(() => {
+      throw safety("temporary catalog cleanup failed safely");
+    });
+    return cleanupPromise;
+  };
+}
+
+async function materializeSnapshot(parsed: ParsedSnapshot): Promise<MaterializedSnapshotCatalog> {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "dsh-catalog-snapshot-"));
+  try {
+    for (const [path, content] of [...parsed.files].sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      const target = resolve(temporaryRoot, path);
+      if (!isContained(temporaryRoot, target)) {
+        throw safety("catalog snapshot public file escaped its temporary root");
+      }
+      await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+      await writeFile(target, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    }
+
+    const canonicalRoot = await realpath(temporaryRoot);
+    if (!isContained(canonicalRoot, canonicalRoot)) {
+      throw safety("temporary catalog root is unsafe");
+    }
+    return {
+      kind: "snapshot",
+      root: canonicalRoot,
+      revision: parsed.revision,
+      cleanup: ownedCleanup(canonicalRoot),
+    };
+  } catch (error) {
+    await rm(temporaryRoot, { recursive: true, force: true }).catch(() => undefined);
+    if (error instanceof CliSafetyError) throw error;
+    throw safety("catalog snapshot could not be materialized safely");
+  }
+}
+
+async function resolvePublicTree(
+  canonicalRoot: string,
+  segments: readonly string[],
+): Promise<string | null> {
+  let current = canonicalRoot;
+  for (const segment of segments) {
+    const candidate = join(current, segment);
+    let info;
+    try {
+      info = await lstat(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw safety("local catalog contains an unsafe public directory");
+    }
+    const canonical = await realpath(candidate);
+    if (!isContained(canonicalRoot, canonical)) {
+      throw safety("local catalog public directory escapes its root");
+    }
+    current = canonical;
+  }
+  return current;
+}
+
+async function inspectPublicTree(
+  canonicalRoot: string,
+  relativeRoot: string,
+  absoluteRoot: string,
+  budget: DirectoryBudget,
+): Promise<void> {
+  const pending: Array<{ absolute: string; relative: string }> = [
+    { absolute: absoluteRoot, relative: relativeRoot },
+  ];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined) break;
+    const directory = await opendir(current.absolute);
+    for await (const entry of directory) {
+      budget.entries += 1;
+      if (budget.entries > CATALOG_SNAPSHOT_LIMITS.directoryEntries) {
+        throw safety("local catalog exceeds the public directory entry limit");
+      }
+
+      const relativePath = `${current.relative}/${entry.name}`;
+      assertSafePublicPath(relativePath);
+      const absolutePath = join(current.absolute, entry.name);
+      const info = await lstat(absolutePath);
+      if (info.isSymbolicLink()) {
+        throw safety("local catalog contains an unsafe public symlink");
+      }
+      const canonicalPath = await realpath(absolutePath);
+      if (!isContained(canonicalRoot, canonicalPath)) {
+        throw safety("local catalog public path escapes its root");
+      }
+
+      if (info.isDirectory()) {
+        pending.push({ absolute: canonicalPath, relative: relativePath });
+        continue;
+      }
+      if (!info.isFile()) {
+        throw safety("local catalog contains an unsafe public file type");
+      }
+
+      budget.files += 1;
+      budget.bytes += info.size;
+      if (budget.files > CATALOG_SNAPSHOT_LIMITS.files) {
+        throw safety("local catalog exceeds the public file count limit");
+      }
+      if (info.size > CATALOG_SNAPSHOT_LIMITS.fileBytes) {
+        throw safety("local catalog contains an oversized public file");
+      }
+      if (budget.bytes > CATALOG_SNAPSHOT_LIMITS.totalFileBytes) {
+        throw safety("local catalog exceeds the public file byte limit");
+      }
+    }
+  }
+}
+
+async function canonicalPinnedDirectory(root: string): Promise<string> {
+  try {
+    const info = await lstat(root);
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw safety("pinned local catalog root is not a safe directory");
+    }
+    return await realpath(root);
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw safety("pinned local catalog root could not be resolved safely");
+  }
+}
+
+async function materializeDirectory(root: string): Promise<MaterializedDirectoryCatalog> {
+  try {
+    const rootInfo = await lstat(root);
+    if (rootInfo.isSymbolicLink() || !rootInfo.isDirectory()) {
+      throw safety("local catalog root is not a safe directory");
+    }
+    const canonicalRoot = await realpath(root);
+    const budget: DirectoryBudget = { entries: 0, files: 0, bytes: 0 };
+    for (const segments of [["schemas"], ["catalog", "plugins"]] as const) {
+      const publicRoot = await resolvePublicTree(canonicalRoot, segments);
+      if (publicRoot !== null) {
+        await inspectPublicTree(canonicalRoot, segments.join("/"), publicRoot, budget);
+      }
+    }
+    return {
+      kind: "directory",
+      root: canonicalRoot,
+      cleanup: async () => undefined,
+    };
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw safety("local catalog directory could not be inspected safely");
+  }
+}
+
+export async function materializeCatalog(
+  selection: CatalogMaterializationSelection,
+  dependencies: CatalogMaterializationDependencies = {},
+): Promise<MaterializedCatalog> {
+  if (selection.kind === "directory") {
+    if (selection.revision === undefined) return materializeDirectory(selection.root);
+    const canonicalRoot = await canonicalPinnedDirectory(selection.root);
+    const pin = await proveLocalGitRevision(
+      { kind: "directory", path: canonicalRoot },
+      selection.revision,
+      dependencies,
+    );
+    return materializeSnapshot(
+      await readPinnedDirectory(pin.topLevel, selection.revision, dependencies),
+    );
+  }
+
+  if (selection.kind === "snapshot-file") {
+    if (selection.revision === undefined) {
+      const local = await readLocalSnapshot(selection.path);
+      return materializeSnapshot(parseSnapshot(local.text));
+    }
+    const absolutePath = resolve(selection.path);
+    const pin = await proveLocalGitRevision(
+      { kind: "snapshot-file", path: absolutePath },
+      selection.revision,
+      dependencies,
+    );
+    const text = await readPinnedSnapshotFile(
+      pin.topLevel,
+      absolutePath,
+      selection.revision,
+      dependencies,
+    );
+    return materializeSnapshot(parseSnapshot(text, selection.revision));
+  }
+
+  const text = await downloadSnapshot(selection.url, selection.revision, dependencies);
+  return materializeSnapshot(parseSnapshot(text, selection.revision));
+}

--- a/cli/src/catalogSource.ts
+++ b/cli/src/catalogSource.ts
@@ -1,0 +1,106 @@
+import { lstat } from "node:fs/promises";
+
+import { canonicalPluginKey, loadCatalog } from "./catalog/index.js";
+
+import {
+  materializeCatalog,
+  type CatalogMaterializationDependencies,
+  type MaterializedCatalog,
+} from "./catalogSnapshot.js";
+import { CliSafetyError } from "./errors.js";
+import type { CatalogSelection, CatalogSnapshot } from "./model.js";
+
+export const DEFAULT_CATALOG_REVISION = "f01d1d2d22b80222c121db6dfc0fd4035c24b390";
+
+const DEFAULT_EMPTY_SNAPSHOT: CatalogSnapshot = {
+  source: {
+    kind: "snapshot",
+    declaredRevision: DEFAULT_CATALOG_REVISION,
+    pinStatus: "declared-local",
+  },
+  entries: [],
+  diagnostics: [],
+};
+
+export async function loadDefaultCatalog(
+  selection?: CatalogSelection,
+  dependencies: CatalogMaterializationDependencies = {},
+): Promise<CatalogSnapshot> {
+  if (selection?.root === undefined) {
+    if (selection?.revision !== undefined && selection.revision !== DEFAULT_CATALOG_REVISION) {
+      throw new CliSafetyError("default catalog revision is invalid");
+    }
+    return DEFAULT_EMPTY_SNAPSHOT;
+  }
+
+  const materialized = await materializeSelection(selection, dependencies);
+  try {
+    const loaded =
+      materialized.kind === "snapshot"
+        ? await loadCatalog({
+            kind: "snapshot",
+            root: materialized.root,
+            revision: materialized.revision,
+          })
+        : await loadCatalog({ kind: "directory", root: materialized.root });
+    return {
+      source: loaded.source,
+      diagnostics: loaded.diagnostics,
+      entries: loaded.entries.map((entry) => ({
+        ...entry,
+        canonicalKey: canonicalPluginKey(entry.source.repositoryNodeId, entry.source.subpath),
+      })),
+    };
+  } finally {
+    await materialized.cleanup();
+  }
+}
+
+async function materializeSelection(
+  selection: CatalogSelection,
+  dependencies: CatalogMaterializationDependencies,
+): Promise<MaterializedCatalog> {
+  const root = selection.root;
+  if (root === undefined) {
+    throw new CliSafetyError("catalog source is unavailable");
+  }
+  if (root.startsWith("https://")) {
+    if (selection.revision === undefined) {
+      throw new CliSafetyError("remote catalog snapshots require an exact revision");
+    }
+    return materializeCatalog(
+      { kind: "snapshot-url", url: root, revision: selection.revision },
+      dependencies,
+    );
+  }
+  if (root.includes("://")) {
+    throw new CliSafetyError("catalog source URL is not allowed");
+  }
+
+  let status;
+  try {
+    status = await lstat(root);
+  } catch {
+    throw new CliSafetyError("catalog source is unavailable");
+  }
+  if (status.isSymbolicLink()) {
+    throw new CliSafetyError("catalog source path is unsafe");
+  }
+  if (status.isDirectory()) {
+    return materializeCatalog(
+      selection.revision === undefined
+        ? { kind: "directory", root }
+        : { kind: "directory", root, revision: selection.revision },
+      dependencies,
+    );
+  }
+  if (status.isFile()) {
+    return materializeCatalog(
+      selection.revision === undefined
+        ? { kind: "snapshot-file", path: root }
+        : { kind: "snapshot-file", path: root, revision: selection.revision },
+      dependencies,
+    );
+  }
+  throw new CliSafetyError("catalog source path is unsafe");
+}

--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -1,0 +1,15 @@
+import type { PublicCatalogEntry } from "../model.js";
+import { executePluginMutation, type MutationDependencies } from "./mutate.js";
+
+export function addCommand(
+  entry: PublicCatalogEntry,
+  profile: string,
+  dryRun: boolean,
+  allowCodeExecution: boolean,
+  dependencies?: Partial<MutationDependencies>,
+): Promise<number> {
+  return executePluginMutation(
+    { operation: "add", entry, profile, dryRun, allowCodeExecution },
+    dependencies,
+  );
+}

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -1,0 +1,349 @@
+import { readFile, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import { parse as parseYaml } from "yaml";
+
+import type { CatalogDiagnostic, CatalogSelection, CatalogSnapshot } from "../model.js";
+
+export interface CommandIo {
+  stdout(value: string): void;
+  stderr(value: string): void;
+}
+
+export interface CatalogCommandContext extends CommandIo {
+  loadCatalog(selection?: CatalogSelection): Promise<CatalogSnapshot>;
+}
+
+function sortedDiagnostics(diagnostics: readonly CatalogDiagnostic[]): CatalogDiagnostic[] {
+  return [...diagnostics].sort((left, right) =>
+    left.file.localeCompare(right.file) ||
+    left.code.localeCompare(right.code) ||
+    left.message.localeCompare(right.message),
+  );
+}
+
+export function writeDiagnostics(io: CommandIo, diagnostics: readonly CatalogDiagnostic[]): void {
+  for (const diagnostic of sortedDiagnostics(diagnostics)) {
+    io.stderr(`${diagnostic.file} [${diagnostic.code}]: ${diagnostic.message}\n`);
+  }
+}
+
+export async function validateCatalogCommand(
+  context: CatalogCommandContext,
+  selection: CatalogSelection | undefined,
+  json: boolean,
+): Promise<number> {
+  const snapshot = await context.loadCatalog(selection);
+  const diagnostics = sortedDiagnostics(snapshot.diagnostics);
+  const valid = diagnostics.length === 0;
+  if (json) {
+    context.stdout(`${JSON.stringify({
+      valid,
+      count: snapshot.entries.length,
+      empty: snapshot.entries.length === 0,
+      diagnostics,
+    })}\n`);
+  } else if (!valid) {
+    writeDiagnostics(context, diagnostics);
+  } else if (snapshot.entries.length === 0) {
+    context.stdout("0 entries valid; catalog is empty\n");
+  } else {
+    context.stdout(`${snapshot.entries.length} entries valid\n`);
+  }
+  return valid ? 0 : 1;
+}
+
+const UNOFFICIAL_NOTICE =
+  "Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.";
+
+async function canonicalRoot(root: string): Promise<string> {
+  return realpath(resolve(root));
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const child = relative(root, candidate);
+  return child === "" || (!child.startsWith(`..${sep}`) && child !== ".." && !isAbsolute(child));
+}
+
+async function readContained(root: string, file: string): Promise<string> {
+  const candidate = await realpath(resolve(root, file));
+  if (!isWithin(root, candidate)) {
+    throw new Error("unsafe-path");
+  }
+  return readFile(candidate, "utf8");
+}
+
+const REQUIRED_DOCS = [
+  "README.md",
+  "CONTRIBUTING.md",
+  "SECURITY.md",
+  "docs/CATEGORIES.md",
+  "docs/CREDIT.md",
+  "docs/RANKING.md",
+  "docs/UNOFFICIAL.md",
+  ".github/PULL_REQUEST_TEMPLATE.md",
+] as const;
+
+const POLICY_MARKERS = new Map<string, readonly string[]>([
+  ["CONTRIBUTING.md", [
+    "<!-- catalog-policy:one-plugin-per-branch-and-pr -->",
+    "<!-- creator-first:direct-pr-supersedes-curation-and-automation -->",
+    "<!-- creator-first:source-bound-git-identity -->",
+    "<!-- catalog-validation:local-structure-and-semantics-only -->",
+    "<!-- maintainer-gate:repository-origin-and-pinned-evidence -->",
+  ]],
+  ["docs/CATEGORIES.md", ["<!-- catalog-policy:aggregators-never-entries -->"]],
+  ["docs/CREDIT.md", [
+    "<!-- creator-first:direct-pr-supersedes-curation-and-automation -->",
+    "<!-- creator-first:source-bound-git-identity -->",
+  ]],
+  [".github/PULL_REQUEST_TEMPLATE.md", [
+    "<!-- catalog-policy:one-plugin-per-branch-and-pr -->",
+    "<!-- creator-first:direct-pr-supersedes-curation-and-automation -->",
+    "<!-- creator-first:source-bound-git-identity -->",
+  ]],
+]);
+
+function hasBalancedMarkdownFences(content: string): boolean {
+  let open: { marker: string; length: number } | null = null;
+  for (const line of content.split(/\r?\n/u)) {
+    const match = /^ {0,3}(`{3,}|~{3,})/u.exec(line);
+    if (match === null) {
+      continue;
+    }
+    const fence = match[1]!;
+    if (open === null) {
+      open = { marker: fence[0]!, length: fence.length };
+    } else if (fence[0] === open.marker && fence.length >= open.length) {
+      open = null;
+    }
+  }
+  return open === null;
+}
+
+function tableValues(content: string, heading: string): string[] | null {
+  const start = content.indexOf(`## ${heading}`);
+  if (start < 0) {
+    return null;
+  }
+  const next = content.indexOf("\n## ", start + heading.length + 3);
+  const section = content.slice(start, next < 0 ? undefined : next);
+  return [...section.matchAll(/^\|\s*`([^`]+)`\s*\|/gmu)].map((match) => match[1]!);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function schemaEnum(document: unknown, property: string): string[] | null {
+  if (!isRecord(document) || !isRecord(document.properties)) {
+    return null;
+  }
+  const definition = document.properties[property];
+  if (!isRecord(definition) || !Array.isArray(definition.enum)) {
+    return null;
+  }
+  return definition.enum.every((value) => typeof value === "string")
+    ? [...definition.enum] as string[]
+    : null;
+}
+
+function sameValues(left: readonly string[], right: readonly string[]): boolean {
+  return [...left].sort().join("\0") === [...right].sort().join("\0");
+}
+
+export async function docsCheckCommand(
+  context: CatalogCommandContext,
+  rootInput: string,
+): Promise<number> {
+  let root: string;
+  try {
+    root = await canonicalRoot(rootInput);
+  } catch {
+    context.stderr("catalog root: directory is unavailable\n");
+    return 1;
+  }
+  const diagnostics: CatalogDiagnostic[] = [];
+  const contents = new Map<string, string>();
+  for (const file of REQUIRED_DOCS) {
+    try {
+      contents.set(file, await readContained(root, file));
+    } catch {
+      diagnostics.push({ file, code: "docs", message: "required document is missing or unsafe" });
+    }
+  }
+  for (const file of ["README.md", "CONTRIBUTING.md", "docs/UNOFFICIAL.md"] as const) {
+    const content = contents.get(file);
+    if (content !== undefined && !content.includes(UNOFFICIAL_NOTICE)) {
+      diagnostics.push({ file, code: "docs", message: "missing unofficial-project notice" });
+    }
+  }
+  for (const [file, markers] of POLICY_MARKERS) {
+    const content = contents.get(file);
+    if (content === undefined) {
+      continue;
+    }
+    for (const marker of markers) {
+      if (!content.includes(marker)) {
+        diagnostics.push({ file, code: "docs", message: `missing policy marker ${marker}` });
+      }
+    }
+  }
+  for (const [file, content] of contents) {
+    if (file.endsWith(".md") && !hasBalancedMarkdownFences(content)) {
+      diagnostics.push({ file, code: "docs", message: "unbalanced Markdown fence" });
+    }
+  }
+  try {
+    const categories = contents.get("docs/CATEGORIES.md");
+    const schema = parseYaml(await readContained(root, "schemas/plugin.schema.yaml"), {
+      maxAliasCount: 0,
+    });
+    const documentedKinds = categories === undefined ? null : tableValues(categories, "Artifact kinds");
+    const documentedCategories = categories === undefined
+      ? null
+      : tableValues(categories, "Primary capability categories");
+    const allowedKinds = schemaEnum(schema, "kind");
+    const allowedCategories = schemaEnum(schema, "primaryCategory");
+    const forbiddenKinds = new Set([
+      "aggregator",
+      "catalog",
+      "list",
+      "marketplace",
+      "marketplace-catalog",
+      "plugin-list",
+    ]);
+    if (
+      documentedKinds === null ||
+      documentedCategories === null ||
+      allowedKinds === null ||
+      allowedCategories === null ||
+      !sameValues(documentedKinds, allowedKinds) ||
+      !sameValues(documentedCategories, allowedCategories) ||
+      [...documentedKinds, ...allowedKinds].some((kind) => forbiddenKinds.has(kind))
+    ) {
+      diagnostics.push({
+        file: "schemas/plugin.schema.yaml",
+        code: "docs",
+        message: "schema/category parity is invalid",
+      });
+    }
+  } catch {
+    diagnostics.push({
+      file: "schemas/plugin.schema.yaml",
+      code: "docs",
+      message: "schema/category parity is invalid",
+    });
+  }
+  const snapshot = await context.loadCatalog({ root: rootInput });
+  diagnostics.push(...snapshot.diagnostics);
+  const readme = contents.get("README.md");
+  if (readme !== undefined && !readme.includes(`**${snapshot.entries.length} plugins merged.**`)) {
+    diagnostics.push({
+      file: "README.md",
+      code: "docs",
+      message: `catalog count must report ${snapshot.entries.length} plugins merged`,
+    });
+  }
+  if (diagnostics.length > 0) {
+    for (const diagnostic of sortedDiagnostics(diagnostics)) {
+      context.stderr(`${diagnostic.file}: ${diagnostic.message}\n`);
+    }
+    return 1;
+  }
+  context.stdout(`Catalog documentation checks passed for ${snapshot.entries.length} entries.\n`);
+  return 0;
+}
+
+interface FormField {
+  type?: unknown;
+  id?: unknown;
+  attributes?: {
+    value?: unknown;
+    options?: unknown;
+  };
+  validations?: { required?: unknown };
+}
+
+interface IssueForm {
+  name?: unknown;
+  description?: unknown;
+  body?: unknown;
+}
+
+const ISSUE_FORMS = ["claim", "correction", "removal"] as const;
+
+const MATERIAL_FORM_FIELD = {
+  claim: null,
+  correction: { id: "correction", type: "textarea" },
+  removal: { id: "action", type: "dropdown" },
+} as const;
+
+function hasRequiredField(
+  fields: readonly FormField[],
+  id: string,
+  type: string,
+): boolean {
+  return fields.some(
+    (field) => field.id === id && field.type === type && field.validations?.required === true,
+  );
+}
+
+function hasRequiredConfirmations(fields: readonly FormField[]): boolean {
+  const confirmations = fields.find(
+    (field) => field.id === "confirmations" && field.type === "checkboxes",
+  );
+  const options = confirmations?.attributes?.options;
+  return Array.isArray(options) && options.length > 0 && options.every(
+    (option) => isRecord(option) && typeof option.label === "string" && option.required === true,
+  );
+}
+
+export async function githubFormsCheckCommand(io: CommandIo, rootInput: string): Promise<number> {
+  let root: string;
+  try {
+    root = await canonicalRoot(rootInput);
+  } catch {
+    io.stderr("catalog root: directory is unavailable\n");
+    return 1;
+  }
+  const diagnostics: CatalogDiagnostic[] = [];
+  for (const name of ISSUE_FORMS) {
+    const file = `.github/ISSUE_TEMPLATE/${name}.yml`;
+    try {
+      const parsed = parseYaml(await readContained(root, file), { maxAliasCount: 0 }) as IssueForm;
+      const body = Array.isArray(parsed.body) ? (parsed.body as FormField[]) : [];
+      const ids = body.flatMap((field) => typeof field.id === "string" ? [field.id] : []);
+      const unique = new Set(ids);
+      const material = MATERIAL_FORM_FIELD[name];
+      const hasUnofficialNotice = body.some((field) => {
+        const value = field.attributes?.value;
+        return field.type === "markdown" &&
+          typeof value === "string" &&
+          value.toLowerCase().includes("unofficial community project") &&
+          value.toLowerCase().includes("not affiliated");
+      });
+      if (
+        typeof parsed.name !== "string" || parsed.name.trim() === "" ||
+        typeof parsed.description !== "string" || parsed.description.trim() === "" ||
+        unique.size !== ids.length ||
+        !hasUnofficialNotice ||
+        !hasRequiredField(body, "plugin_id", "input") ||
+        !hasRequiredField(body, "repository", "input") ||
+        !hasRequiredField(body, "evidence", "textarea") ||
+        (material !== null && !hasRequiredField(body, material.id, material.type)) ||
+        !hasRequiredConfirmations(body)
+      ) {
+        throw new Error("invalid-form");
+      }
+    } catch {
+      diagnostics.push({ file, code: "github-form", message: "invalid structured issue form" });
+    }
+  }
+  if (diagnostics.length > 0) {
+    writeDiagnostics(io, diagnostics);
+    return 1;
+  }
+  io.stdout("3 GitHub issue forms valid.\n");
+  return 0;
+}

--- a/cli/src/commands/discover.ts
+++ b/cli/src/commands/discover.ts
@@ -1,0 +1,196 @@
+/**
+ * `discover` — two-tier plugin finder.
+ *
+ * Tier 1 (curated) answers from OUR reviewed catalog with the same local matching the
+ * `search` command uses. Tier 2 (community) is a live, UNAUTHENTICATED GitHub search over the
+ * public `dsh-plugin` topic, ranked by stars, clearly labeled third-party and bounded by a
+ * short timeout and an in-memory per-query cache. The community tier degrades to a notice —
+ * never to a command failure — and no credential is ever attached.
+ *
+ * Design inspired by awesome-dsh-plugin/dsh-find-plugin (MIT © awesome-dsh-plugin); the
+ * implementation and output contract here are our own.
+ */
+
+import type { CatalogSelection, PublicCatalogEntry } from "../model.js";
+import type { CatalogCommandContext } from "./catalog.js";
+import { writeDiagnostics } from "./catalog.js";
+
+export interface CommunityResult {
+  readonly name: string;
+  readonly fullName: string;
+  readonly url: string;
+  readonly description: string;
+  readonly stars: number;
+  readonly install: string;
+}
+
+export type CommunitySearch = (query: string, limit: number) => Promise<CommunityResult[]>;
+
+const COMMUNITY_TTL_MS = 5 * 60 * 1000;
+const COMMUNITY_TIMEOUT_MS = 4_000;
+const COMMUNITY_MAX_PAGE = 20;
+
+interface CommunitySearchOptions {
+  readonly fetchImplementation?: typeof fetch;
+  readonly clock?: () => number;
+}
+
+interface RawSearchItem {
+  readonly name?: unknown;
+  readonly full_name?: unknown;
+  readonly html_url?: unknown;
+  readonly description?: unknown;
+  readonly stargazers_count?: unknown;
+}
+
+export function createCommunitySearch(options: CommunitySearchOptions = {}): CommunitySearch {
+  const fetchImplementation = options.fetchImplementation ?? fetch;
+  const clock = options.clock ?? Date.now;
+  const cache = new Map<string, { at: number; results: CommunityResult[] }>();
+  return async (query, limit) => {
+    const key = query.normalize("NFKC").toLocaleLowerCase("en-US").trim();
+    const cached = cache.get(key);
+    if (cached !== undefined && clock() - cached.at < COMMUNITY_TTL_MS) {
+      return cached.results.slice(0, limit);
+    }
+    const q = encodeURIComponent(`${query} topic:dsh-plugin`);
+    const perPage = Math.min(Math.max(limit * 2, 1), COMMUNITY_MAX_PAGE);
+    const url = `https://api.github.com/search/repositories?q=${q}&per_page=${perPage}`;
+    const response = await fetchImplementation(url, {
+      // Unauthenticated on purpose: discovery must work for anyone and can never leak a token.
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": "omni-dsh-plugins-discover",
+      },
+      signal: AbortSignal.timeout(COMMUNITY_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub search failed with HTTP ${response.status}`);
+    }
+    const body = (await response.json()) as { items?: readonly RawSearchItem[] };
+    const results = (body.items ?? [])
+      .map((item): CommunityResult | null => {
+        const fullName = typeof item.full_name === "string" ? item.full_name : null;
+        const url_ = typeof item.html_url === "string" ? item.html_url : null;
+        if (fullName === null || url_ === null || !url_.startsWith("https://github.com/")) {
+          return null;
+        }
+        return {
+          name: typeof item.name === "string" ? item.name : fullName,
+          fullName,
+          url: url_,
+          description: typeof item.description === "string" ? item.description : "",
+          stars: Number.isSafeInteger(item.stargazers_count) ? Number(item.stargazers_count) : 0,
+          install: `dsh plugin --profile web add github:${fullName}`,
+        };
+      })
+      .filter((item): item is CommunityResult => item !== null)
+      .sort((left, right) => right.stars - left.stars);
+    cache.set(key, { at: clock(), results });
+    return results.slice(0, limit);
+  };
+}
+
+function tokens(value: string): string[] {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-US")
+    .split(/[^\p{L}\p{N}@._+-]+/u)
+    .filter(Boolean);
+}
+
+function searchable(entry: PublicCatalogEntry): string {
+  const packageName = entry.package.ecosystem === "npm" ? entry.package.name : "source";
+  return [
+    entry.id,
+    entry.name,
+    entry.description.en,
+    entry.creator.github,
+    entry.kind,
+    entry.primaryCategory,
+    ...entry.tags,
+    packageName,
+  ].join(" ").normalize("NFKC").toLocaleLowerCase("en-US");
+}
+
+const THIRD_PARTY_NOTICE =
+  "Community results are third-party code straight from a GitHub topic search — review the " +
+  "source and pin a commit before installing. Curated results come from the reviewed catalog.";
+
+export interface DiscoverOptions {
+  readonly community: CommunitySearch;
+  readonly json: boolean;
+  readonly limit: number;
+  readonly offline?: boolean;
+  readonly selection?: CatalogSelection;
+}
+
+export async function discoverCommand(
+  context: CatalogCommandContext,
+  query: string,
+  options: DiscoverOptions,
+): Promise<number> {
+  const snapshot = await context.loadCatalog(options.selection);
+  if (snapshot.diagnostics.length > 0) {
+    writeDiagnostics(context, snapshot.diagnostics);
+    return 1;
+  }
+  const queryTokens = tokens(query);
+  const curated = snapshot.entries
+    .filter((entry) => queryTokens.every((token) => searchable(entry).includes(token)))
+    .sort((left, right) =>
+      (right.popularity.stars ?? 0) - (left.popularity.stars ?? 0) ||
+      left.id.localeCompare(right.id))
+    .slice(0, options.limit);
+
+  let community: CommunityResult[] = [];
+  let communityNotice: string | null = null;
+  if (options.offline !== true) {
+    try {
+      community = (await options.community(query, options.limit))
+        // Anything already curated shows once, in the curated tier.
+        .filter((item) =>
+          !curated.some((entry) => entry.source.repository.toLowerCase() ===
+            item.url.toLowerCase()))
+        // The limit bounds each tier regardless of what the search implementation returned.
+        .slice(0, options.limit);
+    } catch (error) {
+      communityNotice =
+        `community tier unavailable: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  }
+
+  if (options.json) {
+    context.stdout(`${JSON.stringify({
+      curated,
+      community,
+      notice: THIRD_PARTY_NOTICE,
+      ...(communityNotice === null ? {} : { communityNotice }),
+    })}\n`);
+    return 0;
+  }
+
+  if (curated.length === 0 && community.length === 0) {
+    context.stdout("No plugins found in either tier. Try broader keywords.\n");
+  }
+  for (const entry of curated) {
+    const stars = entry.popularity.stars === null ? "—" : `★${entry.popularity.stars}`;
+    context.stdout(
+      `[curated] ${entry.id} ${stars} — ${entry.description.en}\n` +
+      `  ${entry.source.repository}\n`,
+    );
+  }
+  for (const item of community) {
+    context.stdout(
+      `[community] ${item.fullName} ★${item.stars} — ${item.description}\n` +
+      `  ${item.url}\n  install: ${item.install}\n`,
+    );
+  }
+  if (community.length > 0) {
+    context.stdout(`\n${THIRD_PARTY_NOTICE}\n`);
+  }
+  if (communityNotice !== null) {
+    context.stderr(`${communityNotice}\n`);
+  }
+  return 0;
+}

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -1,0 +1,345 @@
+import { spawn as nodeSpawn } from "node:child_process";
+
+import {
+  DSH_REAP_TIMEOUT_MS,
+  DSH_TERMINATION_GRACE_MS,
+  resolveChildDeadlinePolicy,
+  waitForChildWithDeadline,
+  type ChildProcessDeadlineOptions,
+  isDshProcessTreeAlive,
+} from "../dsh/runDsh.js";
+import { readInstallState, resolveDshHome, type InstallState } from "../dsh/installState.js";
+import {
+  readMutationRecoveryJournal,
+  type MutationRecoveryJournal,
+} from "../dsh/mutationRecoveryJournal.js";
+import type { CatalogSelection, CatalogSnapshot, PublicCatalogEntry } from "../model.js";
+import type { CatalogCommandContext } from "./catalog.js";
+
+export const DOCTOR_STALE_AFTER_DAYS = 30;
+export const DSH_VERSION_TIMEOUT_MS = 5_000;
+
+const MINIMUM_NODE_MAJOR = 20;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1_000;
+const SAFE_SEMVER = /^v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$/u;
+const EMBEDDED_SEMVER = /(?:^|[^0-9A-Za-z])v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)(?=$|[^0-9A-Za-z.-])/u;
+
+export interface DshVersionProbe {
+  readonly status: "present" | "missing" | "timeout" | "aborted" | "failed";
+  readonly version: string | null;
+}
+
+export interface DshVersionProbeDependencies extends ChildProcessDeadlineOptions {
+  readonly spawn?: typeof nodeSpawn;
+}
+
+export interface DoctorDshProbeOptions {
+  readonly signal?: AbortSignal;
+  readonly timeoutMs: number;
+  readonly terminationGraceMs: number;
+  readonly reapTimeoutMs: number;
+}
+
+export interface DoctorRuntimeDependencies {
+  readonly platform: NodeJS.Platform;
+  readonly nodeVersion: string;
+  readonly now: () => Date;
+  readonly probeDsh: (options: DoctorDshProbeOptions) => Promise<DshVersionProbe>;
+  readonly signal: AbortSignal | undefined;
+  readonly dshTimeoutMs: number;
+  readonly terminationGraceMs: number;
+  readonly reapTimeoutMs: number;
+  readonly resolveHome: () => string;
+  readonly readState: (home: string) => Promise<InstallState>;
+  readonly readRecoveryJournal: (home: string) => Promise<MutationRecoveryJournal | null>;
+  readonly isProcessTreeAlive: typeof isDshProcessTreeAlive;
+}
+
+export type DoctorCheckName = "node" | "dsh" | "platform" | "recovery" | "catalog";
+export type DoctorCheckStatus = "ok" | "error";
+
+export interface DoctorCheck {
+  readonly name: DoctorCheckName;
+  readonly status: DoctorCheckStatus;
+  readonly message: string;
+}
+
+const defaultRuntime: DoctorRuntimeDependencies = {
+  platform: process.platform,
+  nodeVersion: process.versions.node,
+  now: () => new Date(),
+  probeDsh: probeDshVersion,
+  signal: undefined,
+  dshTimeoutMs: DSH_VERSION_TIMEOUT_MS,
+  terminationGraceMs: DSH_TERMINATION_GRACE_MS,
+  reapTimeoutMs: DSH_REAP_TIMEOUT_MS,
+  resolveHome: resolveDshHome,
+  readState: readInstallState,
+  readRecoveryJournal: readMutationRecoveryJournal,
+  isProcessTreeAlive: isDshProcessTreeAlive,
+};
+
+function safeExactVersion(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  return SAFE_SEMVER.exec(value)?.[1] ?? null;
+}
+
+function capturedVersion(output: string): string | null {
+  return EMBEDDED_SEMVER.exec(output)?.[1] ?? null;
+}
+
+export async function probeDshVersion(
+  dependencies: DshVersionProbeDependencies = {},
+): Promise<DshVersionProbe> {
+  const policy = resolveChildDeadlinePolicy(dependencies, DSH_VERSION_TIMEOUT_MS);
+  if (policy.signal?.aborted === true) {
+    return { status: "aborted", version: null };
+  }
+  const spawn = dependencies.spawn ?? nodeSpawn;
+  let child: ReturnType<typeof nodeSpawn>;
+  try {
+    child = spawn(
+      "dsh",
+      ["--version"],
+      {
+        detached: policy.platform !== "win32",
+        shell: false,
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+  } catch {
+    return { status: "failed", version: null };
+  }
+
+  let output = "";
+  child.stdout?.on("data", (chunk: Buffer | string) => {
+    if (output.length >= 4_096) return;
+    output += String(chunk).slice(0, 4_096 - output.length);
+  });
+  const outcome = await waitForChildWithDeadline(child, policy);
+  if (outcome.status === "spawn-error") {
+    return {
+      status: outcome.errorCode === "ENOENT" ? "missing" : "failed",
+      version: null,
+    };
+  }
+  if (outcome.status === "terminated") {
+    return {
+      status: outcome.reason === "tree-alive" ? "failed" : outcome.reason,
+      version: null,
+    };
+  }
+  if (outcome.code !== 0) {
+    return { status: "failed", version: null };
+  }
+  return { status: "present", version: capturedVersion(output) };
+}
+
+function nodeCheck(nodeVersion: string): DoctorCheck {
+  const version = safeExactVersion(nodeVersion);
+  if (version === null) {
+    return { name: "node", status: "error", message: "Node version could not be determined" };
+  }
+  const major = Number.parseInt(version.split(".")[0] ?? "", 10);
+  if (major < MINIMUM_NODE_MAJOR) {
+    return { name: "node", status: "error", message: "Node 20 or newer is required" };
+  }
+  return { name: "node", status: "ok", message: `Node ${version} is supported` };
+}
+
+async function dshCheck(probe: () => Promise<DshVersionProbe>): Promise<DoctorCheck> {
+  try {
+    const result = await probe();
+    if (result.status === "missing") {
+      return { name: "dsh", status: "error", message: "dsh executable was not found" };
+    }
+    if (result.status === "timeout") {
+      return { name: "dsh", status: "error", message: "dsh version probe timed out safely" };
+    }
+    if (result.status === "aborted") {
+      return { name: "dsh", status: "error", message: "dsh version probe was cancelled safely" };
+    }
+    if (result.status === "failed") {
+      return { name: "dsh", status: "error", message: "dsh version probe failed safely" };
+    }
+    const version = safeExactVersion(result.version);
+    return version === null
+      ? { name: "dsh", status: "ok", message: "dsh is available (version unavailable)" }
+      : { name: "dsh", status: "ok", message: `dsh ${version} is available` };
+  } catch {
+    return { name: "dsh", status: "error", message: "dsh version probe failed safely" };
+  }
+}
+
+function isStale(entry: PublicCatalogEntry, now: Date): boolean {
+  const checkedAt = Date.parse(entry.verification.checkedAt);
+  if (!Number.isFinite(checkedAt)) {
+    return true;
+  }
+  const age = now.getTime() - checkedAt;
+  return entry.verification.status === "stale" ||
+    age > DOCTOR_STALE_AFTER_DAYS * MILLISECONDS_PER_DAY;
+}
+
+function catalogCheck(snapshot: CatalogSnapshot, now: Date): DoctorCheck {
+  if (snapshot.diagnostics.length > 0) {
+    const count = snapshot.diagnostics.length;
+    return {
+      name: "catalog",
+      status: "error",
+      message: `catalog validation failed with ${count} diagnostic${count === 1 ? "" : "s"}`,
+    };
+  }
+  if (snapshot.entries.length === 0) {
+    return { name: "catalog", status: "ok", message: "catalog is valid and empty" };
+  }
+
+  const staleCount = snapshot.entries.filter((entry) => isStale(entry, now)).length;
+  if (staleCount > 0) {
+    return {
+      name: "catalog",
+      status: "error",
+      message:
+        `catalog has ${staleCount} stale ${staleCount === 1 ? "entry" : "entries"}; ` +
+        `freshness threshold is ${DOCTOR_STALE_AFTER_DAYS} days`,
+    };
+  }
+  return {
+    name: "catalog",
+    status: "ok",
+    message: `catalog is valid and fresh with ${snapshot.entries.length} ` +
+      `${snapshot.entries.length === 1 ? "entry" : "entries"}`,
+  };
+}
+
+async function loadCatalogCheck(
+  context: CatalogCommandContext,
+  selection: CatalogSelection | undefined,
+  now: () => Date,
+): Promise<DoctorCheck> {
+  try {
+    return catalogCheck(await context.loadCatalog(selection), now());
+  } catch {
+    return { name: "catalog", status: "error", message: "catalog could not be loaded safely" };
+  }
+}
+
+async function recoveryCheck(runtime: DoctorRuntimeDependencies): Promise<DoctorCheck | null> {
+  let primary: MutationRecoveryJournal | null;
+  try {
+    primary = await runtime.readRecoveryJournal(runtime.resolveHome());
+  } catch {
+    return {
+      name: "recovery",
+      status: "error",
+      message: "primary recovery journal could not be inspected safely",
+    };
+  }
+  if (primary !== null) {
+    if (primary.phase === "completed" && primary.status === "completed") {
+      return {
+        name: "recovery",
+        status: "error",
+        message: "recovery completed; final journal cleanup is pending",
+      };
+    }
+    if (primary.processTree === undefined) {
+      return {
+        name: "recovery",
+        status: "error",
+        message: "recovery is pending; process identity is incomplete and manual recovery is required",
+      };
+    }
+    if (runtime.platform === "win32" || primary.processTree.platform === "win32") {
+      return {
+        name: "recovery",
+        status: "error",
+        message:
+          "native Windows recovery remains fail-closed; use WSL or documented manual recovery",
+      };
+    }
+    try {
+      const alive = await runtime.isProcessTreeAlive(primary.processTree);
+      return {
+        name: "recovery",
+        status: "error",
+        message: alive
+          ? "recovery is pending; DSH process tree is still alive"
+          : "recovery is pending; DSH process tree is dead and explicit recovery is required",
+      };
+    } catch {
+      return {
+        name: "recovery",
+        status: "error",
+        message: "primary recovery journal could not be inspected safely",
+      };
+    }
+  }
+  try {
+    const marker = (await runtime.readState(runtime.resolveHome())).recoveryRequired;
+    if (marker === undefined) return null;
+    if (runtime.platform === "win32" || marker.processTree.platform === "win32") {
+      return {
+        name: "recovery",
+        status: "error",
+        message:
+          "native Windows recovery remains fail-closed; use WSL or documented manual recovery",
+      };
+    }
+    const alive = await runtime.isProcessTreeAlive(marker.processTree);
+    return {
+      name: "recovery",
+      status: "error",
+      message: alive
+        ? "recovery is pending; DSH process tree is still alive"
+        : "recovery is pending; DSH process tree is dead and explicit recovery is required",
+    };
+  } catch {
+    return {
+      name: "recovery",
+      status: "error",
+      message: "recovery state could not be inspected safely",
+    };
+  }
+}
+
+export async function doctorCommand(
+  context: CatalogCommandContext,
+  selection: CatalogSelection | undefined,
+  json: boolean,
+  overrides: Partial<DoctorRuntimeDependencies> = {},
+): Promise<number> {
+  const runtime: DoctorRuntimeDependencies = { ...defaultRuntime, ...overrides };
+  const probeOptions: DoctorDshProbeOptions = {
+    ...(runtime.signal === undefined ? {} : { signal: runtime.signal }),
+    timeoutMs: runtime.dshTimeoutMs,
+    terminationGraceMs: runtime.terminationGraceMs,
+    reapTimeoutMs: runtime.reapTimeoutMs,
+  };
+  const recovery = await recoveryCheck(runtime);
+  const checks: readonly DoctorCheck[] = [
+    nodeCheck(runtime.nodeVersion),
+    await dshCheck(() => runtime.probeDsh(probeOptions)),
+    ...(runtime.platform === "win32"
+      ? [{
+          name: "platform" as const,
+          status: "error" as const,
+          message: "native Windows plugin mutations are disabled; use WSL",
+        }]
+      : []),
+    ...(recovery === null ? [] : [recovery]),
+    await loadCatalogCheck(context, selection, runtime.now),
+  ];
+  const ok = checks.every((check) => check.status === "ok");
+
+  if (json) {
+    context.stdout(`${JSON.stringify({ ok, checks })}\n`);
+  } else {
+    for (const check of checks) {
+      context.stdout(`${check.name} [${check.status}]: ${check.message}\n`);
+    }
+  }
+  return ok ? 0 : 1;
+}

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -1,0 +1,66 @@
+import type { CatalogSelection, PublicCatalogEntry } from "../model.js";
+import type { CatalogCommandContext } from "./catalog.js";
+import { writeDiagnostics } from "./catalog.js";
+
+function packageDisplay(entry: PublicCatalogEntry): string {
+  if (entry.package.ecosystem === "npm") {
+    return `${entry.package.name}@${entry.package.version}`;
+  }
+  const subpath = entry.source.subpath === null ? "" : `#${entry.source.subpath}`;
+  return `${entry.source.repository}@${entry.source.commit}${subpath}`;
+}
+
+function verificationDisplay(entry: PublicCatalogEntry): string {
+  if (entry.verification.status === "verified") {
+    return "verified (installation-tested)";
+  }
+  if (entry.verification.status === "eligible") {
+    return "eligible (not installation-tested)";
+  }
+  return entry.verification.status;
+}
+
+function starsDisplay(entry: PublicCatalogEntry): string {
+  if (entry.popularity.starsPolicy === "undefined-parent-repository") {
+    return "undefined (parent repository)";
+  }
+  return String(entry.popularity.stars);
+}
+
+export async function infoCommand(
+  context: CatalogCommandContext,
+  id: string,
+  selection: CatalogSelection | undefined,
+  json: boolean,
+): Promise<number> {
+  const snapshot = await context.loadCatalog(selection);
+  if (snapshot.diagnostics.length > 0) {
+    writeDiagnostics(context, snapshot.diagnostics);
+    return 1;
+  }
+  const entry = snapshot.entries.find((candidate) => candidate.id === id);
+  if (entry === undefined) {
+    context.stderr(`Plugin not found: ${id}\n`);
+    return 1;
+  }
+  if (json) {
+    context.stdout(`${JSON.stringify(entry)}\n`);
+    return 0;
+  }
+  context.stdout(
+    [
+      `Name: ${entry.name}`,
+      `ID: ${entry.id}`,
+      `Creator: @${entry.creator.github}`,
+      `Category: ${entry.primaryCategory}`,
+      `Package: ${packageDisplay(entry)}`,
+      `License: ${entry.license.spdx}`,
+      `Verification: ${verificationDisplay(entry)}`,
+      `Stars: ${starsDisplay(entry)}`,
+      `Repository: ${entry.source.repository}`,
+      `Commit: ${entry.source.commit}`,
+      "",
+    ].join("\n"),
+  );
+  return 0;
+}

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -1,0 +1,101 @@
+import type { CommandIo } from "./catalog.js";
+import {
+  readInstallState,
+  resolveDshHome,
+  type InstalledPlugin,
+  type InstallState,
+} from "../dsh/installState.js";
+import { assertSafeProfileName } from "../dsh/paths.js";
+
+export interface ListCommandDependencies extends CommandIo {
+  readonly resolveHome: () => string;
+  readonly readState: (home: string) => Promise<InstallState>;
+}
+
+export interface ListedCatalogInstall {
+  readonly profile: string;
+  readonly id: string;
+  readonly packageName: string;
+  readonly fingerprint: string;
+  readonly installedAt: string;
+  readonly status: "catalog-managed";
+}
+
+const defaultDependencies: ListCommandDependencies = {
+  resolveHome: resolveDshHome,
+  readState: readInstallState,
+  stdout: (value) => process.stdout.write(value),
+  stderr: (value) => process.stderr.write(value),
+};
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareInstalls(left: InstalledPlugin, right: InstalledPlugin): number {
+  return compareText(left.profile, right.profile) || compareText(left.id, right.id);
+}
+
+function listedInstall(install: InstalledPlugin): ListedCatalogInstall {
+  return {
+    profile: install.profile,
+    id: install.id,
+    packageName: install.packageName,
+    fingerprint: install.fingerprint,
+    installedAt: install.installedAt,
+    status: "catalog-managed",
+  };
+}
+
+export async function listCommand(
+  profile: string | undefined,
+  json: boolean,
+  overrides: Partial<ListCommandDependencies> = {},
+): Promise<number> {
+  const dependencies: ListCommandDependencies = { ...defaultDependencies, ...overrides };
+  if (profile !== undefined) {
+    try {
+      assertSafeProfileName(profile);
+    } catch {
+      dependencies.stderr("Profile name is unsafe.\n");
+      return 1;
+    }
+  }
+
+  let state: InstallState;
+  try {
+    state = await dependencies.readState(dependencies.resolveHome());
+  } catch {
+    dependencies.stderr("Catalog-managed install state could not be read safely.\n");
+    return 1;
+  }
+
+  const installs = [...state.installs]
+    .filter((install) => profile === undefined || install.profile === profile)
+    .sort(compareInstalls);
+  if (json) {
+    dependencies.stdout(`${JSON.stringify({
+      profile: profile ?? null,
+      count: installs.length,
+      empty: installs.length === 0,
+      installs: installs.map(listedInstall),
+    })}\n`);
+    return 0;
+  }
+
+  if (installs.length === 0) {
+    dependencies.stdout(
+      profile === undefined
+        ? "No catalog-managed plugins installed.\n"
+        : `No catalog-managed plugins installed for profile "${profile}".\n`,
+    );
+    return 0;
+  }
+
+  for (const install of installs) {
+    dependencies.stdout(
+      `${install.profile}\t${install.id}\t${install.packageName}\tcatalog-managed\n`,
+    );
+  }
+  return 0;
+}

--- a/cli/src/commands/mutate.ts
+++ b/cli/src/commands/mutate.ts
@@ -1,0 +1,1108 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { lstat, realpath, rm } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import type { PublicCatalogEntry } from "../model.js";
+import { sanitizedErrorMessage, CliSafetyError } from "../errors.js";
+import {
+  openArtifactDeliveryChannel,
+  type ArtifactDeliveryChannel,
+} from "../dsh/artifactChannel.js";
+import {
+  EMPTY_INSTALL_STATE,
+  readInstallState,
+  resolveDshHome,
+  writeInstallState,
+  type InstallState,
+  type InstallStateWriteOptions,
+  type ArtifactRecoveryReference,
+  type RecoveryProcessTreeIdentity,
+  type RecoveryRequiredMarker,
+} from "../dsh/installState.js";
+import { acquireProfileLock, type ProfileLock } from "../dsh/profileLock.js";
+import {
+  beginProfileTransaction,
+  finalizeProfileTransactionRecovery,
+  profileFingerprint,
+  recoverProfileTransaction,
+  type ProfileTransaction,
+  type ProfileTransactionOptions,
+  type ProfileTransactionRecoveryReference,
+} from "../dsh/profileTransaction.js";
+import { fingerprintInstallState } from "../dsh/stateEvidence.js";
+import {
+  createMutationRecoveryJournal,
+  MutationRecoveryJournalAuthorityUnknownError,
+  MutationRecoveryJournalDurabilityAmbiguousError,
+  readMutationRecoveryJournal,
+  removeCompletedMutationRecoveryJournal,
+  updateMutationRecoveryJournal,
+  type MutationRecoveryJournal,
+  type MutationRecoveryJournalInput,
+  type MutationRecoveryJournalPatch,
+} from "../dsh/mutationRecoveryJournal.js";
+import {
+  assertSafeProfileName,
+  ensureCanonicalHome,
+  ensureContainedDirectory,
+  isPathWithin,
+} from "../dsh/paths.js";
+import {
+  DshExecutionUncertainError,
+  isDshProcessTreeAlive,
+  runDsh,
+  type RunDshDependencies,
+} from "../dsh/runDsh.js";
+import {
+  stageCatalogEntry,
+  type StagedArtifactLease,
+  type StagedCatalogInstall,
+} from "../dsh/staging.js";
+
+export type PluginMutationOperation = "add" | "update" | "remove";
+
+export interface PluginMutationOptions {
+  readonly operation: PluginMutationOperation;
+  readonly entry?: PublicCatalogEntry;
+  readonly id?: string;
+  readonly profile: string;
+  readonly dryRun: boolean;
+  readonly allowCodeExecution: boolean;
+}
+
+export interface RecoveryDependencies {
+  readonly platform: NodeJS.Platform;
+  readonly dshHome: string;
+  readonly acquireLock: (home: string, profile: string) => Promise<ProfileLock>;
+  readonly readState: (home: string) => Promise<InstallState>;
+  readonly writeState: (
+    home: string,
+    state: InstallState,
+    options: InstallStateWriteOptions,
+  ) => Promise<InstallState | void>;
+  readonly isProcessTreeAlive: (identity: RecoveryProcessTreeIdentity) => Promise<boolean>;
+  readonly recoverTransaction: (
+    home: string,
+    reference: ProfileTransactionRecoveryReference,
+    assertLockOwned: () => Promise<void>,
+  ) => Promise<void>;
+  readonly finalizeRecoveredTransaction: (
+    home: string,
+    reference: ProfileTransactionRecoveryReference,
+    assertLockOwned: () => Promise<void>,
+  ) => Promise<void>;
+  readonly releaseRecoveredArtifact: (
+    home: string,
+    reference: ArtifactRecoveryReference,
+  ) => Promise<void>;
+  readonly readRecoveryJournal: (home: string) => Promise<MutationRecoveryJournal | null>;
+  readonly updateRecoveryJournal: (
+    home: string,
+    expected: MutationRecoveryJournal,
+    patch: MutationRecoveryJournalPatch,
+  ) => Promise<MutationRecoveryJournal>;
+  readonly removeRecoveryJournal: (
+    home: string,
+    expected: MutationRecoveryJournal,
+  ) => Promise<void>;
+  readonly stdout: (value: string) => void;
+  readonly stderr: (value: string) => void;
+  readonly fingerprintActiveProfile: (dshHome: string, profile: string) => Promise<string>;
+}
+
+export interface MutationDependencies extends RecoveryDependencies {
+  readonly stageEntry: (
+    entry: PublicCatalogEntry,
+    options: { dshHome: string },
+  ) => Promise<StagedCatalogInstall>;
+  readonly runDsh: (
+    profile: string,
+    args: readonly string[],
+    dependencies?: Pick<RunDshDependencies, "onSpawn">,
+  ) => Promise<number>;
+  readonly beginTransaction: (
+    home: string,
+    profile: string,
+    options: ProfileTransactionOptions,
+  ) => Promise<ProfileTransaction>;
+  readonly openArtifactChannel: (
+    lease: StagedArtifactLease,
+    options: { sourceFingerprint: string },
+  ) => Promise<ArtifactDeliveryChannel>;
+  readonly createRecoveryJournal: (
+    home: string,
+    input: MutationRecoveryJournalInput,
+  ) => Promise<MutationRecoveryJournal>;
+  readonly now: () => Date;
+}
+
+async function releaseRecoveredArtifact(
+  home: string,
+  reference: ArtifactRecoveryReference,
+): Promise<void> {
+  const canonicalHome = await ensureCanonicalHome(home);
+  const leasesRoot = await ensureContainedDirectory(
+    canonicalHome,
+    ".dsh-plugins",
+    "artifact-leases",
+  );
+  const artifact = resolve(canonicalHome, reference.relativePath);
+  const leaseRoot = dirname(artifact);
+  if (
+    !isPathWithin(leasesRoot, artifact) ||
+    dirname(leaseRoot) !== leasesRoot ||
+    !basename(leaseRoot).startsWith(".lease-") ||
+    basename(artifact) !== "artifact.tgz"
+  ) {
+    throw new CliSafetyError("artifact recovery reference is unsafe");
+  }
+  try {
+    const leaseInfo = await lstat(leaseRoot);
+    const artifactInfo = await lstat(artifact);
+    const canonicalArtifact = await realpath(artifact);
+    if (
+      leaseInfo.isSymbolicLink() || !leaseInfo.isDirectory() ||
+      artifactInfo.isSymbolicLink() || !artifactInfo.isFile() ||
+      artifactInfo.size !== reference.bytes ||
+      !isPathWithin(leasesRoot, canonicalArtifact)
+    ) {
+      throw new CliSafetyError("artifact recovery reference is unsafe");
+    }
+    const hash = createHash("sha512");
+    let bytes = 0;
+    for await (const chunk of createReadStream(artifact)) {
+      const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      bytes += data.byteLength;
+      if (bytes > reference.bytes) throw new CliSafetyError("recovery artifact changed");
+      hash.update(data);
+    }
+    if (bytes !== reference.bytes || `sha512-${hash.digest("base64")}` !== reference.sha512) {
+      throw new CliSafetyError("recovery artifact changed");
+    }
+    await rm(leaseRoot, { recursive: true, force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("recovery artifact could not be released safely");
+  }
+}
+
+const defaultRecoveryDependencies: RecoveryDependencies = {
+  platform: process.platform,
+  dshHome: resolveDshHome(),
+  acquireLock: acquireProfileLock,
+  readState: readInstallState,
+  writeState: writeInstallState,
+  isProcessTreeAlive: isDshProcessTreeAlive,
+  recoverTransaction: recoverProfileTransaction,
+  finalizeRecoveredTransaction: finalizeProfileTransactionRecovery,
+  releaseRecoveredArtifact,
+  readRecoveryJournal: readMutationRecoveryJournal,
+  updateRecoveryJournal: updateMutationRecoveryJournal,
+  removeRecoveryJournal: removeCompletedMutationRecoveryJournal,
+  stdout: (value) => process.stdout.write(value),
+  stderr: (value) => process.stderr.write(value),
+  fingerprintActiveProfile: async (home, profile) =>
+    profileFingerprint(resolve(home, "profiles", profile)),
+};
+
+const defaultDependencies: MutationDependencies = {
+  ...defaultRecoveryDependencies,
+  stageEntry: stageCatalogEntry,
+  runDsh,
+  beginTransaction: beginProfileTransaction,
+  openArtifactChannel: openArtifactDeliveryChannel,
+  createRecoveryJournal: createMutationRecoveryJournal,
+  now: () => new Date(),
+};
+
+function expectedJournalAfterPatch(
+  expected: MutationRecoveryJournal,
+  patch: MutationRecoveryJournalPatch,
+): MutationRecoveryJournal {
+  return {
+    ...expected,
+    ...patch,
+    revision: expected.revision + 1,
+  };
+}
+
+export async function updateJournalAuthoritatively(
+  dependencies: RecoveryDependencies,
+  home: string,
+  expected: MutationRecoveryJournal,
+  patch: MutationRecoveryJournalPatch,
+): Promise<MutationRecoveryJournal> {
+  const update = dependencies.updateRecoveryJournal;
+  try {
+    return await update(home, expected, patch);
+  } catch (error) {
+    if (
+      !(error instanceof MutationRecoveryJournalDurabilityAmbiguousError) ||
+      error.possiblyPublished !== true
+    ) {
+      throw error;
+    }
+    let visible: MutationRecoveryJournal | null;
+    try {
+      visible = await dependencies.readRecoveryJournal(home);
+    } catch {
+      throw new MutationRecoveryJournalAuthorityUnknownError();
+    }
+    if (
+      visible !== null &&
+      isDeepStrictEqual(visible, expectedJournalAfterPatch(expected, patch))
+    ) {
+      return visible;
+    }
+    throw new MutationRecoveryJournalAuthorityUnknownError();
+  }
+}
+
+function describeEntry(entry: PublicCatalogEntry | undefined, id: string): string[] {
+  if (entry === undefined) return [`Plugin: ${id}`];
+  return [
+    `Plugin: ${entry.id} (${entry.name})`,
+    `Creator: @${entry.creator.github}`,
+    `Repository: ${entry.source.repository}@${entry.source.commit}`,
+    `License: ${entry.license.spdx}`,
+    `Verification: ${entry.verification.status}`,
+  ];
+}
+
+function planVerb(operation: PluginMutationOperation): "add" | "remove" {
+  return operation === "remove" ? "remove" : "add";
+}
+
+function writeDryRunPlan(
+  dependencies: MutationDependencies,
+  options: PluginMutationOptions,
+  id: string,
+): void {
+  for (const line of describeEntry(options.entry, id)) dependencies.stdout(`${line}\n`);
+  dependencies.stdout(
+    `DSH command: dsh plugin --profile ${options.profile} ` +
+      `${planVerb(options.operation)} <catalog-artifact:${id}>\n`,
+  );
+  dependencies.stdout(
+    "Dry run: install state, profile, cache, and subprocesses were not accessed.\n",
+  );
+  dependencies.stdout("Dry run: no files or processes changed.\n");
+}
+
+function validateInstallableEntry(
+  options: PluginMutationOptions,
+  id: string,
+  dependencies: MutationDependencies,
+): boolean {
+  if (options.operation === "remove") return true;
+  if (options.entry === undefined) {
+    dependencies.stderr(`Plugin not found: ${id}\n`);
+    return false;
+  }
+  if (options.entry.kind !== "plugin") {
+    dependencies.stderr(`${id} is not an installable native plugin.\n`);
+    return false;
+  }
+  if (!options.entry.dsh.profiles.includes(options.profile)) {
+    dependencies.stderr(`${id} does not declare support for profile ${options.profile}.\n`);
+    return false;
+  }
+  if (
+    options.entry.verification.status !== "eligible" &&
+    options.entry.verification.status !== "verified"
+  ) {
+    dependencies.stderr(
+      `Plugin ${id} is ${options.entry.verification.status} and cannot be installed.\n`,
+    );
+    return false;
+  }
+  return true;
+}
+
+export async function executePluginMutation(
+  options: PluginMutationOptions,
+  overrides: Partial<MutationDependencies> = {},
+): Promise<number> {
+  const dependencies: MutationDependencies = { ...defaultDependencies, ...overrides };
+  const id = options.entry?.id ?? options.id;
+  if (id === undefined || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(id)) {
+    dependencies.stderr("Plugin ID is unsafe.\n");
+    return 1;
+  }
+  try {
+    assertSafeProfileName(options.profile);
+  } catch (error) {
+    dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+    return 1;
+  }
+
+  if (options.dryRun) {
+    if (!validateInstallableEntry(options, id, dependencies)) return 1;
+    writeDryRunPlan(dependencies, options, id);
+    return 0;
+  }
+  if (dependencies.platform === "win32") {
+    dependencies.stderr(
+      "Plugin mutations with code execution are disabled on native Windows " +
+        "because complete process-tree containment cannot be proven. Use WSL.\n",
+    );
+    return 1;
+  }
+  let staged: StagedCatalogInstall | undefined;
+  let artifactLease: StagedArtifactLease | undefined;
+  let artifactChannel: ArtifactDeliveryChannel | undefined;
+  let recoveryJournal: MutationRecoveryJournal | undefined;
+  let retainArtifact = false;
+  let retainChannel = false;
+  let retainLock = false;
+  let lock: ProfileLock;
+  try {
+    lock = await dependencies.acquireLock(dependencies.dshHome, options.profile);
+  } catch (error) {
+    dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+    return 1;
+  }
+
+  try {
+    try {
+      const pending = await dependencies.readRecoveryJournal(dependencies.dshHome);
+      if (pending !== null) {
+        dependencies.stderr("Recovery is required before any new plugin mutation can run.\n");
+        return 1;
+      }
+    } catch (error) {
+      dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+      return 1;
+    }
+    let state: InstallState;
+    try {
+      state = await dependencies.readState(dependencies.dshHome);
+    } catch (error) {
+      dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+      return 1;
+    }
+    if (state.recoveryRequired !== undefined) {
+      dependencies.stderr(
+        "Recovery is required before any new plugin mutation can run.\n",
+      );
+      return 1;
+    }
+    const current = state.installs.find(
+      (install) => install.id === id && install.profile === options.profile,
+    );
+    if (options.operation === "remove" && current === undefined) {
+      dependencies.stdout(`${id} is not installed by dsh-plugins in profile ${options.profile}.\n`);
+      return 0;
+    }
+    if (!options.allowCodeExecution) {
+      dependencies.stderr(
+        "Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.\n" +
+          "Consent required: rerun with --allow-code-execution because DSH delegates to pnpm " +
+          "and may execute package lifecycle code.\n",
+      );
+      return 2;
+    }
+    if (!validateInstallableEntry(options, id, dependencies)) return 1;
+    try {
+      if (options.operation !== "remove") {
+        if (options.entry === undefined) throw new CliSafetyError("catalog entry is required");
+        staged = await dependencies.stageEntry(options.entry, { dshHome: dependencies.dshHome });
+        artifactLease = staged.artifactLease;
+      }
+    } catch (error) {
+      dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+      return 1;
+    }
+    if (options.operation !== "remove" && current?.fingerprint === staged?.fingerprint) {
+      dependencies.stdout(
+        `${id} already matches the pinned catalog artifact in profile ${options.profile}.\n`,
+      );
+      return 0;
+    }
+
+    const intendedInstalls = state.installs.filter(
+      (install) => !(install.id === id && install.profile === options.profile),
+    );
+    if (options.operation !== "remove") {
+      if (staged === undefined) throw new CliSafetyError("verified staging is unavailable");
+      intendedInstalls.push({
+        id,
+        profile: options.profile,
+        packageName: staged.packageName,
+        fingerprint: staged.fingerprint,
+        cacheRelativePath: staged.cacheRelativePath,
+        installedAt: dependencies.now().toISOString(),
+      });
+    }
+    intendedInstalls.sort(
+      (left, right) =>
+        left.profile.localeCompare(right.profile) || left.id.localeCompare(right.id),
+    );
+    const oldFingerprint = fingerprintInstallState(state.installs);
+    const intendedFingerprint = fingerprintInstallState(intendedInstalls);
+
+    for (const line of describeEntry(options.entry, id)) dependencies.stdout(`${line}\n`);
+    const target = options.operation === "remove"
+      ? current?.packageName ?? id
+      : staged?.displayTarget ?? `<verified-staging:${id}>`;
+    dependencies.stdout(
+      `DSH command: dsh plugin --profile ${options.profile} ` +
+        `${planVerb(options.operation)} ${target}\n`,
+    );
+
+    let transaction: ProfileTransaction | undefined;
+    let rollForwardDecided = false;
+    try {
+      transaction = await dependencies.beginTransaction(dependencies.dshHome, options.profile, {
+        fencingToken: lock.fencingToken,
+        committedFencingToken: state.fencingToken ?? 0,
+        assertLockOwned: lock.assertOwned,
+      });
+      await artifactLease?.revalidate();
+      if (artifactLease !== undefined && staged !== undefined) {
+        artifactChannel = await dependencies.openArtifactChannel(artifactLease, {
+          sourceFingerprint: staged.fingerprint,
+        });
+      }
+      recoveryJournal = await dependencies.createRecoveryJournal(dependencies.dshHome, {
+        ownerToken: lock.ownerToken,
+        fencingToken: lock.fencingToken,
+        profile: options.profile,
+        transaction: transaction.recoveryReference,
+        artifact: artifactLease?.recoveryReference ?? null,
+        channel: artifactChannel?.descriptor ?? null,
+        createdAt: dependencies.now().toISOString(),
+        decision: "undecided",
+        stateEvidence: {
+          oldGeneration: state.generation ?? 0,
+          oldFingerprint,
+          oldInstalls: state.installs,
+          intendedFingerprint,
+          intendedInstalls,
+        },
+      });
+      const args = options.operation === "remove"
+        ? ["remove", current?.packageName ?? id]
+        : ["add", artifactChannel?.installTarget ?? ""];
+      const exitCode = await dependencies.runDsh(options.profile, args, {
+        onSpawn: async (processTree) => {
+          if (recoveryJournal === undefined) {
+            throw new CliSafetyError("durable recovery intent is missing");
+          }
+          recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+            dependencies.dshHome,
+            recoveryJournal,
+            { processTree },
+          );
+        },
+      });
+      if (exitCode !== 0) {
+        if (recoveryJournal === undefined) {
+          throw new CliSafetyError("durable recovery intent is missing");
+        }
+        recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          recoveryJournal,
+          { decision: "rollback", status: "recovery_required" },
+        );
+        await transaction.rollback();
+        recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          recoveryJournal,
+          { phase: "profile_restored", status: "recovery_required" },
+        );
+        recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          recoveryJournal,
+          { phase: "profile_finalized", status: "recovery_required" },
+        );
+        await artifactChannel?.close();
+        artifactChannel = undefined;
+        await artifactLease?.release();
+        artifactLease = undefined;
+        recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          recoveryJournal,
+          { phase: "artifact_released", status: "recovery_required" },
+        );
+        recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          recoveryJournal,
+          { status: "completed", phase: "completed" },
+        );
+        await dependencies.removeRecoveryJournal(dependencies.dshHome, recoveryJournal);
+        recoveryJournal = undefined;
+        if (exitCode === 127) {
+          // POSIX shells report "command not found" as exit 127 — the dsh
+          // wrapper (or the pnpm it delegates to) is missing from PATH.
+          dependencies.stderr(
+            "DSH (or pnpm) was not found on PATH (exit 127); install DeepSeek Harness and " +
+              "make sure the 'dsh' command resolves, then retry. " +
+              "The previous profile was restored.\n",
+          );
+        } else {
+          dependencies.stderr("DSH rejected the mutation; the previous profile was restored.\n");
+        }
+        return 1;
+      }
+
+      if (recoveryJournal === undefined) {
+        throw new CliSafetyError("durable recovery intent is missing");
+      }
+      const activeFingerprint = await dependencies.fingerprintActiveProfile(
+        dependencies.dshHome,
+        options.profile,
+      );
+      recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+        dependencies.dshHome,
+        recoveryJournal,
+        {
+          decision: "roll_forward",
+          phase: "dsh_succeeded",
+          status: "recovery_required",
+          activeFingerprint,
+        },
+      );
+      rollForwardDecided = true;
+      await lock.assertOwned();
+      await dependencies.writeState(
+        dependencies.dshHome,
+        { version: 1, installs: intendedInstalls },
+        {
+          expectedGeneration: state.generation ?? 0,
+          fencingToken: lock.fencingToken,
+          assertLockOwned: lock.assertOwned,
+        },
+      );
+      recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+        dependencies.dshHome,
+        recoveryJournal,
+        { phase: "state_published", status: "recovery_required" },
+      );
+      await transaction.commit();
+      recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+        dependencies.dshHome,
+        recoveryJournal,
+        { phase: "profile_finalized", status: "recovery_required" },
+      );
+      await artifactChannel?.close();
+      artifactChannel = undefined;
+      await artifactLease?.release();
+      artifactLease = undefined;
+      recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+        dependencies.dshHome,
+        recoveryJournal,
+        { phase: "artifact_released", status: "recovery_required" },
+      );
+      recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+        dependencies.dshHome,
+        recoveryJournal,
+        { status: "completed", phase: "completed" },
+      );
+      await dependencies.removeRecoveryJournal(dependencies.dshHome, recoveryJournal);
+      recoveryJournal = undefined;
+      dependencies.stdout(
+        `${id} ${options.operation === "remove" ? "removed from" : "installed in"} ` +
+          `profile ${options.profile}.\n`,
+      );
+      return 0;
+    } catch (error) {
+      if (error instanceof MutationRecoveryJournalAuthorityUnknownError) {
+        retainArtifact = true;
+        retainChannel = true;
+        retainLock = true;
+        dependencies.stderr(
+          "Recovery journal authority is unknown; profile, journal, artifact, and lock remain retained.\n",
+        );
+        return 1;
+      }
+      if (
+        error instanceof DshExecutionUncertainError &&
+        error.reaped === false
+      ) {
+        retainArtifact = true;
+        retainChannel = true;
+        retainLock = true;
+        if (recoveryJournal !== undefined) {
+          const emergencyUpdate = updateJournalAuthoritatively(dependencies, 
+            dependencies.dshHome,
+            recoveryJournal,
+            {
+              status: "recovery_required",
+              ...(error.processTree === null ? {} : { processTree: error.processTree }),
+            },
+          ).then((next) => {
+            recoveryJournal = next;
+            return true;
+          }, () => false);
+          const persisted = await Promise.race([
+            emergencyUpdate,
+            new Promise<false>((resolveTimeout) => {
+              const timer = setTimeout(() => resolveTimeout(false), 1_000);
+              timer.unref?.();
+            }),
+          ]);
+          if (!persisted) {
+            dependencies.stderr(
+              "Recovery journal update failed; the durable pre-spawn barrier remains active.\n",
+            );
+          }
+        }
+        if (transaction !== undefined && error.processTree !== null) {
+          const recoveryRequired: RecoveryRequiredMarker = {
+            status: "recovery_required",
+            profile: options.profile,
+            fencingToken: lock.fencingToken,
+            processTree: error.processTree,
+            artifact: artifactLease?.recoveryReference ?? null,
+            transaction: transaction.recoveryReference,
+          };
+          try {
+            await lock.assertOwned();
+            await dependencies.writeState(
+              dependencies.dshHome,
+              { ...state, recoveryRequired },
+              {
+                expectedGeneration: state.generation ?? 0,
+                fencingToken: lock.fencingToken,
+                assertLockOwned: lock.assertOwned,
+              },
+            );
+          } catch {
+            dependencies.stderr(
+              "Recovery marker could not be published; all recovery resources remain retained.\n",
+            );
+          }
+        }
+        dependencies.stderr(`${error.message}\n`);
+        return 1;
+      }
+      if (
+        recoveryJournal?.phase === "completed" &&
+        recoveryJournal.status === "completed"
+      ) {
+        dependencies.stderr(
+          "Mutation completed; final recovery journal cleanup is pending and can be retried.\n",
+        );
+        return 1;
+      }
+      if (rollForwardDecided || recoveryJournal?.decision === "roll_forward") {
+        retainArtifact = true;
+        if (recoveryJournal !== undefined) {
+          try {
+            recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              recoveryJournal,
+              { status: "recovery_required" },
+            );
+          } catch {
+            dependencies.stderr(
+              "Recovery journal update failed; the durable success decision remains active.\n",
+            );
+          }
+        }
+        dependencies.stderr(
+          "DSH succeeded, but finalization requires recovery; rerun dsh-plugins recover.\n",
+        );
+        return 1;
+      }
+      if (transaction !== undefined) {
+        try {
+          await transaction.rollback();
+          if (recoveryJournal !== undefined) {
+            recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              recoveryJournal,
+              {
+                decision: "rollback",
+                status: "recovery_required",
+                phase: "profile_restored",
+              },
+            );
+            recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              recoveryJournal,
+              { status: "recovery_required", phase: "profile_finalized" },
+            );
+            await artifactChannel?.close();
+            artifactChannel = undefined;
+            await artifactLease?.release();
+            artifactLease = undefined;
+            recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              recoveryJournal,
+              { status: "recovery_required", phase: "artifact_released" },
+            );
+            recoveryJournal = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              recoveryJournal,
+              { status: "completed", phase: "completed" },
+            );
+            await dependencies.removeRecoveryJournal(dependencies.dshHome, recoveryJournal);
+            recoveryJournal = undefined;
+          }
+        } catch {
+          retainArtifact = recoveryJournal !== undefined;
+          if (error instanceof DshExecutionUncertainError) {
+            dependencies.stderr(`${error.message}\n`);
+          }
+          dependencies.stderr(
+            "Rollback requires manual recovery from the retained profile backup.\n",
+          );
+          return 1;
+        }
+      }
+      dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+      return 1;
+    }
+  } finally {
+    if (!retainChannel) await artifactChannel?.close().catch(() => undefined);
+    if (!retainArtifact) await artifactLease?.release().catch(() => undefined);
+    if (!retainLock) await lock.release().catch(() => undefined);
+  }
+}
+
+export async function recoverPluginMutation(
+  overrides: Partial<RecoveryDependencies> = {},
+): Promise<number> {
+  const dependencies: RecoveryDependencies = { ...defaultRecoveryDependencies, ...overrides };
+  let durable: MutationRecoveryJournal | null;
+  try {
+    durable = await dependencies.readRecoveryJournal(dependencies.dshHome);
+  } catch {
+    dependencies.stderr("Recovery journal could not be read safely.\n");
+    return 1;
+  }
+  if (durable !== null) {
+    if (dependencies.platform === "win32" || durable.processTree?.platform === "win32") {
+      dependencies.stderr(
+        "Native Windows recovery remains fail-closed because complete descendant containment " +
+          "cannot be proven. Use WSL or perform documented manual recovery.\n",
+      );
+      return 1;
+    }
+    let lock: ProfileLock;
+    try {
+      lock = await dependencies.acquireLock(dependencies.dshHome, durable.profile);
+    } catch (error) {
+      dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+      return 1;
+    }
+    let releaseLock = false;
+    try {
+      const current = await dependencies.readRecoveryJournal(dependencies.dshHome);
+      if (current === null) {
+        releaseLock = true;
+        dependencies.stdout("No mutation recovery is pending.\n");
+        return 0;
+      }
+      durable = current;
+      if (durable.phase !== "completed") {
+        if (durable.processTree === undefined) {
+          dependencies.stderr(
+            "Recovery remains fail-closed because the spawned process tree was not durably identified.\n",
+          );
+          return 1;
+        }
+        let treeAlive: boolean;
+        try {
+          treeAlive = await dependencies.isProcessTreeAlive(durable.processTree);
+        } catch {
+          dependencies.stderr("Recovery process tree could not be inspected safely.\n");
+          return 1;
+        }
+        if (treeAlive) {
+          dependencies.stderr(
+            "Recovery is pending because the DSH process tree is still alive.\n",
+          );
+          return 1;
+        }
+        durable = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          durable,
+          { ownerToken: lock.ownerToken, fencingToken: lock.fencingToken },
+        );
+      }
+      if (durable.decision !== undefined || durable.stateEvidence !== undefined) {
+        if (durable.decision === undefined || durable.stateEvidence === undefined) {
+          throw new CliSafetyError("recovery state evidence is incomplete; manual recovery required");
+        }
+        const evidence = durable.stateEvidence;
+        let state = await dependencies.readState(dependencies.dshHome);
+        const stateFingerprint = fingerprintInstallState(state.installs);
+        if ((state.generation ?? 0) < evidence.oldGeneration) {
+          throw new CliSafetyError("recovery state generation moved backwards; manual recovery required");
+        }
+
+        if (durable.decision === "roll_forward") {
+          if (durable.activeFingerprint === undefined) {
+            throw new CliSafetyError("successful profile fingerprint is missing; manual recovery required");
+          }
+          const observedActive = await dependencies.fingerprintActiveProfile(
+            dependencies.dshHome,
+            durable.profile,
+          );
+          if (observedActive !== durable.activeFingerprint) {
+            throw new CliSafetyError("successful profile fingerprint changed; manual recovery required");
+          }
+          if (durable.phase === "dsh_succeeded") {
+            if (stateFingerprint === evidence.oldFingerprint) {
+              await dependencies.writeState(
+                dependencies.dshHome,
+                { version: 1, installs: [...evidence.intendedInstalls] },
+                {
+                  expectedGeneration: state.generation ?? 0,
+                  fencingToken: lock.fencingToken,
+                  assertLockOwned: lock.assertOwned,
+                },
+              );
+              state = await dependencies.readState(dependencies.dshHome);
+            } else if (stateFingerprint !== evidence.intendedFingerprint) {
+              throw new CliSafetyError("install state does not match recovery evidence");
+            }
+            durable = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              durable,
+              { phase: "state_published", status: "recovery_required" },
+            );
+          }
+          if (
+            durable.phase === "state_published" &&
+            fingerprintInstallState(state.installs) !== evidence.intendedFingerprint
+          ) {
+            throw new CliSafetyError("published install state does not match recovery evidence");
+          }
+          if (durable.phase === "state_published") {
+            await dependencies.finalizeRecoveredTransaction(
+              dependencies.dshHome,
+              durable.transaction,
+              lock.assertOwned,
+            );
+            durable = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              durable,
+              { phase: "profile_finalized", status: "recovery_required" },
+            );
+          }
+        } else {
+          if (stateFingerprint !== evidence.oldFingerprint) {
+            throw new CliSafetyError("rollback state does not match recovery evidence");
+          }
+          if (durable.phase === "needs_restore") {
+            await lock.assertOwned();
+            await dependencies.recoverTransaction(
+              dependencies.dshHome,
+              durable.transaction,
+              lock.assertOwned,
+            );
+            durable = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              durable,
+              {
+                decision: "rollback",
+                phase: "profile_restored",
+                status: "recovery_required",
+              },
+            );
+          }
+          if (durable.phase === "profile_restored") {
+            await dependencies.finalizeRecoveredTransaction(
+              dependencies.dshHome,
+              durable.transaction,
+              lock.assertOwned,
+            );
+            durable = await updateJournalAuthoritatively(dependencies, 
+              dependencies.dshHome,
+              durable,
+              { phase: "profile_finalized", status: "recovery_required" },
+            );
+          }
+        }
+
+        if (durable.phase === "profile_finalized") {
+          if (durable.artifact !== null) {
+            await dependencies.releaseRecoveredArtifact(dependencies.dshHome, durable.artifact);
+          }
+          durable = await updateJournalAuthoritatively(dependencies, 
+            dependencies.dshHome,
+            durable,
+            { phase: "artifact_released", status: "recovery_required" },
+          );
+        }
+        if (durable.phase === "artifact_released") {
+          state = await dependencies.readState(dependencies.dshHome);
+          const expected = durable.decision === "roll_forward"
+            ? evidence.intendedFingerprint
+            : evidence.oldFingerprint;
+          if (fingerprintInstallState(state.installs) !== expected) {
+            throw new CliSafetyError("final install state does not match recovery evidence");
+          }
+          if (state.recoveryRequired !== undefined) {
+            await dependencies.writeState(
+              dependencies.dshHome,
+              { version: 1, installs: state.installs },
+              {
+                expectedGeneration: state.generation ?? 0,
+                fencingToken: lock.fencingToken,
+                assertLockOwned: lock.assertOwned,
+              },
+            );
+          }
+          durable = await updateJournalAuthoritatively(dependencies, 
+            dependencies.dshHome,
+            durable,
+            { phase: "completed", status: "completed" },
+          );
+        }
+        await dependencies.removeRecoveryJournal(dependencies.dshHome, durable);
+        releaseLock = true;
+        dependencies.stdout(`Recovery completed for profile ${durable.profile}.\n`);
+        return 0;
+      }
+      if (durable.phase === "needs_restore") {
+        await lock.assertOwned();
+        await dependencies.recoverTransaction(
+          dependencies.dshHome,
+          durable.transaction,
+          lock.assertOwned,
+        );
+        durable = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          durable,
+          { phase: "profile_restored", status: "recovery_required" },
+        );
+      }
+      if (durable.phase === "profile_restored") {
+        await dependencies.finalizeRecoveredTransaction(
+          dependencies.dshHome,
+          durable.transaction,
+          lock.assertOwned,
+        );
+        if (durable.artifact !== null) {
+          await dependencies.releaseRecoveredArtifact(dependencies.dshHome, durable.artifact);
+        }
+        durable = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          durable,
+          { phase: "artifact_released", status: "recovery_required" },
+        );
+      }
+      if (durable.phase === "artifact_released") {
+        const state = await dependencies.readState(dependencies.dshHome);
+        if (state.recoveryRequired !== undefined) {
+          await dependencies.writeState(
+            dependencies.dshHome,
+            { version: 1, installs: state.installs },
+            {
+              expectedGeneration: state.generation ?? 0,
+              fencingToken: lock.fencingToken,
+              assertLockOwned: lock.assertOwned,
+            },
+          );
+        }
+        durable = await updateJournalAuthoritatively(dependencies, 
+          dependencies.dshHome,
+          durable,
+          { phase: "completed", status: "completed" },
+        );
+      }
+      await dependencies.removeRecoveryJournal(dependencies.dshHome, durable);
+      releaseLock = true;
+      dependencies.stdout(`Recovery completed for profile ${durable.profile}.\n`);
+      return 0;
+    } catch (error) {
+      dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+      return 1;
+    } finally {
+      if (releaseLock) await lock.release().catch(() => undefined);
+    }
+  }
+  let observed: InstallState;
+  try {
+    observed = await dependencies.readState(dependencies.dshHome);
+  } catch {
+    dependencies.stderr("Recovery state could not be read safely.\n");
+    return 1;
+  }
+  if (observed.recoveryRequired === undefined) {
+    dependencies.stdout("No mutation recovery is pending.\n");
+    return 0;
+  }
+
+  if (
+    dependencies.platform === "win32" ||
+    observed.recoveryRequired.processTree.platform === "win32"
+  ) {
+    dependencies.stderr(
+      "Native Windows recovery remains fail-closed because complete descendant containment " +
+        "cannot be proven. Use WSL or perform documented manual recovery.\n",
+    );
+    return 1;
+  }
+
+  let lock: ProfileLock;
+  try {
+    lock = await dependencies.acquireLock(
+      dependencies.dshHome,
+      observed.recoveryRequired.profile,
+    );
+  } catch (error) {
+    dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+    return 1;
+  }
+  let releaseLock = false;
+  try {
+    const state = await dependencies.readState(dependencies.dshHome);
+    const marker = state.recoveryRequired;
+    if (marker === undefined) {
+      releaseLock = true;
+      dependencies.stdout("No mutation recovery is pending.\n");
+      return 0;
+    }
+    let treeAlive: boolean;
+    try {
+      treeAlive = await dependencies.isProcessTreeAlive(marker.processTree);
+    } catch {
+      dependencies.stderr("Recovery process tree could not be inspected safely.\n");
+      return 1;
+    }
+    if (treeAlive) {
+      dependencies.stderr(
+        "Recovery is pending because the DSH process tree is still alive.\n",
+      );
+      return 1;
+    }
+    await lock.assertOwned();
+    await dependencies.recoverTransaction(
+      dependencies.dshHome,
+      marker.transaction,
+      lock.assertOwned,
+    );
+    if (marker.artifact !== null) {
+      await dependencies.releaseRecoveredArtifact(dependencies.dshHome, marker.artifact);
+    }
+    await lock.assertOwned();
+    await dependencies.writeState(
+      dependencies.dshHome,
+      { version: 1, installs: state.installs },
+      {
+        expectedGeneration: state.generation ?? 0,
+        fencingToken: lock.fencingToken,
+        assertLockOwned: lock.assertOwned,
+      },
+    );
+    releaseLock = true;
+    dependencies.stdout(`Recovery completed for profile ${marker.profile}.\n`);
+    return 0;
+  } catch (error) {
+    dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+    return 1;
+  } finally {
+    if (releaseLock) await lock.release().catch(() => undefined);
+  }
+}
+
+export { EMPTY_INSTALL_STATE };

--- a/cli/src/commands/remove.ts
+++ b/cli/src/commands/remove.ts
@@ -1,0 +1,16 @@
+import type { PublicCatalogEntry } from "../model.js";
+import { executePluginMutation, type MutationDependencies } from "./mutate.js";
+
+export function removeCommand(
+  id: string,
+  entry: PublicCatalogEntry | undefined,
+  profile: string,
+  dryRun: boolean,
+  allowCodeExecution: boolean,
+  dependencies?: Partial<MutationDependencies>,
+): Promise<number> {
+  return executePluginMutation(
+    { operation: "remove", id, ...(entry === undefined ? {} : { entry }), profile, dryRun, allowCodeExecution },
+    dependencies,
+  );
+}

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -1,0 +1,54 @@
+import type { CatalogSelection, PublicCatalogEntry } from "../model.js";
+import type { CatalogCommandContext } from "./catalog.js";
+import { writeDiagnostics } from "./catalog.js";
+
+function tokens(value: string): string[] {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase("en-US")
+    .split(/[^\p{L}\p{N}@._+-]+/u)
+    .filter(Boolean);
+}
+
+function searchable(entry: PublicCatalogEntry): string {
+  const packageName = entry.package.ecosystem === "npm" ? entry.package.name : "source";
+  return [
+    entry.id,
+    entry.name,
+    entry.description.en,
+    entry.creator.github,
+    entry.kind,
+    entry.primaryCategory,
+    ...entry.tags,
+    packageName,
+    entry.license.spdx,
+    entry.verification.status,
+  ].join(" ").normalize("NFKC").toLocaleLowerCase("en-US");
+}
+
+export async function searchCommand(
+  context: CatalogCommandContext,
+  query: string,
+  selection: CatalogSelection | undefined,
+  json: boolean,
+): Promise<number> {
+  const snapshot = await context.loadCatalog(selection);
+  if (snapshot.diagnostics.length > 0) {
+    writeDiagnostics(context, snapshot.diagnostics);
+    return 1;
+  }
+  const queryTokens = tokens(query);
+  const matches = snapshot.entries
+    .filter((entry) => queryTokens.every((token) => searchable(entry).includes(token)))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  if (json) {
+    context.stdout(`${JSON.stringify(matches)}\n`);
+  } else if (matches.length === 0) {
+    context.stdout("No plugins found.\n");
+  } else {
+    for (const entry of matches) {
+      context.stdout(`${entry.id}\t${entry.name}\t@${entry.creator.github}\t${entry.verification.status}\n`);
+    }
+  }
+  return 0;
+}

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,0 +1,15 @@
+import type { PublicCatalogEntry } from "../model.js";
+import { executePluginMutation, type MutationDependencies } from "./mutate.js";
+
+export function updateCommand(
+  entry: PublicCatalogEntry,
+  profile: string,
+  dryRun: boolean,
+  allowCodeExecution: boolean,
+  dependencies?: Partial<MutationDependencies>,
+): Promise<number> {
+  return executePluginMutation(
+    { operation: "update", entry, profile, dryRun, allowCodeExecution },
+    dependencies,
+  );
+}

--- a/cli/src/dsh/artifactChannel.ts
+++ b/cli/src/dsh/artifactChannel.ts
@@ -1,0 +1,179 @@
+import { createHash, randomBytes } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+
+import { CliSafetyError } from "../errors.js";
+import type { StagedArtifactLease } from "./staging.js";
+
+const DEFAULT_CHANNEL_TIMEOUT_MS = 120_000;
+const DEFAULT_CHANNEL_BYTES = 64 * 1024 * 1024;
+
+export interface ArtifactChannelDescriptor {
+  readonly kind: "loopback-buffer-v1";
+  readonly sha512: string;
+  readonly bytes: number;
+  readonly sourceFingerprint: string;
+}
+
+export interface ArtifactDeliveryChannel {
+  readonly installTarget: string;
+  readonly descriptor: ArtifactChannelDescriptor;
+  close(): Promise<void>;
+}
+
+export interface ArtifactDeliveryChannelOptions {
+  readonly sourceFingerprint: string;
+  readonly timeoutMs?: number;
+  readonly maxBytes?: number;
+  readonly signal?: AbortSignal;
+}
+
+function boundedPositive(value: number | undefined, fallback: number): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0 || resolved > 2_147_483_647) {
+    throw new CliSafetyError("artifact delivery channel limits are invalid");
+  }
+  return resolved;
+}
+
+function isLoopback(address: string | undefined): boolean {
+  return address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
+}
+
+export async function openArtifactDeliveryChannel(
+  lease: StagedArtifactLease,
+  options: ArtifactDeliveryChannelOptions,
+): Promise<ArtifactDeliveryChannel> {
+  const timeoutMs = boundedPositive(options.timeoutMs, DEFAULT_CHANNEL_TIMEOUT_MS);
+  const maxBytes = boundedPositive(options.maxBytes, DEFAULT_CHANNEL_BYTES);
+  if (options.signal?.aborted === true) throw new CliSafetyError("artifact delivery was cancelled");
+  if (
+    typeof options.sourceFingerprint !== "string" ||
+    options.sourceFingerprint.length < 8 ||
+    options.sourceFingerprint.length > 256
+  ) {
+    throw new CliSafetyError("artifact source fingerprint is invalid");
+  }
+
+  const reference = lease.recoveryReference;
+  if (reference.bytes <= 0 || reference.bytes > maxBytes) {
+    throw new CliSafetyError("artifact exceeds the delivery byte limit");
+  }
+  const bytes = Buffer.from(await lease.readVerifiedBytes());
+  if (bytes.byteLength !== reference.bytes || bytes.byteLength > maxBytes) {
+    throw new CliSafetyError("transaction artifact changed; recovery required");
+  }
+  const sha512 = `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+  if (sha512 !== reference.sha512) {
+    throw new CliSafetyError("transaction artifact changed; recovery required");
+  }
+
+  const token = randomBytes(32).toString("base64url");
+  const pathname = `/${token}/artifact.tgz`;
+  let headServed = false;
+  let getServed = false;
+  let closed = false;
+  let closePromise: Promise<void> | undefined;
+  const sockets = new Set<Socket>();
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+
+  const server: Server = createServer((request, response) => {
+    if (!isLoopback(request.socket.remoteAddress)) {
+      response.writeHead(403, { "content-length": "0", connection: "close" });
+      response.end();
+      return;
+    }
+    if (request.url !== pathname) {
+      response.writeHead(404, { "content-length": "0", connection: "close" });
+      response.end();
+      return;
+    }
+    if (request.headers.range !== undefined) {
+      response.writeHead(416, { "content-length": "0", connection: "close" });
+      response.end();
+      return;
+    }
+    const headers = {
+      "cache-control": "no-store",
+      "content-length": String(bytes.byteLength),
+      "content-type": "application/octet-stream",
+      "x-content-type-options": "nosniff",
+    };
+    if (request.method === "HEAD" && !headServed && !getServed) {
+      headServed = true;
+      response.writeHead(200, headers);
+      response.end();
+      return;
+    }
+    if (request.method === "GET" && !getServed) {
+      getServed = true;
+      response.writeHead(200, headers);
+      response.end(bytes);
+      return;
+    }
+    response.writeHead(request.method === "HEAD" || request.method === "GET" ? 410 : 405, {
+      allow: "HEAD, GET",
+      "content-length": "0",
+      connection: "close",
+    });
+    response.end();
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+
+  const onAbort = (): void => {
+    void close();
+  };
+  const close = async (): Promise<void> => {
+    if (closePromise !== undefined) return closePromise;
+    closed = true;
+    if (deadline !== undefined) clearTimeout(deadline);
+    options.signal?.removeEventListener("abort", onAbort);
+    closePromise = new Promise<void>((resolve) => {
+      for (const socket of sockets) socket.destroy();
+      if (!server.listening) {
+        resolve();
+        return;
+      }
+      server.close(() => resolve());
+    });
+    return closePromise;
+  };
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (): void => reject(new CliSafetyError("artifact delivery channel failed"));
+      server.once("error", onError);
+      server.listen({ host: "127.0.0.1", port: 0, exclusive: true }, () => {
+        server.removeListener("error", onError);
+        resolve();
+      });
+    });
+  } catch (error) {
+    await close();
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("artifact delivery channel failed");
+  }
+  server.unref();
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+  deadline = setTimeout(() => void close(), timeoutMs);
+  deadline.unref?.();
+  const address = server.address();
+  if (closed || address === null || typeof address === "string") {
+    await close();
+    throw new CliSafetyError("artifact delivery channel failed");
+  }
+
+  return {
+    installTarget: `http://127.0.0.1:${(address as AddressInfo).port}${pathname}`,
+    descriptor: {
+      kind: "loopback-buffer-v1",
+      sha512,
+      bytes: bytes.byteLength,
+      sourceFingerprint: options.sourceFingerprint,
+    },
+    close,
+  };
+}

--- a/cli/src/dsh/childSupervisor.ts
+++ b/cli/src/dsh/childSupervisor.ts
@@ -1,0 +1,262 @@
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+
+export interface ChildSpawnOptions {
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly shell: false;
+  readonly detached: boolean;
+  readonly stdio: readonly ["ignore", "pipe", "pipe"];
+}
+
+export type ChildSpawn = (
+  command: string,
+  args: readonly string[],
+  options: ChildSpawnOptions,
+) => ChildProcess;
+
+export type ProcessGroupSignaler = (
+  processGroupId: number,
+  signal: NodeJS.Signals,
+) => boolean;
+
+export type ChildTerminationReason = "timeout" | "aborted" | "output-limit" | "spawn-error";
+
+export interface SupervisedChildRequest {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly timeoutMs: number;
+  readonly termGraceMs: number;
+  readonly reapTimeoutMs: number;
+  readonly maxOutputBytes: number;
+  readonly processGroup: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export interface ChildSupervisorDependencies {
+  readonly spawn?: ChildSpawn;
+  readonly signalProcessGroup?: ProcessGroupSignaler;
+}
+
+interface ChildResultBase {
+  readonly stdout: Buffer;
+  readonly outputBytes: number;
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+export interface ReapedChildResult extends ChildResultBase {
+  readonly reaped: true;
+  readonly reason: "exit" | ChildTerminationReason;
+  readonly terminationReason: ChildTerminationReason | null;
+}
+
+export interface UnreapedChildResult extends ChildResultBase {
+  readonly reaped: false;
+  readonly reason: "reap-timeout";
+  readonly terminationReason: ChildTerminationReason;
+}
+
+export type SupervisedChildResult = ReapedChildResult | UnreapedChildResult;
+
+function assertBoundedPositiveInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new RangeError(`${label} must be a positive safe integer`);
+  }
+}
+
+function defaultSpawn(
+  command: string,
+  args: readonly string[],
+  options: ChildSpawnOptions,
+): ChildProcess {
+  return nodeSpawn(command, [...args], {
+    cwd: options.cwd,
+    env: options.env,
+    shell: false,
+    detached: options.detached,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function defaultSignalProcessGroup(
+  processGroupId: number,
+  signal: NodeJS.Signals,
+): boolean {
+  process.kill(processGroupId, signal);
+  return true;
+}
+
+function chunkBuffer(chunk: Buffer | Uint8Array | string): Buffer {
+  if (Buffer.isBuffer(chunk)) return chunk;
+  return Buffer.from(chunk);
+}
+
+export async function runSupervisedChild(
+  request: SupervisedChildRequest,
+  dependencies: ChildSupervisorDependencies = {},
+): Promise<SupervisedChildResult> {
+  assertBoundedPositiveInteger(request.timeoutMs, "timeoutMs");
+  assertBoundedPositiveInteger(request.termGraceMs, "termGraceMs");
+  assertBoundedPositiveInteger(request.reapTimeoutMs, "reapTimeoutMs");
+  assertBoundedPositiveInteger(request.maxOutputBytes, "maxOutputBytes");
+  if (request.command.length === 0 || request.command.includes("\0")) {
+    throw new TypeError("command must be a non-empty executable path");
+  }
+
+  const spawn = dependencies.spawn ?? defaultSpawn;
+  const signalProcessGroup = dependencies.signalProcessGroup ?? defaultSignalProcessGroup;
+  let child: ChildProcess;
+  try {
+    child = spawn(request.command, request.args, {
+      cwd: request.cwd,
+      env: request.env,
+      shell: false,
+      detached: request.processGroup,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    return {
+      reaped: true,
+      reason: "spawn-error",
+      terminationReason: "spawn-error",
+      stdout: Buffer.alloc(0),
+      outputBytes: 0,
+      exitCode: null,
+      signal: null,
+    };
+  }
+
+  return new Promise<SupervisedChildResult>((resolvePromise) => {
+    const stdoutChunks: Buffer[] = [];
+    let outputBytes = 0;
+    let storedStdoutBytes = 0;
+    let settled = false;
+    let terminationReason: ChildTerminationReason | undefined;
+    let termGraceTimer: NodeJS.Timeout | undefined;
+    let reapTimer: NodeJS.Timeout | undefined;
+
+    const clearTimers = () => {
+      clearTimeout(executionTimer);
+      if (termGraceTimer !== undefined) clearTimeout(termGraceTimer);
+      if (reapTimer !== undefined) clearTimeout(reapTimer);
+    };
+
+    const removeListeners = () => {
+      child.removeListener("error", onError);
+      child.removeListener("close", onClose);
+      child.stdout?.removeListener("data", onStdout);
+      child.stderr?.removeListener("data", onStderr);
+      request.signal?.removeEventListener("abort", onAbort);
+    };
+
+    const capturedStdout = () => Buffer.concat(stdoutChunks, storedStdoutBytes);
+
+    const signalChildTree = (signal: NodeJS.Signals) => {
+      let groupSignaled = false;
+      if (request.processGroup && child.pid !== undefined && child.pid > 0) {
+        try {
+          groupSignaled = signalProcessGroup(-child.pid, signal);
+        } catch {
+          groupSignaled = false;
+        }
+      }
+      if (!groupSignaled) {
+        try {
+          child.kill(signal);
+        } catch {
+          // The finite reap deadline remains authoritative when signaling fails.
+        }
+      }
+    };
+
+    const finishUnreaped = () => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      removeListeners();
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      child.unref();
+      resolvePromise({
+        reaped: false,
+        reason: "reap-timeout",
+        terminationReason: terminationReason ?? "timeout",
+        stdout: capturedStdout(),
+        outputBytes,
+        exitCode: child.exitCode,
+        signal: child.signalCode,
+      });
+    };
+
+    const escalate = () => {
+      if (settled) return;
+      signalChildTree("SIGKILL");
+      reapTimer = setTimeout(finishUnreaped, request.reapTimeoutMs);
+      reapTimer.unref();
+    };
+
+    const beginTermination = (reason: ChildTerminationReason) => {
+      if (settled || terminationReason !== undefined) return;
+      terminationReason = reason;
+      signalChildTree("SIGTERM");
+      termGraceTimer = setTimeout(escalate, request.termGraceMs);
+      termGraceTimer.unref();
+    };
+
+    const collect = (chunk: Buffer | Uint8Array | string, keep: boolean) => {
+      const bytes = chunkBuffer(chunk);
+      const remaining = Math.max(0, request.maxOutputBytes - outputBytes);
+      if (keep && remaining > 0) {
+        const captured = bytes.subarray(0, Math.min(remaining, bytes.byteLength));
+        stdoutChunks.push(Buffer.from(captured));
+        storedStdoutBytes += captured.byteLength;
+      }
+      outputBytes += bytes.byteLength;
+      if (outputBytes > request.maxOutputBytes) beginTermination("output-limit");
+    };
+
+    function onStdout(chunk: Buffer | Uint8Array | string): void {
+      collect(chunk, true);
+    }
+
+    function onStderr(chunk: Buffer | Uint8Array | string): void {
+      collect(chunk, false);
+    }
+
+    function onError(): void {
+      beginTermination("spawn-error");
+    }
+
+    function onAbort(): void {
+      beginTermination("aborted");
+    }
+
+    function onClose(code: number | null, signal: NodeJS.Signals | null): void {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      removeListeners();
+      resolvePromise({
+        reaped: true,
+        reason: terminationReason ?? "exit",
+        terminationReason: terminationReason ?? null,
+        stdout: capturedStdout(),
+        outputBytes,
+        exitCode: code,
+        signal,
+      });
+    }
+
+    child.stdout?.on("data", onStdout);
+    child.stderr?.on("data", onStderr);
+    child.once("error", onError);
+    child.once("close", onClose);
+    request.signal?.addEventListener("abort", onAbort, { once: true });
+
+    const executionTimer = setTimeout(() => beginTermination("timeout"), request.timeoutMs);
+    executionTimer.unref();
+    if (request.signal?.aborted === true) beginTermination("aborted");
+  });
+}

--- a/cli/src/dsh/installState.ts
+++ b/cli/src/dsh/installState.ts
@@ -1,0 +1,830 @@
+import { randomUUID } from "node:crypto";
+import { homedir, hostname as localHostname } from "node:os";
+import { join, resolve } from "node:path";
+import { lstat, mkdir, readFile, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
+
+import { CliSafetyError } from "../errors.js";
+import {
+  assertSafeCacheSegment,
+  assertSafeProfileName,
+  ensureCanonicalHome,
+  ensureContainedDirectory,
+  isPathWithin,
+} from "./paths.js";
+
+export interface StagedInstall {
+  readonly fingerprint: string;
+  readonly installTarget: string;
+  readonly displayTarget: string;
+  readonly packageName: string;
+  readonly cacheRelativePath: string;
+}
+
+export interface InstalledPlugin {
+  readonly id: string;
+  readonly profile: string;
+  readonly packageName: string;
+  readonly fingerprint: string;
+  readonly cacheRelativePath: string;
+  readonly installedAt: string;
+}
+
+export interface InstallState {
+  readonly version: 1;
+  readonly generation?: number;
+  readonly fencingToken?: number;
+  readonly installs: readonly InstalledPlugin[];
+  readonly recoveryRequired?: RecoveryRequiredMarker;
+}
+
+export interface ArtifactRecoveryReference {
+  readonly relativePath: string;
+  readonly sha512: string;
+  readonly bytes: number;
+  readonly packageName: string;
+}
+
+export interface RecoveryProcessTreeIdentity {
+  readonly pid: number;
+  readonly processGroupId: number | null;
+  readonly treeIdentity: string;
+  readonly processStartIdentity: string | null;
+  readonly platform: NodeJS.Platform;
+}
+
+export interface ProfileTransactionRecoveryReference {
+  readonly profile: string;
+  readonly fencingToken: number;
+  readonly existed: boolean;
+  readonly journalRelativePath: string;
+  readonly backupRelativePath: string;
+}
+
+export interface RecoveryRequiredMarker {
+  readonly status: "recovery_required";
+  readonly profile: string;
+  readonly fencingToken: number;
+  readonly processTree: RecoveryProcessTreeIdentity;
+  readonly artifact: ArtifactRecoveryReference | null;
+  readonly transaction: ProfileTransactionRecoveryReference;
+}
+
+export const EMPTY_INSTALL_STATE: InstallState = {
+  version: 1,
+  generation: 0,
+  fencingToken: 0,
+  installs: [],
+};
+
+export interface InstallStateWriterContext {
+  readonly ownerToken: string;
+  readonly fencingToken: number;
+}
+
+export interface InstallStateWriterOptions {
+  readonly leaseMs?: number;
+  readonly heartbeatMs?: number;
+  readonly acquireTimeoutMs?: number;
+  readonly retryMs?: number;
+  readonly now?: () => number;
+  readonly ownerToken?: () => string;
+  readonly pid?: number;
+  readonly processStartIdentity?: string;
+  readonly hostname?: string;
+  readonly isProcessAlive?: (
+    pid: number,
+    processStartIdentity: string,
+  ) => boolean | Promise<boolean>;
+  readonly beforeRename?: (context: InstallStateWriterContext) => Promise<void>;
+}
+
+export interface InstallStateWriteOptions {
+  readonly expectedGeneration: number;
+  readonly fencingToken: number;
+  readonly assertLockOwned: () => Promise<void>;
+  readonly writer?: InstallStateWriterOptions;
+}
+
+export class InstallStateGenerationError extends CliSafetyError {
+  constructor() {
+    super("install state generation changed; recovery required");
+    this.name = "InstallStateGenerationError";
+  }
+}
+
+export class InstallStateFencingError extends CliSafetyError {
+  constructor() {
+    super("install state fencing token is stale; recovery required");
+    this.name = "InstallStateFencingError";
+  }
+}
+
+export class InstallStateWriterBusyError extends CliSafetyError {
+  constructor() {
+    super("install state publication lock is busy");
+    this.name = "InstallStateWriterBusyError";
+  }
+}
+
+export class InstallStateWriterOwnershipError extends CliSafetyError {
+  constructor() {
+    super("install state publication ownership changed; recovery required");
+    this.name = "InstallStateWriterOwnershipError";
+  }
+}
+
+interface StateWriterOwnerRecord {
+  readonly version: 1;
+  readonly ownerToken: string;
+  readonly fencingToken: number;
+  readonly acquiredAt: number;
+  readonly leaseMs: number;
+  readonly pid: number;
+  readonly processStartIdentity: string;
+  readonly hostname: string;
+}
+
+interface StateWriterLease {
+  readonly context: InstallStateWriterContext;
+  readonly assertOwned: () => Promise<void>;
+  readonly release: () => Promise<void>;
+}
+
+const DEFAULT_WRITER_LEASE_MS = 30_000;
+const DEFAULT_WRITER_HEARTBEAT_MS = 10_000;
+const DEFAULT_WRITER_ACQUIRE_TIMEOUT_MS = 5_000;
+const DEFAULT_WRITER_RETRY_MS = 10;
+const SAFE_WRITER_TOKEN = /^[A-Za-z0-9_-]{1,100}$/u;
+const SAFE_PROCESS_IDENTITY = /^[A-Za-z0-9._:-]{1,200}$/u;
+const CURRENT_PROCESS_STARTED_AT = Math.floor(Date.now() - process.uptime() * 1_000);
+
+const PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/u;
+const FINGERPRINT = /^sha256:[0-9a-f]{64}$/u;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u;
+const SHA512_REFERENCE = /^sha512-[A-Za-z0-9+/]{86}==$/u;
+const SAFE_IDENTITY = /^[A-Za-z0-9._:-]{1,240}$/u;
+
+function safeRecoveryPath(value: string, expectedPrefix: string): boolean {
+  if (!value.startsWith(expectedPrefix) || value.startsWith("/") || value.includes("\\")) {
+    return false;
+  }
+  return value.split("/").every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+function parseRecoveryMarker(value: unknown): RecoveryRequiredMarker | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "object" || value === null) {
+    throw new CliSafetyError("install state recovery marker is invalid");
+  }
+  const marker = value as Record<string, unknown>;
+  const profile = marker.profile;
+  const fencingToken = marker.fencingToken;
+  const processTree = marker.processTree;
+  const transaction = marker.transaction;
+  const artifact = marker.artifact;
+  if (
+    marker.status !== "recovery_required" ||
+    typeof profile !== "string" ||
+    !Number.isSafeInteger(fencingToken) ||
+    Number(fencingToken) <= 0 ||
+    typeof processTree !== "object" || processTree === null ||
+    typeof transaction !== "object" || transaction === null
+  ) {
+    throw new CliSafetyError("install state recovery marker is invalid");
+  }
+  assertSafeProfileName(profile);
+  const tree = processTree as Record<string, unknown>;
+  if (
+    !Number.isSafeInteger(tree.pid) || Number(tree.pid) <= 0 ||
+    !(tree.processGroupId === null ||
+      (Number.isSafeInteger(tree.processGroupId) && Number(tree.processGroupId) > 0)) ||
+    typeof tree.treeIdentity !== "string" || !SAFE_IDENTITY.test(tree.treeIdentity) ||
+    !(tree.processStartIdentity === null ||
+      (typeof tree.processStartIdentity === "string" &&
+        SAFE_IDENTITY.test(tree.processStartIdentity))) ||
+    typeof tree.platform !== "string" || !SAFE_IDENTITY.test(tree.platform)
+  ) {
+    throw new CliSafetyError("install state recovery marker is invalid");
+  }
+  const transactionRecord = transaction as Record<string, unknown>;
+  if (
+    transactionRecord.profile !== profile ||
+    transactionRecord.fencingToken !== fencingToken ||
+    typeof transactionRecord.existed !== "boolean" ||
+    typeof transactionRecord.journalRelativePath !== "string" ||
+    !safeRecoveryPath(
+      transactionRecord.journalRelativePath,
+      `profiles/.dsh-plugins-transaction-${profile}-`,
+    ) ||
+    !transactionRecord.journalRelativePath.endsWith(".json") ||
+    typeof transactionRecord.backupRelativePath !== "string" ||
+    !safeRecoveryPath(
+      transactionRecord.backupRelativePath,
+      `profiles/.dsh-plugins-backup-${profile}-`,
+    )
+  ) {
+    throw new CliSafetyError("install state recovery marker is invalid");
+  }
+  let artifactReference: ArtifactRecoveryReference | null = null;
+  if (artifact !== null) {
+    if (typeof artifact !== "object") {
+      throw new CliSafetyError("install state recovery marker is invalid");
+    }
+    const artifactRecord = artifact as Record<string, unknown>;
+    if (
+      typeof artifactRecord.relativePath !== "string" ||
+      !safeRecoveryPath(
+        artifactRecord.relativePath,
+        ".dsh-plugins/artifact-leases/.lease-",
+      ) ||
+      !artifactRecord.relativePath.endsWith("/artifact.tgz") ||
+      typeof artifactRecord.sha512 !== "string" ||
+      !SHA512_REFERENCE.test(artifactRecord.sha512) ||
+      !Number.isSafeInteger(artifactRecord.bytes) || Number(artifactRecord.bytes) <= 0 ||
+      typeof artifactRecord.packageName !== "string" || !PACKAGE_NAME.test(artifactRecord.packageName)
+    ) {
+      throw new CliSafetyError("install state recovery marker is invalid");
+    }
+    artifactReference = {
+      relativePath: artifactRecord.relativePath,
+      sha512: artifactRecord.sha512,
+      bytes: Number(artifactRecord.bytes),
+      packageName: artifactRecord.packageName,
+    };
+  }
+  return {
+    status: "recovery_required",
+    profile,
+    fencingToken: Number(fencingToken),
+    processTree: {
+      pid: Number(tree.pid),
+      processGroupId: tree.processGroupId === null ? null : Number(tree.processGroupId),
+      treeIdentity: tree.treeIdentity,
+      processStartIdentity: tree.processStartIdentity as string | null,
+      platform: tree.platform as NodeJS.Platform,
+    },
+    artifact: artifactReference,
+    transaction: {
+      profile,
+      fencingToken: Number(fencingToken),
+      existed: transactionRecord.existed,
+      journalRelativePath: transactionRecord.journalRelativePath,
+      backupRelativePath: transactionRecord.backupRelativePath,
+    },
+  };
+}
+
+export function resolveDshHome(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.DSH_HOME?.trim();
+  return resolve(configured === undefined || configured === "" ? join(homedir(), ".dsh") : configured);
+}
+
+function safeRelativeCachePath(value: string): boolean {
+  const segments = value.split("/");
+  return segments.length >= 3 && segments.every((segment) => {
+    if (segment.endsWith(".tgz")) {
+      return SAFE_FILE.test(segment);
+    }
+    return /^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(segment) && segment !== "." && segment !== "..";
+  });
+}
+
+const SAFE_FILE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+
+function parseState(value: unknown): InstallState {
+  if (typeof value !== "object" || value === null) {
+    throw new CliSafetyError("install state is invalid");
+  }
+  const record = value as {
+    version?: unknown;
+    generation?: unknown;
+    fencingToken?: unknown;
+    installs?: unknown;
+    recoveryRequired?: unknown;
+  };
+  if (record.version !== 1 || !Array.isArray(record.installs)) {
+    throw new CliSafetyError("install state is invalid");
+  }
+  const generation = record.generation ?? 0;
+  const fencingToken = record.fencingToken ?? 0;
+  if (
+    !Number.isSafeInteger(generation) ||
+    Number(generation) < 0 ||
+    !Number.isSafeInteger(fencingToken) ||
+    Number(fencingToken) < 0
+  ) {
+    throw new CliSafetyError("install state is invalid");
+  }
+  const keys = new Set<string>();
+  const installs: InstalledPlugin[] = [];
+  for (const item of record.installs) {
+    if (typeof item !== "object" || item === null) {
+      throw new CliSafetyError("install state is invalid");
+    }
+    const candidate = item as Record<string, unknown>;
+    const id = candidate.id;
+    const profile = candidate.profile;
+    const packageName = candidate.packageName;
+    const fingerprint = candidate.fingerprint;
+    const cacheRelativePath = candidate.cacheRelativePath;
+    const installedAt = candidate.installedAt;
+    if (
+      typeof id !== "string" ||
+      typeof profile !== "string" ||
+      typeof packageName !== "string" ||
+      typeof fingerprint !== "string" ||
+      typeof cacheRelativePath !== "string" ||
+      typeof installedAt !== "string"
+    ) {
+      throw new CliSafetyError("install state is invalid");
+    }
+    assertSafeCacheSegment(id, "installed plugin ID");
+    assertSafeProfileName(profile);
+    if (!PACKAGE_NAME.test(packageName) || !FINGERPRINT.test(fingerprint) ||
+        !safeRelativeCachePath(cacheRelativePath) || !ISO_DATE.test(installedAt)) {
+      throw new CliSafetyError("install state is invalid");
+    }
+    const key = `${profile}\0${id}`;
+    if (keys.has(key)) {
+      throw new CliSafetyError("install state contains duplicate records");
+    }
+    keys.add(key);
+    installs.push({ id, profile, packageName, fingerprint, cacheRelativePath, installedAt });
+  }
+  installs.sort((left, right) => left.profile.localeCompare(right.profile) || left.id.localeCompare(right.id));
+  const recoveryRequired = parseRecoveryMarker(record.recoveryRequired);
+  return {
+    version: 1,
+    generation: Number(generation),
+    fencingToken: Number(fencingToken),
+    installs,
+    ...(recoveryRequired === undefined ? {} : { recoveryRequired }),
+  };
+}
+
+export async function readInstallState(home: string): Promise<InstallState> {
+  const absoluteHome = resolve(home);
+  let canonicalHome: string;
+  try {
+    const homeInfo = await lstat(absoluteHome);
+    if (homeInfo.isSymbolicLink() || !homeInfo.isDirectory()) {
+      throw new CliSafetyError("DSH home is not a safe directory");
+    }
+    canonicalHome = await realpath(absoluteHome);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return EMPTY_INSTALL_STATE;
+    }
+    throw error;
+  }
+  const statePath = join(canonicalHome, ".dsh-plugins", "state.json");
+  try {
+    const info = await lstat(statePath);
+    if (info.isSymbolicLink() || !info.isFile()) {
+      throw new CliSafetyError("install state path is unsafe");
+    }
+    const canonicalState = await realpath(statePath);
+    if (!isPathWithin(canonicalHome, canonicalState)) {
+      throw new CliSafetyError("install state path is unsafe");
+    }
+    const content = await readFile(canonicalState, "utf8");
+    if (content.length > 1024 * 1024) {
+      throw new CliSafetyError("install state is too large");
+    }
+    return parseState(JSON.parse(content) as unknown);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return EMPTY_INSTALL_STATE;
+    }
+    if (error instanceof CliSafetyError) {
+      throw error;
+    }
+    throw new CliSafetyError("install state is invalid");
+  }
+}
+
+function stateWriterErrorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException).code;
+}
+
+function writerDuration(value: number | undefined, fallback: number, allowZero: boolean): number {
+  const duration = value ?? fallback;
+  if (!Number.isFinite(duration) || (allowZero ? duration < 0 : duration <= 0)) {
+    throw new CliSafetyError("install state writer configuration is invalid");
+  }
+  return duration;
+}
+
+async function linuxProcessStartIdentity(pid: number): Promise<string | null> {
+  try {
+    const source = await readFile(`/proc/${pid}/stat`, "utf8");
+    const commandEnd = source.lastIndexOf(")");
+    if (commandEnd < 0) return null;
+    const fields = source.slice(commandEnd + 1).trim().split(/\s+/u);
+    const startTicks = fields[19];
+    return startTicks !== undefined && /^\d+$/u.test(startTicks) ? `linux:${startTicks}` : null;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultProcessStartIdentity(pid: number): Promise<string> {
+  return await linuxProcessStartIdentity(pid) ??
+    `node:${pid}:${pid === process.pid ? CURRENT_PROCESS_STARTED_AT : "unknown"}`;
+}
+
+async function defaultProcessAlive(pid: number, expectedIdentity: string): Promise<boolean> {
+  const currentIdentity = await linuxProcessStartIdentity(pid);
+  if (currentIdentity !== null) return currentIdentity === expectedIdentity;
+  if (
+    pid === process.pid &&
+    expectedIdentity === `node:${pid}:${CURRENT_PROCESS_STARTED_AT}`
+  ) {
+    return true;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return stateWriterErrorCode(error) !== "ESRCH";
+  }
+}
+
+async function readStateWriterOwner(lockPath: string): Promise<StateWriterOwnerRecord | null> {
+  try {
+    const info = await lstat(lockPath);
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw new CliSafetyError("install state publication lock path is unsafe");
+    }
+    const source = await readFile(join(lockPath, "owner.json"), "utf8");
+    if (source.length > 4_096) throw new Error("oversized-owner");
+    const value = JSON.parse(source) as Partial<StateWriterOwnerRecord>;
+    if (
+      value.version !== 1 ||
+      typeof value.ownerToken !== "string" ||
+      !SAFE_WRITER_TOKEN.test(value.ownerToken) ||
+      !Number.isSafeInteger(value.fencingToken) ||
+      (value.fencingToken ?? 0) < 0 ||
+      !Number.isFinite(value.acquiredAt) ||
+      !Number.isFinite(value.leaseMs) ||
+      (value.leaseMs ?? 0) <= 0 ||
+      !Number.isSafeInteger(value.pid) ||
+      (value.pid ?? 0) <= 0 ||
+      typeof value.processStartIdentity !== "string" ||
+      !SAFE_PROCESS_IDENTITY.test(value.processStartIdentity) ||
+      typeof value.hostname !== "string" ||
+      value.hostname.length === 0 ||
+      value.hostname.length > 255
+    ) {
+      throw new Error("invalid-owner");
+    }
+    return value as StateWriterOwnerRecord;
+  } catch (error) {
+    if (stateWriterErrorCode(error) === "ENOENT") return null;
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("install state publication lock metadata is invalid");
+  }
+}
+
+async function readStateWriterFence(path: string): Promise<number> {
+  try {
+    const value = JSON.parse(await readFile(path, "utf8")) as { version?: unknown; value?: unknown };
+    if (value.version !== 1 || !Number.isSafeInteger(value.value) || Number(value.value) < 0) {
+      throw new Error("invalid-fence");
+    }
+    return Number(value.value);
+  } catch (error) {
+    if (stateWriterErrorCode(error) === "ENOENT") return 0;
+    throw new CliSafetyError("install state publication fence is invalid");
+  }
+}
+
+async function writeStateWriterFence(path: string, value: number): Promise<void> {
+  const temporary = `${path}.tmp-${randomUUID()}`;
+  try {
+    await writeFile(temporary, `${JSON.stringify({ version: 1, value })}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await rename(temporary, path);
+  } catch {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw new CliSafetyError("install state publication fence could not be published");
+  }
+}
+
+async function writeStateWriterOwner(
+  lockPath: string,
+  owner: StateWriterOwnerRecord,
+): Promise<void> {
+  const temporary = join(lockPath, `.owner-${randomUUID()}.tmp`);
+  try {
+    await writeFile(temporary, `${JSON.stringify(owner)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await rename(temporary, join(lockPath, "owner.json"));
+  } catch {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw new CliSafetyError("install state publication lock metadata could not be published");
+  }
+}
+
+async function latestStateWriterHeartbeat(
+  lockPath: string,
+  owner: StateWriterOwnerRecord,
+): Promise<number> {
+  let latest = owner.acquiredAt;
+  const prefix = `heartbeat-${owner.ownerToken}-`;
+  try {
+    for (const entry of await readdir(lockPath, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue;
+      const timestamp = Number(entry.name.slice(prefix.length));
+      if (Number.isFinite(timestamp)) latest = Math.max(latest, timestamp);
+    }
+  } catch (error) {
+    if (stateWriterErrorCode(error) !== "ENOENT") {
+      throw new CliSafetyError("install state publication heartbeat is unreadable");
+    }
+  }
+  return latest;
+}
+
+async function writerSleep(milliseconds: number): Promise<void> {
+  if (milliseconds === 0) return;
+  await new Promise((complete) => setTimeout(complete, milliseconds));
+}
+
+async function acquireStateWriter(
+  stateDirectory: string,
+  options: InstallStateWriterOptions = {},
+): Promise<StateWriterLease> {
+  const leaseMs = writerDuration(options.leaseMs, DEFAULT_WRITER_LEASE_MS, false);
+  const heartbeatMs = writerDuration(
+    options.heartbeatMs,
+    DEFAULT_WRITER_HEARTBEAT_MS,
+    false,
+  );
+  const acquireTimeoutMs = writerDuration(
+    options.acquireTimeoutMs,
+    DEFAULT_WRITER_ACQUIRE_TIMEOUT_MS,
+    true,
+  );
+  const retryMs = writerDuration(options.retryMs, DEFAULT_WRITER_RETRY_MS, true);
+  const now = options.now ?? Date.now;
+  const makeOwnerToken = options.ownerToken ?? randomUUID;
+  const pid = options.pid ?? process.pid;
+  const hostname = options.hostname ?? localHostname();
+  const processStartIdentity = options.processStartIdentity ??
+    await defaultProcessStartIdentity(pid);
+  const isProcessAlive = options.isProcessAlive ?? defaultProcessAlive;
+  if (
+    !Number.isSafeInteger(pid) || pid <= 0 ||
+    !SAFE_PROCESS_IDENTITY.test(processStartIdentity) ||
+    hostname.length === 0 || hostname.length > 255
+  ) {
+    throw new CliSafetyError("install state writer identity is invalid");
+  }
+  const lockPath = join(stateDirectory, ".state-write.lock");
+  const fencePath = join(stateDirectory, ".state-write.fence.json");
+  const startedAt = now();
+
+  while (true) {
+    const ownerToken = makeOwnerToken();
+    if (!SAFE_WRITER_TOKEN.test(ownerToken)) {
+      throw new CliSafetyError("install state writer owner token is invalid");
+    }
+    const candidate = join(stateDirectory, `.state-write.claim-${randomUUID()}`);
+    const provisionalOwner: StateWriterOwnerRecord = {
+      version: 1,
+      ownerToken,
+      fencingToken: 0,
+      acquiredAt: now(),
+      leaseMs,
+      pid,
+      processStartIdentity,
+      hostname,
+    };
+    let claimed = false;
+    let fencingToken = 0;
+    try {
+      await mkdir(candidate, { mode: 0o700 });
+      await writeFile(join(candidate, "owner.json"), `${JSON.stringify(provisionalOwner)}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+        flag: "wx",
+      });
+      await rename(candidate, lockPath);
+      claimed = true;
+      fencingToken = await readStateWriterFence(fencePath) + 1;
+      await writeStateWriterFence(fencePath, fencingToken);
+      await writeStateWriterOwner(lockPath, { ...provisionalOwner, fencingToken });
+    } catch (error) {
+      await rm(candidate, { recursive: true, force: true }).catch(() => undefined);
+      if (claimed) {
+        const failedPath = join(stateDirectory, `.state-write.failed-${randomUUID()}`);
+        try {
+          const current = await readStateWriterOwner(lockPath);
+          if (current?.ownerToken === ownerToken) {
+            await rename(lockPath, failedPath);
+            await rm(failedPath, { recursive: true, force: true });
+          }
+        } catch {
+          // The fenced failed claim is recoverable only after its lease expires.
+        }
+        throw new CliSafetyError("install state publication lock could not be acquired");
+      }
+      if (!["EEXIST", "ENOTEMPTY"].includes(stateWriterErrorCode(error) ?? "")) {
+        throw new CliSafetyError("install state publication lock could not be acquired");
+      }
+
+      const current = await readStateWriterOwner(lockPath);
+      if (current !== null) {
+        const latestHeartbeat = await latestStateWriterHeartbeat(lockPath, current);
+        const leaseExpired = now() - latestHeartbeat > current.leaseMs;
+        let ownerProvenDead = false;
+        if (leaseExpired && current.hostname === hostname) {
+          try {
+            ownerProvenDead = !(await isProcessAlive(
+              current.pid,
+              current.processStartIdentity,
+            ));
+          } catch {
+            ownerProvenDead = false;
+          }
+        }
+        if (leaseExpired && ownerProvenDead) {
+          const confirmed = await readStateWriterOwner(lockPath);
+          if (
+            confirmed?.ownerToken === current.ownerToken &&
+            confirmed.fencingToken === current.fencingToken &&
+            now() - await latestStateWriterHeartbeat(lockPath, confirmed) > confirmed.leaseMs
+          ) {
+            const stalePath = join(stateDirectory, `.state-write.stale-${randomUUID()}`);
+            try {
+              await rename(lockPath, stalePath);
+              const detached = await readStateWriterOwner(stalePath);
+              if (
+                detached?.ownerToken === current.ownerToken &&
+                detached.fencingToken === current.fencingToken
+              ) {
+                await rm(stalePath, { recursive: true, force: true });
+                continue;
+              }
+              await rename(stalePath, lockPath).catch(() => undefined);
+            } catch (takeoverError) {
+              if (![
+                "ENOENT",
+                "EEXIST",
+                "ENOTEMPTY",
+              ].includes(stateWriterErrorCode(takeoverError) ?? "")) {
+                throw new CliSafetyError("stale install state publication lock is unsafe");
+              }
+            }
+          }
+        }
+      }
+      if (now() - startedAt >= acquireTimeoutMs) throw new InstallStateWriterBusyError();
+      await writerSleep(retryMs);
+    }
+
+    let released = false;
+    let lost = false;
+    const assertOwned = async (): Promise<void> => {
+      if (released || lost) throw new InstallStateWriterOwnershipError();
+      const current = await readStateWriterOwner(lockPath);
+      if (
+        current === null ||
+        current.ownerToken !== ownerToken ||
+        current.fencingToken !== fencingToken ||
+        current.processStartIdentity !== processStartIdentity
+      ) {
+        lost = true;
+        throw new InstallStateWriterOwnershipError();
+      }
+    };
+    const heartbeat = async (): Promise<void> => {
+      await assertOwned();
+      try {
+        await mkdir(join(lockPath, `heartbeat-${ownerToken}-${now()}`), { mode: 0o700 });
+      } catch (error) {
+        if (stateWriterErrorCode(error) !== "EEXIST") {
+          lost = true;
+          throw new InstallStateWriterOwnershipError();
+        }
+      }
+    };
+    const timer = setInterval(() => {
+      void heartbeat().catch(() => {
+        lost = true;
+      });
+    }, heartbeatMs);
+    timer.unref();
+
+    const release = async (): Promise<void> => {
+      if (released) return;
+      released = true;
+      clearInterval(timer);
+      const current = await readStateWriterOwner(lockPath);
+      if (
+        current === null ||
+        current.ownerToken !== ownerToken ||
+        current.fencingToken !== fencingToken ||
+        current.processStartIdentity !== processStartIdentity
+      ) {
+        return;
+      }
+      const releasePath = join(stateDirectory, `.state-write.release-${ownerToken}`);
+      try {
+        await rename(lockPath, releasePath);
+        const detached = await readStateWriterOwner(releasePath);
+        if (
+          detached?.ownerToken === ownerToken &&
+          detached.fencingToken === fencingToken &&
+          detached.processStartIdentity === processStartIdentity
+        ) {
+          await rm(releasePath, { recursive: true, force: true });
+        } else {
+          await rename(releasePath, lockPath).catch(() => undefined);
+        }
+      } catch (error) {
+        if (stateWriterErrorCode(error) !== "ENOENT") {
+          throw new CliSafetyError("install state publication lock could not be released safely");
+        }
+      }
+    };
+
+    return {
+      context: { ownerToken, fencingToken },
+      assertOwned,
+      release,
+    };
+  }
+}
+
+export async function writeInstallState(
+  home: string,
+  state: InstallState,
+  options?: InstallStateWriteOptions,
+): Promise<InstallState> {
+  const normalized = parseState(state);
+  const canonicalHome = await ensureCanonicalHome(home);
+  const stateDirectory = await ensureContainedDirectory(canonicalHome, ".dsh-plugins");
+  const writer = await acquireStateWriter(stateDirectory, options?.writer);
+  const target = join(stateDirectory, "state.json");
+  const temporary = join(stateDirectory, `.state-${randomUUID()}.tmp`);
+  try {
+    const current = await readInstallState(canonicalHome);
+    const currentGeneration = current.generation ?? 0;
+    const currentFence = current.fencingToken ?? 0;
+    const expectedGeneration = options?.expectedGeneration ?? currentGeneration;
+    const fencingToken = options?.fencingToken ?? Math.max(currentFence, normalized.fencingToken ?? 0);
+    if (currentGeneration !== expectedGeneration) throw new InstallStateGenerationError();
+    if (fencingToken < currentFence) throw new InstallStateFencingError();
+    const next: InstallState = {
+      version: 1,
+      generation: expectedGeneration + 1,
+      fencingToken,
+      installs: normalized.installs,
+      ...(normalized.recoveryRequired === undefined
+        ? {}
+        : { recoveryRequired: normalized.recoveryRequired }),
+    };
+    await writeFile(temporary, `${JSON.stringify(next, undefined, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await options?.writer?.beforeRename?.(writer.context);
+    const latest = await readInstallState(canonicalHome);
+    let writerOwnershipError: InstallStateWriterOwnershipError | undefined;
+    try {
+      await writer.assertOwned();
+    } catch (error) {
+      if (error instanceof InstallStateWriterOwnershipError) {
+        writerOwnershipError = error;
+      } else {
+        throw error;
+      }
+    }
+    if (writerOwnershipError !== undefined) throw writerOwnershipError;
+    const latestGeneration = latest.generation ?? 0;
+    const latestFence = latest.fencingToken ?? 0;
+    if (latestGeneration !== expectedGeneration) throw new InstallStateGenerationError();
+    if (fencingToken < latestFence) throw new InstallStateFencingError();
+    await options?.assertLockOwned();
+    await writer.assertOwned();
+    await rename(temporary, target);
+    return { ...next, generation: latestGeneration + 1 };
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    if (error instanceof CliSafetyError) {
+      throw error;
+    }
+    throw new CliSafetyError("install state could not be written atomically");
+  } finally {
+    await writer.release();
+  }
+}

--- a/cli/src/dsh/mutationRecoveryJournal.ts
+++ b/cli/src/dsh/mutationRecoveryJournal.ts
@@ -1,0 +1,406 @@
+import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  rename,
+  rm,
+} from "node:fs/promises";
+import { join } from "node:path";
+
+import { CliSafetyError } from "../errors.js";
+import type { ArtifactChannelDescriptor } from "./artifactChannel.js";
+import type { InstalledPlugin } from "./installState.js";
+import { ensureCanonicalHome, ensureContainedDirectory } from "./paths.js";
+import type { ProfileTransactionRecoveryReference } from "./profileTransaction.js";
+import type { DshProcessTreeIdentity } from "./runDsh.js";
+import type { ArtifactRecoveryReference } from "./staging.js";
+
+export type MutationRecoveryPhase =
+  | "needs_restore"
+  | "profile_restored"
+  | "dsh_succeeded"
+  | "state_published"
+  | "profile_finalized"
+  | "artifact_released"
+  | "completed";
+
+export type MutationDecision = "undecided" | "rollback" | "roll_forward";
+
+export interface MutationStateEvidence {
+  readonly oldGeneration: number;
+  readonly oldFingerprint: string;
+  readonly oldInstalls: readonly InstalledPlugin[];
+  readonly intendedFingerprint: string;
+  readonly intendedInstalls: readonly InstalledPlugin[];
+}
+
+export interface MutationRecoveryJournal {
+  readonly version: 1;
+  readonly revision: number;
+  readonly status: "in_progress" | "recovery_required" | "completed";
+  readonly phase: MutationRecoveryPhase;
+  readonly decision?: MutationDecision;
+  readonly stateEvidence?: MutationStateEvidence;
+  readonly activeFingerprint?: string;
+  readonly ownerToken: string;
+  readonly fencingToken: number;
+  readonly profile: string;
+  readonly transaction: ProfileTransactionRecoveryReference;
+  readonly artifact: ArtifactRecoveryReference | null;
+  readonly channel: ArtifactChannelDescriptor | null;
+  readonly processTree?: DshProcessTreeIdentity;
+  readonly createdAt: string;
+}
+
+export interface MutationRecoveryJournalInput {
+  readonly ownerToken: string;
+  readonly fencingToken: number;
+  readonly profile: string;
+  readonly transaction: ProfileTransactionRecoveryReference;
+  readonly artifact: ArtifactRecoveryReference | null;
+  readonly channel: ArtifactChannelDescriptor | null;
+  readonly createdAt: string;
+  readonly decision?: MutationDecision;
+  readonly stateEvidence?: MutationStateEvidence;
+  readonly activeFingerprint?: string;
+}
+
+export interface MutationRecoveryJournalPatch {
+  readonly status?: MutationRecoveryJournal["status"];
+  readonly phase?: MutationRecoveryPhase;
+  readonly ownerToken?: string;
+  readonly fencingToken?: number;
+  readonly processTree?: DshProcessTreeIdentity;
+  readonly decision?: MutationDecision;
+  readonly activeFingerprint?: string;
+}
+
+export interface MutationRecoveryJournalIoDependencies {
+  readonly syncDirectory?: (path: string) => Promise<void>;
+  readonly beforeRename?: () => Promise<void>;
+  readonly afterRename?: () => Promise<void>;
+}
+
+export class MutationRecoveryJournalDurabilityAmbiguousError extends CliSafetyError {
+  readonly possiblyPublished = true;
+
+  constructor(operation: "update" | "remove") {
+    super(
+      operation === "update"
+        ? "mutation recovery journal update may already be visible; reconcile from disk"
+        : "mutation recovery journal removal may already be visible; reconcile from disk",
+    );
+    this.name = "MutationRecoveryJournalDurabilityAmbiguousError";
+  }
+}
+
+export class MutationRecoveryJournalAuthorityUnknownError extends CliSafetyError {
+  readonly authorityUnknown = true;
+
+  constructor() {
+    super("mutation recovery journal authority is unknown; recovery resources remain retained");
+    this.name = "MutationRecoveryJournalAuthorityUnknownError";
+  }
+}
+
+interface JournalPaths {
+  readonly recoveryRoot: string;
+  readonly active: string;
+  readonly marker: string;
+}
+
+const SRI = /^sha512-[A-Za-z0-9+/]{86}==$/u;
+const SAFE_TOKEN = /^[A-Za-z0-9._:-]{1,256}$/u;
+const PHASES = new Set<MutationRecoveryPhase>([
+  "needs_restore",
+  "profile_restored",
+  "dsh_succeeded",
+  "state_published",
+  "profile_finalized",
+  "artifact_released",
+  "completed",
+]);
+
+const STATE_FINGERPRINT = /^sha256:[0-9a-f]{64}$/u;
+
+function isInstalledPlugin(value: unknown): value is InstalledPlugin {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.id === "string" && record.id.length <= 128 &&
+    typeof record.profile === "string" && record.profile.length <= 64 &&
+    typeof record.packageName === "string" && record.packageName.length <= 256 &&
+    typeof record.fingerprint === "string" && record.fingerprint.length <= 512 &&
+    typeof record.cacheRelativePath === "string" && record.cacheRelativePath.length <= 1024 &&
+    typeof record.installedAt === "string" && Number.isFinite(Date.parse(record.installedAt));
+}
+
+function validateStateEvidence(record: Record<string, unknown>): void {
+  const decision = record.decision;
+  const evidence = record.stateEvidence;
+  const activeFingerprint = record.activeFingerprint;
+  if (decision === undefined && evidence === undefined && activeFingerprint === undefined) return;
+  if (
+    !["undecided", "rollback", "roll_forward"].includes(String(decision)) ||
+    typeof evidence !== "object" || evidence === null || Array.isArray(evidence)
+  ) {
+    throw new CliSafetyError("mutation recovery journal requires manual recovery");
+  }
+  const state = evidence as Record<string, unknown>;
+  if (
+    !Number.isSafeInteger(state.oldGeneration) || Number(state.oldGeneration) < 0 ||
+    typeof state.oldFingerprint !== "string" || !STATE_FINGERPRINT.test(state.oldFingerprint) ||
+    typeof state.intendedFingerprint !== "string" ||
+      !STATE_FINGERPRINT.test(state.intendedFingerprint) ||
+    !Array.isArray(state.oldInstalls) || state.oldInstalls.length > 10_000 ||
+    state.oldInstalls.some((install) => !isInstalledPlugin(install)) ||
+    !Array.isArray(state.intendedInstalls) || state.intendedInstalls.length > 10_000 ||
+    state.intendedInstalls.some((install) => !isInstalledPlugin(install)) ||
+    !(activeFingerprint === undefined ||
+      (typeof activeFingerprint === "string" && SRI.test(activeFingerprint)))
+  ) {
+    throw new CliSafetyError("mutation recovery journal requires manual recovery");
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  try {
+    const handle = await open(path, fsConstants.O_RDONLY);
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (process.platform !== "win32" || !["EINVAL", "EPERM", "EISDIR"].includes(code ?? "")) {
+      throw error;
+    }
+  }
+}
+
+async function createPaths(home: string): Promise<JournalPaths> {
+  const canonicalHome = await ensureCanonicalHome(home);
+  const recoveryRoot = await ensureContainedDirectory(canonicalHome, ".dsh-plugins", "recovery");
+  return {
+    recoveryRoot,
+    active: join(recoveryRoot, "active"),
+    marker: join(recoveryRoot, "active", "marker.json"),
+  };
+}
+
+async function existingPaths(home: string): Promise<JournalPaths | null> {
+  let canonicalHome: string;
+  try {
+    canonicalHome = await realpath(home);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new CliSafetyError("mutation recovery journal could not be inspected safely");
+  }
+  const dshPlugins = join(canonicalHome, ".dsh-plugins");
+  const recoveryRoot = join(dshPlugins, "recovery");
+  const active = join(recoveryRoot, "active");
+  try {
+    for (const path of [dshPlugins, recoveryRoot, active]) {
+      const info = await lstat(path);
+      if (info.isSymbolicLink() || !info.isDirectory()) {
+        throw new CliSafetyError("mutation recovery journal requires manual recovery");
+      }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("mutation recovery journal could not be inspected safely");
+  }
+  return { recoveryRoot, active, marker: join(active, "marker.json") };
+}
+
+function safeRelative(value: unknown, prefix: string): value is string {
+  return typeof value === "string" && value.startsWith(prefix) &&
+    !value.includes("\\") && !value.includes("..") && !value.startsWith("/");
+}
+
+function parseProcessTree(value: unknown): DshProcessTreeIdentity | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new CliSafetyError("mutation recovery journal requires manual recovery");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    !Number.isSafeInteger(record.pid) || Number(record.pid) <= 0 ||
+    !(record.processGroupId === null ||
+      (Number.isSafeInteger(record.processGroupId) && Number(record.processGroupId) > 0)) ||
+    typeof record.treeIdentity !== "string" || record.treeIdentity.length > 512 ||
+    !(record.processStartIdentity === null || typeof record.processStartIdentity === "string") ||
+    typeof record.platform !== "string"
+  ) {
+    throw new CliSafetyError("mutation recovery journal requires manual recovery");
+  }
+  const members = record.members;
+  if (members !== undefined && (!Array.isArray(members) || members.some((member) => {
+    if (typeof member !== "object" || member === null || Array.isArray(member)) return true;
+    const candidate = member as Record<string, unknown>;
+    return !Number.isSafeInteger(candidate.pid) || Number(candidate.pid) <= 0 ||
+      typeof candidate.creationIdentity !== "string" || candidate.creationIdentity.length > 256;
+  }))) {
+    throw new CliSafetyError("mutation recovery journal requires manual recovery");
+  }
+  return record as unknown as DshProcessTreeIdentity;
+}
+
+function parseJournal(value: unknown): MutationRecoveryJournal {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new CliSafetyError("mutation recovery journal requires manual recovery");
+  }
+  const record = value as Record<string, unknown>;
+  const transaction = record.transaction as Record<string, unknown> | undefined;
+  const artifact = record.artifact as Record<string, unknown> | null | undefined;
+  const channel = record.channel as Record<string, unknown> | null | undefined;
+  if (
+    record.version !== 1 || !Number.isSafeInteger(record.revision) || Number(record.revision) <= 0 ||
+    !["in_progress", "recovery_required", "completed"].includes(String(record.status)) ||
+    !PHASES.has(record.phase as MutationRecoveryPhase) ||
+    typeof record.ownerToken !== "string" || !SAFE_TOKEN.test(record.ownerToken) ||
+    !Number.isSafeInteger(record.fencingToken) || Number(record.fencingToken) <= 0 ||
+    typeof record.profile !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u.test(record.profile) ||
+    typeof record.createdAt !== "string" || !Number.isFinite(Date.parse(record.createdAt)) ||
+    transaction === undefined || transaction.profile !== record.profile ||
+    (Number(record.revision) === 1 && transaction.fencingToken !== record.fencingToken) ||
+    typeof transaction.existed !== "boolean" ||
+    !safeRelative(transaction.journalRelativePath, "profiles/.dsh-plugins-transaction-") ||
+    !safeRelative(transaction.backupRelativePath, "profiles/.dsh-plugins-backup-") ||
+    !(transaction.backupFingerprint === null ||
+      (typeof transaction.backupFingerprint === "string" && SRI.test(transaction.backupFingerprint))) ||
+    !(artifact === null || artifact !== undefined &&
+      safeRelative(artifact.relativePath, ".dsh-plugins/artifact-leases/.lease-") &&
+      typeof artifact.sha512 === "string" && SRI.test(artifact.sha512) &&
+      Number.isSafeInteger(artifact.bytes) && Number(artifact.bytes) > 0 &&
+      typeof artifact.packageName === "string") ||
+    !(channel === null || channel !== undefined && channel.kind === "loopback-buffer-v1" &&
+      typeof channel.sha512 === "string" && SRI.test(channel.sha512) &&
+      Number.isSafeInteger(channel.bytes) && Number(channel.bytes) > 0 &&
+      typeof channel.sourceFingerprint === "string" && channel.sourceFingerprint.length <= 256)
+  ) {
+    throw new CliSafetyError("mutation recovery journal requires manual recovery");
+  }
+  parseProcessTree(record.processTree);
+  validateStateEvidence(record);
+  return record as unknown as MutationRecoveryJournal;
+}
+
+async function writeMarker(
+  paths: JournalPaths,
+  value: MutationRecoveryJournal,
+  dependencies: MutationRecoveryJournalIoDependencies = {},
+): Promise<void> {
+  const temporary = join(paths.active, `.marker-${randomUUID()}.tmp`);
+  const handle = await open(temporary, "wx", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(value)}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await rename(temporary, paths.marker);
+  try {
+    await (dependencies.syncDirectory ?? syncDirectory)(paths.active);
+  } catch {
+    throw new MutationRecoveryJournalDurabilityAmbiguousError("update");
+  }
+}
+
+export async function readMutationRecoveryJournal(
+  home: string,
+): Promise<MutationRecoveryJournal | null> {
+  const paths = await existingPaths(home);
+  if (paths === null) return null;
+  try {
+    return parseJournal(JSON.parse(await readFile(paths.marker, "utf8")) as unknown);
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("mutation recovery journal requires manual recovery");
+  }
+}
+
+export async function createMutationRecoveryJournal(
+  home: string,
+  input: MutationRecoveryJournalInput,
+): Promise<MutationRecoveryJournal> {
+  const paths = await createPaths(home);
+  try {
+    await mkdir(paths.active, { mode: 0o700 });
+    await syncDirectory(paths.recoveryRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new CliSafetyError("recovery is required before any new mutation can run");
+    }
+    throw new CliSafetyError("durable recovery intent could not be created");
+  }
+  const value = parseJournal({
+    version: 1,
+    revision: 1,
+    status: "in_progress",
+    phase: "needs_restore",
+    ...input,
+  });
+  try {
+    await writeMarker(paths, value);
+    return value;
+  } catch {
+    // The active directory deliberately remains as a fail-closed barrier.
+    throw new CliSafetyError("durable recovery intent could not be published");
+  }
+}
+
+export async function updateMutationRecoveryJournal(
+  home: string,
+  expected: MutationRecoveryJournal,
+  patch: MutationRecoveryJournalPatch,
+  dependencies: MutationRecoveryJournalIoDependencies = {},
+): Promise<MutationRecoveryJournal> {
+  const paths = await existingPaths(home);
+  if (paths === null) throw new CliSafetyError("durable recovery intent is missing");
+  const current = await readMutationRecoveryJournal(home);
+  if (
+    current === null || current.revision !== expected.revision ||
+    current.ownerToken !== expected.ownerToken || current.fencingToken !== expected.fencingToken
+  ) {
+    throw new CliSafetyError("durable recovery intent ownership changed; recovery required");
+  }
+  const next = parseJournal({ ...current, ...patch, revision: current.revision + 1 });
+  await writeMarker(paths, next, dependencies);
+  return next;
+}
+
+export async function removeCompletedMutationRecoveryJournal(
+  home: string,
+  expected: MutationRecoveryJournal,
+  dependencies: MutationRecoveryJournalIoDependencies = {},
+): Promise<void> {
+  if (expected.phase !== "completed" || expected.status !== "completed") {
+    throw new CliSafetyError("durable recovery intent cannot be removed yet");
+  }
+  const paths = await existingPaths(home);
+  if (paths === null) return;
+  const current = await readMutationRecoveryJournal(home);
+  if (
+    current === null || current.revision !== expected.revision ||
+    current.ownerToken !== expected.ownerToken || current.fencingToken !== expected.fencingToken ||
+    current.phase !== "completed"
+  ) {
+    throw new CliSafetyError("durable recovery intent ownership changed; recovery required");
+  }
+  const completed = join(paths.recoveryRoot, `.completed-${randomUUID()}`);
+  await dependencies.beforeRename?.();
+  await rename(paths.active, completed);
+  try {
+    await dependencies.afterRename?.();
+    await (dependencies.syncDirectory ?? syncDirectory)(paths.recoveryRoot);
+    await rm(completed, { recursive: true, force: true });
+  } catch {
+    throw new MutationRecoveryJournalDurabilityAmbiguousError("remove");
+  }
+}

--- a/cli/src/dsh/paths.ts
+++ b/cli/src/dsh/paths.ts
@@ -1,0 +1,64 @@
+import { lstat, mkdir, realpath } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import { CliSafetyError } from "../errors.js";
+
+const SAFE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+
+export function isPathWithin(root: string, candidate: string): boolean {
+  const child = relative(root, candidate);
+  return child === "" || (!isAbsolute(child) && child !== ".." && !child.startsWith(`..${sep}`));
+}
+
+export function assertSafeProfileName(profile: string): void {
+  if (!SAFE_SEGMENT.test(profile) || profile === "." || profile === "..") {
+    throw new CliSafetyError("profile name is unsafe");
+  }
+}
+
+export function assertSafeCacheSegment(value: string, label: string): void {
+  if ((value !== ".dsh-plugins" && !SAFE_SEGMENT.test(value)) || value === "." || value === "..") {
+    throw new CliSafetyError(`${label} is unsafe`);
+  }
+}
+
+export async function ensureCanonicalHome(home: string): Promise<string> {
+  const absolute = resolve(home);
+  await mkdir(absolute, { recursive: true, mode: 0o700 });
+  const info = await lstat(absolute);
+  if (info.isSymbolicLink() || !info.isDirectory()) {
+    throw new CliSafetyError("DSH home is not a safe directory");
+  }
+  return realpath(absolute);
+}
+
+export async function ensureContainedDirectory(
+  canonicalRoot: string,
+  ...segments: readonly string[]
+): Promise<string> {
+  let current = canonicalRoot;
+  for (const segment of segments) {
+    assertSafeCacheSegment(segment, "managed path segment");
+    const candidate = join(current, segment);
+    if (!isPathWithin(canonicalRoot, candidate)) {
+      throw new CliSafetyError("managed path escapes its root");
+    }
+    try {
+      const info = await lstat(candidate);
+      if (info.isSymbolicLink() || !info.isDirectory()) {
+        throw new CliSafetyError("managed path contains an unsafe symlink");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      await mkdir(candidate, { mode: 0o700 });
+    }
+    const canonical = await realpath(candidate);
+    if (!isPathWithin(canonicalRoot, canonical)) {
+      throw new CliSafetyError("managed path contains an unsafe symlink");
+    }
+    current = canonical;
+  }
+  return current;
+}

--- a/cli/src/dsh/profileLock.ts
+++ b/cli/src/dsh/profileLock.ts
@@ -1,0 +1,381 @@
+import { randomUUID } from "node:crypto";
+import { hostname as localHostname } from "node:os";
+import { join } from "node:path";
+import { lstat, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+
+import { CliSafetyError } from "../errors.js";
+import {
+  assertSafeProfileName,
+  ensureCanonicalHome,
+  ensureContainedDirectory,
+} from "./paths.js";
+
+const DEFAULT_LEASE_MS = 30_000;
+const DEFAULT_HEARTBEAT_MS = 10_000;
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_MS = 50;
+const SAFE_TOKEN = /^[A-Za-z0-9_-]{1,100}$/u;
+
+interface LockOwnerRecord {
+  readonly version: 1;
+  readonly ownerToken: string;
+  readonly fencingToken: number;
+  readonly profile: string;
+  readonly acquiredAt: number;
+  readonly leaseMs: number;
+  readonly pid: number;
+  readonly hostname: string;
+}
+
+export interface AcquireProfileLockOptions {
+  readonly leaseMs?: number;
+  readonly heartbeatMs?: number;
+  readonly acquireTimeoutMs?: number;
+  readonly retryMs?: number;
+  readonly now?: () => number;
+  readonly ownerToken?: () => string;
+  readonly pid?: number;
+  readonly hostname?: string;
+  readonly isProcessAlive?: (pid: number) => boolean;
+}
+
+export interface ProfileLock {
+  readonly canonicalHome: string;
+  readonly profile: string;
+  readonly ownerToken: string;
+  readonly fencingToken: number;
+  readonly assertOwned: () => Promise<void>;
+  readonly heartbeat: () => Promise<void>;
+  readonly release: () => Promise<void>;
+}
+
+export class ProfileLockBusyError extends CliSafetyError {
+  constructor() {
+    super("profile mutation lock is busy");
+    this.name = "ProfileLockBusyError";
+  }
+}
+
+export class ProfileLockOwnershipError extends CliSafetyError {
+  constructor() {
+    super("profile mutation lock ownership changed; recovery required");
+    this.name = "ProfileLockOwnershipError";
+  }
+}
+
+function finiteDuration(value: number | undefined, fallback: number, allowZero: boolean): number {
+  const duration = value ?? fallback;
+  if (!Number.isFinite(duration) || (allowZero ? duration < 0 : duration <= 0)) {
+    throw new CliSafetyError("profile mutation lock configuration is invalid");
+  }
+  return duration;
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException).code;
+}
+
+async function readOwner(lockPath: string): Promise<LockOwnerRecord | null> {
+  try {
+    const info = await lstat(lockPath);
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw new CliSafetyError("profile mutation lock path is unsafe");
+    }
+    const source = await readFile(join(lockPath, "owner.json"), "utf8");
+    if (source.length > 4_096) throw new Error("oversized-owner");
+    const value = JSON.parse(source) as Partial<LockOwnerRecord>;
+    if (
+      value.version !== 1 ||
+      typeof value.ownerToken !== "string" ||
+      !SAFE_TOKEN.test(value.ownerToken) ||
+      !Number.isSafeInteger(value.fencingToken) ||
+      (value.fencingToken ?? 0) < 0 ||
+      typeof (value as { profile?: unknown }).profile !== "string" ||
+      !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test((value as { profile: string }).profile) ||
+      !Number.isFinite(value.acquiredAt) ||
+      !Number.isFinite(value.leaseMs) ||
+      !Number.isSafeInteger(value.pid) ||
+      (value.pid ?? 0) <= 0 ||
+      typeof value.hostname !== "string" ||
+      value.hostname.length === 0 ||
+      value.hostname.length > 255
+    ) {
+      throw new Error("invalid-owner");
+    }
+    return value as LockOwnerRecord;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return null;
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("profile mutation lock metadata is invalid");
+  }
+}
+
+async function writeOwner(lockPath: string, owner: LockOwnerRecord): Promise<void> {
+  const temporary = join(lockPath, `.owner-${randomUUID()}.tmp`);
+  try {
+    await writeFile(temporary, `${JSON.stringify(owner)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await rename(temporary, join(lockPath, "owner.json"));
+  } catch {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw new CliSafetyError("profile mutation lock metadata could not be published");
+  }
+}
+
+async function readFence(path: string): Promise<number> {
+  try {
+    const value = JSON.parse(await readFile(path, "utf8")) as { version?: unknown; value?: unknown };
+    if (value.version !== 1 || !Number.isSafeInteger(value.value) || Number(value.value) < 0) {
+      throw new Error("invalid-fence");
+    }
+    return Number(value.value);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return 0;
+    throw new CliSafetyError("profile mutation fence is invalid");
+  }
+}
+
+async function writeFence(path: string, value: number): Promise<void> {
+  const temporary = `${path}.tmp-${randomUUID()}`;
+  try {
+    await writeFile(temporary, `${JSON.stringify({ version: 1, value })}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await rename(temporary, path);
+  } catch {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw new CliSafetyError("profile mutation fence could not be published");
+  }
+}
+
+async function readLegacyFenceMaximum(lockDirectory: string): Promise<number> {
+  let maximum = 0;
+  try {
+    for (const entry of await readdir(lockDirectory, { withFileTypes: true })) {
+      if (!entry.isFile() || !/^[a-z0-9]+(?:-[a-z0-9]+)*\.fence\.json$/u.test(entry.name)) {
+        continue;
+      }
+      maximum = Math.max(maximum, await readFence(join(lockDirectory, entry.name)));
+    }
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") {
+      throw new CliSafetyError("legacy profile mutation fences are unreadable");
+    }
+  }
+  return maximum;
+}
+
+async function latestHeartbeat(lockPath: string, owner: LockOwnerRecord): Promise<number> {
+  let latest = owner.acquiredAt;
+  const prefix = `heartbeat-${owner.ownerToken}-`;
+  try {
+    for (const entry of await readdir(lockPath, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue;
+      const timestamp = Number(entry.name.slice(prefix.length));
+      if (Number.isFinite(timestamp)) latest = Math.max(latest, timestamp);
+    }
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") {
+      throw new CliSafetyError("profile mutation heartbeat is unreadable");
+    }
+  }
+  return latest;
+}
+
+async function sleep(milliseconds: number): Promise<void> {
+  if (milliseconds === 0) return;
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export async function acquireProfileLock(
+  home: string,
+  profile: string,
+  options: AcquireProfileLockOptions = {},
+): Promise<ProfileLock> {
+  assertSafeProfileName(profile);
+  const leaseMs = finiteDuration(options.leaseMs, DEFAULT_LEASE_MS, false);
+  const heartbeatMs = finiteDuration(options.heartbeatMs, DEFAULT_HEARTBEAT_MS, false);
+  const acquireTimeoutMs = finiteDuration(
+    options.acquireTimeoutMs,
+    DEFAULT_ACQUIRE_TIMEOUT_MS,
+    true,
+  );
+  const retryMs = finiteDuration(options.retryMs, DEFAULT_RETRY_MS, true);
+  const now = options.now ?? Date.now;
+  const makeOwnerToken = options.ownerToken ?? randomUUID;
+  const pid = options.pid ?? process.pid;
+  const hostname = options.hostname ?? localHostname();
+  const isProcessAlive = options.isProcessAlive ?? processAlive;
+  const canonicalHome = await ensureCanonicalHome(home);
+  const lockDirectory = await ensureContainedDirectory(canonicalHome, ".dsh-plugins", "locks");
+  const lockPath = join(lockDirectory, "mutation.lock");
+  const fencePath = join(lockDirectory, "mutation.fence.json");
+  const startedAt = now();
+
+  while (true) {
+    const ownerToken = makeOwnerToken();
+    if (!SAFE_TOKEN.test(ownerToken)) {
+      throw new CliSafetyError("profile mutation owner token is invalid");
+    }
+    let fencingToken = 0;
+    const candidate = join(lockDirectory, `.mutation.claim-${randomUUID()}`);
+    const provisionalRecord: LockOwnerRecord = {
+      version: 1,
+      ownerToken,
+      fencingToken: 0,
+      profile,
+      acquiredAt: now(),
+      leaseMs,
+      pid,
+      hostname,
+    };
+    let claimed = false;
+
+    try {
+      await mkdir(candidate, { mode: 0o700 });
+      await writeFile(join(candidate, "owner.json"), `${JSON.stringify(provisionalRecord)}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+        flag: "wx",
+      });
+      await rename(candidate, lockPath);
+      claimed = true;
+      fencingToken = Math.max(
+        await readFence(fencePath),
+        await readLegacyFenceMaximum(lockDirectory),
+      ) + 1;
+      await writeFence(fencePath, fencingToken);
+      await writeOwner(lockPath, { ...provisionalRecord, fencingToken });
+    } catch (error) {
+      await rm(candidate, { recursive: true, force: true }).catch(() => undefined);
+      if (claimed) {
+        const failedPath = join(lockDirectory, `.mutation.failed-${randomUUID()}`);
+        try {
+          const current = await readOwner(lockPath);
+          if (current?.ownerToken === ownerToken) {
+            await rename(lockPath, failedPath);
+            await rm(failedPath, { recursive: true, force: true });
+          }
+        } catch {
+          // A failed claim remains fenced and can only be recovered as stale.
+        }
+        throw new CliSafetyError("profile mutation lock could not be acquired");
+      }
+      if (!["EEXIST", "ENOTEMPTY"].includes(errorCode(error) ?? "")) {
+        throw new CliSafetyError("profile mutation lock could not be acquired");
+      }
+
+      const current = await readOwner(lockPath);
+      if (current !== null) {
+        const leaseExpired = now() - await latestHeartbeat(lockPath, current) > current.leaseMs;
+        const localOwnerAlive = current.hostname === hostname && isProcessAlive(current.pid);
+        if (leaseExpired && !localOwnerAlive) {
+          const stalePath = join(lockDirectory, `.mutation.stale-${randomUUID()}`);
+          try {
+            await rename(lockPath, stalePath);
+            await rm(stalePath, { recursive: true, force: true });
+            continue;
+          } catch (takeoverError) {
+            if (!["ENOENT", "EEXIST", "ENOTEMPTY"].includes(errorCode(takeoverError) ?? "")) {
+              throw new CliSafetyError("stale profile mutation lock could not be recovered");
+            }
+          }
+        }
+      }
+
+      if (now() - startedAt >= acquireTimeoutMs) throw new ProfileLockBusyError();
+      await sleep(retryMs);
+      continue;
+    }
+
+    let released = false;
+    let lost = false;
+    const assertOwned = async (): Promise<void> => {
+      if (released || lost) throw new ProfileLockOwnershipError();
+      const current = await readOwner(lockPath);
+      if (
+        current === null ||
+        current.ownerToken !== ownerToken ||
+        current.fencingToken !== fencingToken ||
+        current.profile !== profile
+      ) {
+        lost = true;
+        throw new ProfileLockOwnershipError();
+      }
+    };
+    const heartbeat = async (): Promise<void> => {
+      await assertOwned();
+      try {
+        await mkdir(join(lockPath, `heartbeat-${ownerToken}-${now()}`), { mode: 0o700 });
+      } catch (error) {
+        if (errorCode(error) !== "EEXIST") {
+          lost = true;
+          throw new ProfileLockOwnershipError();
+        }
+      }
+    };
+    const timer = setInterval(() => {
+      void heartbeat().catch(() => {
+        lost = true;
+      });
+    }, heartbeatMs);
+    timer.unref();
+
+    const release = async (): Promise<void> => {
+      if (released) return;
+      released = true;
+      clearInterval(timer);
+      const current = await readOwner(lockPath);
+      if (
+        current === null ||
+        current.ownerToken !== ownerToken ||
+        current.fencingToken !== fencingToken ||
+        current.profile !== profile
+      ) {
+        return;
+      }
+      const releasePath = join(lockDirectory, `.mutation.release-${ownerToken}`);
+      try {
+        await rename(lockPath, releasePath);
+        const detached = await readOwner(releasePath);
+        if (
+          detached?.ownerToken === ownerToken &&
+          detached.fencingToken === fencingToken &&
+          detached.profile === profile
+        ) {
+          await rm(releasePath, { recursive: true, force: true });
+        } else {
+          await rename(releasePath, lockPath).catch(() => undefined);
+        }
+      } catch (error) {
+        if (errorCode(error) !== "ENOENT") {
+          throw new CliSafetyError("profile mutation lock could not be released safely");
+        }
+      }
+    };
+
+    return {
+      canonicalHome,
+      profile,
+      ownerToken,
+      fencingToken,
+      assertOwned,
+      heartbeat,
+      release,
+    };
+  }
+}

--- a/cli/src/dsh/profileTransaction.ts
+++ b/cli/src/dsh/profileTransaction.ts
@@ -1,0 +1,325 @@
+import { createHash, randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { cp, lstat, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+
+import { CliSafetyError } from "../errors.js";
+import {
+  assertSafeProfileName,
+  ensureCanonicalHome,
+  ensureContainedDirectory,
+} from "./paths.js";
+
+export interface ProfileTransaction {
+  readonly recoveryReference: ProfileTransactionRecoveryReference;
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
+}
+
+export interface ProfileTransactionRecoveryReference {
+  readonly profile: string;
+  readonly fencingToken: number;
+  readonly existed: boolean;
+  readonly journalRelativePath: string;
+  readonly backupRelativePath: string;
+  readonly backupFingerprint?: string | null;
+}
+
+export interface ProfileTransactionOptions {
+  readonly fencingToken?: number;
+  readonly committedFencingToken?: number;
+  readonly assertLockOwned?: () => Promise<void>;
+}
+
+interface TransactionJournal {
+  readonly version: 1;
+  readonly profile: string;
+  readonly fencingToken: number;
+  readonly existed: boolean;
+  readonly backupName: string;
+  readonly backupFingerprint?: string | null;
+}
+
+export async function profileFingerprint(root: string): Promise<string> {
+  const hash = createHash("sha512");
+  let files = 0;
+  let bytes = 0;
+  const visit = async (directory: string, prefix: string): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => Buffer.from(left.name).compare(Buffer.from(right.name)));
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      const relativePath = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+      const info = await lstat(path);
+      if (info.isSymbolicLink()) throw new CliSafetyError("profile backup contains a symlink");
+      if (info.isDirectory()) {
+        hash.update(`D\0${relativePath}\0`);
+        await visit(path, relativePath);
+        continue;
+      }
+      if (!info.isFile()) throw new CliSafetyError("profile backup contains an unsafe file");
+      files += 1;
+      bytes += info.size;
+      if (files > 20_000 || bytes > 512 * 1024 * 1024) {
+        throw new CliSafetyError("profile backup exceeds the recovery fingerprint budget");
+      }
+      const content = await readFile(path);
+      hash.update(`F\0${relativePath}\0${info.mode & 0o777}\0${content.byteLength}\0`);
+      hash.update(content);
+    }
+  };
+  await visit(root, "");
+  return `sha512-${hash.digest("base64")}`;
+}
+
+async function activeExists(active: string): Promise<boolean> {
+  try {
+    const info = await lstat(active);
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw new CliSafetyError("profile path is unsafe");
+    }
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function recoverTransactions(
+  profiles: string,
+  active: string,
+  profile: string,
+  committedFencingToken: number,
+  assertLockOwned: () => Promise<void>,
+): Promise<void> {
+  const prefix = `.dsh-plugins-transaction-${profile}-`;
+  const journals: Array<{ path: string; value: TransactionJournal }> = [];
+  for (const entry of await readdir(profiles, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.startsWith(prefix) || !entry.name.endsWith(".json")) continue;
+    try {
+      const value = JSON.parse(await readFile(join(profiles, entry.name), "utf8")) as TransactionJournal;
+      if (
+        value.version !== 1 ||
+        value.profile !== profile ||
+        !Number.isSafeInteger(value.fencingToken) ||
+        typeof value.existed !== "boolean" ||
+        !value.backupName.startsWith(`.dsh-plugins-backup-${profile}-`) ||
+        value.backupName.includes("/") ||
+        value.backupName.includes("\\")
+      ) {
+        throw new Error("invalid-journal");
+      }
+      journals.push({ path: join(profiles, entry.name), value });
+    } catch {
+      throw new CliSafetyError("profile transaction journal requires manual recovery");
+    }
+  }
+  journals.sort((left, right) => right.value.fencingToken - left.value.fencingToken);
+  for (const journal of journals) {
+    const backup = join(profiles, journal.value.backupName);
+    if (journal.value.fencingToken <= committedFencingToken) {
+      await rm(backup, { recursive: true, force: true }).catch(() => undefined);
+      await rm(journal.path, { force: true }).catch(() => undefined);
+      continue;
+    }
+    await assertLockOwned();
+    try {
+      await rm(active, { recursive: true, force: true });
+      if (journal.value.existed) await rename(backup, active);
+      else await rm(backup, { recursive: true, force: true });
+      await rm(journal.path, { force: true });
+    } catch {
+      throw new CliSafetyError("profile rollback requires the retained recovery backup");
+    }
+  }
+}
+
+export async function beginProfileTransaction(
+  home: string,
+  profile: string,
+  options: ProfileTransactionOptions = {},
+): Promise<ProfileTransaction> {
+  assertSafeProfileName(profile);
+  const fencingToken = options.fencingToken ?? 0;
+  const committedFencingToken = options.committedFencingToken ?? -1;
+  const assertLockOwned = options.assertLockOwned ?? (async () => undefined);
+  await assertLockOwned();
+  const canonicalHome = await ensureCanonicalHome(home);
+  const profiles = await ensureContainedDirectory(canonicalHome, "profiles");
+  const active = join(profiles, profile);
+  await recoverTransactions(
+    profiles,
+    active,
+    profile,
+    committedFencingToken,
+    assertLockOwned,
+  );
+
+  const suffix = randomUUID();
+  const backupName = `.dsh-plugins-backup-${profile}-${suffix}`;
+  const backup = join(profiles, backupName);
+  const journal = join(profiles, `.dsh-plugins-transaction-${profile}-${suffix}.json`);
+  const journalTemporary = `${journal}.tmp`;
+  const existed = await activeExists(active);
+  let backupFingerprint: string | null = null;
+  try {
+    if (existed) {
+      await cp(active, backup, {
+        recursive: true,
+        force: false,
+        errorOnExist: true,
+        dereference: false,
+        preserveTimestamps: true,
+      });
+      backupFingerprint = await profileFingerprint(backup);
+    }
+    const value: TransactionJournal = {
+      version: 1,
+      profile,
+      fencingToken,
+      existed,
+      backupName,
+      backupFingerprint,
+    };
+    await writeFile(journalTemporary, `${JSON.stringify(value)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await rename(journalTemporary, journal);
+  } catch (error) {
+    await rm(journalTemporary, { force: true }).catch(() => undefined);
+    await rm(backup, { recursive: true, force: true }).catch(() => undefined);
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("profile backup could not be prepared");
+  }
+
+  let finished = false;
+  const recoveryReference: ProfileTransactionRecoveryReference = {
+    profile,
+    fencingToken,
+    existed,
+    journalRelativePath: `profiles/${journal.slice(profiles.length + 1)}`,
+    backupRelativePath: `profiles/${backupName}`,
+    backupFingerprint,
+  };
+  return {
+    recoveryReference,
+    async commit() {
+      if (finished) return;
+      await assertLockOwned();
+      await rm(backup, { recursive: true, force: true });
+      await rm(journal, { force: true });
+      finished = true;
+    },
+    async rollback() {
+      if (finished) return;
+      await assertLockOwned();
+      try {
+        await rm(active, { recursive: true, force: true });
+        if (existed) await rename(backup, active);
+        else await rm(backup, { recursive: true, force: true });
+        await rm(journal, { force: true });
+        finished = true;
+      } catch {
+        throw new CliSafetyError("profile rollback could not restore its retained backup");
+      }
+    },
+  };
+}
+
+export async function recoverProfileTransaction(
+  home: string,
+  reference: ProfileTransactionRecoveryReference,
+  assertLockOwned: () => Promise<void>,
+): Promise<void> {
+  assertSafeProfileName(reference.profile);
+  const journalPrefix = `profiles/.dsh-plugins-transaction-${reference.profile}-`;
+  const backupPrefix = `profiles/.dsh-plugins-backup-${reference.profile}-`;
+  if (
+    !Number.isSafeInteger(reference.fencingToken) || reference.fencingToken <= 0 ||
+    !reference.journalRelativePath.startsWith(journalPrefix) ||
+    !reference.journalRelativePath.endsWith(".json") ||
+    reference.journalRelativePath.includes("\\") ||
+    reference.journalRelativePath.includes("..") ||
+    !reference.backupRelativePath.startsWith(backupPrefix) ||
+    reference.backupRelativePath.includes("\\") ||
+    reference.backupRelativePath.includes("..")
+  ) {
+    throw new CliSafetyError("profile recovery reference is invalid");
+  }
+  const canonicalHome = await ensureCanonicalHome(home);
+  const profiles = await ensureContainedDirectory(canonicalHome, "profiles");
+  const journal = join(canonicalHome, reference.journalRelativePath);
+  const backup = join(canonicalHome, reference.backupRelativePath);
+  const active = join(profiles, reference.profile);
+  const displaced = `${backup}.displaced`;
+  let value: TransactionJournal;
+  try {
+    value = JSON.parse(await readFile(journal, "utf8")) as TransactionJournal;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new CliSafetyError("profile transaction recovery journal is invalid");
+  }
+  if (
+    value.version !== 1 ||
+    value.profile !== reference.profile ||
+    value.fencingToken !== reference.fencingToken ||
+    value.existed !== reference.existed ||
+    `profiles/${value.backupName}` !== reference.backupRelativePath ||
+    (reference.backupFingerprint !== undefined &&
+      value.backupFingerprint !== reference.backupFingerprint)
+  ) {
+    throw new CliSafetyError("profile transaction recovery journal is invalid");
+  }
+  await assertLockOwned();
+  try {
+    if (!reference.existed) {
+      if (await activeExists(active)) await rename(active, displaced);
+      return;
+    }
+    const expected = reference.backupFingerprint ?? value.backupFingerprint;
+    if (typeof expected !== "string") {
+      throw new CliSafetyError("profile recovery fingerprint is unavailable");
+    }
+    let backupPresent = false;
+    try {
+      backupPresent = await activeExists(backup);
+    } catch {
+      throw new CliSafetyError("profile recovery requires the retained backup");
+    }
+    if (backupPresent) {
+      if (await profileFingerprint(backup) !== expected) {
+        throw new CliSafetyError("profile recovery backup fingerprint changed");
+      }
+      if (await activeExists(active)) {
+        if (await profileFingerprint(active) === expected) return;
+        if (await activeExists(displaced)) {
+          throw new CliSafetyError("profile recovery quarantine already exists");
+        }
+        await rename(active, displaced);
+      }
+      await rename(backup, active);
+    }
+    if (!await activeExists(active) || await profileFingerprint(active) !== expected) {
+      throw new CliSafetyError("profile recovery requires the retained backup");
+    }
+  } catch {
+    throw new CliSafetyError("profile recovery requires the retained backup");
+  }
+}
+
+export async function finalizeProfileTransactionRecovery(
+  home: string,
+  reference: ProfileTransactionRecoveryReference,
+  assertLockOwned: () => Promise<void>,
+): Promise<void> {
+  assertSafeProfileName(reference.profile);
+  const canonicalHome = await ensureCanonicalHome(home);
+  await ensureContainedDirectory(canonicalHome, "profiles");
+  const journal = join(canonicalHome, reference.journalRelativePath);
+  const backup = join(canonicalHome, reference.backupRelativePath);
+  await assertLockOwned();
+  await rm(backup, { recursive: true, force: true });
+  await rm(`${backup}.displaced`, { recursive: true, force: true });
+  await rm(journal, { force: true });
+}

--- a/cli/src/dsh/runDsh.ts
+++ b/cli/src/dsh/runDsh.ts
@@ -1,0 +1,544 @@
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import { CliSafetyError } from "../errors.js";
+
+export const DSH_MUTATION_TIMEOUT_MS = 120_000;
+export const DSH_TERMINATION_GRACE_MS = 1_000;
+export const DSH_REAP_TIMEOUT_MS = 5_000;
+
+const MAX_TIMER_MS = 2_147_483_647;
+const WINDOWS_TREE_OUTPUT_BYTES = 64 * 1024;
+const WINDOWS_TREE_TIMEOUT_MS = 2_000;
+
+export type ChildTerminationReason = "timeout" | "aborted" | "tree-alive";
+export type ProcessSignalSender = (pid: number, signal: NodeJS.Signals) => unknown;
+
+export interface WindowsProcessIdentity {
+  readonly pid: number;
+  readonly creationIdentity: string;
+}
+
+export interface DshProcessTreeIdentity {
+  readonly pid: number;
+  readonly processGroupId: number | null;
+  readonly treeIdentity: string;
+  readonly processStartIdentity: string | null;
+  readonly platform: NodeJS.Platform;
+  readonly members?: readonly WindowsProcessIdentity[];
+}
+
+export interface ProcessTreeInspectionDependencies {
+  readonly snapshotWindowsTree?: (rootPid: number) => Promise<readonly WindowsProcessIdentity[]>;
+}
+
+export interface ChildProcessDeadlineOptions extends ProcessTreeInspectionDependencies {
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+  readonly terminationGraceMs?: number;
+  readonly reapTimeoutMs?: number;
+  readonly platform?: NodeJS.Platform;
+  readonly killProcess?: ProcessSignalSender;
+  readonly taskkillSpawn?: typeof nodeSpawn;
+}
+
+export interface ResolvedChildDeadlinePolicy {
+  readonly signal: AbortSignal | undefined;
+  readonly timeoutMs: number;
+  readonly terminationGraceMs: number;
+  readonly reapTimeoutMs: number;
+  readonly platform: NodeJS.Platform;
+  readonly killProcess: ProcessSignalSender;
+  readonly taskkillSpawn: typeof nodeSpawn;
+}
+
+export type ChildProcessOutcome =
+  | {
+      readonly status: "exited";
+      readonly code: number | null;
+      readonly signal: NodeJS.Signals | null;
+    }
+  | {
+      readonly status: "spawn-error";
+      readonly errorCode: string | null;
+    }
+  | {
+      readonly status: "terminated";
+      readonly reason: ChildTerminationReason;
+      readonly reaped: boolean;
+    };
+
+export class DshDeadlineConfigurationError extends CliSafetyError {
+  constructor() {
+    super("dsh subprocess deadline configuration is invalid");
+    this.name = "DshDeadlineConfigurationError";
+  }
+}
+
+export class DshExecutionUncertainError extends CliSafetyError {
+  readonly reason: ChildTerminationReason;
+  readonly ambiguous = true;
+  readonly recoveryRequired = true;
+  readonly reaped: boolean;
+  readonly processTree: DshProcessTreeIdentity | null;
+
+  constructor(
+    reason: ChildTerminationReason,
+    reaped: boolean,
+    processTree: DshProcessTreeIdentity | null = null,
+  ) {
+    super(
+      reason === "timeout"
+        ? "dsh execution timed out; result is ambiguous; recovery required"
+        : reason === "aborted"
+          ? "dsh execution was aborted; result is ambiguous; recovery required"
+          : "dsh process tree remains alive; result is ambiguous; recovery required",
+    );
+    this.name = "DshExecutionUncertainError";
+    this.reason = reason;
+    this.reaped = reaped;
+    this.processTree = processTree;
+  }
+}
+
+export interface RunDshDependencies extends ChildProcessDeadlineOptions {
+  readonly spawn?: typeof nodeSpawn;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly identifyProcessTree?: (
+    pid: number,
+    platform: NodeJS.Platform,
+  ) => Promise<string>;
+  readonly onSpawn?: (identity: DshProcessTreeIdentity) => Promise<void>;
+}
+
+function finiteDuration(value: number | undefined, fallback: number, allowZero: boolean): number {
+  const duration = value ?? fallback;
+  if (
+    !Number.isFinite(duration) ||
+    duration > MAX_TIMER_MS ||
+    (allowZero ? duration < 0 : duration <= 0)
+  ) {
+    throw new DshDeadlineConfigurationError();
+  }
+  return duration;
+}
+
+export function resolveChildDeadlinePolicy(
+  options: ChildProcessDeadlineOptions,
+  defaultTimeoutMs: number,
+): ResolvedChildDeadlinePolicy {
+  return {
+    signal: options.signal,
+    timeoutMs: finiteDuration(options.timeoutMs, defaultTimeoutMs, false),
+    terminationGraceMs: finiteDuration(
+      options.terminationGraceMs,
+      DSH_TERMINATION_GRACE_MS,
+      true,
+    ),
+    reapTimeoutMs: finiteDuration(options.reapTimeoutMs, DSH_REAP_TIMEOUT_MS, false),
+    platform: options.platform ?? process.platform,
+    killProcess: options.killProcess ?? ((pid, signal) => process.kill(pid, signal)),
+    taskkillSpawn: options.taskkillSpawn ?? nodeSpawn,
+  };
+}
+
+async function defaultProcessTreeIdentity(
+  pid: number,
+  platform: NodeJS.Platform,
+): Promise<string> {
+  if (platform === "linux") {
+    try {
+      const source = await readFile(`/proc/${pid}/stat`, "utf8");
+      const commandEnd = source.lastIndexOf(")");
+      const fields = commandEnd < 0 ? [] : source.slice(commandEnd + 1).trim().split(/\s+/u);
+      const startTicks = fields[19];
+      if (startTicks !== undefined && /^\d+$/u.test(startTicks)) return `linux:${startTicks}`;
+    } catch {
+      // A bounded opaque identity is safer than exposing process inspection failures.
+    }
+  }
+  return `${platform}:${pid}:unknown`;
+}
+
+const WINDOWS_TREE_SCRIPT = [
+  "$root=[int]$env:DSH_ROOT_PID",
+  "$all=@(Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CreationDate)",
+  "$front=@($root)",
+  "$seen=@{}",
+  "$out=@()",
+  "while($front.Count -gt 0){$next=@();foreach($id in $front){foreach($p in $all){if(([int]$p.ProcessId -eq $id)-or([int]$p.ParentProcessId -eq $id)){if(-not $seen.ContainsKey([string]$p.ProcessId)){$seen[[string]$p.ProcessId]=$true;$out+=@{pid=[int]$p.ProcessId;creationIdentity=[string]$p.CreationDate};$next+=[int]$p.ProcessId}}}};$front=$next}",
+  "$out | ConvertTo-Json -Compress",
+].join(";");
+
+async function defaultWindowsTreeSnapshot(rootPid: number): Promise<readonly WindowsProcessIdentity[]> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let outputBytes = 0;
+    const chunks: Buffer[] = [];
+    let child: ChildProcess;
+    try {
+      child = nodeSpawn(
+        "powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_TREE_SCRIPT],
+        {
+          shell: false,
+          windowsHide: true,
+          stdio: ["ignore", "pipe", "ignore"],
+          env: { ...process.env, DSH_ROOT_PID: String(rootPid) },
+        },
+      );
+    } catch {
+      reject(new CliSafetyError("windows process tree could not be inspected safely"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { child.kill("SIGKILL"); } catch { /* bounded helper cleanup */ }
+      reject(new CliSafetyError("windows process tree could not be inspected safely"));
+    }, WINDOWS_TREE_TIMEOUT_MS);
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      outputBytes += data.byteLength;
+      if (outputBytes <= WINDOWS_TREE_OUTPUT_BYTES) chunks.push(data);
+      else {
+        try { child.kill("SIGKILL"); } catch { /* bounded helper cleanup */ }
+      }
+    });
+    child.once("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new CliSafetyError("windows process tree could not be inspected safely"));
+    });
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code !== 0 || outputBytes > WINDOWS_TREE_OUTPUT_BYTES) {
+        reject(new CliSafetyError("windows process tree could not be inspected safely"));
+        return;
+      }
+      try {
+        const source = Buffer.concat(chunks).toString("utf8").trim();
+        const parsed = source === "" ? [] : JSON.parse(source) as unknown;
+        const values = Array.isArray(parsed) ? parsed : [parsed];
+        resolve(values.map((value) => {
+          const record = value as Record<string, unknown>;
+          if (
+            !Number.isSafeInteger(record.pid) || Number(record.pid) <= 0 ||
+            typeof record.creationIdentity !== "string" || record.creationIdentity.length === 0
+          ) {
+            throw new Error("invalid-process");
+          }
+          return { pid: Number(record.pid), creationIdentity: record.creationIdentity };
+        }));
+      } catch {
+        reject(new CliSafetyError("windows process tree could not be inspected safely"));
+      }
+    });
+  });
+}
+
+export async function isDshProcessTreeAlive(
+  identity: DshProcessTreeIdentity,
+  dependencies: ProcessTreeInspectionDependencies = {},
+): Promise<boolean> {
+  if (identity.platform === "win32") {
+    const recorded = identity.members;
+    if (recorded === undefined || recorded.length === 0) {
+      throw new CliSafetyError("windows process tree could not be inspected safely");
+    }
+    const current = await (dependencies.snapshotWindowsTree ?? defaultWindowsTreeSnapshot)(identity.pid);
+    const currentByPid = new Map(current.map((member) => [member.pid, member.creationIdentity]));
+    return recorded.some((member) => currentByPid.get(member.pid) === member.creationIdentity);
+  }
+  const target = identity.processGroupId === null ? identity.pid : -identity.processGroupId;
+  try {
+    process.kill(target, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function signalPosixTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+  policy: ResolvedChildDeadlinePolicy,
+): void {
+  if (child.pid !== undefined && child.pid > 0) {
+    try {
+      policy.killProcess(-child.pid, signal);
+      return;
+    } catch {
+      // Fall back to the direct child when a process group was not established.
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    // A concurrent exit is observed through close; the reap deadline remains bounded.
+  }
+}
+
+function runTaskkill(
+  child: ChildProcess,
+  policy: ResolvedChildDeadlinePolicy,
+): Promise<boolean> {
+  if (child.pid === undefined || child.pid <= 0) return Promise.resolve(false);
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let killer: ChildProcess;
+    const finish = (value: boolean): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      resolve(value);
+    };
+    try {
+      killer = policy.taskkillSpawn(
+        "taskkill",
+        ["/PID", String(child.pid), "/T", "/F"],
+        { shell: false, stdio: "ignore", windowsHide: true },
+      );
+    } catch {
+      resolve(false);
+      return;
+    }
+    timer = setTimeout(() => {
+      try { killer.kill("SIGKILL"); } catch { /* bounded helper cleanup */ }
+      finish(false);
+    }, policy.terminationGraceMs + policy.reapTimeoutMs);
+    killer.once("error", () => finish(false));
+    killer.once("close", (code) => finish(code === 0));
+  });
+}
+
+export function waitForChildWithDeadline(
+  child: ChildProcess,
+  policy: ResolvedChildDeadlinePolicy,
+): Promise<ChildProcessOutcome> {
+  return new Promise<ChildProcessOutcome>((resolve) => {
+    let settled = false;
+    let rootClosed = false;
+    let terminationReason: ChildTerminationReason | null = null;
+    let windowsTermination: Promise<boolean> | undefined;
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
+    let reapTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearTimers = (): void => {
+      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+      if (graceTimer !== undefined) clearTimeout(graceTimer);
+      if (reapTimer !== undefined) clearTimeout(reapTimer);
+    };
+    const finish = (outcome: ChildProcessOutcome): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      child.removeListener("error", onError);
+      child.removeListener("close", onClose);
+      policy.signal?.removeEventListener("abort", onAbort);
+      resolve(outcome);
+    };
+    const onError = (error: Error): void => {
+      if (terminationReason !== null) return;
+      const code = (error as NodeJS.ErrnoException).code;
+      finish({ status: "spawn-error", errorCode: typeof code === "string" ? code : null });
+    };
+    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
+      if (terminationReason === null) {
+        finish({ status: "exited", code, signal });
+        return;
+      }
+      rootClosed = true;
+      if (policy.platform !== "win32") {
+        finish({ status: "terminated", reason: terminationReason, reaped: true });
+        return;
+      }
+      void (windowsTermination ?? Promise.resolve(false)).then((killed) => {
+        finish({ status: "terminated", reason: terminationReason as ChildTerminationReason, reaped: killed });
+      });
+    };
+    const beginTermination = (reason: ChildTerminationReason): void => {
+      if (settled || terminationReason !== null) return;
+      terminationReason = reason;
+      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+      if (policy.platform === "win32") {
+        windowsTermination = runTaskkill(child, policy);
+        void windowsTermination.then((killed) => {
+          if (!killed && !settled) finish({ status: "terminated", reason, reaped: false });
+          else if (killed && rootClosed && !settled) {
+            finish({ status: "terminated", reason, reaped: true });
+          }
+        });
+        reapTimer = setTimeout(() => {
+          if (!settled) finish({ status: "terminated", reason, reaped: false });
+        }, policy.terminationGraceMs + policy.reapTimeoutMs);
+        return;
+      }
+      signalPosixTree(child, "SIGTERM", policy);
+      graceTimer = setTimeout(() => {
+        if (settled) return;
+        signalPosixTree(child, "SIGKILL", policy);
+        reapTimer = setTimeout(() => {
+          if (settled) return;
+          signalPosixTree(child, "SIGKILL", policy);
+          finish({ status: "terminated", reason, reaped: false });
+        }, policy.reapTimeoutMs);
+      }, policy.terminationGraceMs);
+    };
+    const onAbort = (): void => beginTermination("aborted");
+
+    child.once("error", onError);
+    child.once("close", onClose);
+    policy.signal?.addEventListener("abort", onAbort, { once: true });
+    deadlineTimer = setTimeout(() => beginTermination("timeout"), policy.timeoutMs);
+    if (policy.signal?.aborted === true) beginTermination("aborted");
+  });
+}
+
+function mergeMembers(
+  previous: readonly WindowsProcessIdentity[] | undefined,
+  current: readonly WindowsProcessIdentity[],
+): readonly WindowsProcessIdentity[] {
+  const values = new Map<string, WindowsProcessIdentity>();
+  for (const member of [...(previous ?? []), ...current]) {
+    values.set(`${member.pid}:${member.creationIdentity}`, member);
+  }
+  return [...values.values()].sort((left, right) => left.pid - right.pid ||
+    left.creationIdentity.localeCompare(right.creationIdentity));
+}
+
+async function refreshProcessTree(
+  identity: DshProcessTreeIdentity | null,
+  dependencies: RunDshDependencies,
+): Promise<DshProcessTreeIdentity | null> {
+  if (identity === null || identity.platform !== "win32") return identity;
+  try {
+    const current = await (dependencies.snapshotWindowsTree ?? defaultWindowsTreeSnapshot)(identity.pid);
+    const members = mergeMembers(identity.members, current);
+    return {
+      ...identity,
+      members,
+      treeIdentity: `win32:${createHash("sha256").update(JSON.stringify(members)).digest("hex")}`,
+    };
+  } catch {
+    return identity;
+  }
+}
+
+export async function runDsh(
+  profile: string,
+  args: readonly string[],
+  dependencies: RunDshDependencies = {},
+): Promise<number> {
+  const resolvedPolicy = resolveChildDeadlinePolicy(dependencies, DSH_MUTATION_TIMEOUT_MS);
+  if (resolvedPolicy.signal?.aborted === true) {
+    throw new DshExecutionUncertainError("aborted", true);
+  }
+  const controller = new AbortController();
+  const forwardAbort = (): void => controller.abort();
+  resolvedPolicy.signal?.addEventListener("abort", forwardAbort, { once: true });
+  const policy: ResolvedChildDeadlinePolicy = { ...resolvedPolicy, signal: controller.signal };
+  const spawn = dependencies.spawn ?? nodeSpawn;
+  let child: ChildProcess;
+  try {
+    child = spawn(
+      "dsh",
+      ["plugin", "--profile", profile, ...args],
+      {
+        detached: policy.platform !== "win32",
+        shell: false,
+        stdio: "inherit",
+        ...(dependencies.env === undefined ? {} : { env: dependencies.env }),
+      },
+    );
+  } catch {
+    resolvedPolicy.signal?.removeEventListener("abort", forwardAbort);
+    throw new CliSafetyError("dsh invocation failed");
+  }
+
+  const outcomePromise = waitForChildWithDeadline(child, policy);
+  const processTreePromise: Promise<DshProcessTreeIdentity | null> =
+    child.pid === undefined || child.pid <= 0
+      ? Promise.resolve(null)
+      : (dependencies.identifyProcessTree ?? defaultProcessTreeIdentity)(
+          child.pid,
+          policy.platform,
+        ).then(async (treeIdentity) => {
+          const members = policy.platform === "win32"
+            ? await (dependencies.snapshotWindowsTree ?? defaultWindowsTreeSnapshot)(child.pid as number)
+            : undefined;
+          const root = members?.find((member) => member.pid === child.pid);
+          return {
+            pid: child.pid as number,
+            processGroupId: policy.platform === "win32" ? null : child.pid as number,
+            treeIdentity: members === undefined
+              ? treeIdentity
+              : `win32:${createHash("sha256").update(JSON.stringify(members)).digest("hex")}`,
+            processStartIdentity: root?.creationIdentity ??
+              (treeIdentity.endsWith(":unknown") ? null : treeIdentity),
+            platform: policy.platform,
+            ...(members === undefined ? {} : { members }),
+          } satisfies DshProcessTreeIdentity;
+        }).catch(() => ({
+          pid: child.pid as number,
+          processGroupId: policy.platform === "win32" ? null : child.pid as number,
+          treeIdentity: `${policy.platform}:${child.pid}:unknown`,
+          processStartIdentity: null,
+          platform: policy.platform,
+        }));
+
+  let processTree = await processTreePromise;
+  try {
+    if (processTree !== null && dependencies.onSpawn !== undefined) {
+      try {
+        await dependencies.onSpawn(processTree);
+      } catch {
+        controller.abort();
+        await outcomePromise;
+        throw new DshExecutionUncertainError(
+          "aborted",
+          false,
+          processTree,
+        );
+      }
+    }
+
+    const outcome = await outcomePromise;
+    processTree = await refreshProcessTree(processTree, dependencies);
+    if (outcome.status === "spawn-error") {
+      throw new CliSafetyError(
+        outcome.errorCode === "ENOENT" ? "dsh executable was not found" : "dsh invocation failed",
+      );
+    }
+    if (outcome.status === "terminated") {
+      let reaped = outcome.reaped;
+      if (reaped && processTree !== null) {
+        try {
+          reaped = !await isDshProcessTreeAlive(processTree, dependencies);
+        } catch {
+          reaped = false;
+        }
+      }
+      throw new DshExecutionUncertainError(outcome.reason, reaped, processTree);
+    }
+    if (processTree !== null) {
+      try {
+        if (await isDshProcessTreeAlive(processTree, dependencies)) {
+          throw new DshExecutionUncertainError("tree-alive", false, processTree);
+        }
+      } catch (error) {
+        if (error instanceof DshExecutionUncertainError) throw error;
+        throw new DshExecutionUncertainError("tree-alive", false, processTree);
+      }
+    }
+    return outcome.code ?? 1;
+  } finally {
+    resolvedPolicy.signal?.removeEventListener("abort", forwardAbort);
+  }
+}

--- a/cli/src/dsh/staging.ts
+++ b/cli/src/dsh/staging.ts
@@ -1,0 +1,1451 @@
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { once } from "node:events";
+import {
+  closeSync,
+  constants as fsConstants,
+  createWriteStream,
+  fstatSync,
+  openSync,
+  readSync,
+} from "node:fs";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readlink,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { devNull } from "node:os";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { createGzip } from "node:zlib";
+
+import {
+  canonicalPublicId,
+  parseExactSemver,
+  parseSha512Integrity,
+} from "../catalog/index.js";
+
+import { CliSafetyError } from "../errors.js";
+import type { PublicCatalogEntry } from "../model.js";
+import type { StagedInstall } from "./installState.js";
+import {
+  runSupervisedChild,
+  type ChildSupervisorDependencies,
+} from "./childSupervisor.js";
+import {
+  ensureCanonicalHome,
+  ensureContainedDirectory,
+  isPathWithin,
+} from "./paths.js";
+
+const PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/u;
+const SOURCE_REPOSITORY = /^https:\/\/github\.com\/[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]{1,100}$/u;
+const SOURCE_SUBPATH = /^(?!\/)(?!.*\\)(?!\.{1,2}(?:\/|$))(?!.*(?:\/\.{1,2})(?:\/|$))[A-Za-z0-9._@+-]+(?:\/[A-Za-z0-9._@+-]+)*$/u;
+const SHA40 = /^[0-9a-fA-F]{40}$/u;
+const LFS_POINTER = "version https://git-lfs.github.com/spec/v1";
+const NO_FOLLOW = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
+
+export interface StageBudgets {
+  readonly metadataBytes: number;
+  readonly tarballBytes: number;
+  readonly sourceBytes: number;
+  readonly sourceFiles: number;
+  readonly sourceDepth: number;
+  readonly processOutputBytes: number;
+  readonly fetchTimeoutMs: number;
+  readonly gitTimeoutMs: number;
+  readonly killGraceMs: number;
+  readonly gitReapTimeoutMs: number;
+}
+
+export const DEFAULT_STAGE_BUDGETS: Readonly<StageBudgets> = Object.freeze({
+  metadataBytes: 1024 * 1024,
+  tarballBytes: 64 * 1024 * 1024,
+  sourceBytes: 128 * 1024 * 1024,
+  sourceFiles: 20_000,
+  sourceDepth: 32,
+  processOutputBytes: 2 * 1024 * 1024,
+  fetchTimeoutMs: 30_000,
+  gitTimeoutMs: 120_000,
+  killGraceMs: 2_000,
+  gitReapTimeoutMs: 5_000,
+});
+
+export interface ProcessRequest {
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly signal?: AbortSignal;
+  readonly outputBytes?: number;
+  readonly killGraceMs?: number;
+  readonly timeoutMs?: number;
+  readonly reapTimeoutMs?: number;
+  readonly resourceBudget?: Pick<StageBudgets, "sourceBytes" | "sourceFiles" | "sourceDepth">;
+}
+
+export type ProcessRunner = (request: ProcessRequest) => Promise<string>;
+
+export interface StageOptions {
+  readonly dshHome: string;
+  readonly fetchImpl?: typeof fetch;
+  readonly runProcess?: ProcessRunner;
+  readonly signal?: AbortSignal;
+  readonly offline?: boolean;
+  readonly budgets?: Partial<StageBudgets>;
+  readonly childSupervisor?: ChildSupervisorDependencies;
+}
+
+export class GitProcessUnreapedError extends CliSafetyError {
+  readonly reaped = false;
+  readonly recoveryRequired = true;
+
+  constructor() {
+    super("git process tree was not reaped; recovery required");
+    this.name = "GitProcessUnreapedError";
+  }
+}
+
+interface NpmCacheArtifact {
+  readonly kind: "npm";
+  readonly integrity: string;
+  readonly bytes: number;
+}
+
+interface SourceCacheArtifact {
+  readonly kind: "source";
+  readonly commit: string;
+  readonly treeSha512: string;
+  readonly bytes: number;
+  readonly files: number;
+}
+
+interface CacheMetadata {
+  readonly version: 2;
+  readonly fingerprint: string;
+  readonly descriptorHash: string;
+  readonly packageName: string;
+  readonly installRelativePath: string;
+  readonly artifact: NpmCacheArtifact | SourceCacheArtifact;
+}
+
+interface StagedMetadata {
+  readonly packageName: string;
+  readonly installRelativePath: string;
+  readonly artifact: NpmCacheArtifact | SourceCacheArtifact;
+}
+
+interface TreeMeasurement {
+  readonly bytes: number;
+  readonly files: number;
+  readonly digest: string;
+}
+
+export interface ArtifactRecoveryReference {
+  readonly relativePath: string;
+  readonly sha512: string;
+  readonly bytes: number;
+  readonly packageName: string;
+}
+
+export interface StagedArtifactLease {
+  readonly recoveryReference: ArtifactRecoveryReference;
+  revalidate(): Promise<void>;
+  readVerifiedBytes(): Promise<Buffer>;
+  release(): Promise<void>;
+}
+
+export interface StagedCatalogInstall extends StagedInstall {
+  readonly artifactLease: StagedArtifactLease;
+}
+
+interface NpmVerifiedCache {
+  readonly kind: "npm";
+  readonly path: string;
+  readonly expectedDigest: Buffer;
+  readonly bytes: number;
+}
+
+interface SourceVerifiedCache {
+  readonly kind: "source";
+  readonly sourceRoot: string;
+  readonly pluginRoot: string;
+  readonly tree: TreeMeasurement;
+}
+
+const VERIFIED_CACHE = Symbol("verified-cache");
+
+interface VerifiedCachedInstall extends StagedInstall {
+  readonly [VERIFIED_CACHE]: NpmVerifiedCache | SourceVerifiedCache;
+}
+
+function stageBudgets(overrides: Partial<StageBudgets> | undefined): StageBudgets {
+  const budgets = { ...DEFAULT_STAGE_BUDGETS, ...overrides };
+  for (const [name, value] of Object.entries(budgets)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new CliSafetyError(`staging budget ${name} is invalid`);
+    }
+  }
+  return budgets;
+}
+
+function descriptorFor(entry: PublicCatalogEntry): string {
+  return entry.package.ecosystem === "npm"
+    ? `npm\0${entry.package.name}\0${entry.package.version}\0${entry.package.integrity ?? ""}`
+    : `source\0${entry.source.repository}\0${entry.source.commit.toLowerCase()}\0${entry.source.subpath ?? "."}`;
+}
+
+function descriptorHash(entry: PublicCatalogEntry): string {
+  return createHash("sha256").update(descriptorFor(entry)).digest("hex");
+}
+
+function assertAllowlistedHttps(urlValue: string, hosts: readonly string[]): URL {
+  let url: URL;
+  try {
+    url = new URL(urlValue);
+  } catch {
+    throw new CliSafetyError("download URL is invalid");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.port !== "" ||
+    !hosts.includes(url.hostname)
+  ) {
+    throw new CliSafetyError("download source is not allowlisted");
+  }
+  return url;
+}
+
+async function boundedOperation<T>(
+  timeoutMs: number,
+  graceMs: number,
+  parentSignal: AbortSignal | undefined,
+  timeoutMessage: string,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  if (parentSignal?.aborted === true) {
+    throw new CliSafetyError("staging was cancelled");
+  }
+  const controller = new AbortController();
+  let timedOut = false;
+  let cancelled = false;
+  let rejectBoundary: ((error: Error) => void) | undefined;
+  let graceTimer: NodeJS.Timeout | undefined;
+  const boundary = new Promise<never>((_resolve, reject) => {
+    rejectBoundary = reject;
+  });
+  const finishAbort = (message: string): void => {
+    controller.abort();
+    graceTimer = setTimeout(() => rejectBoundary?.(new CliSafetyError(message)), graceMs);
+    graceTimer.unref?.();
+  };
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    finishAbort(timeoutMessage);
+  }, timeoutMs);
+  timeout.unref?.();
+  const onParentAbort = (): void => {
+    cancelled = true;
+    finishAbort("staging was cancelled");
+  };
+  parentSignal?.addEventListener("abort", onParentAbort, { once: true });
+  try {
+    return await Promise.race([operation(controller.signal), boundary]);
+  } catch (error) {
+    if (timedOut) throw new CliSafetyError(timeoutMessage);
+    if (cancelled) {
+      throw new CliSafetyError("staging was cancelled");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    if (graceTimer !== undefined) clearTimeout(graceTimer);
+    parentSignal?.removeEventListener("abort", onParentAbort);
+  }
+}
+
+async function fetchAllowlisted(
+  initial: string,
+  hosts: readonly string[],
+  fetchImpl: typeof fetch,
+  signal: AbortSignal,
+): Promise<Response> {
+  let current = assertAllowlistedHttps(initial, hosts);
+  for (let redirect = 0; redirect <= 3; redirect += 1) {
+    const response = await fetchImpl(current, {
+      redirect: "manual",
+      credentials: "omit",
+      referrerPolicy: "no-referrer",
+      signal,
+    });
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      await response.body?.cancel().catch(() => undefined);
+      if (location === null || redirect === 3) {
+        throw new CliSafetyError("download redirect was rejected");
+      }
+      current = assertAllowlistedHttps(new URL(location, current).href, hosts);
+      continue;
+    }
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new CliSafetyError(`download failed with HTTP ${response.status}`);
+    }
+    return response;
+  }
+  throw new CliSafetyError("download redirect was rejected");
+}
+
+async function responseBytes(response: Response, limit: number, signal: AbortSignal): Promise<Buffer> {
+  const declaredValue = response.headers.get("content-length");
+  let declared: number | undefined;
+  if (declaredValue !== null) {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(declaredValue)) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new CliSafetyError("download Content-Length is invalid");
+    }
+    declared = Number(declaredValue);
+    if (!Number.isSafeInteger(declared)) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new CliSafetyError("download Content-Length is invalid");
+    }
+    if (declared > limit) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new CliSafetyError("download exceeds the safe size limit");
+    }
+  }
+  if (response.body === null) {
+    if (declared !== undefined && declared !== 0) {
+      throw new CliSafetyError("download Content-Length is invalid");
+    }
+    return Buffer.alloc(0);
+  }
+
+  const reader = response.body.getReader();
+  let capacity = Math.max(1, Math.min(declared ?? 8192, limit));
+  let output = Buffer.allocUnsafe(capacity);
+  let length = 0;
+  let cancelled = false;
+  try {
+    while (true) {
+      if (signal.aborted) throw new CliSafetyError("download was cancelled");
+      const part = await reader.read();
+      if (part.done) break;
+      const nextLength = length + part.value.byteLength;
+      if (nextLength > limit) {
+        cancelled = true;
+        await reader.cancel().catch(() => undefined);
+        throw new CliSafetyError("download exceeds the safe size limit");
+      }
+      if (nextLength > capacity) {
+        let nextCapacity = capacity;
+        while (nextCapacity < nextLength) nextCapacity = Math.min(limit, nextCapacity * 2);
+        const grown = Buffer.allocUnsafe(nextCapacity);
+        output.copy(grown, 0, 0, length);
+        output = grown;
+        capacity = nextCapacity;
+      }
+      output.set(part.value, length);
+      length = nextLength;
+    }
+    if (declared !== undefined && declared !== length) {
+      throw new CliSafetyError("download Content-Length is invalid");
+    }
+    return output.subarray(0, length);
+  } finally {
+    if (signal.aborted && !cancelled) await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
+function sameFile(
+  first: { dev: number; ino: number; size: number; ctimeMs: number },
+  second: { dev: number; ino: number; size: number; ctimeMs: number },
+): boolean {
+  return first.dev === second.dev && first.ino === second.ino &&
+    first.size === second.size && first.ctimeMs === second.ctimeMs;
+}
+
+async function readRegularFile(path: string, limit: number, unsafeMessage: string): Promise<Buffer> {
+  let handle;
+  try {
+    const pathInfo = await lstat(path);
+    if (pathInfo.isSymbolicLink() || !pathInfo.isFile() || pathInfo.size > limit) {
+      throw new CliSafetyError(unsafeMessage);
+    }
+    handle = await open(path, fsConstants.O_RDONLY | NO_FOLLOW);
+    const before = await handle.stat();
+    if (!before.isFile() || !sameFile(pathInfo, before) || before.size > limit) {
+      throw new CliSafetyError(unsafeMessage);
+    }
+    const bytes = Buffer.allocUnsafe(before.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const result = await handle.read(bytes, offset, bytes.length - offset, offset);
+      if (result.bytesRead === 0) throw new CliSafetyError(unsafeMessage);
+      offset += result.bytesRead;
+    }
+    const extra = Buffer.allocUnsafe(1);
+    if ((await handle.read(extra, 0, 1, offset)).bytesRead !== 0) {
+      throw new CliSafetyError(unsafeMessage);
+    }
+    const after = await handle.stat();
+    if (!sameFile(before, after)) throw new CliSafetyError(unsafeMessage);
+    return bytes;
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError(unsafeMessage);
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function hashRegularFile(
+  path: string,
+  limit: number,
+  unsafeMessage: string,
+): Promise<{ digest: Buffer; bytes: number; prefix: string }> {
+  let handle;
+  try {
+    const pathInfo = await lstat(path);
+    if (pathInfo.isSymbolicLink() || !pathInfo.isFile() || pathInfo.size > limit) {
+      throw new CliSafetyError(unsafeMessage);
+    }
+    handle = await open(path, fsConstants.O_RDONLY | NO_FOLLOW);
+    const before = await handle.stat();
+    if (!before.isFile() || !sameFile(pathInfo, before) || before.size > limit) {
+      throw new CliSafetyError(unsafeMessage);
+    }
+    const hash = createHash("sha512");
+    const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, Math.max(1, before.size)));
+    const prefixChunks: Buffer[] = [];
+    let prefixBytes = 0;
+    let offset = 0;
+    while (offset < before.size) {
+      const result = await handle.read(buffer, 0, Math.min(buffer.length, before.size - offset), offset);
+      if (result.bytesRead === 0) throw new CliSafetyError(unsafeMessage);
+      const chunk = buffer.subarray(0, result.bytesRead);
+      hash.update(chunk);
+      if (prefixBytes < 128) {
+        const take = Math.min(128 - prefixBytes, chunk.length);
+        prefixChunks.push(Buffer.from(chunk.subarray(0, take)));
+        prefixBytes += take;
+      }
+      offset += result.bytesRead;
+    }
+    const extra = Buffer.allocUnsafe(1);
+    if ((await handle.read(extra, 0, 1, offset)).bytesRead !== 0) {
+      throw new CliSafetyError(unsafeMessage);
+    }
+    const after = await handle.stat();
+    if (!sameFile(before, after)) throw new CliSafetyError(unsafeMessage);
+    return {
+      digest: hash.digest(),
+      bytes: before.size,
+      prefix: Buffer.concat(prefixChunks).toString("utf8"),
+    };
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError(unsafeMessage);
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+function tarOctal(buffer: Buffer, offset: number, length: number, value: number): void {
+  const encoded = value.toString(8);
+  if (encoded.length > length - 1) throw new CliSafetyError("source archive value is unsafe");
+  buffer.write(`${encoded.padStart(length - 1, "0")}\0`, offset, length, "ascii");
+}
+
+function tarPath(path: string): { name: string; prefix: string } {
+  if (Buffer.byteLength(path) <= 100) return { name: path, prefix: "" };
+  for (let separator = path.lastIndexOf("/"); separator > 0; separator = path.lastIndexOf("/", separator - 1)) {
+    const prefix = path.slice(0, separator);
+    const name = path.slice(separator + 1);
+    if (Buffer.byteLength(prefix) <= 155 && Buffer.byteLength(name) <= 100) {
+      return { name, prefix };
+    }
+  }
+  throw new CliSafetyError("source archive path exceeds the safe limit");
+}
+
+function tarHeader(path: string, size: number, mode: number, type: "file" | "directory"): Buffer {
+  const header = Buffer.alloc(512);
+  const split = tarPath(path);
+  header.write(split.name, 0, 100, "utf8");
+  tarOctal(header, 100, 8, mode);
+  tarOctal(header, 108, 8, 0);
+  tarOctal(header, 116, 8, 0);
+  tarOctal(header, 124, 12, size);
+  tarOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header.write(type === "directory" ? "5" : "0", 156, 1, "ascii");
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+  header.write(split.prefix, 345, 155, "utf8");
+  let checksum = 0;
+  for (const byte of header) checksum += byte;
+  header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
+  return header;
+}
+
+async function copyVerifiedNpmArtifact(
+  source: string,
+  destination: string,
+  limit: number,
+  expectedDigest: Buffer,
+  expectedBytes: number,
+): Promise<{ digest: Buffer; bytes: number }> {
+  let sourceHandle;
+  let destinationHandle;
+  try {
+    const sourcePathInfo = await lstat(source);
+    if (sourcePathInfo.isSymbolicLink() || !sourcePathInfo.isFile() || sourcePathInfo.size > limit) {
+      throw new CliSafetyError("verified cache changed before private materialization");
+    }
+    sourceHandle = await open(source, fsConstants.O_RDONLY | NO_FOLLOW);
+    const sourceBefore = await sourceHandle.stat();
+    if (!sameFile(sourcePathInfo, sourceBefore) || sourceBefore.size !== expectedBytes) {
+      throw new CliSafetyError("verified cache changed before private materialization");
+    }
+    destinationHandle = await open(
+      destination,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | NO_FOLLOW,
+      0o400,
+    );
+    const hash = createHash("sha512");
+    const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, Math.max(1, sourceBefore.size)));
+    let position = 0;
+    while (position < sourceBefore.size) {
+      const read = await sourceHandle.read(
+        buffer,
+        0,
+        Math.min(buffer.length, sourceBefore.size - position),
+        position,
+      );
+      if (read.bytesRead === 0) {
+        throw new CliSafetyError("verified cache changed before private materialization");
+      }
+      const chunk = buffer.subarray(0, read.bytesRead);
+      hash.update(chunk);
+      let written = 0;
+      while (written < chunk.length) {
+        const result = await destinationHandle.write(
+          chunk,
+          written,
+          chunk.length - written,
+          position + written,
+        );
+        if (result.bytesWritten === 0) {
+          throw new CliSafetyError("private artifact materialization failed");
+        }
+        written += result.bytesWritten;
+      }
+      position += read.bytesRead;
+    }
+    const extra = Buffer.allocUnsafe(1);
+    if ((await sourceHandle.read(extra, 0, 1, position)).bytesRead !== 0) {
+      throw new CliSafetyError("verified cache changed before private materialization");
+    }
+    const sourceAfter = await sourceHandle.stat();
+    if (!sameFile(sourceBefore, sourceAfter)) {
+      throw new CliSafetyError("verified cache changed before private materialization");
+    }
+    await destinationHandle.sync();
+    const actualDigest = hash.digest();
+    if (actualDigest.length !== expectedDigest.length || !timingSafeEqual(actualDigest, expectedDigest)) {
+      throw new CliSafetyError("verified cache changed before private materialization");
+    }
+    return { digest: actualDigest, bytes: position };
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("private artifact materialization failed");
+  } finally {
+    await destinationHandle?.close().catch(() => undefined);
+    await sourceHandle?.close().catch(() => undefined);
+  }
+}
+
+async function createDeterministicSourceArchive(
+  sourceRoot: string,
+  pluginRoot: string,
+  destination: string,
+  budgets: StageBudgets,
+  expectedTree: TreeMeasurement,
+): Promise<{ digest: Buffer; bytes: number }> {
+  const before = await inspectSourceTree(sourceRoot, budgets);
+  if (
+    before.digest !== expectedTree.digest ||
+    before.bytes !== expectedTree.bytes ||
+    before.files !== expectedTree.files
+  ) {
+    throw new CliSafetyError("verified source cache changed before private materialization");
+  }
+  const gzip = createGzip({ level: 9 });
+  const output = createWriteStream(destination, { flags: "wx", mode: 0o400 });
+  const completion = pipeline(gzip, output);
+  const emit = async (chunk: Buffer): Promise<void> => {
+    if (!gzip.write(chunk)) await once(gzip, "drain");
+  };
+  let archivedBytes = 0;
+  try {
+    await emit(tarHeader("package/", 0, 0o755, "directory"));
+    const visit = async (directory: string, relativeDirectory: string): Promise<void> => {
+      const entries = await readdir(directory, { withFileTypes: true });
+      entries.sort((left, right) => Buffer.from(left.name).compare(Buffer.from(right.name)));
+      for (const entry of entries) {
+        const candidate = join(directory, entry.name);
+        const relativePath = relativeDirectory === "" ? entry.name : `${relativeDirectory}/${entry.name}`;
+        const archivePath = `package/${relativePath}`;
+        const info = await lstat(candidate);
+        if (info.isSymbolicLink()) {
+          throw new CliSafetyError("source archive contains a symlink");
+        }
+        if (info.isDirectory()) {
+          await emit(tarHeader(`${archivePath}/`, 0, 0o755, "directory"));
+          await visit(candidate, relativePath);
+          continue;
+        }
+        if (!info.isFile()) throw new CliSafetyError("source archive contains an unsafe file type");
+        const bytes = await readRegularFile(
+          candidate,
+          budgets.sourceBytes,
+          "source changed during private archive materialization",
+        );
+        if (bytes.subarray(0, 128).toString("utf8").startsWith(LFS_POINTER)) {
+          throw new CliSafetyError("source tree contains Git LFS content");
+        }
+        archivedBytes += bytes.length;
+        if (archivedBytes > budgets.sourceBytes) {
+          throw new CliSafetyError("source archive exceeds the byte limit");
+        }
+        const mode = (info.mode & 0o111) === 0 ? 0o644 : 0o755;
+        await emit(tarHeader(archivePath, bytes.length, mode, "file"));
+        await emit(bytes);
+        const padding = (512 - (bytes.length % 512)) % 512;
+        if (padding !== 0) await emit(Buffer.alloc(padding));
+      }
+    };
+    await visit(pluginRoot, "");
+    await emit(Buffer.alloc(1024));
+    gzip.end();
+    await completion;
+  } catch (error) {
+    gzip.destroy();
+    output.destroy();
+    await completion.catch(() => undefined);
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("private source archive materialization failed");
+  }
+  const after = await inspectSourceTree(sourceRoot, budgets);
+  if (
+    after.digest !== expectedTree.digest ||
+    after.bytes !== expectedTree.bytes ||
+    after.files !== expectedTree.files
+  ) {
+    throw new CliSafetyError("verified source cache changed during private materialization");
+  }
+  const artifact = await hashRegularFile(
+    destination,
+    budgets.tarballBytes,
+    "private source archive is unsafe",
+  );
+  return { digest: artifact.digest, bytes: artifact.bytes };
+}
+
+async function createArtifactLease(
+  cached: VerifiedCachedInstall,
+  home: string,
+  budgets: StageBudgets,
+): Promise<StagedCatalogInstall> {
+  const leasesRoot = await ensureContainedDirectory(home, ".dsh-plugins", "artifact-leases");
+  const leaseRoot = await mkdtemp(join(leasesRoot, ".lease-"));
+  const destination = join(leaseRoot, "artifact.tgz");
+  let heldFd: number | undefined;
+  try {
+    const cache = cached[VERIFIED_CACHE];
+    const materialized = cache.kind === "npm"
+      ? await copyVerifiedNpmArtifact(
+          cache.path,
+          destination,
+          budgets.tarballBytes,
+          cache.expectedDigest,
+          cache.bytes,
+        )
+      : await createDeterministicSourceArchive(
+          cache.sourceRoot,
+          cache.pluginRoot,
+          destination,
+          budgets,
+          cache.tree,
+        );
+    const copied = await hashRegularFile(
+      destination,
+      budgets.tarballBytes,
+      "private transaction artifact is unsafe",
+    );
+    if (
+      copied.bytes !== materialized.bytes ||
+      copied.digest.length !== materialized.digest.length ||
+      !timingSafeEqual(copied.digest, materialized.digest)
+    ) {
+      throw new CliSafetyError("private artifact verification failed");
+    }
+    heldFd = openSync(destination, fsConstants.O_RDONLY | NO_FOLLOW);
+    const heldInfo = fstatSync(heldFd);
+    const pathInfo = await lstat(destination);
+    if (!heldInfo.isFile() || !sameFile(pathInfo, heldInfo)) {
+      throw new CliSafetyError("private artifact verification failed");
+    }
+    let released = false;
+    const recoveryRelativePath = relative(home, destination).split(sep).join("/");
+    const artifactLease: StagedArtifactLease = {
+      recoveryReference: {
+        relativePath: recoveryRelativePath,
+        sha512: `sha512-${materialized.digest.toString("base64")}`,
+        bytes: materialized.bytes,
+        packageName: cached.packageName,
+      },
+      revalidate: async () => {
+        if (released) throw new CliSafetyError("transaction artifact changed; recovery required");
+        try {
+          const currentPath = await lstat(destination);
+          const currentHandle = heldFd === undefined ? undefined : fstatSync(heldFd);
+          if (
+            currentHandle === undefined ||
+            currentPath.isSymbolicLink() ||
+            !currentPath.isFile() ||
+            !sameFile(currentPath, currentHandle) ||
+            !sameFile(heldInfo, currentHandle)
+          ) {
+            throw new CliSafetyError("transaction artifact changed; recovery required");
+          }
+          const current = await hashRegularFile(
+            destination,
+            budgets.tarballBytes,
+            "transaction artifact changed; recovery required",
+          );
+          if (
+            current.bytes !== materialized.bytes ||
+            current.digest.length !== materialized.digest.length ||
+            !timingSafeEqual(current.digest, materialized.digest)
+          ) {
+            throw new CliSafetyError("transaction artifact changed; recovery required");
+          }
+        } catch (error) {
+          if (error instanceof CliSafetyError) throw error;
+          throw new CliSafetyError("transaction artifact changed; recovery required");
+        }
+      },
+      readVerifiedBytes: async () => {
+        if (released || heldFd === undefined) {
+          throw new CliSafetyError("transaction artifact changed; recovery required");
+        }
+        try {
+          const before = fstatSync(heldFd);
+          if (!before.isFile() || !sameFile(heldInfo, before) || before.size !== materialized.bytes) {
+            throw new CliSafetyError("transaction artifact changed; recovery required");
+          }
+          const bytes = Buffer.alloc(materialized.bytes);
+          let offset = 0;
+          while (offset < bytes.byteLength) {
+            const count = readSync(heldFd, bytes, offset, bytes.byteLength - offset, offset);
+            if (count === 0) break;
+            offset += count;
+          }
+          const after = fstatSync(heldFd);
+          const digest = createHash("sha512").update(bytes).digest();
+          if (
+            offset !== materialized.bytes || !sameFile(heldInfo, after) ||
+            digest.length !== materialized.digest.length ||
+            !timingSafeEqual(digest, materialized.digest)
+          ) {
+            throw new CliSafetyError("transaction artifact changed; recovery required");
+          }
+          return bytes;
+        } catch (error) {
+          if (error instanceof CliSafetyError) throw error;
+          throw new CliSafetyError("transaction artifact changed; recovery required");
+        }
+      },
+      release: async () => {
+        if (released) return;
+        released = true;
+        if (heldFd !== undefined) {
+          try {
+            closeSync(heldFd);
+          } catch {
+            // A concurrent recovery may already have closed the descriptor.
+          }
+        }
+        heldFd = undefined;
+        await rm(leaseRoot, { recursive: true, force: true });
+      },
+    };
+    return {
+      fingerprint: cached.fingerprint,
+      installTarget: destination,
+      displayTarget: "$DSH_HOME/.dsh-plugins/artifact-leases/<private>/artifact.tgz",
+      packageName: cached.packageName,
+      cacheRelativePath: cached.cacheRelativePath,
+      artifactLease,
+    };
+  } catch (error) {
+    if (heldFd !== undefined) {
+      try {
+        closeSync(heldFd);
+      } catch {
+        // Preserve the primary materialization error.
+      }
+    }
+    await rm(leaseRoot, { recursive: true, force: true }).catch(() => undefined);
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("private artifact materialization failed");
+  }
+}
+
+function assertTreeBudget(
+  bytes: number,
+  files: number,
+  depth: number,
+  budgets: Pick<StageBudgets, "sourceBytes" | "sourceFiles" | "sourceDepth">,
+): void {
+  if (bytes > budgets.sourceBytes) throw new CliSafetyError("source tree exceeds the byte limit");
+  if (files > budgets.sourceFiles) throw new CliSafetyError("source tree exceeds the file limit");
+  if (depth > budgets.sourceDepth) throw new CliSafetyError("source tree exceeds the depth limit");
+}
+
+async function inspectSourceTree(
+  root: string,
+  budgets: Pick<StageBudgets, "sourceBytes" | "sourceFiles" | "sourceDepth">,
+): Promise<TreeMeasurement> {
+  const hash = createHash("sha512");
+  hash.update("dsh-source-tree-v1\0");
+  let bytes = 0;
+  let files = 0;
+
+  const visit = async (directory: string, depth: number): Promise<void> => {
+    assertTreeBudget(bytes, files, depth, budgets);
+    const before = await lstat(directory);
+    if (before.isSymbolicLink() || !before.isDirectory()) {
+      throw new CliSafetyError("source tree changed during verification");
+    }
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => Buffer.from(left.name).compare(Buffer.from(right.name)));
+    for (const entry of entries) {
+      const candidate = join(directory, entry.name);
+      const relativePath = relative(root, candidate).split(sep).join("/");
+      const candidateDepth = relativePath.split("/").length;
+      assertTreeBudget(bytes, files, candidateDepth, budgets);
+      if (entry.name === ".gitmodules") {
+        throw new CliSafetyError("source tree contains submodules");
+      }
+      const info = await lstat(candidate);
+      if (info.isSymbolicLink()) {
+        files += 1;
+        const target = await readlink(candidate);
+        const resolvedTarget = resolve(dirname(candidate), target);
+        if (!isPathWithin(root, resolvedTarget)) {
+          throw new CliSafetyError("source tree contains a symlink escape");
+        }
+        try {
+          const canonical = await realpath(candidate);
+          if (!isPathWithin(root, canonical)) {
+            throw new CliSafetyError("source tree contains a symlink escape");
+          }
+        } catch (error) {
+          if (error instanceof CliSafetyError) throw error;
+          throw new CliSafetyError("source tree contains a symlink escape");
+        }
+        const after = await lstat(candidate);
+        if (!sameFile(info, after)) throw new CliSafetyError("source tree changed during verification");
+        bytes += Buffer.byteLength(target);
+        assertTreeBudget(bytes, files, candidateDepth, budgets);
+        hash.update(`L\0${relativePath}\0${target}\0`);
+      } else if (info.isDirectory()) {
+        hash.update(`D\0${relativePath}\0`);
+        await visit(candidate, depth + 1);
+      } else if (info.isFile()) {
+        files += 1;
+        const remaining = Math.max(0, budgets.sourceBytes - bytes);
+        const file = await hashRegularFile(candidate, remaining, "source tree changed during verification");
+        if (file.prefix.startsWith(LFS_POINTER)) {
+          throw new CliSafetyError("source tree contains Git LFS content");
+        }
+        bytes += file.bytes;
+        assertTreeBudget(bytes, files, candidateDepth, budgets);
+        hash.update(`F\0${relativePath}\0${file.bytes}\0`);
+        hash.update(file.digest);
+      } else {
+        throw new CliSafetyError("source tree contains an unsafe file type");
+      }
+    }
+    const after = await lstat(directory);
+    if (!sameFile(before, after)) throw new CliSafetyError("source tree changed during verification");
+  };
+
+  await visit(root, 0);
+  return { bytes, files, digest: `sha512-${hash.digest("base64")}` };
+}
+
+async function measureCheckout(
+  root: string,
+  budgets: Pick<StageBudgets, "sourceBytes" | "sourceFiles" | "sourceDepth">,
+): Promise<void> {
+  let bytes = 0;
+  let files = 0;
+  const visit = async (directory: string, depth: number): Promise<void> => {
+    assertTreeBudget(bytes, files, depth, budgets);
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const candidate = join(directory, entry.name);
+      const candidateDepth = depth + 1;
+      const info = await lstat(candidate);
+      if (info.isDirectory() && !info.isSymbolicLink()) {
+        await visit(candidate, candidateDepth);
+      } else {
+        files += 1;
+        bytes += info.size;
+        assertTreeBudget(bytes, files, candidateDepth, budgets);
+      }
+    }
+  };
+  await visit(root, 0);
+}
+
+async function defaultProcessRunner(
+  request: ProcessRequest,
+  dependencies: ChildSupervisorDependencies = {},
+): Promise<string> {
+  const controller = new AbortController();
+  let resourceFailure: CliSafetyError | undefined;
+  let measuring = false;
+  const onAbort = (): void => controller.abort();
+  request.signal?.addEventListener("abort", onAbort, { once: true });
+  if (request.signal?.aborted === true) controller.abort();
+  const monitor = request.resourceBudget === undefined
+    ? undefined
+    : setInterval(() => {
+        if (measuring) return;
+        measuring = true;
+        void measureCheckout(
+          request.cwd,
+          request.resourceBudget as NonNullable<ProcessRequest["resourceBudget"]>,
+        )
+          .catch((error: unknown) => {
+            resourceFailure = error instanceof CliSafetyError
+              ? error
+              : new CliSafetyError("source tree exceeds the byte limit");
+            controller.abort();
+          })
+          .finally(() => { measuring = false; });
+      }, 25);
+  monitor?.unref?.();
+  try {
+    const result = await runSupervisedChild({
+      command: "git",
+      args: request.args,
+      cwd: request.cwd,
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        WINDIR: process.env.WINDIR,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_CONFIG_GLOBAL: devNull,
+        GIT_CONFIG_SYSTEM: devNull,
+        GIT_LFS_SKIP_SMUDGE: "1",
+      },
+      timeoutMs: request.timeoutMs ?? DEFAULT_STAGE_BUDGETS.gitTimeoutMs,
+      termGraceMs: request.killGraceMs ?? DEFAULT_STAGE_BUDGETS.killGraceMs,
+      reapTimeoutMs: request.reapTimeoutMs ?? DEFAULT_STAGE_BUDGETS.gitReapTimeoutMs,
+      maxOutputBytes: request.outputBytes ?? DEFAULT_STAGE_BUDGETS.processOutputBytes,
+      processGroup: process.platform !== "win32",
+      signal: controller.signal,
+    }, dependencies);
+    if (!result.reaped) throw new GitProcessUnreapedError();
+    if (resourceFailure !== undefined) throw resourceFailure;
+    if (result.reason === "spawn-error") {
+      throw new CliSafetyError("git executable was not found");
+    }
+    if (result.reason === "timeout" || result.reason === "aborted") {
+      throw new CliSafetyError("git operation timed out");
+    }
+    if (result.reason === "output-limit") {
+      throw new CliSafetyError("git output exceeds the safe size limit");
+    }
+    if (result.exitCode !== 0) throw new CliSafetyError("pinned source checkout failed");
+    return result.stdout.toString("utf8");
+  } finally {
+    if (monitor !== undefined) clearInterval(monitor);
+    request.signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+async function runGit(
+  runner: ProcessRunner,
+  request: Omit<ProcessRequest, "signal" | "outputBytes" | "killGraceMs" | "resourceBudget">,
+  budgets: StageBudgets,
+  parentSignal: AbortSignal | undefined,
+): Promise<string> {
+  if (parentSignal?.aborted === true) throw new CliSafetyError("staging was cancelled");
+  const output = await runner({
+    ...request,
+    ...(parentSignal === undefined ? {} : { signal: parentSignal }),
+    outputBytes: budgets.processOutputBytes,
+    killGraceMs: budgets.killGraceMs,
+    timeoutMs: budgets.gitTimeoutMs,
+    reapTimeoutMs: budgets.gitReapTimeoutMs,
+    resourceBudget: budgets,
+  });
+  if (Buffer.byteLength(output) > budgets.processOutputBytes) {
+    throw new CliSafetyError("git output exceeds the safe size limit");
+  }
+  await measureCheckout(request.cwd, budgets);
+  return output;
+}
+
+function safeSourceSubpath(subpath: string | null): string {
+  if (subpath === null) return ".";
+  if (!SOURCE_SUBPATH.test(subpath)) throw new CliSafetyError("source subpath is unsafe");
+  return subpath;
+}
+
+function verifyTreeListing(output: string, budgets: StageBudgets): void {
+  let bytes = 0;
+  let files = 0;
+  for (const line of output.split("\n")) {
+    if (line === "") continue;
+    const tab = line.indexOf("\t");
+    if (tab < 0) throw new CliSafetyError("pinned source tree listing is invalid");
+    const [mode, type, _object, size] = line.slice(0, tab).split(/\s+/u);
+    const path = line.slice(tab + 1);
+    if (mode === "160000" || type === "commit") {
+      throw new CliSafetyError("source tree contains submodules");
+    }
+    if (type !== "blob" || !/^[0-9]+$/u.test(size ?? "")) {
+      throw new CliSafetyError("pinned source tree listing is invalid");
+    }
+    files += 1;
+    bytes += Number(size);
+    assertTreeBudget(bytes, files, path.split("/").length, budgets);
+  }
+}
+
+async function stageNpm(
+  entry: PublicCatalogEntry & { package: Extract<PublicCatalogEntry["package"], { ecosystem: "npm" }> },
+  temporary: string,
+  fetchImpl: typeof fetch,
+  budgets: StageBudgets,
+  signal: AbortSignal | undefined,
+): Promise<StagedMetadata> {
+  parseExactSemver(entry.package.version);
+  if (entry.package.integrity === undefined) {
+    throw new CliSafetyError("npm entry has no SHA-512 integrity pin");
+  }
+  const expected = Buffer.from(parseSha512Integrity(entry.package.integrity));
+  const metadataUrl = `https://registry.npmjs.org/${encodeURIComponent(entry.package.name)}`;
+  const metadataBytes = await boundedOperation(
+    budgets.fetchTimeoutMs,
+    budgets.killGraceMs,
+    signal,
+    "download timed out",
+    async (requestSignal) => responseBytes(
+      await fetchAllowlisted(metadataUrl, ["registry.npmjs.org"], fetchImpl, requestSignal),
+      budgets.metadataBytes,
+      requestSignal,
+    ),
+  );
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(metadataBytes.toString("utf8")) as unknown;
+  } catch {
+    throw new CliSafetyError("npm registry metadata is invalid");
+  }
+  const version = (metadata as { versions?: Record<string, { dist?: { integrity?: unknown; tarball?: unknown } }> })
+    .versions?.[entry.package.version];
+  const registryIntegrity = version?.dist?.integrity;
+  const tarball = version?.dist?.tarball;
+  if (typeof registryIntegrity !== "string" || typeof tarball !== "string") {
+    throw new CliSafetyError("pinned npm version is unavailable");
+  }
+  let registryDigest: Buffer;
+  try {
+    registryDigest = Buffer.from(parseSha512Integrity(registryIntegrity));
+  } catch {
+    throw new CliSafetyError("registry integrity is invalid");
+  }
+  if (registryDigest.length !== expected.length || !timingSafeEqual(registryDigest, expected)) {
+    throw new CliSafetyError("catalog and registry checksums disagree");
+  }
+  const bytes = await boundedOperation(
+    budgets.fetchTimeoutMs,
+    budgets.killGraceMs,
+    signal,
+    "download timed out",
+    async (requestSignal) => responseBytes(
+      await fetchAllowlisted(tarball, ["registry.npmjs.org"], fetchImpl, requestSignal),
+      budgets.tarballBytes,
+      requestSignal,
+    ),
+  );
+  const actual = createHash("sha512").update(bytes).digest();
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    throw new CliSafetyError("checksum verification failed");
+  }
+  const artifact = "artifact.tgz";
+  await writeFile(join(temporary, artifact), bytes, { mode: 0o600, flag: "wx" });
+  return {
+    packageName: entry.package.name,
+    installRelativePath: artifact,
+    artifact: { kind: "npm", integrity: entry.package.integrity, bytes: bytes.length },
+  };
+}
+
+async function stageSource(
+  entry: PublicCatalogEntry,
+  temporary: string,
+  runProcess: ProcessRunner,
+  budgets: StageBudgets,
+  signal: AbortSignal | undefined,
+): Promise<StagedMetadata> {
+  if (!SOURCE_REPOSITORY.test(entry.source.repository)) {
+    throw new CliSafetyError("source repository is not allowlisted");
+  }
+  if (!SHA40.test(entry.source.commit)) throw new CliSafetyError("source commit pin is invalid");
+  const subpath = safeSourceSubpath(entry.source.subpath);
+  const source = join(temporary, "source");
+  await mkdir(source, { mode: 0o700 });
+  await runGit(runProcess, { args: ["init", "--quiet"], cwd: source }, budgets, signal);
+  await runGit(
+    runProcess,
+    { args: ["remote", "add", "origin", entry.source.repository], cwd: source },
+    budgets,
+    signal,
+  );
+  await runGit(runProcess, {
+    args: [
+      "-c",
+      "credential.helper=",
+      "-c",
+      "submodule.recurse=false",
+      "fetch",
+      "--quiet",
+      "--depth",
+      "1",
+      "--filter=blob:none",
+      "--no-tags",
+      "--no-recurse-submodules",
+      "origin",
+      entry.source.commit,
+    ],
+    cwd: source,
+  }, budgets, signal);
+  const listing = await runGit(
+    runProcess,
+    { args: ["ls-tree", "-r", "-l", "--full-tree", "FETCH_HEAD"], cwd: source },
+    budgets,
+    signal,
+  );
+  verifyTreeListing(listing, budgets);
+  await runGit(runProcess, {
+    args: ["-c", "submodule.recurse=false", "checkout", "--quiet", "--detach", "--force", "FETCH_HEAD"],
+    cwd: source,
+  }, budgets, signal);
+  const checkedCommit = (await runGit(
+    runProcess,
+    { args: ["rev-parse", "HEAD"], cwd: source },
+    budgets,
+    signal,
+  )).trim();
+  if (checkedCommit.toLowerCase() !== entry.source.commit.toLowerCase()) {
+    throw new CliSafetyError("source checkout does not match the commit pin");
+  }
+  await rm(join(source, ".git"), { recursive: true, force: true });
+  const tree = await inspectSourceTree(source, budgets);
+  const pluginRoot = resolve(source, subpath);
+  const expectedRelativePath = subpath === "." ? "source" : `source/${subpath}`;
+  if (!isPathWithin(source, pluginRoot)) throw new CliSafetyError("source subpath is unsafe");
+  let canonicalPluginRoot: string;
+  try {
+    canonicalPluginRoot = await realpath(pluginRoot);
+    const info = await lstat(canonicalPluginRoot);
+    if (!info.isDirectory() || !isPathWithin(source, canonicalPluginRoot)) {
+      throw new CliSafetyError("source subpath is unsafe");
+    }
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("source subpath is unavailable");
+  }
+  const installRelativePath = relative(temporary, canonicalPluginRoot).split(sep).join("/");
+  if (installRelativePath !== expectedRelativePath) {
+    throw new CliSafetyError("source subpath is unsafe");
+  }
+  let packageName: unknown;
+  try {
+    packageName = (JSON.parse((await readRegularFile(
+      join(canonicalPluginRoot, "package.json"),
+      budgets.metadataBytes,
+      "source package manifest is unsafe",
+    )).toString("utf8")) as { name?: unknown }).name;
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("source package manifest is invalid");
+  }
+  if (typeof packageName !== "string" || !PACKAGE_NAME.test(packageName)) {
+    throw new CliSafetyError("source package name is invalid");
+  }
+  return {
+    packageName,
+    installRelativePath,
+    artifact: {
+      kind: "source",
+      commit: entry.source.commit.toLowerCase(),
+      treeSha512: tree.digest,
+      bytes: tree.bytes,
+      files: tree.files,
+    },
+  };
+}
+
+async function readCached(
+  finalRoot: string,
+  id: string,
+  hash: string,
+  entry: PublicCatalogEntry,
+  budgets: StageBudgets,
+): Promise<VerifiedCachedInstall> {
+  try {
+    const rootInfo = await lstat(finalRoot);
+    if (rootInfo.isSymbolicLink() || !rootInfo.isDirectory()) {
+      throw new CliSafetyError("staging cache path is unsafe");
+    }
+    const canonicalRoot = await realpath(finalRoot);
+    if (canonicalRoot !== resolve(finalRoot) || basename(canonicalRoot) !== hash ||
+        basename(dirname(canonicalRoot)) !== id) {
+      throw new CliSafetyError("staging cache key is invalid");
+    }
+    const metadata = JSON.parse((await readRegularFile(
+      join(canonicalRoot, "metadata.json"),
+      budgets.metadataBytes,
+      "staging cache metadata is unsafe",
+    )).toString("utf8")) as CacheMetadata;
+    const fingerprint = `sha256:${hash}`;
+    if (
+      metadata.version !== 2 ||
+      metadata.fingerprint !== fingerprint ||
+      metadata.descriptorHash !== hash ||
+      typeof metadata.packageName !== "string" ||
+      !PACKAGE_NAME.test(metadata.packageName) ||
+      typeof metadata.installRelativePath !== "string"
+    ) {
+      throw new CliSafetyError("staging cache metadata is invalid");
+    }
+    const targetPath = resolve(canonicalRoot, metadata.installRelativePath);
+    if (!isPathWithin(canonicalRoot, targetPath)) throw new CliSafetyError("staging cache target is unsafe");
+
+    let installTarget: string;
+    let verifiedCache: NpmVerifiedCache | SourceVerifiedCache;
+    if (entry.package.ecosystem === "npm") {
+      if (
+        metadata.artifact.kind !== "npm" ||
+        metadata.packageName !== entry.package.name ||
+        metadata.installRelativePath !== "artifact.tgz" ||
+        metadata.artifact.integrity !== entry.package.integrity ||
+        !Number.isSafeInteger(metadata.artifact.bytes) ||
+        metadata.artifact.bytes < 0
+      ) {
+        throw new CliSafetyError("staging cache metadata is invalid");
+      }
+      if (entry.package.integrity === undefined) {
+        throw new CliSafetyError("npm entry has no SHA-512 integrity pin");
+      }
+      const expected = Buffer.from(parseSha512Integrity(entry.package.integrity));
+      const actual = await hashRegularFile(
+        targetPath,
+        budgets.tarballBytes,
+        "staging cache artifact is unsafe",
+      );
+      if (actual.bytes !== metadata.artifact.bytes || actual.digest.length !== expected.length ||
+          !timingSafeEqual(actual.digest, expected)) {
+        throw new CliSafetyError("staging cache checksum verification failed");
+      }
+      installTarget = targetPath;
+      verifiedCache = {
+        kind: "npm",
+        path: targetPath,
+        expectedDigest: expected,
+        bytes: actual.bytes,
+      };
+    } else {
+      const subpath = safeSourceSubpath(entry.source.subpath);
+      const expectedRelativePath = subpath === "." ? "source" : `source/${subpath}`;
+      if (
+        metadata.artifact.kind !== "source" ||
+        metadata.artifact.commit !== entry.source.commit.toLowerCase() ||
+        metadata.installRelativePath !== expectedRelativePath
+      ) {
+        throw new CliSafetyError("staging cache metadata is invalid");
+      }
+      const sourceRoot = join(canonicalRoot, "source");
+      const tree = await inspectSourceTree(sourceRoot, budgets);
+      if (
+        tree.digest !== metadata.artifact.treeSha512 ||
+        tree.bytes !== metadata.artifact.bytes ||
+        tree.files !== metadata.artifact.files
+      ) {
+        throw new CliSafetyError("staging cache tree verification failed");
+      }
+      const canonicalTarget = await realpath(targetPath);
+      if (!isPathWithin(sourceRoot, canonicalTarget)) {
+        throw new CliSafetyError("staging cache target is unsafe");
+      }
+      const packageInfo = JSON.parse((await readRegularFile(
+        join(canonicalTarget, "package.json"),
+        budgets.metadataBytes,
+        "staging cache package manifest is unsafe",
+      )).toString("utf8")) as { name?: unknown };
+      if (packageInfo.name !== metadata.packageName) {
+        throw new CliSafetyError("staging cache package identity is invalid");
+      }
+      installTarget = `file:${canonicalTarget}`;
+      verifiedCache = {
+        kind: "source",
+        sourceRoot,
+        pluginRoot: canonicalTarget,
+        tree,
+      };
+    }
+    const cacheRelativePath = `${id}/${hash}/${metadata.installRelativePath}`;
+    const result: StagedInstall = {
+      fingerprint: `sha256:${hash}`,
+      installTarget,
+      displayTarget: `$DSH_HOME/.dsh-plugins/cache/${cacheRelativePath}`,
+      packageName: metadata.packageName,
+      cacheRelativePath,
+    };
+    Object.defineProperty(result, VERIFIED_CACHE, {
+      configurable: false,
+      enumerable: false,
+      value: verifiedCache,
+      writable: false,
+    });
+    return result as VerifiedCachedInstall;
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("staging cache is invalid");
+  }
+}
+
+async function quarantineCache(finalRoot: string, idRoot: string, hash: string): Promise<void> {
+  const quarantine = join(idRoot, `.quarantine-${hash}-${randomUUID()}`);
+  try {
+    await rename(finalRoot, quarantine);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new CliSafetyError("staging cache quarantine failed");
+  }
+  await rm(quarantine, { recursive: true, force: true }).catch(() => undefined);
+}
+
+export async function stageCatalogEntry(
+  entry: PublicCatalogEntry,
+  options: StageOptions,
+): Promise<StagedCatalogInstall> {
+  const id = canonicalPublicId(entry.id);
+  const hash = descriptorHash(entry);
+  const fingerprint = `sha256:${hash}`;
+  const budgets = stageBudgets(options.budgets);
+  const home = await ensureCanonicalHome(options.dshHome);
+  const idRoot = await ensureContainedDirectory(home, ".dsh-plugins", "cache", id);
+  const finalRoot = join(idRoot, hash);
+  try {
+    await lstat(finalRoot);
+    try {
+      return await createArtifactLease(
+        await readCached(finalRoot, id, hash, entry, budgets),
+        home,
+        budgets,
+      );
+    } catch {
+      if (options.offline === true) {
+        throw new CliSafetyError("cached artifact failed verification while offline");
+      }
+      await quarantineCache(finalRoot, idRoot, hash);
+    }
+  } catch (error) {
+    if (error instanceof CliSafetyError) throw error;
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  if (options.offline === true) {
+    throw new CliSafetyError("pinned artifact is not cached and offline mode forbids retrieval");
+  }
+
+  const temporary = await mkdtemp(join(idRoot, ".stage-"));
+  try {
+    const staged = entry.package.ecosystem === "npm"
+      ? await stageNpm(
+          entry as PublicCatalogEntry & {
+            package: Extract<PublicCatalogEntry["package"], { ecosystem: "npm" }>;
+          },
+          temporary,
+          options.fetchImpl ?? fetch,
+          budgets,
+          options.signal,
+        )
+      : await stageSource(
+          entry,
+          temporary,
+          options.runProcess ?? ((request) => defaultProcessRunner(request, options.childSupervisor)),
+          budgets,
+          options.signal,
+        );
+    const metadata: CacheMetadata = {
+      version: 2,
+      fingerprint,
+      descriptorHash: hash,
+      ...staged,
+    };
+    await writeFile(join(temporary, "metadata.json"), `${JSON.stringify(metadata)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    try {
+      await rename(temporary, finalRoot);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST" &&
+          (error as NodeJS.ErrnoException).code !== "ENOTEMPTY") {
+        throw error;
+      }
+      try {
+        const winner = await readCached(finalRoot, id, hash, entry, budgets);
+        await rm(temporary, { recursive: true, force: true });
+        return await createArtifactLease(winner, home, budgets);
+      } catch {
+        await quarantineCache(finalRoot, idRoot, hash);
+        await rename(temporary, finalRoot);
+      }
+    }
+    return await createArtifactLease(
+      await readCached(finalRoot, id, hash, entry, budgets),
+      home,
+      budgets,
+    );
+  } catch (error) {
+    if (error instanceof GitProcessUnreapedError) {
+      const quarantine = join(idRoot, `.unreaped-${hash}-${randomUUID()}`);
+      await rename(temporary, quarantine).catch(() => undefined);
+      throw error;
+    }
+    await rm(temporary, { recursive: true, force: true }).catch(() => undefined);
+    if (error instanceof CliSafetyError) throw error;
+    throw new CliSafetyError("verified staging failed");
+  }
+}

--- a/cli/src/dsh/stateEvidence.ts
+++ b/cli/src/dsh/stateEvidence.ts
@@ -1,0 +1,8 @@
+import { createHash } from "node:crypto";
+
+import type { InstalledPlugin } from "./installState.js";
+
+export function fingerprintInstallState(installs: readonly InstalledPlugin[]): string {
+  const bytes = JSON.stringify({ version: 1, installs });
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}

--- a/cli/src/errors.ts
+++ b/cli/src/errors.ts
@@ -1,0 +1,13 @@
+export class CliSafetyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliSafetyError";
+  }
+}
+
+export function sanitizedErrorMessage(error: unknown): string {
+  if (error instanceof CliSafetyError) {
+    return error.message;
+  }
+  return "Operation failed safely; no unverified changes were accepted.";
+}

--- a/cli/src/model.ts
+++ b/cli/src/model.ts
@@ -1,0 +1,67 @@
+export interface CatalogDiagnostic {
+  readonly file: string;
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface PublicCatalogEntry {
+  readonly schemaVersion: 1;
+  readonly id: string;
+  readonly name: string;
+  readonly description: { readonly en: string; readonly evidencePath: string };
+  readonly unofficial: true;
+  readonly kind: string;
+  readonly primaryCategory: string;
+  readonly tags: readonly string[];
+  readonly source: {
+    readonly repository: string;
+    readonly repositoryNodeId: string;
+    readonly subpath: string | null;
+    readonly commit: string;
+  };
+  readonly creator: { readonly github: string };
+  readonly package:
+    | {
+        readonly ecosystem: "npm";
+        readonly name: string;
+        readonly version: string;
+        readonly integrity?: string;
+      }
+    | { readonly ecosystem: "source" };
+  readonly dsh: { readonly profiles: readonly string[]; readonly evidencePath: string };
+  readonly repositoryScope: "dedicated" | "monorepo";
+  readonly popularity: {
+    readonly starsPolicy: "exact-repository" | "undefined-parent-repository";
+    readonly stars: number | null;
+  };
+  readonly license: { readonly spdx: string };
+  readonly verification: {
+    readonly status: "eligible" | "verified" | "stale" | "unavailable" | "archived" | "quarantined";
+    readonly checkedAt: string;
+    readonly repositoryIdentity: "resolved";
+    readonly smokeTest: null | {
+      readonly installTarget: "canonical-install-descriptor";
+      readonly check: { readonly name: string; readonly version: string };
+      readonly result: "passed";
+    };
+  };
+  readonly provenance: { readonly discussion: string | null; readonly comment: string | null };
+  readonly canonicalKey: string;
+}
+
+export interface CatalogSnapshot {
+  readonly source:
+    | { readonly kind: "directory" }
+    | {
+        readonly kind: "snapshot";
+        readonly declaredRevision: string;
+        readonly pinStatus: "declared-local";
+      };
+  readonly entries: readonly PublicCatalogEntry[];
+  readonly diagnostics: readonly CatalogDiagnostic[];
+}
+
+export interface CatalogSelection {
+  readonly root?: string;
+  readonly revision?: string;
+}

--- a/cli/tests/artifact-channel.test.ts
+++ b/cli/tests/artifact-channel.test.ts
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { openArtifactDeliveryChannel } from "../src/dsh/artifactChannel.js";
+import type { StagedArtifactLease } from "../src/dsh/staging.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("immutable artifact delivery channel", () => {
+  it("serves the verified descriptor bytes when the pathname is swapped after revalidation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "dsh-channel-swap-"));
+    roots.push(root);
+    const artifact = join(root, "artifact.tgz");
+    const displaced = join(root, "verified.tgz");
+    const verified = Buffer.from("verified-before-spawn");
+    writeFileSync(artifact, verified);
+    const sha512 = `sha512-${createHash("sha512").update(verified).digest("base64")}`;
+    const lease = {
+      recoveryReference: {
+        relativePath: ".dsh-plugins/artifact-leases/.lease-test/artifact.tgz",
+        sha512,
+        bytes: verified.length,
+        packageName: "fixture-plugin",
+      },
+      revalidate: vi.fn(async () => undefined),
+      readVerifiedBytes: vi.fn(async () => Buffer.from(verified)),
+      release: vi.fn(async () => undefined),
+    } as StagedArtifactLease;
+
+    await lease.revalidate();
+    const channel = await openArtifactDeliveryChannel(lease, {
+      sourceFingerprint: "sha256:pinned-source",
+      timeoutMs: 5_000,
+    });
+
+    // This is the DSH spawn seam: the old pathname is replaced before pnpm opens its target.
+    renameSync(artifact, displaced);
+    writeFileSync(artifact, "malicious-after-revalidate");
+    const response = await fetch(channel.installTarget);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBe(String(verified.length));
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(verified);
+    expect(channel.descriptor).toEqual({
+      kind: "loopback-buffer-v1",
+      sha512,
+      bytes: verified.length,
+      sourceFingerprint: "sha256:pinned-source",
+    });
+    expect(channel.installTarget).not.toContain(artifact);
+    await channel.close();
+  });
+
+  it("accepts at most one HEAD and one GET and rejects range requests", async () => {
+    const bytes = Buffer.from("one-shot");
+    const lease = {
+      recoveryReference: {
+        relativePath: ".dsh-plugins/artifact-leases/.lease-test/artifact.tgz",
+        sha512: `sha512-${createHash("sha512").update(bytes).digest("base64")}`,
+        bytes: bytes.length,
+        packageName: "fixture-plugin",
+      },
+      revalidate: vi.fn(async () => undefined),
+      readVerifiedBytes: vi.fn(async () => Buffer.from(bytes)),
+      release: vi.fn(async () => undefined),
+    } as StagedArtifactLease;
+    const channel = await openArtifactDeliveryChannel(lease, {
+      sourceFingerprint: "sha256:pinned-source",
+      timeoutMs: 5_000,
+    });
+
+    expect((await fetch(channel.installTarget, { method: "HEAD" })).status).toBe(200);
+    expect((await fetch(channel.installTarget, { headers: { range: "bytes=0-1" } })).status).toBe(416);
+    expect(Buffer.from(await (await fetch(channel.installTarget)).arrayBuffer())).toEqual(bytes);
+    await channel.close();
+  });
+});

--- a/cli/tests/artifact-lease.test.ts
+++ b/cli/tests/artifact-lease.test.ts
@@ -1,0 +1,177 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { gunzipSync } from "node:zlib";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  stageCatalogEntry,
+  type ProcessRequest,
+  type StagedCatalogInstall,
+} from "../src/dsh/staging.js";
+import type { PublicCatalogEntry } from "../src/model.js";
+
+const roots: string[] = [];
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function entryFor(packageDescriptor: PublicCatalogEntry["package"]): PublicCatalogEntry {
+  return {
+    schemaVersion: 1,
+    id: "leased-plugin",
+    name: "Leased Plugin",
+    description: { en: "A leased test plugin.", evidencePath: "README.md" },
+    unofficial: true,
+    kind: "plugin",
+    primaryCategory: "developer-tools",
+    tags: ["test"],
+    source: {
+      repository: "https://github.com/creator/leased-plugin",
+      repositoryNodeId: "R_leased",
+      subpath: null,
+      commit: "c".repeat(40),
+    },
+    creator: { github: "creator" },
+    package: packageDescriptor,
+    dsh: { profiles: ["web"], evidencePath: "package.json" },
+    repositoryScope: "dedicated",
+    popularity: { starsPolicy: "exact-repository", stars: 1 },
+    license: { spdx: "MIT" },
+    verification: {
+      status: "eligible",
+      checkedAt: "2026-08-16T00:00:00Z",
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+    canonicalKey: "R_leased:.",
+  };
+}
+
+async function stageNpm(home: string): Promise<{ staged: StagedCatalogInstall; bytes: Buffer }> {
+  const bytes = Buffer.from("verified leased tarball");
+  const integrity = `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+  const entry = entryFor({
+    ecosystem: "npm",
+    name: "@creator/leased-plugin",
+    version: "1.0.0",
+    integrity,
+  });
+  const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+    if (String(input).includes("%40creator%2Fleased-plugin")) {
+      return new Response(JSON.stringify({
+        versions: {
+          "1.0.0": {
+            dist: {
+              integrity,
+              tarball: "https://registry.npmjs.org/@creator/leased-plugin/-/leased-plugin-1.0.0.tgz",
+            },
+          },
+        },
+      }), { status: 200 });
+    }
+    return new Response(bytes, {
+      status: 200,
+      headers: { "content-length": String(bytes.length) },
+    });
+  });
+  return {
+    staged: await stageCatalogEntry(entry, { dshHome: home, fetchImpl: fetchImpl as typeof fetch }),
+    bytes,
+  };
+}
+
+describe("transaction-private artifact leases", () => {
+  it("never returns the mutable shared cache pathname to the DSH consumer", async () => {
+    const home = tempRoot("dsh-private-lease-");
+    const { staged, bytes } = await stageNpm(home);
+
+    expect(staged.installTarget).toContain(join(".dsh-plugins", "artifact-leases"));
+    expect(staged.installTarget).not.toContain(join(".dsh-plugins", "cache"));
+    expect(readFileSync(staged.installTarget)).toEqual(bytes);
+    expect(staged.artifactLease.recoveryReference.relativePath).toContain("artifact-leases/");
+    await expect(staged.artifactLease.revalidate()).resolves.toBeUndefined();
+  });
+
+  it("detects a file-to-symlink swap after transaction setup and before spawn", async () => {
+    const home = tempRoot("dsh-private-symlink-");
+    const outside = join(tempRoot("dsh-private-outside-"), "malicious.tgz");
+    writeFileSync(outside, "malicious-after-verification");
+    const { staged } = await stageNpm(home);
+
+    rmSync(staged.installTarget);
+    symlinkSync(outside, staged.installTarget);
+
+    await expect(staged.artifactLease.revalidate()).rejects.toThrow(
+      "transaction artifact changed; recovery required",
+    );
+  });
+
+  it("detects same-content inode replacement by comparing the held descriptor", async () => {
+    const home = tempRoot("dsh-private-inode-");
+    const { staged, bytes } = await stageNpm(home);
+    const displaced = `${staged.installTarget}.old`;
+    renameSync(staged.installTarget, displaced);
+    writeFileSync(staged.installTarget, bytes, { mode: 0o400 });
+
+    await expect(staged.artifactLease.revalidate()).rejects.toThrow(
+      "transaction artifact changed; recovery required",
+    );
+  });
+
+  it("creates independent leases for concurrent consumers of one verified cache", async () => {
+    const home = tempRoot("dsh-private-concurrent-");
+    const first = await stageNpm(home);
+    const second = await stageNpm(home);
+
+    expect(first.staged.installTarget).not.toBe(second.staged.installTarget);
+    expect(readFileSync(first.staged.installTarget)).toEqual(second.bytes);
+    expect(readFileSync(second.staged.installTarget)).toEqual(first.bytes);
+    await first.staged.artifactLease.release();
+    expect(existsSync(dirname(first.staged.installTarget))).toBe(false);
+    expect(existsSync(second.staged.installTarget)).toBe(true);
+  });
+
+  it("materializes source installs as deterministic private archives, never live directories", async () => {
+    const home = tempRoot("dsh-source-archive-");
+    const entry = entryFor({ ecosystem: "source" });
+    const runProcess = vi.fn(async (request: ProcessRequest) => {
+      if (request.args.includes("checkout")) {
+        mkdirSync(join(request.cwd, "lib"), { recursive: true });
+        writeFileSync(join(request.cwd, "package.json"), JSON.stringify({ name: "source-plugin" }));
+        writeFileSync(join(request.cwd, "lib", "index.js"), "export default 1;\n");
+      }
+      return request.args.includes("rev-parse") ? `${entry.source.commit}\n` : "";
+    });
+
+    const first = await stageCatalogEntry(entry, { dshHome: home, runProcess });
+    const second = await stageCatalogEntry(entry, { dshHome: home, runProcess });
+    expect(first.installTarget.endsWith(".tgz")).toBe(true);
+    expect(first.installTarget.startsWith("file:")).toBe(false);
+    expect(readFileSync(first.installTarget)).toEqual(readFileSync(second.installTarget));
+    const tar = gunzipSync(readFileSync(first.installTarget));
+    expect(tar.subarray(0, 100).toString("utf8")).toContain("package/");
+    expect(tar.includes(Buffer.from("source-plugin"))).toBe(true);
+    await expect(first.artifactLease.revalidate()).resolves.toBeUndefined();
+  });
+});

--- a/cli/tests/catalog-command.test.ts
+++ b/cli/tests/catalog-command.test.ts
@@ -1,0 +1,374 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli, type CliDependencies } from "../src/app.js";
+import { loadDefaultCatalog } from "../src/catalogSource.js";
+import { CliSafetyError } from "../src/errors.js";
+
+function git(root: string, args: readonly string[]): string {
+  return execFileSync("git", [...args], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function commitCatalogFixture(root: string): string {
+  git(root, ["init", "--quiet"]);
+  git(root, ["config", "user.name", "Catalog Test"]);
+  git(root, ["config", "user.email", "catalog-test@example.invalid"]);
+  git(root, ["add", "-A"]);
+  git(root, ["commit", "--quiet", "-m", "catalog fixture"]);
+  return git(root, ["rev-parse", "HEAD"]);
+}
+
+function harness(snapshot: Awaited<ReturnType<CliDependencies["loadCatalog"]>>) {
+  let stdout = "";
+  let stderr = "";
+  const dependencies: CliDependencies = {
+    loadCatalog: async () => snapshot,
+    stdout: (value) => {
+      stdout += value;
+    },
+    stderr: (value) => {
+      stderr += value;
+    },
+  };
+  return {
+    dependencies,
+    output: () => ({ stdout, stderr }),
+  };
+}
+
+describe("catalog validate", () => {
+  it("loads a local directory without a revision only as a development catalog", async () => {
+    // Hermetic fixture: pointing at the live public checkout made this test depend on
+    // however many entries happen to be merged at the moment it runs.
+    const root = mkdtempSync(join(tmpdir(), "dsh-plugins-directory-integration-"));
+    temporaryRoots.push(root);
+    // The catalog schema is a sibling now: the CLI lives inside the public catalog repository,
+    // so this reads the very schema the entries beside it are validated against — no longer a
+    // relative hop across two checkouts.
+    const publicRoot = fileURLToPath(new URL("../../", import.meta.url));
+    mkdirSync(join(root, "schemas"), { recursive: true });
+    writeFileSync(
+      join(root, "schemas/plugin.schema.yaml"),
+      readFileSync(join(publicRoot, "schemas/plugin.schema.yaml"), "utf8"),
+    );
+    const snapshot = await loadDefaultCatalog({ root });
+    expect(snapshot).toMatchObject({
+      source: { kind: "directory" },
+      entries: [],
+      diagnostics: [],
+    });
+  });
+
+  it("loads a clean exact-HEAD Git catalog as a declared pinned snapshot", async () => {
+    const root = mkdtempSync(join(tmpdir(), "dsh-plugins-git-integration-"));
+    temporaryRoots.push(root);
+    // The catalog schema is a sibling now: the CLI lives inside the public catalog repository,
+    // so this reads the very schema the entries beside it are validated against — no longer a
+    // relative hop across two checkouts.
+    const publicRoot = fileURLToPath(new URL("../../", import.meta.url));
+    mkdirSync(join(root, "schemas"), { recursive: true });
+    writeFileSync(
+      join(root, "schemas/plugin.schema.yaml"),
+      readFileSync(join(publicRoot, "schemas/plugin.schema.yaml"), "utf8"),
+    );
+    const revision = commitCatalogFixture(root);
+    writeFileSync(join(root, "schemas/plugin.schema.yaml"), "not the committed schema\n");
+
+    const snapshot = await loadDefaultCatalog({ root, revision });
+    expect(snapshot).toMatchObject({
+      source: { kind: "snapshot", declaredRevision: revision, pinStatus: "declared-local" },
+      entries: [],
+      diagnostics: [],
+    });
+  });
+
+  it("rejects a declared revision for a non-Git local catalog", async () => {
+    const root = mkdtempSync(join(tmpdir(), "dsh-plugins-non-git-integration-"));
+    temporaryRoots.push(root);
+
+    await expect(
+      loadDefaultCatalog({ root, revision: "a".repeat(40) }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+  });
+
+  it("loads a bounded local snapshot file through the same catalog-core validation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "dsh-plugins-snapshot-integration-"));
+    temporaryRoots.push(root);
+    // The catalog schema is a sibling now: the CLI lives inside the public catalog repository,
+    // so this reads the very schema the entries beside it are validated against — no longer a
+    // relative hop across two checkouts.
+    const publicRoot = fileURLToPath(new URL("../../", import.meta.url));
+    const snapshotPath = join(root, "catalog.snapshot.json");
+    writeFileSync(snapshotPath, JSON.stringify({
+      format: "omni-dsh-catalog-snapshot-v1",
+      revision: "a".repeat(40),
+      files: {
+        "schemas/plugin.schema.yaml": readFileSync(
+          join(publicRoot, "schemas/plugin.schema.yaml"),
+          "utf8",
+        ),
+      },
+    }));
+
+    const snapshot = await loadDefaultCatalog({ root: snapshotPath });
+    expect(snapshot).toMatchObject({
+      source: {
+        kind: "snapshot",
+        declaredRevision: "a".repeat(40),
+        pinStatus: "declared-local",
+      },
+      entries: [],
+      diagnostics: [],
+    });
+  });
+
+  it("rejects a pinned local snapshot file whose declared revision does not match the pin", async () => {
+    const root = mkdtempSync(join(tmpdir(), "dsh-plugins-snapshot-pin-mismatch-"));
+    temporaryRoots.push(root);
+    const snapshotPath = join(root, "catalog.snapshot.json");
+    writeFileSync(snapshotPath, JSON.stringify({
+      format: "omni-dsh-catalog-snapshot-v1",
+      revision: "a".repeat(40),
+      files: {},
+    }));
+    const revision = commitCatalogFixture(root);
+    expect(revision).not.toBe("a".repeat(40));
+
+    await expect(loadDefaultCatalog({ root: snapshotPath, revision })).rejects.toMatchObject({
+      name: "CliSafetyError",
+      message: "catalog snapshot revision does not match the requested commit",
+    });
+  });
+
+  it("does not consume ignored catalog files for a pinned directory", async () => {
+    const root = mkdtempSync(join(tmpdir(), "dsh-plugins-ignored-integration-"));
+    temporaryRoots.push(root);
+    // The catalog schema is a sibling now: the CLI lives inside the public catalog repository,
+    // so this reads the very schema the entries beside it are validated against — no longer a
+    // relative hop across two checkouts.
+    const publicRoot = fileURLToPath(new URL("../../", import.meta.url));
+    writeFileSync(join(root, ".gitignore"), "schemas/\ncatalog/\n");
+    writeFileSync(join(root, "README.md"), "# Ignored catalog fixture\n");
+    const revision = commitCatalogFixture(root);
+    mkdirSync(join(root, "schemas"), { recursive: true });
+    mkdirSync(join(root, "catalog/plugins"), { recursive: true });
+    writeFileSync(
+      join(root, "schemas/plugin.schema.yaml"),
+      readFileSync(join(publicRoot, "schemas/plugin.schema.yaml"), "utf8"),
+    );
+    writeFileSync(join(root, "catalog/plugins/ignored.yaml"), "not: a valid plugin\n");
+
+    const snapshot = await loadDefaultCatalog({ root, revision });
+
+    expect(snapshot.source).toMatchObject({ kind: "snapshot", declaredRevision: revision });
+    expect(snapshot.entries).toEqual([]);
+    expect(snapshot.diagnostics).toEqual([
+      {
+        file: "schemas/plugin.schema.yaml",
+        code: "invalid-public-schema",
+        message: "public catalog schema is missing or invalid",
+      },
+    ]);
+  });
+
+  it("accepts the intentional zero-entry catalog in text and JSON modes", async () => {
+    const snapshot = {
+      source: { kind: "snapshot" as const, declaredRevision: "a".repeat(40), pinStatus: "declared-local" as const },
+      entries: [],
+      diagnostics: [],
+    };
+    const text = harness(snapshot);
+    expect(await runCli(["catalog", "validate"], text.dependencies)).toBe(0);
+    expect(text.output()).toEqual({
+      stdout: "0 entries valid; catalog is empty\n",
+      stderr: "",
+    });
+
+    const json = harness(snapshot);
+    expect(await runCli(["catalog", "validate", "--json"], json.dependencies)).toBe(0);
+    expect(JSON.parse(json.output().stdout)).toEqual({
+      valid: true,
+      count: 0,
+      empty: true,
+      diagnostics: [],
+    });
+  });
+
+  it("returns exit 1 with sorted file-specific diagnostics", async () => {
+    const invalid = harness({
+      source: { kind: "directory" as const },
+      entries: [],
+      diagnostics: [
+        { file: "catalog/plugins/z.yaml", code: "schema", message: "/id must match pattern" },
+        { file: "catalog/plugins/a.yaml", code: "yaml", message: "invalid YAML document" },
+      ],
+    });
+
+    expect(await runCli(["catalog", "validate"], invalid.dependencies)).toBe(1);
+    expect(invalid.output()).toEqual({
+      stdout: "",
+      stderr:
+        "catalog/plugins/a.yaml [yaml]: invalid YAML document\n" +
+        "catalog/plugins/z.yaml [schema]: /id must match pattern\n",
+    });
+  });
+});
+
+const temporaryRoots: string[] = [];
+
+function publicRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "dsh-plugins-public-"));
+  temporaryRoots.push(root);
+  for (const directory of ["docs", ".github/ISSUE_TEMPLATE", "schemas", "catalog/plugins"]) {
+    mkdirSync(join(root, directory), { recursive: true });
+  }
+  const notice = "Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.";
+  const onePlugin = "<!-- catalog-policy:one-plugin-per-branch-and-pr -->";
+  const precedence = "<!-- creator-first:direct-pr-supersedes-curation-and-automation -->";
+  const sourceBound = "<!-- creator-first:source-bound-git-identity -->";
+  const localValidation = "<!-- catalog-validation:local-structure-and-semantics-only -->";
+  const provenance = "<!-- maintainer-gate:repository-origin-and-pinned-evidence -->";
+  const aggregators = "<!-- catalog-policy:aggregators-never-entries -->";
+  writeFileSync(join(root, "README.md"), `${notice}\n\n**0 plugins merged.**\n`);
+  writeFileSync(
+    join(root, "CONTRIBUTING.md"),
+    [notice, onePlugin, precedence, sourceBound, localValidation, provenance, ""].join("\n"),
+  );
+  writeFileSync(join(root, "SECURITY.md"), "# Security Policy\n");
+  writeFileSync(
+    join(root, "docs/CATEGORIES.md"),
+    `# Catalog Categories\n\n${aggregators}\n\n## Artifact kinds\n\n` +
+      "| Value | Meaning |\n|---|---|\n| `plugin` | Plugin |\n| `skill` | Skill |\n\n" +
+      "## Primary capability categories\n\n| Value | Label |\n|---|---|\n" +
+      "| `coding-developer-tools` | Coding |\n",
+  );
+  writeFileSync(join(root, "docs/CREDIT.md"), `${precedence}\n${sourceBound}\n`);
+  writeFileSync(join(root, "docs/RANKING.md"), "# Ranking Methodology\n");
+  writeFileSync(join(root, "docs/UNOFFICIAL.md"), `${notice}\n`);
+  writeFileSync(
+    join(root, ".github/PULL_REQUEST_TEMPLATE.md"),
+    `${onePlugin}\n${precedence}\n${sourceBound}\n`,
+  );
+  writeFileSync(
+    join(root, "schemas/plugin.schema.yaml"),
+    "type: object\nproperties:\n" +
+      "  kind:\n    enum:\n      - plugin\n      - skill\n" +
+      "  primaryCategory:\n    enum:\n      - coding-developer-tools\n",
+  );
+  for (const [name, materialField] of [
+    ["claim", ""],
+    ["correction", "correction"],
+    ["removal", "action"],
+  ] as const) {
+    const material = materialField === "" ? "" :
+      `  - type: ${materialField === "action" ? "dropdown" : "textarea"}\n` +
+      `    id: ${materialField}\n    validations:\n      required: true\n`;
+    writeFileSync(
+      join(root, `.github/ISSUE_TEMPLATE/${name}.yml`),
+      `name: ${name}\ndescription: ${name}\nbody:\n` +
+        "  - type: markdown\n    attributes:\n      value: Unofficial community project, not affiliated with DeepSeek.\n" +
+        "  - type: input\n    id: plugin_id\n    validations:\n      required: true\n" +
+        "  - type: input\n    id: repository\n    validations:\n      required: true\n" +
+        material +
+        "  - type: textarea\n    id: evidence\n    validations:\n      required: true\n" +
+        "  - type: checkboxes\n    id: confirmations\n    attributes:\n      options:\n" +
+        "        - label: I confirm the material policy.\n          required: true\n",
+    );
+  }
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("public repository checks", () => {
+  it("checks the required docs and their zero-entry statement", async () => {
+    const root = publicRoot();
+    const test = harness({ source: { kind: "directory" }, entries: [], diagnostics: [] });
+    expect(await runCli(["catalog", "docs-check", root], test.dependencies)).toBe(0);
+    expect(test.output()).toEqual({
+      stdout: "Catalog documentation checks passed for 0 entries.\n",
+      stderr: "",
+    });
+  });
+
+  it("validates all three structured GitHub forms", async () => {
+    const root = publicRoot();
+    const test = harness({ source: { kind: "directory" }, entries: [], diagnostics: [] });
+    expect(await runCli(["catalog", "github-forms-check", root], test.dependencies)).toBe(0);
+    expect(test.output()).toEqual({ stdout: "3 GitHub issue forms valid.\n", stderr: "" });
+  });
+
+  it("fails closed when the unofficial notice is absent", async () => {
+    const root = publicRoot();
+    writeFileSync(join(root, "README.md"), "**0 plugins merged.**\n");
+    const test = harness({ source: { kind: "directory" }, entries: [], diagnostics: [] });
+    expect(await runCli(["catalog", "docs-check", root], test.dependencies)).toBe(1);
+    expect(test.output().stderr).toBe("README.md: missing unofficial-project notice\n");
+  });
+
+  it.each([
+    ["docs/CREDIT.md", "creator-first:source-bound-git-identity"],
+    [".github/PULL_REQUEST_TEMPLATE.md", "catalog-policy:one-plugin-per-branch-and-pr"],
+    ["CONTRIBUTING.md", "catalog-validation:local-structure-and-semantics-only"],
+  ])("fails closed when %s loses the %s policy marker", async (file, marker) => {
+    const root = publicRoot();
+    const path = join(root, file);
+    writeFileSync(path, readFileSync(path, "utf8").replace(`<!-- ${marker} -->`, ""));
+    const test = harness({ source: { kind: "directory" }, entries: [], diagnostics: [] });
+
+    expect(await runCli(["catalog", "docs-check", root], test.dependencies)).toBe(1);
+    expect(test.output().stderr).toContain(file);
+  });
+
+  it("detects unbalanced Markdown fences and schema/category drift", async () => {
+    const fenceRoot = publicRoot();
+    writeFileSync(join(fenceRoot, "docs/CREDIT.md"), "```text\nunclosed\n");
+    const fenceTest = harness({ source: { kind: "directory" }, entries: [], diagnostics: [] });
+    expect(await runCli(["catalog", "docs-check", fenceRoot], fenceTest.dependencies)).toBe(1);
+    expect(fenceTest.output().stderr).toContain("Markdown fence");
+
+    const parityRoot = publicRoot();
+    const schemaPath = join(parityRoot, "schemas/plugin.schema.yaml");
+    writeFileSync(
+      schemaPath,
+      readFileSync(schemaPath, "utf8").replace("      - skill\n", "      - skill\n      - bridge-adapter\n"),
+    );
+    const parityTest = harness({ source: { kind: "directory" }, entries: [], diagnostics: [] });
+    expect(await runCli(["catalog", "docs-check", parityRoot], parityTest.dependencies)).toBe(1);
+    expect(parityTest.output().stderr).toContain("schema/category parity");
+  });
+
+  it.each([
+    ["claim", "evidence"],
+    ["correction", "correction"],
+    ["removal", "action"],
+    ["removal", "confirmations"],
+  ])("rejects %s when required material field %s becomes optional", async (form, field) => {
+    const root = publicRoot();
+    const path = join(root, `.github/ISSUE_TEMPLATE/${form}.yml`);
+    const content = readFileSync(path, "utf8");
+    const start = content.indexOf(`    id: ${field}\n`);
+    const required = content.indexOf("required: true", start);
+    writeFileSync(
+      path,
+      `${content.slice(0, required)}required: false${content.slice(required + "required: true".length)}`,
+    );
+    const test = harness({ source: { kind: "directory" }, entries: [], diagnostics: [] });
+
+    expect(await runCli(["catalog", "github-forms-check", root], test.dependencies)).toBe(1);
+    expect(test.output().stderr).toContain(`.github/ISSUE_TEMPLATE/${form}.yml`);
+  });
+});

--- a/cli/tests/catalog-slice-boundary.test.ts
+++ b/cli/tests/catalog-slice-boundary.test.ts
@@ -1,0 +1,89 @@
+// The CLI is a CONSUMER of the public catalog. The code under src/catalog/ was vendored from the
+// private curation engine when the CLI moved into this repository, and the boundary that keeps
+// curation out of a published binary is not self-enforcing: someone vendoring "one more helper"
+// from the same origin is how an engine leaks into a client.
+//
+// So this suite asserts the boundary on the two artifacts that matter — the vendored sources and
+// the bundle that actually ships.
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const cliRoot = fileURLToPath(new URL("../", import.meta.url));
+const sliceDirectory = `${cliRoot}src/catalog`;
+
+// Exactly the closure the CLI needs to read and validate a catalog entry. Adding a file here is
+// a deliberate act that has to be argued for in review, which is the entire point.
+const ALLOWED_SLICE = [
+  "bundleMarker.ts",
+  "canonical.ts",
+  "index.ts",
+  "loadCatalog.ts",
+  "publicCatalogValidator.ts",
+  "publicSchema.ts",
+  "types.ts",
+];
+
+// Identifiers that only exist to CURATE a catalog — deciding which candidate is an upstream copy,
+// which is a duplicate, where a harvest cursor stopped. A client never needs to answer these.
+const CURATION_IDENTIFIERS = [
+  "isUpstreamHarness",
+  "UPSTREAM_HARNESS",
+  "isUpstreamCopy",
+  "annotateDuplicates",
+  "isRepositoryFixture",
+  "cursorProgress",
+  "harvest",
+  "candidateLedger",
+  "manual-approvals",
+  "qualification-report",
+  "clone-inventory",
+  "ApprovedWriteBatch",
+  "preparePullRequest",
+];
+
+describe("the vendored catalog slice stays a reading contract", () => {
+  it("contains exactly the agreed files", () => {
+    expect(readdirSync(sliceDirectory).sort()).toEqual(ALLOWED_SLICE);
+  });
+
+  it("carries no curation logic", () => {
+    const sources = readdirSync(sliceDirectory)
+      .map((name) => readFileSync(`${sliceDirectory}/${name}`, "utf8"))
+      .join("\n");
+
+    for (const identifier of CURATION_IDENTIFIERS) {
+      expect(sources).not.toContain(identifier);
+    }
+  });
+
+  it("reaches nothing outside the CLI", () => {
+    const sources = readdirSync(sliceDirectory)
+      .map((name) => readFileSync(`${sliceDirectory}/${name}`, "utf8"))
+      .join("\n");
+
+    // A relative import climbing past src/ would silently re-couple the slice to whatever sits
+    // beside it, and a workspace specifier would resurrect the dependency this move removed.
+    expect(sources).not.toContain("@omni-dsh/");
+    expect(sources).not.toMatch(/from "\.\.\/\.\./u);
+  });
+});
+
+describe("the shipped bundle", () => {
+  it("contains no curation identifier", () => {
+    // Source-level purity is not enough: the binary is what people install, and esbuild decides
+    // what survives. Build it if it is not already there so the assertion is never vacuous.
+    const bundle = `${cliRoot}dist/bin.js`;
+    if (!existsSync(bundle)) {
+      execFileSync("npm", ["run", "build"], { cwd: cliRoot, stdio: "ignore" });
+    }
+    const built = readFileSync(bundle, "utf8");
+    expect(built.length).toBeGreaterThan(100_000);
+
+    for (const identifier of CURATION_IDENTIFIERS) {
+      expect(built).not.toContain(identifier);
+    }
+  });
+});

--- a/cli/tests/catalog-snapshot.test.ts
+++ b/cli/tests/catalog-snapshot.test.ts
@@ -1,0 +1,500 @@
+import { execFileSync } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { access, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CATALOG_SNAPSHOT_FORMAT_V1,
+  PUBLIC_CATALOG_RAW_ORIGIN,
+  PUBLIC_SNAPSHOT_SITE_URL,
+  materializeCatalog,
+} from "../src/catalogSnapshot.js";
+import type { ChildSpawn } from "../src/dsh/childSupervisor.js";
+import { CliSafetyError } from "../src/errors.js";
+
+const REVISION_A = "a".repeat(40);
+const REVISION_B = "b".repeat(40);
+const temporaryRoots: string[] = [];
+
+function snapshot(
+  files: Record<string, string>,
+  revision = REVISION_A,
+): string {
+  return JSON.stringify({
+    format: CATALOG_SNAPSHOT_FORMAT_V1,
+    revision,
+    files,
+  });
+}
+
+function publicSnapshotUrl(revision = REVISION_A): string {
+  return `${PUBLIC_CATALOG_RAW_ORIGIN}/${revision}/catalog.snapshot.json`;
+}
+
+async function temporaryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function git(root: string, args: readonly string[]): string {
+  return execFileSync("git", [...args], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+async function initializeGitRepository(
+  root: string,
+  ignoredFiles: readonly string[] = [],
+): Promise<string> {
+  git(root, ["init", "--quiet"]);
+  git(root, ["config", "user.name", "Catalog Test"]);
+  git(root, ["config", "user.email", "catalog-test@example.invalid"]);
+  await writeFile(join(root, "README.md"), "# Catalog fixture\n");
+  if (ignoredFiles.length > 0) {
+    await writeFile(join(root, ".gitignore"), `${ignoredFiles.join("\n")}\n`);
+  }
+  git(root, ["add", "-A"]);
+  git(root, ["commit", "--quiet", "-m", "catalog fixture"]);
+  return git(root, ["rev-parse", "HEAD"]);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("catalog snapshot materialization", () => {
+  it("returns a canonical local directory without taking ownership of it", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-directory-");
+    await mkdir(join(sourceRoot, "catalog/plugins"), { recursive: true });
+
+    const materialized = await materializeCatalog({ kind: "directory", root: sourceRoot });
+
+    expect(materialized).toMatchObject({
+      kind: "directory",
+      root: await realpath(sourceRoot),
+    });
+    await materialized.cleanup();
+    await materialized.cleanup();
+    await expect(access(sourceRoot)).resolves.toBeUndefined();
+  });
+
+  it("materializes a pinned directory into an owned temporary root", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-git-");
+    const revision = await initializeGitRepository(sourceRoot);
+
+    const materialized = await materializeCatalog({
+      kind: "directory",
+      root: sourceRoot,
+      revision,
+    });
+
+    expect(materialized).toMatchObject({ kind: "snapshot", revision });
+    expect(materialized.root).not.toBe(await realpath(sourceRoot));
+    await materialized.cleanup();
+    await expect(access(sourceRoot)).resolves.toBeUndefined();
+  });
+
+  it("rejects a declared revision for a non-Git local directory", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-non-git-");
+
+    await expect(
+      materializeCatalog({ kind: "directory", root: sourceRoot, revision: REVISION_A }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+  });
+
+  it("materializes the selected commit even when HEAD has advanced", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-wrong-head-");
+    await mkdir(join(sourceRoot, "schemas"), { recursive: true });
+    await writeFile(join(sourceRoot, "schemas/version.txt"), "selected commit\n");
+    const previousRevision = await initializeGitRepository(sourceRoot);
+    await writeFile(join(sourceRoot, "schemas/version.txt"), "new HEAD\n");
+    git(sourceRoot, ["add", "schemas/version.txt"]);
+    git(sourceRoot, ["commit", "--quiet", "-m", "second revision"]);
+
+    const materialized = await materializeCatalog({
+      kind: "directory",
+      root: sourceRoot,
+      revision: previousRevision,
+    });
+
+    expect(await readFile(join(materialized.root, "schemas/version.txt"), "utf8"))
+      .toBe("selected commit\n");
+    expect(await readFile(join(sourceRoot, "schemas/version.txt"), "utf8")).toBe("new HEAD\n");
+    await materialized.cleanup();
+  });
+
+  it("ignores tracked working-tree modifications and reads the committed blob", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-dirty-");
+    await mkdir(join(sourceRoot, "catalog/plugins"), { recursive: true });
+    const pluginPath = join(sourceRoot, "catalog/plugins/example.yaml");
+    await writeFile(pluginPath, "id: committed\n");
+    const revision = await initializeGitRepository(sourceRoot);
+    await writeFile(pluginPath, "id: dirty-working-tree\n");
+
+    const materialized = await materializeCatalog({ kind: "directory", root: sourceRoot, revision });
+
+    expect(await readFile(join(materialized.root, "catalog/plugins/example.yaml"), "utf8"))
+      .toBe("id: committed\n");
+    await materialized.cleanup();
+  });
+
+  it("materializes a local JSON snapshot and cleans it up idempotently", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-file-");
+    const sourcePath = join(sourceRoot, "catalog.snapshot.json");
+    await writeFile(
+      sourcePath,
+      snapshot({
+        "schemas/plugin.schema.json": "{\"type\":\"object\"}\n",
+        "catalog/plugins/example.yaml": "schemaVersion: 1\nid: example\n",
+      }),
+    );
+
+    const materialized = await materializeCatalog({
+      kind: "snapshot-file",
+      path: sourcePath,
+    });
+    if (materialized.kind !== "snapshot") throw new Error("expected snapshot result");
+
+    expect(materialized.revision).toBe(REVISION_A);
+    expect(await readFile(join(materialized.root, "catalog/plugins/example.yaml"), "utf8"))
+      .toBe("schemaVersion: 1\nid: example\n");
+    const stagedRoot = materialized.root;
+    await materialized.cleanup();
+    await materialized.cleanup();
+    await expect(access(stagedRoot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a pinned snapshot file whose declared revision does not match the requested commit", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-file-git-");
+    const sourcePath = join(sourceRoot, "catalog.snapshot.json");
+    await writeFile(
+      sourcePath,
+      snapshot({ "schemas/from-commit.txt": "committed snapshot bytes\n" }, REVISION_A),
+    );
+    const revision = await initializeGitRepository(sourceRoot);
+    expect(revision).not.toBe(REVISION_A);
+    await writeFile(sourcePath, "working tree replacement is not JSON\n");
+
+    // The committed blob declares REVISION_A while the pin requests the actual
+    // commit; rebadging the snapshot as "verified at <revision>" must fail with
+    // the same mismatch validation the snapshot-URL path applies. The specific
+    // mismatch message also proves the bytes came from the tracked commit blob:
+    // reading the working-tree replacement would fail JSON parsing instead.
+    await expect(
+      materializeCatalog({
+        kind: "snapshot-file",
+        path: sourcePath,
+        revision,
+      }),
+    ).rejects.toMatchObject({
+      name: "CliSafetyError",
+      message: "catalog snapshot revision does not match the requested commit",
+    });
+  });
+
+  it("rejects an ignored or untracked local snapshot absent from the selected commit", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-file-untracked-");
+    const revision = await initializeGitRepository(sourceRoot, ["catalog.snapshot.json"]);
+    const sourcePath = join(sourceRoot, "catalog.snapshot.json");
+    await writeFile(sourcePath, snapshot({}, REVISION_A));
+
+    await expect(
+      materializeCatalog({ kind: "snapshot-file", path: sourcePath, revision }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+  });
+
+  it("rejects a symlink recorded in the selected catalog tree", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-tree-symlink-");
+    await mkdir(join(sourceRoot, "catalog/plugins"), { recursive: true });
+    await symlink("../target.yaml", join(sourceRoot, "catalog/plugins/link.yaml"));
+    const revision = await initializeGitRepository(sourceRoot);
+
+    await expect(
+      materializeCatalog({ kind: "directory", root: sourceRoot, revision }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+  });
+
+  it("rejects a gitlink recorded in the selected catalog tree", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-tree-gitlink-");
+    const parentRevision = await initializeGitRepository(sourceRoot);
+    git(sourceRoot, [
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      `160000,${parentRevision},catalog/plugins/nested-repository`,
+    ]);
+    git(sourceRoot, ["commit", "--quiet", "-m", "add gitlink"]);
+    const revision = git(sourceRoot, ["rev-parse", "HEAD"]);
+
+    await expect(
+      materializeCatalog({ kind: "directory", root: sourceRoot, revision }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+  });
+
+  it("rejects unsafe and over-deep paths recorded in the selected tree", async () => {
+    const unsafeRoot = await temporaryRoot("dsh-catalog-tree-unsafe-");
+    await mkdir(join(unsafeRoot, "catalog/plugins"), { recursive: true });
+    await writeFile(join(unsafeRoot, "catalog/plugins/%2e%2e.yaml"), "unsafe\n");
+    const unsafeRevision = await initializeGitRepository(unsafeRoot);
+
+    await expect(
+      materializeCatalog({ kind: "directory", root: unsafeRoot, revision: unsafeRevision }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+
+    const deepRoot = await temporaryRoot("dsh-catalog-tree-deep-");
+    const deepPath = join(deepRoot, "schemas", ...Array.from({ length: 20 }, () => "level"));
+    await mkdir(deepPath, { recursive: true });
+    await writeFile(join(deepPath, "schema.json"), "{}\n");
+    const deepRevision = await initializeGitRepository(deepRoot);
+
+    await expect(
+      materializeCatalog({ kind: "directory", root: deepRoot, revision: deepRevision }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+  });
+
+  it("accepts an intentional zero-entry snapshot", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-empty-");
+    const sourcePath = join(sourceRoot, "catalog.snapshot.json");
+    await writeFile(sourcePath, snapshot({}));
+
+    const materialized = await materializeCatalog({ kind: "snapshot-file", path: sourcePath });
+    if (materialized.kind !== "snapshot") throw new Error("expected snapshot result");
+
+    expect(materialized.revision).toBe(REVISION_A);
+    expect(materialized.root).toBe(await realpath(materialized.root));
+    await materialized.cleanup();
+  });
+
+  it("fetches only a pinned public raw snapshot without credentials", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchSnapshot = async (url: string, init: RequestInit): Promise<Response> => {
+      calls.push({ url, init });
+      return new Response(snapshot({}), {
+        status: 200,
+        headers: { "content-length": String(Buffer.byteLength(snapshot({}))) },
+      });
+    };
+
+    const materialized = await materializeCatalog(
+      { kind: "snapshot-url", url: publicSnapshotUrl(), revision: REVISION_A },
+      { fetch: fetchSnapshot },
+    );
+
+    expect(materialized).toMatchObject({ kind: "snapshot", revision: REVISION_A });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(publicSnapshotUrl());
+    expect(calls[0]?.init.redirect).toBe("manual");
+    expect(calls[0]?.init.credentials).toBe("omit");
+    const headers = new Headers(calls[0]?.init.headers);
+    expect(headers.has("authorization")).toBe(false);
+    expect(headers.has("cookie")).toBe(false);
+    await materialized.cleanup();
+  });
+
+  it("fetches the site-hosted snapshot when its declared revision matches the requested pin", async () => {
+    // REV-44: a snapshot committed to the catalog repository can never declare its own commit,
+    // so the site-hosted stable URL is the operational remote source. The caller's revision
+    // remains the out-of-band anchor.
+    const calls: string[] = [];
+    const fetchSnapshot = async (url: string): Promise<Response> => {
+      calls.push(url);
+      return new Response(snapshot({}, REVISION_A), { status: 200 });
+    };
+
+    const materialized = await materializeCatalog(
+      { kind: "snapshot-url", url: PUBLIC_SNAPSHOT_SITE_URL, revision: REVISION_A },
+      { fetch: fetchSnapshot },
+    );
+
+    expect(materialized).toMatchObject({ kind: "snapshot", revision: REVISION_A });
+    expect(calls).toEqual([PUBLIC_SNAPSHOT_SITE_URL]);
+    await materialized.cleanup();
+  });
+
+  it("rejects a site-hosted snapshot whose declared revision differs from the requested pin", async () => {
+    const fetchSnapshot = async (): Promise<Response> =>
+      new Response(snapshot({}, REVISION_B), { status: 200 });
+
+    await expect(
+      materializeCatalog(
+        { kind: "snapshot-url", url: PUBLIC_SNAPSHOT_SITE_URL, revision: REVISION_A },
+        { fetch: fetchSnapshot },
+      ),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+  });
+
+  it.each([
+    "https://dsh-plugins.omniroute.online/other.json",
+    "https://dsh-plugins.omniroute.online/catalog.snapshot.json?x=1",
+    "https://dsh-plugins.omniroute.online:8443/catalog.snapshot.json",
+    "https://evil.invalid/catalog.snapshot.json",
+  ])("rejects the near-miss site URL %s without fetching", async (badUrl) => {
+    let fetched = false;
+    const fetchSnapshot = async (): Promise<Response> => {
+      fetched = true;
+      return new Response(snapshot({}, REVISION_A));
+    };
+
+    await expect(
+      materializeCatalog(
+        { kind: "snapshot-url", url: badUrl, revision: REVISION_A },
+        { fetch: fetchSnapshot },
+      ),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+    expect(fetched).toBe(false);
+  });
+
+  it("aborts a stalled response body at the configured deadline and cancels its reader", async () => {
+    let requestedSignal: AbortSignal | null = null;
+    let readerCanceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{"));
+      },
+      cancel() {
+        readerCanceled = true;
+      },
+    });
+    const fetchSnapshot = async (_url: string, init: RequestInit): Promise<Response> => {
+      requestedSignal = init.signal ?? null;
+      return new Response(body, { status: 200 });
+    };
+
+    const operation = materializeCatalog(
+      { kind: "snapshot-url", url: publicSnapshotUrl(), revision: REVISION_A },
+      { fetch: fetchSnapshot, fetchTimeoutMs: 40 },
+    );
+    const guarded = Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        setTimeout(() => reject(new Error("catalog fetch deadline was not enforced")), 300);
+      }),
+    ]);
+
+    await expect(guarded).rejects.toBeInstanceOf(CliSafetyError);
+    expect((requestedSignal as AbortSignal | null)?.aborted).toBe(true);
+    expect(readerCanceled).toBe(true);
+  });
+
+  it("rejects a URL whose embedded commit does not match the requested revision", async () => {
+    let fetched = false;
+    const fetchSnapshot = async (): Promise<Response> => {
+      fetched = true;
+      return new Response(snapshot({}));
+    };
+
+    await expect(
+      materializeCatalog(
+        { kind: "snapshot-url", url: publicSnapshotUrl(REVISION_A), revision: REVISION_B },
+        { fetch: fetchSnapshot },
+      ),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+    expect(fetched).toBe(false);
+  });
+
+  it.each([
+    "/absolute.yaml",
+    "../escape.yaml",
+    "catalog/plugins/../../escape.yaml",
+    "catalog\\plugins\\escape.yaml",
+    "catalog/plugins/%2e%2e/escape.yaml",
+  ])("rejects unsafe snapshot path %s", async (unsafePath) => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-traversal-");
+    const sourcePath = join(sourceRoot, "catalog.snapshot.json");
+    await writeFile(sourcePath, snapshot({ [unsafePath]: "unsafe" }));
+
+    await expect(
+      materializeCatalog({ kind: "snapshot-file", path: sourcePath }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+    await expect(access(join(sourceRoot, "escape.yaml"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a symlinked local snapshot", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-symlink-");
+    const targetPath = join(sourceRoot, "target.json");
+    const linkPath = join(sourceRoot, "catalog.snapshot.json");
+    await writeFile(targetPath, snapshot({}));
+    await symlink(targetPath, linkPath);
+
+    await expect(
+      materializeCatalog({ kind: "snapshot-file", path: linkPath }),
+    ).rejects.toBeInstanceOf(CliSafetyError);
+  });
+
+  it("rejects a manual redirect that escapes the public catalog host", async () => {
+    const calls: string[] = [];
+    const fetchSnapshot = async (url: string): Promise<Response> => {
+      calls.push(url);
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: `https://catalog.invalid/${REVISION_A}/catalog.snapshot.json`,
+        },
+      });
+    };
+
+    const result = materializeCatalog(
+      { kind: "snapshot-url", url: publicSnapshotUrl(), revision: REVISION_A },
+      { fetch: fetchSnapshot },
+    );
+    await expect(result).rejects.toBeInstanceOf(CliSafetyError);
+    await expect(result).rejects.not.toThrow(/catalog\.invalid/);
+    expect(calls).toEqual([publicSnapshotUrl()]);
+  });
+
+  it("terminates, kills and reaps a Git probe that exceeds its deadline", async () => {
+    const sourceRoot = await temporaryRoot("dsh-catalog-git-timeout-");
+    const events = new EventEmitter();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const signals: NodeJS.Signals[] = [];
+    let closed = false;
+    const child = Object.assign(events, {
+      stdout,
+      stderr,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      kill(signal: NodeJS.Signals) {
+        signals.push(signal);
+        if (signal === "SIGKILL") {
+          child.signalCode = signal;
+          queueMicrotask(() => {
+            closed = true;
+            events.emit("close", null, signal);
+            stdout.end();
+            stderr.end();
+          });
+        }
+        return true;
+      },
+    });
+    const spawnGit = (() => child) as unknown as ChildSpawn;
+    let rejectedBeforeClose = false;
+
+    const operation = materializeCatalog(
+        { kind: "directory", root: sourceRoot, revision: REVISION_A },
+        {
+          spawnGit,
+          gitTimeoutMs: 20,
+          gitKillGraceMs: 20,
+        },
+      ).catch((error: unknown) => {
+        rejectedBeforeClose = !closed;
+        throw error;
+      });
+    await expect(operation).rejects.toBeInstanceOf(CliSafetyError);
+
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(closed).toBe(true);
+    expect(rejectedBeforeClose).toBe(false);
+  });
+});

--- a/cli/tests/child-supervisor.test.ts
+++ b/cli/tests/child-supervisor.test.ts
@@ -1,0 +1,117 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { tmpdir } from "node:os";
+import { PassThrough } from "node:stream";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  runSupervisedChild,
+  type ChildSpawn,
+  type ProcessGroupSignaler,
+} from "../src/dsh/childSupervisor.js";
+
+interface FakeChild {
+  readonly child: ChildProcess;
+  readonly events: EventEmitter;
+  readonly stdout: PassThrough;
+  readonly stderr: PassThrough;
+  readonly spawn: ChildSpawn;
+  readonly wasUnrefed: () => boolean;
+}
+
+function fakeChild(): FakeChild {
+  const events = new EventEmitter();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let unrefed = false;
+  const child = Object.assign(events, {
+    pid: 4_242,
+    stdout,
+    stderr,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: () => true,
+    unref: () => {
+      unrefed = true;
+    },
+  }) as unknown as ChildProcess;
+  return {
+    child,
+    events,
+    stdout,
+    stderr,
+    spawn: (() => child) as ChildSpawn,
+    wasUnrefed: () => unrefed,
+  };
+}
+
+const REQUEST = {
+  command: "git",
+  args: ["status"],
+  cwd: tmpdir(),
+  env: {},
+  timeoutMs: 15,
+  termGraceMs: 15,
+  reapTimeoutMs: 25,
+  maxOutputBytes: 1_024,
+  processGroup: true,
+} as const;
+
+describe("child process supervisor", () => {
+  it("signals the whole process group and rejects only after close reaps the child", async () => {
+    const fake = fakeChild();
+    const signals: Array<{ groupId: number; signal: NodeJS.Signals }> = [];
+    let closed = false;
+    const signalProcessGroup: ProcessGroupSignaler = (groupId, signal) => {
+      signals.push({ groupId, signal });
+      if (signal === "SIGKILL") {
+        queueMicrotask(() => {
+          closed = true;
+          fake.events.emit("close", null, signal);
+        });
+      }
+      return true;
+    };
+
+    const result = await runSupervisedChild(REQUEST, {
+      spawn: fake.spawn,
+      signalProcessGroup,
+    });
+
+    expect(result).toMatchObject({ reaped: true, reason: "timeout" });
+    expect(closed).toBe(true);
+    expect(signals).toEqual([
+      { groupId: -4_242, signal: "SIGTERM" },
+      { groupId: -4_242, signal: "SIGKILL" },
+    ]);
+  });
+
+  it("returns a bounded typed unreaped result when close never arrives", async () => {
+    const fake = fakeChild();
+    const signals: NodeJS.Signals[] = [];
+    const signalProcessGroup: ProcessGroupSignaler = (_groupId, signal) => {
+      signals.push(signal);
+      return true;
+    };
+
+    const guarded = Promise.race([
+      runSupervisedChild(REQUEST, { spawn: fake.spawn, signalProcessGroup }),
+      new Promise<never>((_resolve, reject) => {
+        setTimeout(() => reject(new Error("supervisor did not enforce its reap deadline")), 250);
+      }),
+    ]);
+    const result = await guarded;
+
+    expect(result).toMatchObject({
+      reaped: false,
+      reason: "reap-timeout",
+      terminationReason: "timeout",
+    });
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(fake.wasUnrefed()).toBe(true);
+    expect(fake.stdout.destroyed).toBe(true);
+    expect(fake.stderr.destroyed).toBe(true);
+    expect(fake.events.listenerCount("close")).toBe(0);
+  });
+});

--- a/cli/tests/cli-error-output.test.ts
+++ b/cli/tests/cli-error-output.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli, type CliDependencies } from "../src/app.js";
+import { loadDefaultCatalog } from "../src/catalogSource.js";
+
+function harness(loadCatalog: CliDependencies["loadCatalog"]) {
+  let stdout = "";
+  let stderr = "";
+  const dependencies: CliDependencies = {
+    loadCatalog,
+    stdout: (value) => {
+      stdout += value;
+    },
+    stderr: (value) => {
+      stderr += value;
+    },
+  };
+  return { dependencies, output: () => ({ stdout, stderr }) };
+}
+
+describe("CLI failure output", () => {
+  it("explains a remote catalog URL without --revision instead of failing silently", async () => {
+    const { dependencies, output } = harness(loadDefaultCatalog);
+
+    const exitCode = await runCli(
+      [
+        "add",
+        "fixture-plugin",
+        "--profile",
+        "web",
+        "--catalog",
+        "https://raw.githubusercontent.com/diegosouzapw/awesome-omni-dsh-plugins/main/catalog.snapshot.json",
+      ],
+      dependencies,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(output().stderr).toContain("remote catalog snapshots require an exact revision");
+    expect(output().stderr).toContain("Command failed safely; no changes were made.");
+  });
+
+  it("keeps unexpected internal error details out of the failure output", async () => {
+    const { dependencies, output } = harness(async () => {
+      throw new Error("boom-internal-detail");
+    });
+
+    const exitCode = await runCli(
+      ["add", "fixture-plugin", "--profile", "web"],
+      dependencies,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(output().stderr).toContain(
+      "Operation failed safely; no unverified changes were accepted.",
+    );
+    expect(output().stderr).toContain("Command failed safely; no changes were made.");
+    expect(output().stderr).not.toContain("boom-internal-detail");
+    // Stack-frame marker: a leaked V8 stack always renders " at /abs/path".
+    expect(output().stderr).not.toContain(" at /");
+    expect(output().stdout).not.toContain(" at /");
+  });
+});

--- a/cli/tests/discover-command.test.ts
+++ b/cli/tests/discover-command.test.ts
@@ -1,0 +1,196 @@
+// `discover` is the two-tier plugin finder: the curated tier answers from OUR reviewed
+// catalog, the community tier from a live GitHub topic search that is clearly labeled
+// third-party. Design inspired by awesome-dsh-plugin/dsh-find-plugin (MIT) — the code and the
+// output contract here are our own. The community tier must degrade to silence (with a
+// notice), never to an error, and must never send a credential.
+import { describe, expect, it } from "vitest";
+
+import {
+  createCommunitySearch,
+  discoverCommand,
+  type CommunityResult,
+} from "../src/commands/discover.js";
+import type { CatalogSnapshot, PublicCatalogEntry } from "../src/model.js";
+
+function curatedEntry(overrides: Partial<PublicCatalogEntry> & { id: string }): PublicCatalogEntry {
+  return {
+    schemaVersion: 1,
+    name: overrides.id,
+    kind: "plugin",
+    primaryCategory: "user-interface-dashboards",
+    tags: ["tui"],
+    description: { en: "A curated terminal client for DeepSeek Harness sessions.", evidencePath: "README.md" },
+    unofficial: true,
+    source: {
+      repository: `https://github.com/creator/${overrides.id}`,
+      repositoryNodeId: `R_${overrides.id}`,
+      subpath: null,
+      commit: "a".repeat(40),
+    },
+    creator: { github: "creator", profile: "https://github.com/creator" },
+    package: { ecosystem: "source", name: null },
+    dsh: { profiles: ["web"], evidencePath: "cordis.patch.yml" },
+    repositoryScope: "dedicated",
+    license: { spdx: "MIT" },
+    popularity: { starsPolicy: "exact-repository", stars: 5 },
+    verification: {
+      status: "eligible",
+      checkedAt: "2026-08-19T00:00:00.000Z",
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+    ...overrides,
+  } as PublicCatalogEntry;
+}
+
+function fixtureSnapshot(entries: readonly PublicCatalogEntry[]): CatalogSnapshot {
+  return {
+    source: { kind: "snapshot", declaredRevision: "b".repeat(40), pinStatus: "declared-local" },
+    entries,
+    diagnostics: [],
+  } as unknown as CatalogSnapshot;
+}
+
+function fixtureContext(entries: readonly PublicCatalogEntry[]) {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    context: {
+      loadCatalog: async () => fixtureSnapshot(entries),
+      stdout: (text: string) => out.push(text),
+      stderr: (text: string) => err.push(text),
+    },
+    out,
+    err,
+  };
+}
+
+const COMMUNITY_FIXTURE: readonly CommunityResult[] = [
+  {
+    name: "dsh-hot",
+    fullName: "hot/dsh-hot",
+    url: "https://github.com/hot/dsh-hot",
+    description: "hot community plugin",
+    stars: 90,
+    install: "dsh plugin --profile web add github:hot/dsh-hot",
+  },
+  {
+    name: "dsh-cold",
+    fullName: "cold/dsh-cold",
+    url: "https://github.com/cold/dsh-cold",
+    description: "cold community plugin",
+    stars: 2,
+    install: "dsh plugin --profile web add github:cold/dsh-cold",
+  },
+];
+
+describe("community search client", () => {
+  it("queries the dsh-plugin topic unauthenticated, ranks by stars and caches per query", async () => {
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    let now = 1_000_000;
+    const search = createCommunitySearch({
+      fetchImplementation: (async (url: string, init: { headers: Record<string, string> }) => {
+        calls.push({ url, headers: init.headers });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [
+              { name: "dsh-cold", full_name: "cold/dsh-cold", html_url: "https://github.com/cold/dsh-cold", description: "cold", stargazers_count: 2 },
+              { name: "dsh-hot", full_name: "hot/dsh-hot", html_url: "https://github.com/hot/dsh-hot", description: "hot", stargazers_count: 90 },
+            ],
+          }),
+        };
+      }) as unknown as typeof fetch,
+      clock: () => now,
+    });
+
+    const first = await search("tui client", 5);
+    expect(first.map((item) => item.fullName)).toEqual(["hot/dsh-hot", "cold/dsh-cold"]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toContain("topic%3Adsh-plugin");
+    expect(calls[0]?.url).toContain("tui%20client");
+    // Unauthenticated by design: no credential header may ever be attached.
+    expect(Object.keys(calls[0]?.headers ?? {}).map((key) => key.toLowerCase()))
+      .not.toContain("authorization");
+
+    // Within the TTL the same query never re-fetches; after it, it does.
+    await search("tui client", 5);
+    expect(calls).toHaveLength(1);
+    now += 6 * 60 * 1000;
+    await search("tui client", 5);
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe("discover command", () => {
+  it("answers with the curated tier first and the labeled community tier after", async () => {
+    const { context, out } = fixtureContext([curatedEntry({ id: "dsh-tui-ours" })]);
+
+    const exitCode = await discoverCommand(context, "tui", {
+      community: async () => [...COMMUNITY_FIXTURE],
+      json: false,
+      limit: 8,
+    });
+
+    const text = out.join("");
+    expect(exitCode).toBe(0);
+    expect(text.indexOf("dsh-tui-ours")).toBeLessThan(text.indexOf("hot/dsh-hot"));
+    expect(text).toContain("[curated]");
+    expect(text).toContain("[community]");
+    expect(text).toContain("third-party");
+    expect(text).toContain("dsh plugin --profile web add github:hot/dsh-hot");
+  });
+
+  it("emits a stable JSON shape separating the tiers", async () => {
+    const { context, out } = fixtureContext([curatedEntry({ id: "dsh-tui-ours" })]);
+
+    await discoverCommand(context, "tui", {
+      community: async () => [...COMMUNITY_FIXTURE],
+      json: true,
+      limit: 1,
+    });
+
+    const document = JSON.parse(out.join(""));
+    expect(document.curated.map((entry: { id: string }) => entry.id)).toEqual(["dsh-tui-ours"]);
+    // The limit bounds each tier independently.
+    expect(document.community).toHaveLength(1);
+    expect(document.community[0].fullName).toBe("hot/dsh-hot");
+    expect(typeof document.notice).toBe("string");
+  });
+
+  it("degrades to curated-only with a notice when the community tier fails", async () => {
+    const { context, out, err } = fixtureContext([curatedEntry({ id: "dsh-tui-ours" })]);
+
+    const exitCode = await discoverCommand(context, "tui", {
+      community: async () => {
+        throw new Error("network unavailable");
+      },
+      json: false,
+      limit: 8,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(out.join("")).toContain("dsh-tui-ours");
+    expect(`${out.join("")}${err.join("")}`).toContain("community tier unavailable");
+  });
+
+  it("skips the network entirely with --offline", async () => {
+    const { context, out } = fixtureContext([curatedEntry({ id: "dsh-tui-ours" })]);
+    let networkCalls = 0;
+
+    await discoverCommand(context, "tui", {
+      community: async () => {
+        networkCalls += 1;
+        return [];
+      },
+      json: false,
+      limit: 8,
+      offline: true,
+    });
+
+    expect(networkCalls).toBe(0);
+    expect(out.join("")).toContain("dsh-tui-ours");
+  });
+});

--- a/cli/tests/discovery.test.ts
+++ b/cli/tests/discovery.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli, type CliDependencies } from "../src/app.js";
+
+const entry = {
+  schemaVersion: 1 as const,
+  id: "vision-helper",
+  name: "Vision Helper",
+  description: { en: "A creator-built vision workflow for DSH users.", evidencePath: "README.md" },
+  unofficial: true as const,
+  kind: "plugin" as const,
+  primaryCategory: "vision-audio-multimodal",
+  tags: ["vision", "web-ui"],
+  source: {
+    repository: "https://github.com/creator/vision-helper",
+    repositoryNodeId: "R_vision",
+    subpath: "packages/dsh",
+    commit: "b".repeat(40),
+  },
+  creator: { github: "creator" },
+  package: {
+    ecosystem: "npm" as const,
+    name: "@creator/vision-helper",
+    version: "1.2.3",
+    integrity:
+      "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+  },
+  dsh: { profiles: ["web"], evidencePath: "packages/dsh/package.json" },
+  repositoryScope: "monorepo" as const,
+  popularity: { starsPolicy: "undefined-parent-repository" as const, stars: null },
+  license: { spdx: "MIT" },
+  verification: {
+    status: "eligible" as const,
+    checkedAt: "2026-08-16T00:00:00Z",
+    repositoryIdentity: "resolved" as const,
+    smokeTest: null,
+  },
+  provenance: { discussion: null, comment: null },
+  canonicalKey: "R_vision:packages/dsh",
+};
+
+function harness() {
+  let stdout = "";
+  let stderr = "";
+  const dependencies: CliDependencies = {
+    loadCatalog: async () => ({
+      source: { kind: "snapshot", declaredRevision: "a".repeat(40), pinStatus: "declared-local" },
+      entries: [entry],
+      diagnostics: [],
+    }),
+    stdout: (value) => {
+      stdout += value;
+    },
+    stderr: (value) => {
+      stderr += value;
+    },
+  };
+  return { dependencies, output: () => ({ stdout, stderr }) };
+}
+
+describe("catalog discovery", () => {
+  it("searches tokenized public fields locally", async () => {
+    const test = harness();
+    expect(await runCli(["search", "creator vision"], test.dependencies)).toBe(0);
+    expect(test.output().stdout).toContain("vision-helper\tVision Helper\t@creator\teligible");
+    expect(test.output().stderr).toBe("");
+  });
+
+  it("prints creator, package, license, verification and monorepo stars honestly", async () => {
+    const test = harness();
+    expect(await runCli(["info", "vision-helper"], test.dependencies)).toBe(0);
+    expect(test.output().stdout).toContain("Name: Vision Helper");
+    expect(test.output().stdout).toContain("Creator: @creator");
+    expect(test.output().stdout).toContain("Package: @creator/vision-helper@1.2.3");
+    expect(test.output().stdout).toContain("License: MIT");
+    expect(test.output().stdout).toContain("Verification: eligible (not installation-tested)");
+    expect(test.output().stdout).toContain("Stars: undefined (parent repository)");
+  });
+
+  it("reports a missing entry without leaking its catalog source", async () => {
+    const test = harness();
+    expect(await runCli(["info", "missing-plugin"], test.dependencies)).toBe(1);
+    expect(test.output()).toEqual({ stdout: "", stderr: "Plugin not found: missing-plugin\n" });
+  });
+});

--- a/cli/tests/doctor-primary-journal.test.ts
+++ b/cli/tests/doctor-primary-journal.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { doctorCommand } from "../src/commands/doctor.js";
+
+const context = (output: string[]) => ({
+  loadCatalog: async () => ({ source: { kind: "directory" as const }, entries: [], diagnostics: [] }),
+  stdout: (value: string) => output.push(value),
+  stderr: (value: string) => output.push(value),
+});
+
+const primary = (overrides: Record<string, unknown> = {}) => ({
+  version: 1,
+  revision: 2,
+  status: "recovery_required",
+  phase: "needs_restore",
+  ownerToken: "secret-owner-token",
+  fencingToken: 9,
+  profile: "web",
+  processTree: {
+    pid: 44,
+    processGroupId: 44,
+    treeIdentity: "secret-tree-identity",
+    processStartIdentity: "secret-start-identity",
+    platform: "linux",
+  },
+  ...overrides,
+});
+
+function runtime(output: string[], marker: unknown) {
+  return {
+    platform: "linux" as const,
+    nodeVersion: "20.0.0",
+    probeDsh: async () => ({ status: "present" as const, version: "1.2.3" }),
+    readRecoveryJournal: vi.fn(async () => marker as never),
+    readState: vi.fn(async () => ({ version: 1 as const, installs: [] })),
+    resolveHome: () => "/not-exposed",
+    isProcessTreeAlive: vi.fn(async () => false),
+    stdout: (value: string) => output.push(value),
+  };
+}
+
+describe("doctor primary mutation journal", () => {
+  it("prefers a POSIX primary journal when the state mirror is absent", async () => {
+    const output: string[] = [];
+    const dependencies = runtime(output, primary());
+    expect(await doctorCommand(context(output), undefined, false, dependencies)).toBe(1);
+    expect(output.join("")).toMatch(/recovery.*pending/iu);
+    expect(dependencies.readState).not.toHaveBeenCalled();
+    expect(output.join("")).not.toContain("secret-owner-token");
+    expect(output.join("")).not.toContain("secret-tree-identity");
+    expect(output.join("")).not.toContain("/not-exposed");
+  });
+
+  it("reports completed primary cleanup without process probing", async () => {
+    const output: string[] = [];
+    const dependencies = runtime(output, primary({ status: "completed", phase: "completed" }));
+    expect(await doctorCommand(context(output), undefined, false, dependencies)).toBe(1);
+    expect(output.join("")).toMatch(/completed.*cleanup/iu);
+    expect(dependencies.isProcessTreeAlive).not.toHaveBeenCalled();
+  });
+
+  it("keeps a Windows primary marker manual without liveness inference", async () => {
+    const output: string[] = [];
+    const dependencies = runtime(output, primary({
+      processTree: { ...primary().processTree, platform: "win32" },
+    }));
+    expect(await doctorCommand(context(output), undefined, false, dependencies)).toBe(1);
+    expect(output.join("")).toMatch(/native Windows.*manual/iu);
+    expect(dependencies.isProcessTreeAlive).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes an unreadable primary journal and does not fall through to state", async () => {
+    const output: string[] = [];
+    const dependencies = runtime(output, null);
+    dependencies.readRecoveryJournal.mockRejectedValue(
+      new Error("secret /absolute/path owner-token"),
+    );
+    expect(await doctorCommand(context(output), undefined, false, dependencies)).toBe(1);
+    expect(output.join("")).toMatch(/journal.*safely/iu);
+    expect(output.join("")).not.toMatch(/secret|absolute|owner-token/iu);
+    expect(dependencies.readState).not.toHaveBeenCalled();
+  });
+});

--- a/cli/tests/doctor.test.ts
+++ b/cli/tests/doctor.test.ts
@@ -1,0 +1,368 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DOCTOR_STALE_AFTER_DAYS,
+  doctorCommand,
+  probeDshVersion,
+} from "../src/commands/doctor.js";
+import { listCommand } from "../src/commands/list.js";
+import type { CatalogCommandContext } from "../src/commands/catalog.js";
+import type { InstallState, RecoveryRequiredMarker } from "../src/dsh/installState.js";
+import type { CatalogSnapshot, PublicCatalogEntry } from "../src/model.js";
+
+function outputHarness(): {
+  readonly stdout: (value: string) => void;
+  readonly stderr: (value: string) => void;
+  readonly output: () => { readonly stdout: string; readonly stderr: string };
+} {
+  let stdout = "";
+  let stderr = "";
+  return {
+    stdout: (value) => {
+      stdout += value;
+    },
+    stderr: (value) => {
+      stderr += value;
+    },
+    output: () => ({ stdout, stderr }),
+  };
+}
+
+const installState: InstallState = {
+  version: 1,
+  installs: [
+    {
+      id: "zeta",
+      profile: "web",
+      packageName: "@creator/zeta",
+      fingerprint: `sha256:${"a".repeat(64)}`,
+      cacheRelativePath: "zeta/fingerprint/zeta.tgz",
+      installedAt: "2026-08-15T12:00:00.000Z",
+    },
+    {
+      id: "terminal-only",
+      profile: "terminal",
+      packageName: "terminal-only",
+      fingerprint: `sha256:${"b".repeat(64)}`,
+      cacheRelativePath: "terminal-only/fingerprint/terminal-only.tgz",
+      installedAt: "2026-08-13T12:00:00.000Z",
+    },
+    {
+      id: "alpha",
+      profile: "web",
+      packageName: "@creator/alpha",
+      fingerprint: `sha256:${"c".repeat(64)}`,
+      cacheRelativePath: "alpha/fingerprint/alpha.tgz",
+      installedAt: "2026-08-14T12:00:00.000Z",
+    },
+  ],
+};
+
+function catalogEntry(checkedAt: string): PublicCatalogEntry {
+  return {
+    schemaVersion: 1,
+    id: "fixture-plugin",
+    name: "Fixture Plugin",
+    description: {
+      en: "A sufficiently detailed fixture plugin description for doctor checks.",
+      evidencePath: "README.md",
+    },
+    unofficial: true,
+    kind: "plugin",
+    primaryCategory: "diagnostics-observability",
+    tags: ["diagnostics"],
+    source: {
+      repository: "https://github.com/creator/fixture-plugin",
+      repositoryNodeId: "R_fixture",
+      subpath: null,
+      commit: "a".repeat(40),
+    },
+    creator: { github: "creator" },
+    package: { ecosystem: "npm", name: "fixture-plugin", version: "1.0.0" },
+    dsh: { profiles: ["default"], evidencePath: "package.json" },
+    repositoryScope: "dedicated",
+    popularity: { starsPolicy: "exact-repository", stars: 1 },
+    license: { spdx: "MIT" },
+    verification: {
+      status: "eligible",
+      checkedAt,
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+    canonicalKey: "R_fixture:.",
+  };
+}
+
+function doctorHarness(snapshot: CatalogSnapshot): {
+  readonly context: CatalogCommandContext;
+  readonly output: () => { readonly stdout: string; readonly stderr: string };
+} {
+  const io = outputHarness();
+  return {
+    context: {
+      loadCatalog: vi.fn(async () => snapshot),
+      stdout: io.stdout,
+      stderr: io.stderr,
+    },
+    output: io.output,
+  };
+}
+
+describe("catalog-managed list", () => {
+  it("filters by profile and renders deterministic catalog-managed state without mutation", async () => {
+    const io = outputHarness();
+    const resolveHome = vi.fn(() => "/must-not-be-created");
+    const readState = vi.fn(async () => installState);
+
+    expect(await listCommand("web", false, {
+      resolveHome,
+      readState,
+      stdout: io.stdout,
+      stderr: io.stderr,
+    })).toBe(0);
+
+    expect(resolveHome).toHaveBeenCalledOnce();
+    expect(readState).toHaveBeenCalledWith("/must-not-be-created");
+    expect(io.output()).toEqual({
+      stdout:
+        "web\talpha\t@creator/alpha\tcatalog-managed\n" +
+        "web\tzeta\t@creator/zeta\tcatalog-managed\n",
+      stderr: "",
+    });
+  });
+
+  it("emits a stable JSON zero-state without exposing state or cache paths", async () => {
+    const io = outputHarness();
+
+    expect(await listCommand("empty", true, {
+      resolveHome: () => "/private/dsh-home",
+      readState: async () => installState,
+      stdout: io.stdout,
+      stderr: io.stderr,
+    })).toBe(0);
+
+    expect(io.output()).toEqual({
+      stdout: `${JSON.stringify({
+        profile: "empty",
+        count: 0,
+        empty: true,
+        installs: [],
+      })}\n`,
+      stderr: "",
+    });
+    expect(io.output().stdout).not.toContain("/private/dsh-home");
+    expect(io.output().stdout).not.toContain("cacheRelativePath");
+  });
+
+  it("sanitizes state-read failures", async () => {
+    const io = outputHarness();
+
+    expect(await listCommand(undefined, false, {
+      resolveHome: () => "/private/dsh-home",
+      readState: async () => {
+        throw new Error("token=secret at /private/dsh-home/state.json\n    at stack");
+      },
+      stdout: io.stdout,
+      stderr: io.stderr,
+    })).toBe(1);
+
+    expect(io.output()).toEqual({
+      stdout: "",
+      stderr: "Catalog-managed install state could not be read safely.\n",
+    });
+  });
+});
+
+describe("doctor", () => {
+  it("diagnoses unsupported Node, missing dsh and a snapshot stale after 30 days", async () => {
+    const test = doctorHarness({
+      source: { kind: "snapshot", declaredRevision: "a".repeat(40), pinStatus: "declared-local" },
+      entries: [catalogEntry("2026-06-01T00:00:00.000Z")],
+      diagnostics: [],
+    });
+
+    expect(DOCTOR_STALE_AFTER_DAYS).toBe(30);
+    expect(await doctorCommand(test.context, undefined, false, {
+      nodeVersion: "18.19.0",
+      now: () => new Date("2026-08-16T12:00:00.000Z"),
+      probeDsh: async () => ({ status: "missing", version: null }),
+    })).toBe(1);
+
+    expect(test.output()).toEqual({
+      stdout:
+        "node [error]: Node 20 or newer is required\n" +
+        "dsh [error]: dsh executable was not found\n" +
+        "catalog [error]: catalog has 1 stale entry; freshness threshold is 30 days\n",
+      stderr: "",
+    });
+  });
+
+  it("reports present dsh and an empty valid catalog as healthy stable JSON", async () => {
+    const test = doctorHarness({
+      source: { kind: "snapshot", declaredRevision: "b".repeat(40), pinStatus: "declared-local" },
+      entries: [],
+      diagnostics: [],
+    });
+
+    expect(await doctorCommand(test.context, undefined, true, {
+      nodeVersion: "22.4.0",
+      now: () => new Date("2026-08-16T12:00:00.000Z"),
+      probeDsh: async () => ({ status: "present", version: "1.2.3" }),
+    })).toBe(0);
+
+    expect(test.output()).toEqual({
+      stdout: `${JSON.stringify({
+        ok: true,
+        checks: [
+          { name: "node", status: "ok", message: "Node 22.4.0 is supported" },
+          { name: "dsh", status: "ok", message: "dsh 1.2.3 is available" },
+          { name: "catalog", status: "ok", message: "catalog is valid and empty" },
+        ],
+      })}\n`,
+      stderr: "",
+    });
+  });
+
+  it("uses literal dsh --version argv with shell disabled and sanitizes captured output", async () => {
+    const child = new EventEmitter() as EventEmitter & { stdout: PassThrough };
+    child.stdout = new PassThrough();
+    const spawn = vi.fn(() => child);
+
+    const probing = probeDshVersion({ spawn: spawn as never });
+    child.stdout.write("DeepSeek Harness v2.3.4 token=must-not-leak\n");
+    child.emit("close", 0, null);
+
+    await expect(probing).resolves.toEqual({ status: "present", version: "2.3.4" });
+    expect(spawn).toHaveBeenCalledWith(
+      "dsh",
+      ["--version"],
+      {
+        detached: process.platform !== "win32",
+        shell: false,
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+  });
+
+  it("reports a bounded dsh deadline as a sanitized error check", async () => {
+    const test = doctorHarness({
+      source: { kind: "snapshot", declaredRevision: "c".repeat(40), pinStatus: "declared-local" },
+      entries: [],
+      diagnostics: [],
+    });
+    const controller = new AbortController();
+    const probeDsh = vi.fn(async () => ({ status: "timeout" as const, version: null }));
+
+    expect(await doctorCommand(test.context, undefined, false, {
+      nodeVersion: "22.4.0",
+      now: () => new Date("2026-08-16T12:00:00.000Z"),
+      probeDsh,
+      signal: controller.signal,
+      dshTimeoutMs: 25,
+      terminationGraceMs: 5,
+      reapTimeoutMs: 10,
+    })).toBe(1);
+
+    expect(probeDsh).toHaveBeenCalledWith({
+      signal: controller.signal,
+      timeoutMs: 25,
+      terminationGraceMs: 5,
+      reapTimeoutMs: 10,
+    });
+    expect(test.output()).toEqual({
+      stdout:
+        "node [ok]: Node 22.4.0 is supported\n" +
+        "dsh [error]: dsh version probe timed out safely\n" +
+        "catalog [ok]: catalog is valid and empty\n",
+      stderr: "",
+    });
+  });
+
+  it("never emits raw paths, tokens or stacks when probes fail", async () => {
+    const io = outputHarness();
+    const context: CatalogCommandContext = {
+      loadCatalog: async () => {
+        throw new Error("token=secret at /private/catalog\n    at stack");
+      },
+      stdout: io.stdout,
+      stderr: io.stderr,
+    };
+
+    expect(await doctorCommand(context, undefined, false, {
+      nodeVersion: "not-a-version /private/node",
+      now: () => new Date("2026-08-16T12:00:00.000Z"),
+      probeDsh: async () => {
+        throw new Error("token=secret at /private/dsh\n    at stack");
+      },
+    })).toBe(1);
+
+    expect(io.output()).toEqual({
+      stdout:
+        "node [error]: Node version could not be determined\n" +
+        "dsh [error]: dsh version probe failed safely\n" +
+        "catalog [error]: catalog could not be loaded safely\n",
+      stderr: "",
+    });
+    expect(io.output().stdout).not.toMatch(/secret|\/private|stack/iu);
+  });
+
+  it.each([
+    [true, "recovery is pending; DSH process tree is still alive"],
+    [false, "recovery is pending; DSH process tree is dead and explicit recovery is required"],
+  ] as const)("reports pending recovery with tree alive=%s without mutating", async (
+    alive,
+    message,
+  ) => {
+    const recoveryRequired: RecoveryRequiredMarker = {
+      status: "recovery_required",
+      profile: "web",
+      fencingToken: 5,
+      processTree: {
+        pid: 5_555,
+        processGroupId: 5_555,
+        treeIdentity: "linux:555",
+        processStartIdentity: "linux:555",
+        platform: "linux",
+      },
+      artifact: null,
+      transaction: {
+        profile: "web",
+        fencingToken: 5,
+        existed: true,
+        journalRelativePath: "profiles/.dsh-plugins-transaction-web-doctor.json",
+        backupRelativePath: "profiles/.dsh-plugins-backup-web-doctor",
+      },
+    };
+    const test = doctorHarness({
+      source: { kind: "snapshot", declaredRevision: "d".repeat(40), pinStatus: "declared-local" },
+      entries: [],
+      diagnostics: [],
+    });
+    const readState = vi.fn(async () => ({
+      version: 1 as const,
+      generation: 1,
+      fencingToken: 5,
+      installs: [],
+      recoveryRequired,
+    }));
+    const isProcessTreeAlive = vi.fn(async () => alive);
+
+    expect(await doctorCommand(test.context, undefined, false, {
+      nodeVersion: "22.4.0",
+      now: () => new Date("2026-08-16T12:00:00.000Z"),
+      probeDsh: async () => ({ status: "present", version: "1.2.3" }),
+      resolveHome: () => "/private/dsh-home",
+      readState,
+      isProcessTreeAlive,
+    })).toBe(1);
+
+    expect(readState).toHaveBeenCalledWith("/private/dsh-home");
+    expect(isProcessTreeAlive).toHaveBeenCalledWith(recoveryRequired.processTree);
+    expect(test.output().stdout).toContain(`recovery [error]: ${message}\n`);
+    expect(test.output().stdout).not.toContain("/private/dsh-home");
+  });
+});

--- a/cli/tests/dry-run.test.ts
+++ b/cli/tests/dry-run.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runCli, type CliDependencies } from "../src/app.js";
+import { executePluginMutation } from "../src/commands/mutate.js";
+import type { CatalogSnapshot, PublicCatalogEntry } from "../src/model.js";
+
+function entry(): PublicCatalogEntry {
+  return {
+    schemaVersion: 1,
+    id: "fixture-plugin",
+    name: "Fixture Plugin",
+    description: { en: "A detailed fixture plugin used for strict dry-run tests.", evidencePath: "README.md" },
+    unofficial: true,
+    kind: "plugin",
+    primaryCategory: "coding-developer-tools",
+    tags: ["coding"],
+    source: {
+      repository: "https://github.com/creator/fixture-plugin",
+      repositoryNodeId: "R_fixture",
+      subpath: null,
+      commit: "a".repeat(40),
+    },
+    creator: { github: "creator" },
+    package: { ecosystem: "npm", name: "fixture-plugin", version: "1.0.0" },
+    dsh: { profiles: ["web"], evidencePath: "package.json" },
+    repositoryScope: "dedicated",
+    popularity: { starsPolicy: "exact-repository", stars: 1 },
+    license: { spdx: "MIT" },
+    verification: {
+      status: "eligible",
+      checkedAt: "2026-08-16T00:00:00.000Z",
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+    canonicalKey: "R_fixture:.",
+  };
+}
+
+function snapshot(entries: readonly PublicCatalogEntry[]): CatalogSnapshot {
+  return {
+    source: {
+      kind: "snapshot",
+      declaredRevision: "c".repeat(40),
+      pinStatus: "declared-local",
+    },
+    entries,
+    diagnostics: [],
+  };
+}
+
+function forbidden(): ReturnType<typeof vi.fn> {
+  return vi.fn(() => {
+    throw new Error("strict dry-run touched a forbidden dependency");
+  });
+}
+
+function forbiddenMutationDependencies() {
+  return {
+    acquireLock: forbidden() as never,
+    readState: forbidden() as never,
+    writeState: forbidden() as never,
+    stageEntry: forbidden() as never,
+    beginTransaction: forbidden() as never,
+    runDsh: forbidden() as never,
+    now: forbidden() as never,
+  };
+}
+
+function appHarness(loadCatalog: ReturnType<typeof vi.fn>) {
+  let stdout = "";
+  let stderr = "";
+  const mutationDependencies = forbiddenMutationDependencies();
+  const dependencies: CliDependencies = {
+    loadCatalog: loadCatalog as never,
+    stdout: (value) => {
+      stdout += value;
+    },
+    stderr: (value) => {
+      stderr += value;
+    },
+    mutationDependencies,
+  };
+  return {
+    dependencies,
+    mutationDependencies,
+    output: () => ({ stdout, stderr }),
+  };
+}
+
+describe("strict dry-run", () => {
+  it("prints the resolved plan before lock, state, staging, transaction, network or process access", async () => {
+    let stdout = "";
+    let stderr = "";
+    const acquireLock = forbidden();
+    const readState = forbidden();
+    const writeState = forbidden();
+    const stageEntry = forbidden();
+    const beginTransaction = forbidden();
+    const runDsh = forbidden();
+    const now = forbidden();
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry: entry(),
+      profile: "web",
+      dryRun: true,
+      allowCodeExecution: false,
+    }, {
+      dshHome: "/must-not-be-touched",
+      acquireLock: acquireLock as never,
+      readState: readState as never,
+      writeState: writeState as never,
+      stageEntry: stageEntry as never,
+      beginTransaction: beginTransaction as never,
+      runDsh: runDsh as never,
+      now: now as never,
+      stdout: (value) => {
+        stdout += value;
+      },
+      stderr: (value) => {
+        stderr += value;
+      },
+    })).toBe(0);
+
+    for (const dependency of [
+      acquireLock,
+      readState,
+      writeState,
+      stageEntry,
+      beginTransaction,
+      runDsh,
+      now,
+    ]) {
+      expect(dependency).not.toHaveBeenCalled();
+    }
+    expect(stdout).toContain("Plugin: fixture-plugin (Fixture Plugin)");
+    expect(stdout).toContain("Creator: @creator");
+    expect(stdout).toContain(
+      "DSH command: dsh plugin --profile web add <catalog-artifact:fixture-plugin>",
+    );
+    expect(stdout).toContain(
+      "install state, profile, cache, and subprocesses were not accessed",
+    );
+    expect(stdout).toContain("Dry run: no files or processes changed.");
+    expect(stderr).toBe("");
+  });
+
+  it("rejects a dry-run entry that fails installability validation without mutation access", async () => {
+    let stdout = "";
+    let stderr = "";
+    const quarantined: PublicCatalogEntry = {
+      ...entry(),
+      verification: { ...entry().verification, status: "quarantined" },
+    };
+    const stageEntry = forbidden();
+    const runDsh = forbidden();
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry: quarantined,
+      profile: "web",
+      dryRun: true,
+      allowCodeExecution: false,
+    }, {
+      stageEntry: stageEntry as never,
+      runDsh: runDsh as never,
+      stdout: (value) => {
+        stdout += value;
+      },
+      stderr: (value) => {
+        stderr += value;
+      },
+    })).toBe(1);
+
+    expect(stageEntry).not.toHaveBeenCalled();
+    expect(runDsh).not.toHaveBeenCalled();
+    expect(stderr).toContain("is quarantined and cannot be installed");
+    expect(stdout).not.toContain("DSH command:");
+  });
+
+  it("resolves the requested catalog selection during dry-run without mutation side effects", async () => {
+    const loadCatalog = vi.fn(async () => snapshot([entry()]));
+    const { dependencies, mutationDependencies, output } = appHarness(loadCatalog);
+
+    expect(await runCli([
+      "add",
+      "fixture-plugin",
+      "--profile",
+      "web",
+      "--catalog",
+      "/tmp/example-catalog",
+      "--revision",
+      "d".repeat(40),
+      "--dry-run",
+    ], dependencies)).toBe(0);
+
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({
+      root: "/tmp/example-catalog",
+      revision: "d".repeat(40),
+    });
+    for (const dependency of Object.values(mutationDependencies)) {
+      expect(dependency).not.toHaveBeenCalled();
+    }
+    expect(output().stdout).toContain("Plugin: fixture-plugin (Fixture Plugin)");
+    expect(output().stdout).toContain("Dry run: no files or processes changed.");
+    expect(output().stderr).toBe("");
+  });
+
+  it("fails a dry-run for a plugin the resolved catalog does not contain", async () => {
+    const loadCatalog = vi.fn(async () => snapshot([entry()]));
+    const { dependencies, mutationDependencies, output } = appHarness(loadCatalog);
+
+    expect(await runCli([
+      "add",
+      "missing-plugin",
+      "--profile",
+      "web",
+      "--dry-run",
+    ], dependencies)).toBe(1);
+
+    expect(loadCatalog).toHaveBeenCalledOnce();
+    for (const dependency of Object.values(mutationDependencies)) {
+      expect(dependency).not.toHaveBeenCalled();
+    }
+    expect(output().stderr).toContain("Plugin not found: missing-plugin");
+    expect(output().stdout).not.toContain("DSH command:");
+  });
+
+  it("keeps remove dry-run available for ids outside the resolved catalog", async () => {
+    const loadCatalog = vi.fn(async () => snapshot([entry()]));
+    const { dependencies, mutationDependencies, output } = appHarness(loadCatalog);
+
+    expect(await runCli([
+      "remove",
+      "not-in-catalog",
+      "--profile",
+      "web",
+      "--dry-run",
+    ], dependencies)).toBe(0);
+
+    expect(loadCatalog).toHaveBeenCalledOnce();
+    for (const dependency of Object.values(mutationDependencies)) {
+      expect(dependency).not.toHaveBeenCalled();
+    }
+    expect(output().stdout).toContain("Plugin: not-in-catalog");
+    expect(output().stdout).toContain(
+      "DSH command: dsh plugin --profile web remove <catalog-artifact:not-in-catalog>",
+    );
+    expect(output().stdout).toContain("Dry run: no files or processes changed.");
+    expect(output().stderr).toBe("");
+  });
+});

--- a/cli/tests/identity-publication-failclosed.test.ts
+++ b/cli/tests/identity-publication-failclosed.test.ts
@@ -1,0 +1,61 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DshExecutionUncertainError,
+  runDsh,
+} from "../src/dsh/runDsh.js";
+
+interface FakeChild extends EventEmitter {
+  readonly pid: number;
+  readonly stdout: PassThrough;
+  readonly kill: ReturnType<typeof vi.fn>;
+}
+
+function child(pid: number): FakeChild {
+  const value = new EventEmitter() as FakeChild;
+  Object.defineProperties(value, {
+    pid: { value: pid },
+    stdout: { value: new PassThrough() },
+    kill: { value: vi.fn(() => true) },
+  });
+  return value;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("spawned identity persistence failure", () => {
+  it("is unreaped even when the root closes while an observed descendant remains alive", async () => {
+    const root = child(4_001);
+    const snapshots = vi.fn(async () => [
+      { pid: 4_001, creationIdentity: "root-created" },
+      { pid: 4_002, creationIdentity: "descendant-created" },
+    ]);
+    const execution = runDsh("web", ["add", "http://127.0.0.1/artifact.tgz"], {
+      spawn: vi.fn(() => root) as never,
+      platform: "win32",
+      snapshotWindowsTree: snapshots,
+      identifyProcessTree: async () => "win32:root-created",
+      onSpawn: async () => {
+        root.emit("close", 0, null);
+        throw new Error("durable identity update failed");
+      },
+    });
+
+    await expect(execution).rejects.toMatchObject({
+      name: "DshExecutionUncertainError",
+      reason: "aborted",
+      reaped: false,
+      recoveryRequired: true,
+      processTree: expect.objectContaining({
+        members: expect.arrayContaining([
+          { pid: 4_002, creationIdentity: "descendant-created" },
+        ]),
+      }),
+    } satisfies Partial<DshExecutionUncertainError>);
+  });
+});

--- a/cli/tests/install-state-writer.test.ts
+++ b/cli/tests/install-state-writer.test.ts
@@ -1,0 +1,239 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  InstallStateWriterBusyError,
+  InstallStateWriterOwnershipError,
+  readInstallState,
+  writeInstallState,
+  type InstallState,
+  type InstallStateWriterContext,
+  type InstallStateWriterOptions,
+} from "../src/dsh/installState.js";
+
+const roots: string[] = [];
+
+async function temporaryHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), "dsh-state-writer-"));
+  roots.push(home);
+  return home;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+function plugin(id: string): InstallState["installs"][number] {
+  return {
+    id,
+    profile: "web",
+    packageName: id,
+    fingerprint: `sha256:${"a".repeat(64)}`,
+    cacheRelativePath: `npm/${id}/${id}.tgz`,
+    installedAt: "2026-08-16T00:00:00.000Z",
+  };
+}
+
+function writer(
+  ownerToken: string,
+  pid: number,
+  processStartIdentity: string,
+  now: () => number,
+  beforeRename?: (context: InstallStateWriterContext) => Promise<void>,
+  isProcessAlive: InstallStateWriterOptions["isProcessAlive"] = async () => true,
+): InstallStateWriterOptions {
+  return {
+    leaseMs: 50,
+    heartbeatMs: 10_000,
+    acquireTimeoutMs: 0,
+    retryMs: 0,
+    ownerToken: () => ownerToken,
+    pid,
+    processStartIdentity,
+    hostname: "test-host",
+    now,
+    isProcessAlive,
+    ...(beforeRename === undefined ? {} : { beforeRename }),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("install state writer fencing", () => {
+  it("lets a dead-owner takeover publish and rejects paused stale writer A", async () => {
+    const home = await temporaryHome();
+    let now = 1_000;
+    const observedWriterFences: number[] = [];
+    const aPaused = deferred();
+    const resumeA = deferred();
+
+    const seed = await writeInstallState(
+      home,
+      { version: 1, installs: [] },
+      {
+        expectedGeneration: 0,
+        fencingToken: 1,
+        assertLockOwned: async () => undefined,
+        writer: writer("seed-writer", 100, "start-seed", () => now, async (context) => {
+          observedWriterFences.push(context.fencingToken);
+        }),
+      },
+    );
+    expect(seed.generation).toBe(1);
+
+    const staleWrite = writeInstallState(
+      home,
+      { version: 1, installs: [plugin("loser")] },
+      {
+        expectedGeneration: 1,
+        fencingToken: 2,
+        assertLockOwned: async () => undefined,
+        writer: writer("writer-a", 101, "start-a", () => now, async (context) => {
+          observedWriterFences.push(context.fencingToken);
+          aPaused.resolve();
+          await resumeA.promise;
+        }),
+      },
+    );
+    await aPaused.promise;
+
+    now = 2_000;
+    const winner = await writeInstallState(
+      home,
+      { version: 1, installs: [plugin("winner")] },
+      {
+        expectedGeneration: 1,
+        fencingToken: 3,
+        assertLockOwned: async () => undefined,
+        writer: writer(
+          "writer-b",
+          202,
+          "start-b",
+          () => now,
+          async (context) => {
+            observedWriterFences.push(context.fencingToken);
+          },
+          async (pid, identity) => !(pid === 101 && identity === "start-a"),
+        ),
+      },
+    );
+    expect(winner).toMatchObject({ generation: 2, fencingToken: 3 });
+
+    resumeA.resolve();
+    await expect(staleWrite).rejects.toBeInstanceOf(InstallStateWriterOwnershipError);
+    expect(await readInstallState(home)).toMatchObject({
+      generation: 2,
+      fencingToken: 3,
+      installs: [{ id: "winner" }],
+    });
+    expect(observedWriterFences).toEqual([1, 2, 3]);
+  });
+
+  it("never steals an expired writer lease from the same live process identity", async () => {
+    const home = await temporaryHome();
+    let now = 1_000;
+    const aPaused = deferred();
+    const resumeA = deferred();
+    const firstWrite = writeInstallState(
+      home,
+      { version: 1, installs: [plugin("first")] },
+      {
+        expectedGeneration: 0,
+        fencingToken: 1,
+        assertLockOwned: async () => undefined,
+        writer: writer("live-writer", 303, "start-live", () => now, async () => {
+          aPaused.resolve();
+          await resumeA.promise;
+        }),
+      },
+    );
+    await aPaused.promise;
+    now = 2_000;
+
+    await expect(writeInstallState(
+      home,
+      { version: 1, installs: [plugin("contender")] },
+      {
+        expectedGeneration: 0,
+        fencingToken: 2,
+        assertLockOwned: async () => undefined,
+        writer: writer(
+          "contender",
+          404,
+          "start-contender",
+          () => now,
+          undefined,
+          async (pid, identity) => pid === 303 && identity === "start-live",
+        ),
+      },
+    )).rejects.toBeInstanceOf(InstallStateWriterBusyError);
+
+    resumeA.resolve();
+    await expect(firstWrite).resolves.toMatchObject({ generation: 1, fencingToken: 1 });
+  });
+
+  it("uses release owner-CAS so stale writer A cannot detach writer B", async () => {
+    const home = await temporaryHome();
+    let now = 1_000;
+    const aPaused = deferred();
+    const resumeA = deferred();
+    const bPaused = deferred();
+    const resumeB = deferred();
+    const staleWrite = writeInstallState(
+      home,
+      { version: 1, installs: [plugin("loser")] },
+      {
+        expectedGeneration: 0,
+        fencingToken: 1,
+        assertLockOwned: async () => undefined,
+        writer: writer("writer-a", 505, "start-a", () => now, async () => {
+          aPaused.resolve();
+          await resumeA.promise;
+        }),
+      },
+    );
+    await aPaused.promise;
+    now = 2_000;
+
+    const winningWrite = writeInstallState(
+      home,
+      { version: 1, installs: [plugin("winner")] },
+      {
+        expectedGeneration: 0,
+        fencingToken: 2,
+        assertLockOwned: async () => undefined,
+        writer: writer(
+          "writer-b",
+          606,
+          "start-b",
+          () => now,
+          async () => {
+            bPaused.resolve();
+            await resumeB.promise;
+          },
+          async (pid, identity) => !(pid === 505 && identity === "start-a"),
+        ),
+      },
+    );
+    await bPaused.promise;
+
+    resumeA.resolve();
+    await expect(staleWrite).rejects.toBeInstanceOf(InstallStateWriterOwnershipError);
+    resumeB.resolve();
+    await expect(winningWrite).resolves.toMatchObject({ generation: 1, fencingToken: 2 });
+    expect(await readInstallState(home)).toMatchObject({
+      generation: 1,
+      fencingToken: 2,
+      installs: [{ id: "winner" }],
+    });
+  });
+});

--- a/cli/tests/journal-finalization.test.ts
+++ b/cli/tests/journal-finalization.test.ts
@@ -1,0 +1,143 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { executePluginMutation, recoverPluginMutation } from "../src/commands/mutate.js";
+
+const ACTIVE_FINGERPRINT = `sha512-${createHash("sha512").update("active").digest("base64")}`;
+
+describe("completed mutation journal finalization", () => {
+  it("never downgrades completed after final removal fails and a fresh recovery removes it", async () => {
+    const lock = {
+      canonicalHome: "/dsh",
+      profile: "web",
+      ownerToken: "owner-1",
+      fencingToken: 7,
+      assertOwned: vi.fn(async () => undefined),
+      heartbeat: vi.fn(async () => undefined),
+      release: vi.fn(async () => undefined),
+    };
+    const transaction = {
+      recoveryReference: {
+        profile: "web",
+        fencingToken: 7,
+        existed: true,
+        journalRelativePath: "profiles/.dsh-plugins-transaction-web-one.json",
+        backupRelativePath: "profiles/.dsh-plugins-backup-web-one",
+        backupFingerprint: ACTIVE_FINGERPRINT,
+      },
+      commit: vi.fn(async () => undefined),
+      rollback: vi.fn(async () => undefined),
+    };
+    const artifact = {
+      relativePath: ".dsh-plugins/artifact-leases/.lease-one/artifact.tgz",
+      sha512: ACTIVE_FINGERPRINT,
+      bytes: 6,
+      packageName: "@example/plugin",
+    };
+    const lease = {
+      recoveryReference: artifact,
+      revalidate: vi.fn(async () => undefined),
+      readVerifiedBytes: vi.fn(async () => Buffer.from("plugin")),
+      release: vi.fn(async () => undefined),
+    };
+    const channel = {
+      installTarget: "http://127.0.0.1:43123/token/artifact.tgz",
+      descriptor: {
+        kind: "loopback-buffer-v1" as const,
+        sha512: ACTIVE_FINGERPRINT,
+        bytes: 6,
+        sourceFingerprint: "npm:@example/plugin@1.0.0",
+      },
+      close: vi.fn(async () => undefined),
+    };
+    let state = { version: 1 as const, generation: 3, fencingToken: 2, installs: [] };
+    let journal: Record<string, unknown> | null = null;
+    let removeAttempts = 0;
+    const updateJournal = vi.fn(async (_home, current, patch) => {
+      journal = {
+        ...current,
+        ...patch,
+        revision: Number((current as { revision: number }).revision) + 1,
+      };
+      return journal as never;
+    });
+    const removeJournal = vi.fn(async () => {
+      removeAttempts += 1;
+      if (removeAttempts === 1) throw new Error("remove failed before rename");
+      journal = null;
+    });
+    const common = {
+      platform: "linux" as const,
+      dshHome: "/dsh",
+      acquireLock: vi.fn(async () => lock),
+      readState: vi.fn(async () => state),
+      writeState: vi.fn(async (_home, next) => {
+        state = { ...next, generation: state.generation + 1, fencingToken: 7 };
+        return state;
+      }),
+      readRecoveryJournal: vi.fn(async () => journal as never),
+      updateRecoveryJournal: updateJournal,
+      removeRecoveryJournal: removeJournal,
+      fingerprintActiveProfile: vi.fn(async () => ACTIVE_FINGERPRINT),
+      isProcessTreeAlive: vi.fn(async () => false),
+      recoverTransaction: vi.fn(async () => undefined),
+      finalizeRecoveredTransaction: vi.fn(async () => undefined),
+      releaseRecoveredArtifact: vi.fn(async () => undefined),
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    };
+
+    const exitCode = await executePluginMutation(
+      {
+        operation: "add",
+        entry: {
+          id: "example-plugin",
+          name: "Example Plugin",
+          kind: "plugin",
+          creator: { github: "example" },
+          source: { repository: "https://github.com/example/plugin", commit: "a".repeat(40) },
+          license: { spdx: "MIT" },
+          dsh: { profiles: ["web"] },
+          verification: { status: "verified" },
+        } as never,
+        profile: "web",
+        dryRun: false,
+        allowCodeExecution: true,
+      },
+      {
+        ...common,
+        stageEntry: vi.fn(async () => ({
+          packageName: "@example/plugin",
+          installTarget: "@example/plugin@1.0.0",
+          displayTarget: "@example/plugin@1.0.0",
+          fingerprint: "npm:@example/plugin@1.0.0",
+          cacheRelativePath: ".dsh-plugins/cache/example",
+          artifactLease: lease,
+        })),
+        runDsh: vi.fn(async () => 0),
+        beginTransaction: vi.fn(async () => transaction),
+        openArtifactChannel: vi.fn(async () => channel),
+        createRecoveryJournal: vi.fn(async (_home, input) => {
+          journal = {
+            version: 1,
+            revision: 1,
+            status: "in_progress",
+            phase: "needs_restore",
+            ...input,
+          };
+          return journal as never;
+        }),
+        now: () => new Date("2026-08-16T12:00:00.000Z"),
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(journal).toMatchObject({ status: "completed", phase: "completed" });
+    expect(transaction.rollback).not.toHaveBeenCalled();
+
+    expect(await recoverPluginMutation(common)).toBe(0);
+    expect(removeJournal).toHaveBeenCalledTimes(2);
+    expect(journal).toBeNull();
+  });
+});

--- a/cli/tests/journal-rename-ambiguity.test.ts
+++ b/cli/tests/journal-rename-ambiguity.test.ts
@@ -1,0 +1,245 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  updateJournalAuthoritatively,
+  type RecoveryDependencies,
+} from "../src/commands/mutate.js";
+import {
+  createMutationRecoveryJournal,
+  MutationRecoveryJournalAuthorityUnknownError,
+  MutationRecoveryJournalDurabilityAmbiguousError,
+  readMutationRecoveryJournal,
+  removeCompletedMutationRecoveryJournal,
+  updateMutationRecoveryJournal,
+  type MutationRecoveryJournal,
+  type MutationRecoveryJournalPatch,
+} from "../src/dsh/mutationRecoveryJournal.js";
+
+const SHA512 = `sha512-${createHash("sha512").update("profile").digest("base64")}`;
+const SHA256 = `sha256:${createHash("sha256").update(JSON.stringify({ version: 1, installs: [] })).digest("hex")}`;
+
+async function fixture() {
+  const home = await mkdtemp(join(tmpdir(), "dsh-journal-ambiguity-"));
+  await mkdir(join(home, "profiles"));
+  const journal = await createMutationRecoveryJournal(home, {
+    ownerToken: "owner-one",
+    fencingToken: 1,
+    profile: "web",
+    transaction: {
+      profile: "web",
+      fencingToken: 1,
+      existed: false,
+      journalRelativePath: "profiles/.dsh-plugins-transaction-web-one.json",
+      backupRelativePath: "profiles/.dsh-plugins-backup-web-one",
+      backupFingerprint: null,
+    },
+    artifact: null,
+    channel: null,
+    createdAt: "2026-08-16T12:00:00.000Z",
+    decision: "undecided",
+    stateEvidence: {
+      oldGeneration: 0,
+      oldFingerprint: SHA256,
+      oldInstalls: [],
+      intendedFingerprint: SHA256,
+      intendedInstalls: [],
+    },
+  });
+  return { home, journal };
+}
+
+function reconciliationDependencies(
+  updateRecoveryJournal: RecoveryDependencies["updateRecoveryJournal"],
+  readRecoveryJournal: RecoveryDependencies["readRecoveryJournal"],
+): RecoveryDependencies {
+  return { updateRecoveryJournal, readRecoveryJournal } as RecoveryDependencies;
+}
+
+describe("mutation journal rename/fsync ambiguity", () => {
+  it("exposes possiblyPublished while each visible decision/phase remains authoritative", async () => {
+    const { home, journal: initial } = await fixture();
+    let current = initial;
+    const patches = [
+      { decision: "roll_forward" as const, phase: "dsh_succeeded" as const, activeFingerprint: SHA512 },
+      { phase: "state_published" as const },
+      { phase: "profile_finalized" as const },
+      { phase: "artifact_released" as const },
+      { phase: "completed" as const, status: "completed" as const },
+    ];
+    const updateWithFault = updateMutationRecoveryJournal as unknown as (
+      home: string,
+      expected: typeof current,
+      patch: (typeof patches)[number],
+      dependencies: { syncDirectory: (path: string) => Promise<void> },
+    ) => Promise<typeof current>;
+
+    for (const patch of patches) {
+      const before = current;
+      await expect(updateWithFault(home, before, patch, {
+        syncDirectory: async () => { throw new Error("directory fsync failed"); },
+      })).rejects.toMatchObject({ possiblyPublished: true });
+      const visible = await readMutationRecoveryJournal(home);
+      expect(visible).not.toBeNull();
+      expect(visible?.revision).toBe(before.revision + 1);
+      expect(visible).toMatchObject(patch);
+      current = visible!;
+    }
+  });
+
+  it("adopts only its exact next revision after a typed durability ambiguity", async () => {
+    const { home, journal } = await fixture();
+    const patch: MutationRecoveryJournalPatch = { status: "recovery_required" };
+    const visible = {
+      ...journal,
+      ...patch,
+      revision: journal.revision + 1,
+    } as MutationRecoveryJournal;
+    const readRecoveryJournal = vi.fn(async () => visible);
+
+    await expect(updateJournalAuthoritatively(
+      reconciliationDependencies(
+        vi.fn(async () => {
+          throw new MutationRecoveryJournalDurabilityAmbiguousError("update");
+        }),
+        readRecoveryJournal,
+      ),
+      home,
+      journal,
+      patch,
+    )).resolves.toEqual(visible);
+    expect(readRecoveryJournal).toHaveBeenCalledOnce();
+  });
+
+  it("propagates generic update errors without consulting or adopting disk", async () => {
+    const { home, journal } = await fixture();
+    const patch: MutationRecoveryJournalPatch = { status: "recovery_required" };
+    const genericError = Object.assign(new Error("ownership changed"), {
+      possiblyPublished: true,
+    });
+    const readRecoveryJournal = vi.fn(async () => ({
+      ...journal,
+      ...patch,
+      revision: journal.revision + 1,
+    } as MutationRecoveryJournal));
+
+    await expect(updateJournalAuthoritatively(
+      reconciliationDependencies(
+        vi.fn(async () => { throw genericError; }),
+        readRecoveryJournal,
+      ),
+      home,
+      journal,
+      patch,
+    )).rejects.toBe(genericError);
+    expect(readRecoveryJournal).not.toHaveBeenCalled();
+  });
+
+  it("returns typed authority-unknown when an ambiguous publication cannot be reread", async () => {
+    const { home, journal } = await fixture();
+    const patch: MutationRecoveryJournalPatch = { status: "recovery_required" };
+
+    await expect(updateJournalAuthoritatively(
+      reconciliationDependencies(
+        vi.fn(async () => {
+          throw new MutationRecoveryJournalDurabilityAmbiguousError("update");
+        }),
+        vi.fn(async () => { throw new Error("marker unreadable"); }),
+      ),
+      home,
+      journal,
+      patch,
+    )).rejects.toBeInstanceOf(MutationRecoveryJournalAuthorityUnknownError);
+  });
+
+  it.each([
+    ["later revision", (next: MutationRecoveryJournal) => ({
+      ...next,
+      revision: next.revision + 1,
+    })],
+    ["different owner", (next: MutationRecoveryJournal) => ({
+      ...next,
+      ownerToken: "owner-two",
+    })],
+    ["different fencing token", (next: MutationRecoveryJournal) => ({
+      ...next,
+      fencingToken: next.fencingToken + 1,
+    })],
+    ["different transaction", (next: MutationRecoveryJournal) => ({
+      ...next,
+      transaction: {
+        ...next.transaction,
+        journalRelativePath: "profiles/.dsh-plugins-transaction-web-other.json",
+      },
+    })],
+    ["unexpected phase with the same patch", (next: MutationRecoveryJournal) => ({
+      ...next,
+      phase: "profile_restored" as const,
+    })],
+    ["unexpected decision with the same patch", (next: MutationRecoveryJournal) => ({
+      ...next,
+      decision: "rollback" as const,
+    })],
+  ] as const)("rejects %s instead of adopting another writer", async (_label, mutateVisible) => {
+    const { home, journal } = await fixture();
+    const patch: MutationRecoveryJournalPatch = { status: "recovery_required" };
+    const exactNext = {
+      ...journal,
+      ...patch,
+      revision: journal.revision + 1,
+    } as MutationRecoveryJournal;
+    const visible = mutateVisible(exactNext) as MutationRecoveryJournal;
+
+    await expect(updateJournalAuthoritatively(
+      reconciliationDependencies(
+        vi.fn(async () => {
+          throw new MutationRecoveryJournalDurabilityAmbiguousError("update");
+        }),
+        vi.fn(async () => visible),
+      ),
+      home,
+      journal,
+      patch,
+    )).rejects.toBeInstanceOf(MutationRecoveryJournalAuthorityUnknownError);
+  });
+
+  it("keeps completed active before rename failure and treats post-rename failure as ambiguous removal", async () => {
+    const before = await fixture();
+    const completed = await updateMutationRecoveryJournal(before.home, before.journal, {
+      phase: "completed",
+      status: "completed",
+    });
+    const removeWithFault = removeCompletedMutationRecoveryJournal as unknown as (
+      home: string,
+      expected: typeof completed,
+      dependencies: {
+        beforeRename?: () => Promise<void>;
+        afterRename?: () => Promise<void>;
+      },
+    ) => Promise<void>;
+
+    await expect(removeWithFault(before.home, completed, {
+      beforeRename: async () => { throw new Error("before rename"); },
+    })).rejects.toThrow();
+    expect(await readMutationRecoveryJournal(before.home)).toMatchObject({
+      phase: "completed",
+      status: "completed",
+    });
+    await removeCompletedMutationRecoveryJournal(before.home, completed);
+    expect(await readMutationRecoveryJournal(before.home)).toBeNull();
+
+    const after = await fixture();
+    const afterCompleted = await updateMutationRecoveryJournal(after.home, after.journal, {
+      phase: "completed",
+      status: "completed",
+    });
+    await expect(removeWithFault(after.home, afterCompleted, {
+      afterRename: async () => { throw new Error("after rename"); },
+    })).rejects.toMatchObject({ possiblyPublished: true });
+    expect(await readMutationRecoveryJournal(after.home)).toBeNull();
+  });
+});

--- a/cli/tests/mutation-commit-recovery.test.ts
+++ b/cli/tests/mutation-commit-recovery.test.ts
@@ -1,0 +1,454 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executePluginMutation,
+  recoverPluginMutation,
+  type MutationDependencies,
+} from "../src/commands/mutate.js";
+import type { InstallState, InstalledPlugin } from "../src/dsh/installState.js";
+import {
+  MutationRecoveryJournalDurabilityAmbiguousError,
+  type MutationRecoveryJournal,
+} from "../src/dsh/mutationRecoveryJournal.js";
+import type { PublicCatalogEntry } from "../src/model.js";
+
+const entry: PublicCatalogEntry = {
+  schemaVersion: 1,
+  id: "fixture-plugin",
+  name: "Fixture Plugin",
+  description: { en: "Commit protocol fixture.", evidencePath: "README.md" },
+  unofficial: true,
+  kind: "plugin",
+  primaryCategory: "developer-tools",
+  tags: ["fixture"],
+  source: {
+    repository: "https://github.com/creator/fixture-plugin",
+    repositoryNodeId: "R_fixture",
+    subpath: null,
+    commit: "a".repeat(40),
+  },
+  creator: { github: "creator" },
+  package: { ecosystem: "npm", name: "fixture-plugin", version: "1.0.0" },
+  dsh: { profiles: ["web"], evidencePath: "package.json" },
+  repositoryScope: "dedicated",
+  popularity: { starsPolicy: "exact-repository", stars: 1 },
+  license: { spdx: "MIT" },
+  verification: {
+    status: "eligible",
+    checkedAt: "2026-08-16T00:00:00.000Z",
+    repositoryIdentity: "resolved",
+    smokeTest: null,
+  },
+  provenance: { discussion: null, comment: null },
+  canonicalKey: "R_fixture:.",
+};
+
+const oldInstall: InstalledPlugin = {
+  id: "fixture-plugin",
+  profile: "web",
+  packageName: "fixture-plugin",
+  fingerprint: "sha256:old",
+  cacheRelativePath: "fixture/old.tgz",
+  installedAt: "2026-08-15T00:00:00.000Z",
+};
+
+const newInstall: InstalledPlugin = {
+  ...oldInstall,
+  fingerprint: "sha256:new",
+  cacheRelativePath: "fixture/new.tgz",
+  installedAt: "2026-08-16T00:00:00.000Z",
+};
+
+function stateFingerprint(installs: readonly InstalledPlugin[]): string {
+  return `sha256:${createHash("sha256").update(JSON.stringify({ version: 1, installs })).digest("hex")}`;
+}
+
+function harness(state: InstallState) {
+  let journalInput: Record<string, unknown> | undefined;
+  let journal: MutationRecoveryJournal = {
+    version: 1,
+    revision: 1,
+    status: "in_progress",
+    phase: "needs_restore",
+    ownerToken: "owner",
+    fencingToken: 7,
+    profile: "web",
+    transaction: {
+      profile: "web",
+      fencingToken: 7,
+      existed: true,
+      journalRelativePath: "profiles/.dsh-plugins-transaction-web-state.json",
+      backupRelativePath: "profiles/.dsh-plugins-backup-web-state",
+      backupFingerprint: `sha512-${"A".repeat(86)}==`,
+    },
+    artifact: {
+      relativePath: ".dsh-plugins/artifact-leases/.lease-state/artifact.tgz",
+      sha512: `sha512-${"B".repeat(86)}==`,
+      bytes: 128,
+      packageName: "fixture-plugin",
+    },
+    channel: {
+      kind: "loopback-buffer-v1",
+      sha512: `sha512-${"B".repeat(86)}==`,
+      bytes: 128,
+      sourceFingerprint: "sha256:new",
+    },
+    createdAt: "2026-08-16T00:00:00.000Z",
+  };
+  const artifactLease = {
+    recoveryReference: journal.artifact!,
+    revalidate: vi.fn(async () => undefined),
+    readVerifiedBytes: vi.fn(async () => Buffer.alloc(128)),
+    release: vi.fn(async () => undefined),
+  };
+  const transaction = {
+    recoveryReference: journal.transaction,
+    commit: vi.fn(async () => undefined),
+    rollback: vi.fn(async () => undefined),
+  };
+  const lock = {
+    canonicalHome: "/canonical/home",
+    profile: "web",
+    ownerToken: "owner",
+    fencingToken: 7,
+    assertOwned: vi.fn(async () => undefined),
+    heartbeat: vi.fn(async () => undefined),
+    release: vi.fn(async () => undefined),
+  };
+  const artifactChannel = {
+    installTarget: "http://127.0.0.1:43123/secret/artifact.tgz",
+    descriptor: journal.channel!,
+    close: vi.fn(async () => undefined),
+  };
+  const dependencies = {
+    dshHome: "/canonical/home",
+    platform: "linux" as const,
+    acquireLock: vi.fn(async () => lock),
+    readRecoveryJournal: vi.fn(async () => null),
+    readState: vi.fn(async () => state),
+    writeState: vi.fn(async () => undefined),
+    stageEntry: vi.fn(async () => ({
+      fingerprint: newInstall.fingerprint,
+      installTarget: "/private/artifact.tgz",
+      displayTarget: "<private>",
+      packageName: newInstall.packageName,
+      cacheRelativePath: newInstall.cacheRelativePath,
+      artifactLease,
+    })),
+    beginTransaction: vi.fn(async () => transaction),
+    fingerprintActiveProfile: vi.fn(async () => `sha512-${"C".repeat(86)}==`),
+    openArtifactChannel: vi.fn(async () => artifactChannel),
+    createRecoveryJournal: vi.fn(async (_home: string, input: object) => {
+      journalInput = input as Record<string, unknown>;
+      journal = { ...journal, ...input } as MutationRecoveryJournal;
+      return journal;
+    }),
+    updateRecoveryJournal: vi.fn(async (_home: string, current: MutationRecoveryJournal, patch: object) => {
+      journal = { ...current, ...patch, revision: current.revision + 1 } as MutationRecoveryJournal;
+      return journal;
+    }),
+    removeRecoveryJournal: vi.fn(async () => undefined),
+    runDsh: vi.fn<MutationDependencies["runDsh"]>(async () => 0),
+    now: () => new Date("2026-08-16T00:00:00.000Z"),
+    stdout: vi.fn(),
+    stderr: vi.fn(),
+  };
+  return {
+    dependencies,
+    transaction,
+    artifactLease,
+    artifactChannel,
+    lock,
+    journal: () => journal,
+    journalInput: () => journalInput,
+  };
+}
+
+describe("durable profile/state commit decision", () => {
+  it.each([
+    ["add", { version: 1 as const, generation: 3, installs: [] }, [newInstall]],
+    ["update", { version: 1 as const, generation: 3, installs: [oldInstall] }, [newInstall]],
+    ["remove", { version: 1 as const, generation: 3, installs: [oldInstall] }, []],
+  ] as const)("records deterministic old/new state evidence for %s", async (operation, state, intended) => {
+    const test = harness(state);
+    expect(await executePluginMutation({
+      operation,
+      ...(operation === "remove" ? { id: "fixture-plugin" } : { entry }),
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, test.dependencies)).toBe(0);
+
+    expect(test.journalInput()).toMatchObject({
+      decision: "undecided",
+      stateEvidence: {
+        oldGeneration: 3,
+        oldFingerprint: stateFingerprint(state.installs),
+        oldInstalls: state.installs,
+        intendedFingerprint: stateFingerprint(intended),
+        intendedInstalls: intended,
+      },
+    });
+  });
+
+  it("retains ambiguous success resources and a retry converges from the disk journal", async () => {
+    const initialState: InstallState = { version: 1, generation: 3, installs: [] };
+    const test = harness(initialState);
+    const processTree = {
+      pid: 7_777,
+      processGroupId: 7_777,
+      treeIdentity: "linux:created",
+      processStartIdentity: "linux:created",
+      platform: "linux" as const,
+    };
+    let published: MutationRecoveryJournal | undefined;
+    test.dependencies.runDsh.mockImplementation(async (_profile, _args, runDependencies) => {
+      await runDependencies?.onSpawn?.(processTree);
+      return 0;
+    });
+    test.dependencies.updateRecoveryJournal.mockImplementation(async (_home, current, patch) => {
+      const next = {
+        ...current,
+        ...patch,
+        revision: current.revision + 1,
+      } as MutationRecoveryJournal;
+      if ((patch as Partial<MutationRecoveryJournal>).decision === "roll_forward") {
+        published = next;
+        throw new MutationRecoveryJournalDurabilityAmbiguousError("update");
+      }
+      return next;
+    });
+    test.dependencies.readRecoveryJournal
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("published marker cannot be reread"));
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, test.dependencies)).toBe(1);
+
+    expect(published).toMatchObject({
+      decision: "roll_forward",
+      phase: "dsh_succeeded",
+      status: "recovery_required",
+      processTree,
+    });
+    expect(test.transaction.rollback).not.toHaveBeenCalled();
+    expect(test.transaction.commit).not.toHaveBeenCalled();
+    expect(test.artifactLease.release).not.toHaveBeenCalled();
+    expect(test.artifactChannel.close).not.toHaveBeenCalled();
+    expect(test.lock.release).not.toHaveBeenCalled();
+    expect(test.dependencies.removeRecoveryJournal).not.toHaveBeenCalled();
+    expect(test.dependencies.writeState).not.toHaveBeenCalled();
+
+    if (published === undefined) throw new Error("test fixture did not publish the journal");
+    let durable: MutationRecoveryJournal | null = published;
+    let recoveredState = initialState;
+    const recoveryLock = {
+      canonicalHome: "/canonical/home",
+      profile: "web",
+      ownerToken: "recovery-owner",
+      fencingToken: 8,
+      assertOwned: vi.fn(async () => undefined),
+      heartbeat: vi.fn(async () => undefined),
+      release: vi.fn(async () => undefined),
+    };
+    const finalizeRecoveredTransaction = vi.fn(async () => undefined);
+    const releaseRecoveredArtifact = vi.fn(async () => undefined);
+
+    expect(await recoverPluginMutation({
+      dshHome: "/canonical/home",
+      platform: "linux",
+      acquireLock: vi.fn(async () => recoveryLock),
+      readRecoveryJournal: vi.fn(async () => durable),
+      updateRecoveryJournal: vi.fn(async (_home, current, patch) => {
+        const next = {
+          ...current,
+          ...patch,
+          revision: current.revision + 1,
+        } as MutationRecoveryJournal;
+        durable = next;
+        return next;
+      }),
+      removeRecoveryJournal: vi.fn(async () => { durable = null; }),
+      readState: vi.fn(async () => recoveredState),
+      writeState: vi.fn(async (_home, next) => {
+        recoveredState = {
+          ...next,
+          generation: (recoveredState.generation ?? 0) + 1,
+          fencingToken: recoveryLock.fencingToken,
+        };
+        return recoveredState;
+      }),
+      isProcessTreeAlive: vi.fn(async () => false),
+      fingerprintActiveProfile: vi.fn(async () => `sha512-${"C".repeat(86)}==`),
+      recoverTransaction: vi.fn(async () => undefined),
+      finalizeRecoveredTransaction,
+      releaseRecoveredArtifact,
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    })).toBe(0);
+
+    expect(recoveredState.installs).toEqual([newInstall]);
+    expect(finalizeRecoveredTransaction).toHaveBeenCalledOnce();
+    expect(releaseRecoveredArtifact).toHaveBeenCalledOnce();
+    expect(recoveryLock.release).toHaveBeenCalledOnce();
+    expect(durable).toBeNull();
+  });
+
+  it("never rolls back after the new state is published but the next journal phase fails", async () => {
+    const test = harness({ version: 1, generation: 3, installs: [] });
+    let statePublished = false;
+    test.dependencies.writeState.mockImplementation(async () => {
+      statePublished = true;
+      return undefined;
+    });
+    test.dependencies.updateRecoveryJournal.mockImplementation(async (_home, current, patch) => {
+      const candidate = { ...current, ...patch, revision: current.revision + 1 } as MutationRecoveryJournal;
+      if (statePublished) throw new Error("crash after state rename");
+      return candidate;
+    });
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, test.dependencies)).toBe(1);
+
+    expect(test.dependencies.writeState).toHaveBeenCalledOnce();
+    expect(test.transaction.rollback).not.toHaveBeenCalled();
+    expect(test.transaction.commit).not.toHaveBeenCalled();
+    expect(test.artifactLease.release).not.toHaveBeenCalled();
+  });
+
+  it("rolls forward when state is already new even if the durable phase is still dsh_succeeded", async () => {
+    const state: InstallState = { version: 1, generation: 4, fencingToken: 7, installs: [newInstall] };
+    let durable = {
+      version: 1,
+      revision: 3,
+      status: "recovery_required",
+      phase: "dsh_succeeded",
+      decision: "roll_forward",
+      ownerToken: "old-owner",
+      fencingToken: 7,
+      profile: "web",
+      transaction: {
+        profile: "web",
+        fencingToken: 7,
+        existed: true,
+        journalRelativePath: "profiles/.dsh-plugins-transaction-web-forward.json",
+        backupRelativePath: "profiles/.dsh-plugins-backup-web-forward",
+        backupFingerprint: `sha512-${"A".repeat(86)}==`,
+      },
+      artifact: {
+        relativePath: ".dsh-plugins/artifact-leases/.lease-forward/artifact.tgz",
+        sha512: `sha512-${"B".repeat(86)}==`,
+        bytes: 128,
+        packageName: "fixture-plugin",
+      },
+      channel: null,
+      processTree: {
+        pid: 7_777,
+        processGroupId: 7_777,
+        treeIdentity: "linux:created",
+        processStartIdentity: "linux:created",
+        platform: "linux",
+      },
+      stateEvidence: {
+        oldGeneration: 3,
+        oldFingerprint: stateFingerprint([]),
+        oldInstalls: [],
+        intendedFingerprint: stateFingerprint([newInstall]),
+        intendedInstalls: [newInstall],
+      },
+      activeFingerprint: `sha512-${"C".repeat(86)}==`,
+      createdAt: "2026-08-16T00:00:00.000Z",
+    } as unknown as MutationRecoveryJournal;
+    const order: string[] = [];
+    const recoverTransaction = vi.fn(async () => undefined);
+    const finalizeRecoveredTransaction = vi.fn(async () => { order.push("finalize-profile"); });
+
+    expect(await recoverPluginMutation({
+      dshHome: "/canonical/home",
+      platform: "linux",
+      acquireLock: vi.fn(async () => ({
+        canonicalHome: "/canonical/home",
+        profile: "web",
+        ownerToken: "new-owner",
+        fencingToken: 8,
+        assertOwned: vi.fn(async () => undefined),
+        heartbeat: vi.fn(async () => undefined),
+        release: vi.fn(async () => { order.push("release-lock"); }),
+      })),
+      readRecoveryJournal: vi.fn(async () => durable),
+      updateRecoveryJournal: vi.fn(async (_home, current, patch) => {
+        durable = { ...current, ...patch, revision: current.revision + 1 } as typeof durable;
+        return durable as unknown as MutationRecoveryJournal;
+      }),
+      removeRecoveryJournal: vi.fn(async () => { order.push("remove-marker"); }),
+      readState: vi.fn(async () => state),
+      writeState: vi.fn(async () => undefined),
+      isProcessTreeAlive: vi.fn(async () => false),
+      fingerprintActiveProfile: vi.fn(async () => `sha512-${"C".repeat(86)}==`),
+      recoverTransaction,
+      finalizeRecoveredTransaction,
+      releaseRecoveredArtifact: vi.fn(async () => { order.push("release-artifact"); }),
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    })).toBe(0);
+
+    expect(recoverTransaction).not.toHaveBeenCalled();
+    expect(finalizeRecoveredTransaction).toHaveBeenCalledOnce();
+    expect(order).toEqual([
+      "finalize-profile",
+      "release-artifact",
+      "remove-marker",
+      "release-lock",
+    ]);
+  });
+});
+
+describe("dsh missing-on-PATH exit UX", () => {
+  it("explains exit 127 as DSH/pnpm missing from PATH instead of a generic rejection", async () => {
+    const test = harness({ version: 1, generation: 3, installs: [] });
+    test.dependencies.runDsh.mockImplementation(async () => 127);
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, test.dependencies)).toBe(1);
+
+    const stderr = test.dependencies.stderr.mock.calls.map((call) => call[0]).join("");
+    expect(stderr).toContain("DSH (or pnpm) was not found on PATH");
+    expect(stderr).not.toContain("DSH rejected the mutation");
+    expect(test.transaction.rollback).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the generic rejection message for ordinary nonzero exits", async () => {
+    const test = harness({ version: 1, generation: 3, installs: [] });
+    test.dependencies.runDsh.mockImplementation(async () => 1);
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, test.dependencies)).toBe(1);
+
+    const stderr = test.dependencies.stderr.mock.calls.map((call) => call[0]).join("");
+    expect(stderr).toContain("DSH rejected the mutation; the previous profile was restored.");
+    expect(stderr).not.toContain("was not found on PATH");
+    expect(test.transaction.rollback).toHaveBeenCalledOnce();
+  });
+});

--- a/cli/tests/mutation-journal.test.ts
+++ b/cli/tests/mutation-journal.test.ts
@@ -1,0 +1,319 @@
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { executePluginMutation } from "../src/commands/mutate.js";
+import {
+  createMutationRecoveryJournal,
+  readMutationRecoveryJournal,
+  type MutationRecoveryJournal,
+} from "../src/dsh/mutationRecoveryJournal.js";
+import type { PublicCatalogEntry } from "../src/model.js";
+
+const roots: string[] = [];
+
+function home(): string {
+  const root = mkdtempSync(join(tmpdir(), "dsh-durable-intent-"));
+  roots.push(root);
+  mkdirSync(join(root, "profiles", "web"), { recursive: true });
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const entry: PublicCatalogEntry = {
+  schemaVersion: 1,
+  id: "fixture-plugin",
+  name: "Fixture Plugin",
+  description: { en: "Durable recovery intent fixture.", evidencePath: "README.md" },
+  unofficial: true,
+  kind: "plugin",
+  primaryCategory: "developer-tools",
+  tags: ["fixture"],
+  source: {
+    repository: "https://github.com/creator/fixture-plugin",
+    repositoryNodeId: "R_fixture",
+    subpath: null,
+    commit: "a".repeat(40),
+  },
+  creator: { github: "creator" },
+  package: { ecosystem: "npm", name: "fixture-plugin", version: "1.0.0" },
+  dsh: { profiles: ["web"], evidencePath: "package.json" },
+  repositoryScope: "dedicated",
+  popularity: { starsPolicy: "exact-repository", stars: 1 },
+  license: { spdx: "MIT" },
+  verification: {
+    status: "eligible",
+    checkedAt: "2026-08-16T00:00:00.000Z",
+    repositoryIdentity: "resolved",
+    smokeTest: null,
+  },
+  provenance: { discussion: null, comment: null },
+  canonicalKey: "R_fixture:.",
+};
+
+function journalInput(homePath: string) {
+  return {
+    ownerToken: "owner-token",
+    fencingToken: 7,
+    profile: "web",
+    transaction: {
+      profile: "web",
+      fencingToken: 7,
+      existed: true,
+      journalRelativePath: "profiles/.dsh-plugins-transaction-web-test.json",
+      backupRelativePath: "profiles/.dsh-plugins-backup-web-test",
+      backupFingerprint: `sha512-${"A".repeat(86)}==`,
+    },
+    artifact: {
+      relativePath: ".dsh-plugins/artifact-leases/.lease-test/artifact.tgz",
+      sha512: `sha512-${"B".repeat(86)}==`,
+      bytes: 128,
+      packageName: "fixture-plugin",
+    },
+    channel: {
+      kind: "loopback-buffer-v1" as const,
+      sha512: `sha512-${"B".repeat(86)}==`,
+      bytes: 128,
+      sourceFingerprint: "sha256:pinned-source",
+    },
+    createdAt: "2026-08-16T00:00:00.000Z",
+    home: homePath,
+  };
+}
+
+describe("durable pre-spawn mutation intent", () => {
+  it("publishes an in-progress fail-closed journal before a child can exist", async () => {
+    const root = home();
+    const created = await createMutationRecoveryJournal(root, journalInput(root));
+
+    expect(created).toMatchObject({
+      status: "in_progress",
+      phase: "needs_restore",
+      revision: 1,
+      ownerToken: "owner-token",
+      fencingToken: 7,
+    });
+    expect(await readMutationRecoveryJournal(root)).toEqual(created);
+  });
+
+  it("does not spawn when durable pre-spawn publication fails", async () => {
+    const root = home();
+    const runDsh = vi.fn(async () => 0);
+    const rollback = vi.fn(async () => undefined);
+    const lock = {
+      canonicalHome: root,
+      profile: "web",
+      ownerToken: "owner-token",
+      fencingToken: 7,
+      assertOwned: vi.fn(async () => undefined),
+      heartbeat: vi.fn(async () => undefined),
+      release: vi.fn(async () => undefined),
+    };
+    const artifactLease = {
+      recoveryReference: journalInput(root).artifact,
+      revalidate: vi.fn(async () => undefined),
+      readVerifiedBytes: vi.fn(async () => Buffer.from("verified")),
+      release: vi.fn(async () => undefined),
+    };
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, {
+      dshHome: root,
+      acquireLock: vi.fn(async () => lock),
+      readRecoveryJournal: vi.fn(async () => null),
+      readState: vi.fn(async () => ({ version: 1 as const, generation: 0, installs: [] })),
+      stageEntry: vi.fn(async () => ({
+        fingerprint: "sha256:pinned-source",
+        installTarget: join(root, "artifact.tgz"),
+        displayTarget: "<private>",
+        packageName: "fixture-plugin",
+        cacheRelativePath: "fixture/cache.tgz",
+        artifactLease,
+      })),
+      beginTransaction: vi.fn(async () => ({
+        recoveryReference: journalInput(root).transaction,
+        commit: vi.fn(async () => undefined),
+        rollback,
+      })),
+      openArtifactChannel: vi.fn(async () => ({
+        installTarget: "http://127.0.0.1:1/secret/artifact.tgz",
+        descriptor: journalInput(root).channel,
+        close: vi.fn(async () => undefined),
+      })),
+      createRecoveryJournal: vi.fn(async () => {
+        throw new Error("disk full");
+      }),
+      runDsh,
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    })).toBe(1);
+
+    expect(runDsh).not.toHaveBeenCalled();
+    expect(rollback).toHaveBeenCalledOnce();
+  });
+
+  it("blocks a later process from staging when an in-progress journal survives lease expiry", async () => {
+    const root = home();
+    const pending = {
+      version: 1,
+      revision: 1,
+      status: "in_progress",
+      phase: "needs_restore",
+      ...journalInput(root),
+    } as MutationRecoveryJournal;
+    const stageEntry = vi.fn();
+    const runDsh = vi.fn();
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, {
+      dshHome: root,
+      acquireLock: vi.fn(async () => ({
+        canonicalHome: root,
+        profile: "web",
+        ownerToken: "later-owner",
+        fencingToken: 8,
+        assertOwned: vi.fn(async () => undefined),
+        heartbeat: vi.fn(async () => undefined),
+        release: vi.fn(async () => undefined),
+      })),
+      readRecoveryJournal: vi.fn(async () => pending),
+      readState: vi.fn(async () => ({ version: 1 as const, installs: [] })),
+      stageEntry,
+      runDsh,
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    })).toBe(1);
+
+    expect(stageEntry).not.toHaveBeenCalled();
+    expect(runDsh).not.toHaveBeenCalled();
+  });
+
+  it("remains fail-closed when both the timeout update and state mirror publication fail", async () => {
+    const root = home();
+    const processTree = {
+      pid: 9_009,
+      processGroupId: 9_009,
+      treeIdentity: "linux:created",
+      processStartIdentity: "linux:created",
+      platform: "linux" as const,
+    };
+    const input = journalInput(root);
+    let durable: MutationRecoveryJournal = {
+      version: 1,
+      revision: 1,
+      status: "in_progress",
+      phase: "needs_restore",
+      ...input,
+    };
+    const lock = {
+      canonicalHome: root,
+      profile: "web",
+      ownerToken: "owner-token",
+      fencingToken: 7,
+      assertOwned: vi.fn(async () => undefined),
+      heartbeat: vi.fn(async () => undefined),
+      release: vi.fn(async () => undefined),
+    };
+    const artifactLease = {
+      recoveryReference: input.artifact,
+      revalidate: vi.fn(async () => undefined),
+      readVerifiedBytes: vi.fn(async () => Buffer.from("verified")),
+      release: vi.fn(async () => undefined),
+    };
+    const channel = {
+      installTarget: "http://127.0.0.1:1/secret/artifact.tgz",
+      descriptor: input.channel,
+      close: vi.fn(async () => undefined),
+    };
+    const updateRecoveryJournal = vi.fn(async (_home: string, current: MutationRecoveryJournal, patch: object) => {
+      if ("status" in patch && (patch as { status?: string }).status === "recovery_required") {
+        throw new Error("injected durable update failure");
+      }
+      durable = { ...current, ...patch, revision: current.revision + 1 } as MutationRecoveryJournal;
+      return durable;
+    });
+    const runDsh = vi.fn(async (_profile: string, _args: readonly string[], options?: {
+      onSpawn?: (identity: typeof processTree) => Promise<void>;
+    }) => {
+      await options?.onSpawn?.(processTree);
+      const { DshExecutionUncertainError } = await import("../src/dsh/runDsh.js");
+      throw new DshExecutionUncertainError("timeout", false, processTree);
+    });
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, {
+      dshHome: root,
+      acquireLock: vi.fn(async () => lock),
+      readRecoveryJournal: vi.fn(async () => null),
+      readState: vi.fn(async () => ({ version: 1 as const, generation: 0, installs: [] })),
+      writeState: vi.fn(async () => { throw new Error("state rename failed"); }),
+      stageEntry: vi.fn(async () => ({
+        fingerprint: "sha256:pinned-source",
+        installTarget: join(root, "artifact.tgz"),
+        displayTarget: "<private>",
+        packageName: "fixture-plugin",
+        cacheRelativePath: "fixture/cache.tgz",
+        artifactLease,
+      })),
+      beginTransaction: vi.fn(async () => ({
+        recoveryReference: input.transaction,
+        commit: vi.fn(async () => undefined),
+        rollback: vi.fn(async () => undefined),
+      })),
+      openArtifactChannel: vi.fn(async () => channel),
+      createRecoveryJournal: vi.fn(async () => durable),
+      updateRecoveryJournal,
+      runDsh,
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    })).toBe(1);
+
+    expect(durable.status).toBe("in_progress");
+    expect(durable.processTree).toEqual(processTree);
+    expect(artifactLease.release).not.toHaveBeenCalled();
+    expect(channel.close).not.toHaveBeenCalled();
+    expect(lock.release).not.toHaveBeenCalled();
+
+    const laterStage = vi.fn();
+    const laterRun = vi.fn();
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, {
+      dshHome: root,
+      acquireLock: vi.fn(async () => ({ ...lock, ownerToken: "later-owner", fencingToken: 8 })),
+      readRecoveryJournal: vi.fn(async () => durable),
+      readState: vi.fn(async () => ({ version: 1 as const, installs: [] })),
+      stageEntry: laterStage,
+      runDsh: laterRun,
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    })).toBe(1);
+    expect(laterStage).not.toHaveBeenCalled();
+    expect(laterRun).not.toHaveBeenCalled();
+  });
+});

--- a/cli/tests/package-contents.test.ts
+++ b/cli/tests/package-contents.test.ts
@@ -26,7 +26,9 @@ const manifestVersion = (
     version: string;
   }
 ).version;
-const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+// The repository root, one level above the CLI now that it lives inside the catalog repo. Used
+// only to assert the bundle embeds no absolute build path.
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const output = mkdtempSync(join(tmpdir(), "dsh-plugins-pack-"));
 let dryRun: PackResult;
 let packed: PackResult;
@@ -44,10 +46,10 @@ function npmPack(args: readonly string[]): PackResult {
 // The build + double npm pack competes with the rest of the suite for CPU;
 // 30s flaked under full-suite load (same REV-33 class as the npx smoke).
 beforeAll(() => {
-  execFileSync("pnpm", ["--filter", "@diegosouza.pw/dsh-plugins", "build"], {
-    cwd: repoRoot,
-    stdio: "pipe",
-  });
+  // Plain npm in the CLI directory: this package is no longer a member of a pnpm workspace, and
+  // invoking a package manager the environment may not have is a failure that only shows up off
+  // the author's machine.
+  execFileSync("npm", ["run", "build"], { cwd: cliRoot, stdio: "pipe" });
   dryRun = npmPack(["--dry-run"]);
   packed = npmPack(["--pack-destination", output]);
   tarball = join(output, packed.filename);

--- a/cli/tests/package-contents.test.ts
+++ b/cli/tests/package-contents.test.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+interface PackFile {
+  path: string;
+  size: number;
+  mode: number;
+}
+
+interface PackResult {
+  id: string;
+  name: string;
+  version: string;
+  filename: string;
+  files: PackFile[];
+}
+
+const cliRoot = fileURLToPath(new URL("../", import.meta.url));
+const manifestVersion = (
+  JSON.parse(readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8")) as {
+    version: string;
+  }
+).version;
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const output = mkdtempSync(join(tmpdir(), "dsh-plugins-pack-"));
+let dryRun: PackResult;
+let packed: PackResult;
+let tarball = "";
+
+function npmPack(args: readonly string[]): PackResult {
+  const raw = execFileSync("npm", ["pack", "--json", ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return (JSON.parse(raw) as PackResult[])[0] as PackResult;
+}
+
+// The build + double npm pack competes with the rest of the suite for CPU;
+// 30s flaked under full-suite load (same REV-33 class as the npx smoke).
+beforeAll(() => {
+  execFileSync("pnpm", ["--filter", "@diegosouza.pw/dsh-plugins", "build"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+  dryRun = npmPack(["--dry-run"]);
+  packed = npmPack(["--pack-destination", output]);
+  tarball = join(output, packed.filename);
+}, 60_000);
+
+afterAll(() => {
+  rmSync(output, { recursive: true, force: true });
+});
+
+describe("packed public CLI", () => {
+  it("contains only package metadata, public docs and the executable bundle", () => {
+    // The tarball must declare the same identity the manifest does. Asserting a literal version
+    // here made every release red for shipping a new version.
+    expect(packed.name).toBe("@diegosouza.pw/dsh-plugins");
+    expect(packed.version).toBe(manifestVersion);
+    expect(packed.version).toMatch(/^\d+\.\d+\.\d+$/u);
+    const paths = dryRun.files.map((file) => file.path).sort();
+    expect(paths).toEqual(["LICENSE", "README.md", "dist/bin.js", "package.json"]);
+    const bin = packed.files.find((file) => file.path === "dist/bin.js");
+    expect(bin).toBeDefined();
+    expect((bin?.mode ?? 0) & 0o111).not.toBe(0);
+    const readme = readFileSync(join(cliRoot, "README.md"), "utf8");
+    expect(readme).toContain("local structural and semantic validation");
+    expect(readme).toContain("does not prove repository identity or pinned-source evidence");
+  });
+
+  it("ships no source maps, private source, ledgers, fixtures or absolute build paths", () => {
+    const paths = packed.files.map((file) => file.path).join("\n");
+    expect(paths).not.toMatch(/(?:^|\/)(?:src|tests|fixtures|private-data|\.superpowers)(?:\/|$)/u);
+    expect(paths).not.toMatch(/\.map$/mu);
+    const bundle = readFileSync(join(cliRoot, "dist/bin.js"), "utf8");
+    expect(bundle).not.toContain("sourceMappingURL");
+    expect(bundle).not.toContain(repoRoot);
+    expect(bundle).not.toContain("discussion-harvester");
+    expect(bundle).not.toContain("private-data");
+    expect(bundle).not.toContain("packages/ledger");
+  });
+
+  // The npx smoke installs the packed tarball and spawns the binary; the 10s
+  // suite default flaked under load (REV-33), so give it an explicit budget.
+  it("runs the packed scoped binary through npx", { timeout: 60_000 }, () => {
+    const smoke = join(output, "smoke");
+    mkdirSync(smoke);
+    execFileSync(
+      "npm",
+      ["install", "--ignore-scripts", "--no-audit", "--no-fund", tarball],
+      { cwd: smoke, stdio: ["ignore", "pipe", "pipe"], timeout: 30_000 },
+    );
+    // The binary must announce the version it actually shipped as. The tarball metadata above
+    // agreeing with the manifest is not enough: 1.0.0 packed correctly while the executable
+    // inside still answered 0.1.0, and an immutable npm version cannot be corrected afterwards.
+    const reported = execFileSync("npx", ["--no-install", "dsh-plugins", "--version"], {
+      cwd: smoke,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+    expect(reported.trim()).toBe(manifestVersion);
+
+    const help = execFileSync("npx", ["--no-install", "dsh-plugins", "--help"], {
+      cwd: smoke,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+    expect(help).toContain("Usage: dsh-plugins");
+    for (const command of [
+      "catalog",
+      "search",
+      "info",
+      "add",
+      "update",
+      "remove",
+      "list",
+      "doctor",
+    ]) {
+      expect(help).toContain(command);
+    }
+    expect(help).toContain("Unofficial community project");
+  });
+});

--- a/cli/tests/package.test.ts
+++ b/cli/tests/package.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+interface PackageManifest {
+  name: string;
+  version: string;
+  type: string;
+  license: string;
+  engines: { node: string };
+  bin: Record<string, string>;
+  files: string[];
+  publishConfig: { access: string };
+  scripts: Record<string, string>;
+  dependencies?: Record<string, string>;
+}
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as PackageManifest;
+
+describe("published CLI package metadata", () => {
+  it("owns the exact scoped package and executable", () => {
+    expect(pkg.name).toBe("@diegosouza.pw/dsh-plugins");
+    // Not a frozen literal: the version moves every release, and freezing it means the release
+    // itself fails the test for doing the one thing a release does. What must hold is that it is
+    // exact semver — a range or a prerelease tag here would publish something npm resolves
+    // differently from what the tag claims.
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/u);
+    expect(pkg.type).toBe("module");
+    expect(pkg.bin).toEqual({ "dsh-plugins": "dist/bin.js" });
+    expect(pkg.license).toBe("MIT");
+    expect(pkg.engines.node).toBe(">=20");
+  });
+
+  it("publishes only built code and public package documents", () => {
+    expect(pkg.files).toEqual(["dist", "README.md", "LICENSE"]);
+    // Owner decision (2026-08-18, REV-14): provenance stays OFF until trusted
+    // publishing lands (REL-01); with it present every local npm publish would
+    // fail unless --provenance=false were passed manually.
+    expect(pkg.publishConfig).toEqual({ access: "public" });
+    expect(pkg.scripts.build).toContain("esbuild");
+    expect(pkg.scripts.build).not.toContain("sourcemap");
+    expect(pkg.dependencies ?? {}).not.toHaveProperty("@omni-dsh/catalog-core");
+  });
+});

--- a/cli/tests/profile-lock.test.ts
+++ b/cli/tests/profile-lock.test.ts
@@ -1,0 +1,229 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  InstallStateGenerationError,
+  readInstallState,
+  writeInstallState,
+} from "../src/dsh/installState.js";
+import {
+  ProfileLockBusyError,
+  ProfileLockOwnershipError,
+  acquireProfileLock,
+} from "../src/dsh/profileLock.js";
+import { beginProfileTransaction } from "../src/dsh/profileTransaction.js";
+
+const roots: string[] = [];
+
+async function temporaryHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), "dsh-profile-lock-"));
+  roots.push(home);
+  return home;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("profile mutation lock", () => {
+  it("serializes alternating profiles behind one home-global mutation fence", async () => {
+    const home = await temporaryHome();
+    const seed = await acquireProfileLock(home, "web", {
+      leaseMs: 5_000,
+      heartbeatMs: 1_000,
+      ownerToken: () => "seed-owner",
+      pid: 101,
+      hostname: "test-host",
+      isProcessAlive: () => true,
+    });
+    expect(seed.fencingToken).toBe(1);
+    await seed.release();
+
+    const web = await acquireProfileLock(home, "web", {
+      leaseMs: 5_000,
+      heartbeatMs: 1_000,
+      ownerToken: () => "web-owner",
+      pid: 202,
+      hostname: "test-host",
+      isProcessAlive: () => true,
+    });
+    expect(web.fencingToken).toBe(2);
+
+    let acquiredTerminal = false;
+    let terminal: Awaited<ReturnType<typeof acquireProfileLock>> | undefined;
+    const terminalOperation = acquireProfileLock(home, "terminal", {
+      leaseMs: 5_000,
+      heartbeatMs: 1_000,
+      acquireTimeoutMs: 500,
+      retryMs: 5,
+      ownerToken: () => "terminal-owner",
+      pid: 303,
+      hostname: "test-host",
+      isProcessAlive: () => true,
+    }).then((lock) => {
+      acquiredTerminal = true;
+      terminal = lock;
+      return lock;
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(acquiredTerminal).toBe(false);
+      await web.release();
+      terminal = await terminalOperation;
+      expect(terminal.profile).toBe("terminal");
+      expect(terminal.fencingToken).toBe(3);
+      await terminal.release();
+      terminal = undefined;
+
+      const webAgain = await acquireProfileLock(home, "web", {
+        ownerToken: () => "web-owner-again",
+        pid: 404,
+        hostname: "test-host",
+        isProcessAlive: () => true,
+      });
+      expect(webAgain.fencingToken).toBe(4);
+      await webAgain.release();
+    } finally {
+      await web.release();
+      await terminal?.release();
+    }
+  });
+
+  it("does not steal an expired lease while the local owner PID is alive", async () => {
+    const home = await temporaryHome();
+    let now = 1_000;
+    const first = await acquireProfileLock(home, "web", {
+      now: () => now,
+      leaseMs: 50,
+      heartbeatMs: 10_000,
+      ownerToken: () => "live-owner",
+      pid: 303,
+      hostname: "test-host",
+      isProcessAlive: (pid) => pid === 303,
+    });
+    now = 5_000;
+
+    await expect(acquireProfileLock(home, "web", {
+      now: () => now,
+      leaseMs: 50,
+      heartbeatMs: 10_000,
+      acquireTimeoutMs: 0,
+      retryMs: 0,
+      ownerToken: () => "contender",
+      pid: 404,
+      hostname: "test-host",
+      isProcessAlive: (pid) => pid === 303,
+    })).rejects.toBeInstanceOf(ProfileLockBusyError);
+    await first.release();
+  });
+
+  it("fences stale owners from state publication and release after dead-owner takeover", async () => {
+    const home = await temporaryHome();
+    let now = 1_000;
+    let firstAlive = true;
+    const liveness = (pid: number): boolean => pid !== 505 || firstAlive;
+    const first = await acquireProfileLock(home, "web", {
+      now: () => now,
+      leaseMs: 50,
+      heartbeatMs: 10_000,
+      ownerToken: () => "stale-owner",
+      pid: 505,
+      hostname: "test-host",
+      isProcessAlive: liveness,
+    });
+    const firstState = await writeInstallState(
+      home,
+      { version: 1, installs: [] },
+      {
+        expectedGeneration: 0,
+        fencingToken: first.fencingToken,
+        assertLockOwned: first.assertOwned,
+      },
+    );
+    expect(firstState.generation).toBe(1);
+
+    firstAlive = false;
+    now = 2_000;
+    const second = await acquireProfileLock(home, "web", {
+      now: () => now,
+      leaseMs: 50,
+      heartbeatMs: 10_000,
+      ownerToken: () => "new-owner",
+      pid: 606,
+      hostname: "test-host",
+      isProcessAlive: liveness,
+    });
+    expect(second.fencingToken).toBeGreaterThan(first.fencingToken);
+
+    await expect(writeInstallState(
+      home,
+      { version: 1, installs: [] },
+      {
+        expectedGeneration: 1,
+        fencingToken: first.fencingToken,
+        assertLockOwned: first.assertOwned,
+      },
+    )).rejects.toBeInstanceOf(ProfileLockOwnershipError);
+
+    const secondState = await writeInstallState(
+      home,
+      { version: 1, installs: [] },
+      {
+        expectedGeneration: 1,
+        fencingToken: second.fencingToken,
+        assertLockOwned: second.assertOwned,
+      },
+    );
+    expect(secondState).toMatchObject({
+      generation: 2,
+      fencingToken: second.fencingToken,
+    });
+
+    await first.release();
+    await expect(second.assertOwned()).resolves.toBeUndefined();
+    await expect(writeInstallState(
+      home,
+      { version: 1, installs: [] },
+      {
+        expectedGeneration: 1,
+        fencingToken: second.fencingToken,
+        assertLockOwned: second.assertOwned,
+      },
+    )).rejects.toBeInstanceOf(InstallStateGenerationError);
+    expect(await readInstallState(home)).toMatchObject({
+      generation: 2,
+      fencingToken: second.fencingToken,
+    });
+    await second.release();
+  });
+});
+
+describe("recoverable profile transaction", () => {
+  it("restores a retained pre-commit backup after a simulated crash", async () => {
+    const home = await temporaryHome();
+    const profile = join(home, "profiles", "web");
+    await mkdir(profile, { recursive: true });
+    await writeFile(join(profile, "package.json"), "before\n", "utf8");
+    const first = await beginProfileTransaction(home, "web", {
+      fencingToken: 1,
+      committedFencingToken: 0,
+      assertLockOwned: async () => undefined,
+    });
+    await writeFile(join(profile, "package.json"), "crashed mutation\n", "utf8");
+
+    const second = await beginProfileTransaction(home, "web", {
+      fencingToken: 2,
+      committedFencingToken: 0,
+      assertLockOwned: async () => undefined,
+    });
+
+    expect(await readFile(join(profile, "package.json"), "utf8")).toBe("before\n");
+    await second.rollback();
+    expect(await readFile(join(profile, "package.json"), "utf8")).toBe("before\n");
+    await first.commit();
+  });
+});

--- a/cli/tests/recovery-phase-machine.test.ts
+++ b/cli/tests/recovery-phase-machine.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { recoverPluginMutation } from "../src/commands/mutate.js";
+import type { MutationRecoveryJournal } from "../src/dsh/mutationRecoveryJournal.js";
+
+describe("durable recovery phase machine", () => {
+  it("retries from needs_restore after a crash before profile_restored publication", async () => {
+    const order: string[] = [];
+    let failAfterPhysicalRestore = true;
+    let durable: MutationRecoveryJournal | null = {
+      version: 1,
+      revision: 1,
+      status: "recovery_required",
+      phase: "needs_restore",
+      ownerToken: "old-owner",
+      fencingToken: 7,
+      profile: "web",
+      transaction: {
+        profile: "web",
+        fencingToken: 7,
+        existed: true,
+        journalRelativePath: "profiles/.dsh-plugins-transaction-web-phase.json",
+        backupRelativePath: "profiles/.dsh-plugins-backup-web-phase",
+        backupFingerprint: `sha512-${"A".repeat(86)}==`,
+      },
+      artifact: {
+        relativePath: ".dsh-plugins/artifact-leases/.lease-phase/artifact.tgz",
+        sha512: `sha512-${"B".repeat(86)}==`,
+        bytes: 128,
+        packageName: "fixture-plugin",
+      },
+      channel: {
+        kind: "loopback-buffer-v1",
+        sha512: `sha512-${"B".repeat(86)}==`,
+        bytes: 128,
+        sourceFingerprint: "sha256:pinned-source",
+      },
+      processTree: {
+        pid: 7_777,
+        processGroupId: 7_777,
+        treeIdentity: "linux:created",
+        processStartIdentity: "linux:created",
+        platform: "linux",
+      },
+      createdAt: "2026-08-16T00:00:00.000Z",
+    };
+    let lockNumber = 0;
+    const locks = [0, 1].map((index) => ({
+      canonicalHome: "/canonical/home",
+      profile: "web",
+      ownerToken: `recovery-owner-${index + 1}`,
+      fencingToken: 8 + index,
+      assertOwned: vi.fn(async () => undefined),
+      heartbeat: vi.fn(async () => undefined),
+      release: vi.fn(async () => {
+        order.push(`release-lock-${index + 1}`);
+      }),
+    }));
+    const dependencies = {
+      dshHome: "/canonical/home",
+      acquireLock: vi.fn(async () => locks[lockNumber++]!),
+      readRecoveryJournal: vi.fn(async () => durable),
+      updateRecoveryJournal: vi.fn(async (_home: string, current: MutationRecoveryJournal, patch: object) => {
+        if (
+          failAfterPhysicalRestore &&
+          "phase" in patch &&
+          (patch as { phase?: string }).phase === "profile_restored"
+        ) {
+          failAfterPhysicalRestore = false;
+          throw new Error("injected crash after backup-to-active rename");
+        }
+        durable = { ...current, ...patch, revision: current.revision + 1 } as MutationRecoveryJournal;
+        return durable;
+      }),
+      removeRecoveryJournal: vi.fn(async () => {
+        order.push("remove-marker");
+        durable = null;
+      }),
+      readState: vi.fn(async () => ({ version: 1 as const, installs: [] })),
+      writeState: vi.fn(async () => undefined),
+      isProcessTreeAlive: vi.fn(async () => false),
+      recoverTransaction: vi.fn(async () => {
+        order.push("restore-profile");
+      }),
+      finalizeRecoveredTransaction: vi.fn(async () => {
+        order.push("finalize-profile");
+      }),
+      releaseRecoveredArtifact: vi.fn(async () => {
+        order.push("release-artifact");
+      }),
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    };
+
+    expect(await recoverPluginMutation(dependencies)).toBe(1);
+    expect(durable?.phase).toBe("needs_restore");
+    expect(locks[0]!.release).not.toHaveBeenCalled();
+
+    expect(await recoverPluginMutation(dependencies)).toBe(0);
+    expect(durable).toBeNull();
+    expect(order).toEqual([
+      "restore-profile",
+      "restore-profile",
+      "finalize-profile",
+      "release-artifact",
+      "remove-marker",
+      "release-lock-2",
+    ]);
+  });
+});

--- a/cli/tests/recovery-phases.test.ts
+++ b/cli/tests/recovery-phases.test.ts
@@ -1,0 +1,52 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  beginProfileTransaction,
+  recoverProfileTransaction,
+} from "../src/dsh/profileTransaction.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("crash-idempotent profile recovery", () => {
+  it("retries safely after backup was renamed to active but the journal still exists", async () => {
+    const home = mkdtempSync(join(tmpdir(), "dsh-recovery-rename-crash-"));
+    roots.push(home);
+    const active = join(home, "profiles", "web");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(join(active, "package.json"), "before\n");
+    const transaction = await beginProfileTransaction(home, "web", { fencingToken: 7 });
+    writeFileSync(join(active, "package.json"), "after\n");
+
+    const reference = transaction.recoveryReference;
+    expect(reference.backupFingerprint).toMatch(/^sha512-/u);
+    rmSync(active, { recursive: true, force: true });
+    renameSync(join(home, reference.backupRelativePath), active);
+    expect(existsSync(join(home, reference.journalRelativePath))).toBe(true);
+    expect(existsSync(join(home, reference.backupRelativePath))).toBe(false);
+
+    await expect(recoverProfileTransaction(
+      home,
+      reference,
+      async () => undefined,
+    )).resolves.toBeUndefined();
+
+    expect(readFileSync(join(active, "package.json"), "utf8")).toBe("before\n");
+    expect(existsSync(join(home, reference.journalRelativePath))).toBe(true);
+  });
+});

--- a/cli/tests/recovery.test.ts
+++ b/cli/tests/recovery.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runCli } from "../src/app.js";
+import {
+  executePluginMutation,
+  recoverPluginMutation,
+} from "../src/commands/mutate.js";
+import type {
+  InstallState,
+  RecoveryRequiredMarker,
+} from "../src/dsh/installState.js";
+import type { ProfileLock } from "../src/dsh/profileLock.js";
+import type { PublicCatalogEntry } from "../src/model.js";
+
+const marker: RecoveryRequiredMarker = {
+  status: "recovery_required",
+  profile: "web",
+  fencingToken: 7,
+  processTree: {
+    pid: 4_242,
+    processGroupId: 4_242,
+    treeIdentity: "linux:123456",
+    processStartIdentity: "linux:123456",
+    platform: "linux",
+  },
+  artifact: {
+    relativePath: ".dsh-plugins/artifact-leases/.lease-recovery/artifact.tgz",
+    sha512: `sha512-${"A".repeat(86)}==`,
+    bytes: 512,
+    packageName: "fixture-plugin",
+  },
+  transaction: {
+    profile: "web",
+    fencingToken: 7,
+    existed: true,
+    journalRelativePath: "profiles/.dsh-plugins-transaction-web-recovery.json",
+    backupRelativePath: "profiles/.dsh-plugins-backup-web-recovery",
+  },
+};
+
+const recoveryState: InstallState = {
+  version: 1,
+  generation: 9,
+  fencingToken: 7,
+  installs: [],
+  recoveryRequired: marker,
+};
+
+function recoveryHarness(treeAlive: boolean) {
+  let stdout = "";
+  let stderr = "";
+  const order: string[] = [];
+  const lock: ProfileLock = {
+    canonicalHome: "/canonical/home",
+    profile: "web",
+    ownerToken: "recovery-owner",
+    fencingToken: 8,
+    assertOwned: vi.fn(async () => undefined),
+    heartbeat: vi.fn(async () => undefined),
+    release: vi.fn(async () => {
+      order.push("release-lock");
+    }),
+  };
+  const dependencies = {
+    dshHome: "/canonical/home",
+    acquireLock: vi.fn(async () => lock),
+    readState: vi.fn(async () => recoveryState),
+    writeState: vi.fn(async () => {
+      order.push("clear-marker");
+      return undefined;
+    }),
+    isProcessTreeAlive: vi.fn(async () => treeAlive),
+    recoverTransaction: vi.fn(async () => {
+      order.push("restore-profile");
+    }),
+    releaseRecoveredArtifact: vi.fn(async () => {
+      order.push("release-artifact");
+    }),
+    stdout: (value: string) => { stdout += value; },
+    stderr: (value: string) => { stderr += value; },
+  };
+  return { dependencies, lock, order, output: () => ({ stdout, stderr }) };
+}
+
+function entry(): PublicCatalogEntry {
+  return {
+    schemaVersion: 1,
+    id: "fixture-plugin",
+    name: "Fixture Plugin",
+    description: { en: "A detailed fixture plugin for recovery tests.", evidencePath: "README.md" },
+    unofficial: true,
+    kind: "plugin",
+    primaryCategory: "developer-tools",
+    tags: ["fixture"],
+    source: {
+      repository: "https://github.com/creator/fixture-plugin",
+      repositoryNodeId: "R_fixture",
+      subpath: null,
+      commit: "a".repeat(40),
+    },
+    creator: { github: "creator" },
+    package: { ecosystem: "npm", name: "fixture-plugin", version: "1.0.0" },
+    dsh: { profiles: ["web"], evidencePath: "package.json" },
+    repositoryScope: "dedicated",
+    popularity: { starsPolicy: "exact-repository", stars: 1 },
+    license: { spdx: "MIT" },
+    verification: {
+      status: "eligible",
+      checkedAt: "2026-08-16T00:00:00.000Z",
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+    canonicalKey: "R_fixture:.",
+  };
+}
+
+describe("explicit mutation recovery", () => {
+  it("blocks every new mutation at the recovery marker before staging or spawn", async () => {
+    const lock = recoveryHarness(false).lock;
+    const stageEntry = vi.fn();
+    const runDsh = vi.fn();
+
+    expect(await executePluginMutation({
+      operation: "add",
+      entry: entry(),
+      profile: "web",
+      dryRun: false,
+      allowCodeExecution: true,
+    }, {
+      dshHome: "/canonical/home",
+      acquireLock: vi.fn(async () => lock),
+      readState: vi.fn(async () => recoveryState),
+      stageEntry,
+      runDsh,
+      stderr: vi.fn(),
+    })).toBe(1);
+
+    expect(stageEntry).not.toHaveBeenCalled();
+    expect(runDsh).not.toHaveBeenCalled();
+  });
+
+  it("does not restore, clean or release anything while the process tree is alive", async () => {
+    const test = recoveryHarness(true);
+
+    expect(await recoverPluginMutation(test.dependencies)).toBe(1);
+    expect(test.dependencies.isProcessTreeAlive).toHaveBeenCalledWith(marker.processTree);
+    expect(test.dependencies.recoverTransaction).not.toHaveBeenCalled();
+    expect(test.dependencies.releaseRecoveredArtifact).not.toHaveBeenCalled();
+    expect(test.dependencies.writeState).not.toHaveBeenCalled();
+    expect(test.lock.release).not.toHaveBeenCalled();
+    expect(test.output().stderr).toBe(
+      "Recovery is pending because the DSH process tree is still alive.\n",
+    );
+  });
+
+  it("restores and clears fenced recovery state only after the whole tree is dead", async () => {
+    const test = recoveryHarness(false);
+
+    expect(await recoverPluginMutation(test.dependencies)).toBe(0);
+    expect(test.dependencies.recoverTransaction).toHaveBeenCalledWith(
+      test.dependencies.dshHome,
+      marker.transaction,
+      test.lock.assertOwned,
+    );
+    expect(test.dependencies.releaseRecoveredArtifact).toHaveBeenCalledWith(
+      test.dependencies.dshHome,
+      marker.artifact,
+    );
+    expect(test.dependencies.writeState).toHaveBeenCalledWith(
+      test.dependencies.dshHome,
+      { version: 1, installs: [] },
+      expect.objectContaining({ expectedGeneration: 9, fencingToken: 8 }),
+    );
+    expect(test.order).toEqual([
+      "restore-profile",
+      "release-artifact",
+      "clear-marker",
+      "release-lock",
+    ]);
+  });
+
+  it("wires recover without loading a catalog", async () => {
+    const test = recoveryHarness(false);
+    const loadCatalog = vi.fn(async () => {
+      throw new Error("catalog must not load");
+    });
+
+    expect(await runCli(["recover"], {
+      loadCatalog,
+      stdout: test.dependencies.stdout,
+      stderr: test.dependencies.stderr,
+      mutationDependencies: test.dependencies,
+    })).toBe(0);
+    expect(loadCatalog).not.toHaveBeenCalled();
+  });
+});

--- a/cli/tests/reported-version.test.ts
+++ b/cli/tests/reported-version.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { runCli, type CliDependencies } from "../src/app.js";
+import { loadDefaultCatalog } from "../src/catalogSource.js";
+
+const manifestVersion = (
+  JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+    version: string;
+  }
+).version;
+
+function harness() {
+  let stdout = "";
+  let stderr = "";
+  const dependencies: CliDependencies = {
+    loadCatalog: loadDefaultCatalog,
+    stdout: (value) => {
+      stdout += value;
+    },
+    stderr: (value) => {
+      stderr += value;
+    },
+  };
+  return { dependencies, output: () => ({ stdout, stderr }) };
+}
+
+describe("the version the CLI reports", () => {
+  // npm versions are immutable: a release whose binary reports a different version than the
+  // tarball it shipped in can never be corrected in place, only superseded. The manifest is the
+  // single source of truth, so nothing may restate the number independently.
+  it("matches the published package manifest", async () => {
+    const { dependencies, output } = harness();
+
+    const exitCode = await runCli(["--version"], dependencies);
+
+    expect(exitCode).toBe(0);
+    expect(output().stdout.trim()).toBe(manifestVersion);
+  });
+
+  // The help footer used to name the version inline ("disabled in v0.1.0"), which is the same
+  // hardcoding one level removed: it silently ages into a false claim at the next release.
+  it("never states a version number in help text", async () => {
+    const { dependencies, output } = harness();
+
+    await runCli(["--help"], dependencies);
+
+    expect(output().stdout).not.toMatch(/v?\d+\.\d+\.\d+/u);
+  });
+});

--- a/cli/tests/runDsh-deadline.test.ts
+++ b/cli/tests/runDsh-deadline.test.ts
@@ -1,0 +1,220 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { probeDshVersion } from "../src/commands/doctor.js";
+import {
+  DshDeadlineConfigurationError,
+  DshExecutionUncertainError,
+  runDsh,
+} from "../src/dsh/runDsh.js";
+
+interface FakeChild extends EventEmitter {
+  readonly pid: number;
+  readonly stdout: PassThrough;
+  readonly kill: ReturnType<typeof vi.fn>;
+}
+
+function fakeChild(pid = 4_242): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  Object.defineProperties(child, {
+    pid: { value: pid, enumerable: true },
+    stdout: { value: new PassThrough(), enumerable: true },
+    kill: { value: vi.fn(() => true), enumerable: true },
+  });
+  return child;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("DSH subprocess deadlines", () => {
+  it("escalates TERM to KILL for the process group and settles only after close/reap", async () => {
+    vi.useFakeTimers();
+    const child = fakeChild();
+    const spawn = vi.fn(() => child);
+    const killProcess = vi.fn(() => true);
+    const execution = runDsh("web", ["add", "pkg && untouched"], {
+      spawn: spawn as never,
+      timeoutMs: 100,
+      terminationGraceMs: 50,
+      reapTimeoutMs: 200,
+      platform: "linux",
+      killProcess,
+    });
+    let settled = false;
+    void execution.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    expect(spawn).toHaveBeenCalledWith(
+      "dsh",
+      ["plugin", "--profile", "web", "add", "pkg && untouched"],
+      expect.objectContaining({ shell: false, stdio: "inherit", detached: true }),
+    );
+    await vi.advanceTimersByTimeAsync(100);
+    expect(killProcess).toHaveBeenNthCalledWith(1, -4_242, "SIGTERM");
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(killProcess).toHaveBeenNthCalledWith(2, -4_242, "SIGKILL");
+    expect(settled).toBe(false);
+
+    child.emit("close", null, "SIGKILL");
+    await expect(execution).rejects.toMatchObject({
+      name: "DshExecutionUncertainError",
+      reason: "timeout",
+      ambiguous: true,
+      recoveryRequired: true,
+      reaped: true,
+      message: "dsh execution timed out; result is ambiguous; recovery required",
+    } satisfies Partial<DshExecutionUncertainError>);
+    expect(settled).toBe(true);
+  });
+
+  it("turns AbortSignal cancellation into a sanitized ambiguous result for rollback", async () => {
+    vi.useFakeTimers();
+    const child = fakeChild(7_007);
+    const spawn = vi.fn(() => child);
+    const killProcess = vi.fn(() => true);
+    const controller = new AbortController();
+    const execution = runDsh("web", ["remove", "fixture"], {
+      spawn: spawn as never,
+      signal: controller.signal,
+      timeoutMs: 5_000,
+      terminationGraceMs: 100,
+      reapTimeoutMs: 100,
+      platform: "linux",
+      killProcess,
+    });
+
+    controller.abort();
+    expect(killProcess).toHaveBeenCalledWith(-7_007, "SIGTERM");
+    child.emit("close", null, "SIGTERM");
+
+    await expect(execution).rejects.toMatchObject({
+      name: "DshExecutionUncertainError",
+      reason: "aborted",
+      ambiguous: true,
+      recoveryRequired: true,
+      reaped: true,
+      message: "dsh execution was aborted; result is ambiguous; recovery required",
+    } satisfies Partial<DshExecutionUncertainError>);
+    expect(killProcess).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds a never-closing doctor probe after TERM, KILL and the reap deadline", async () => {
+    vi.useFakeTimers();
+    const child = fakeChild(8_008);
+    const spawn = vi.fn(() => child);
+    const killProcess = vi.fn(() => true);
+    const probing = probeDshVersion({
+      spawn: spawn as never,
+      timeoutMs: 20,
+      terminationGraceMs: 10,
+      reapTimeoutMs: 10,
+      platform: "linux",
+      killProcess,
+    });
+
+    await vi.advanceTimersByTimeAsync(40);
+
+    await expect(probing).resolves.toEqual({ status: "timeout", version: null });
+    expect(killProcess.mock.calls).toEqual([
+      [-8_008, "SIGTERM"],
+      [-8_008, "SIGKILL"],
+      [-8_008, "SIGKILL"],
+    ]);
+    expect(spawn).toHaveBeenCalledWith(
+      "dsh",
+      ["--version"],
+      expect.objectContaining({ shell: false, detached: true }),
+    );
+  });
+
+  it("rejects non-finite deadline configuration before spawning", async () => {
+    const spawn = vi.fn(() => fakeChild());
+
+    await expect(runDsh("web", ["add", "fixture"], {
+      spawn: spawn as never,
+      timeoutMs: Number.POSITIVE_INFINITY,
+    })).rejects.toEqual(expect.objectContaining({
+      name: "DshDeadlineConfigurationError",
+      message: "dsh subprocess deadline configuration is invalid",
+    } satisfies Partial<DshDeadlineConfigurationError>));
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it.each(["timeout", "aborted"] as const)(
+    "returns an unreaped %s with the retained process-tree identity",
+    async (reason) => {
+      vi.useFakeTimers();
+      const child = fakeChild(9_009);
+      const controller = new AbortController();
+      const execution = runDsh("web", ["add", "/private/artifact.tgz"], {
+        spawn: vi.fn(() => child) as never,
+        signal: controller.signal,
+        timeoutMs: 20,
+        terminationGraceMs: 10,
+        reapTimeoutMs: 10,
+        platform: "linux",
+        killProcess: vi.fn(() => true),
+        identifyProcessTree: async () => "linux:424242",
+      });
+      const rejection = expect(execution).rejects.toMatchObject({
+        name: "DshExecutionUncertainError",
+        reason,
+        reaped: false,
+        processTree: {
+          pid: 9_009,
+          processGroupId: 9_009,
+          treeIdentity: "linux:424242",
+          processStartIdentity: "linux:424242",
+          platform: "linux",
+        },
+      } satisfies Partial<DshExecutionUncertainError>);
+      if (reason === "aborted") controller.abort();
+      await vi.advanceTimersByTimeAsync(reason === "timeout" ? 40 : 20);
+      await rejection;
+    },
+  );
+
+  it("uses literal taskkill argv for a Windows process tree", async () => {
+    vi.useFakeTimers();
+    const child = fakeChild(8_181);
+    const taskkillChild = fakeChild(8_182);
+    Object.defineProperty(taskkillChild, "unref", { value: vi.fn(), enumerable: true });
+    const taskkillSpawn = vi.fn(() => taskkillChild);
+    let snapshotCalls = 0;
+    const execution = runDsh("web", ["remove", "fixture"], {
+      spawn: vi.fn(() => child) as never,
+      timeoutMs: 20,
+      terminationGraceMs: 10,
+      reapTimeoutMs: 10,
+      platform: "win32",
+      taskkillSpawn: taskkillSpawn as never,
+      identifyProcessTree: async () => "win32:8181:created",
+      snapshotWindowsTree: async () => snapshotCalls++ === 0
+        ? [{ pid: 8_181, creationIdentity: "created" }]
+        : [],
+    });
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(taskkillSpawn).toHaveBeenCalledWith(
+      "taskkill",
+      ["/PID", "8181", "/T", "/F"],
+      { shell: false, stdio: "ignore", windowsHide: true },
+    );
+    taskkillChild.emit("close", 0, null);
+    child.emit("close", null, "SIGKILL");
+    await expect(execution).rejects.toMatchObject({ reaped: true, reason: "timeout" });
+  });
+});

--- a/cli/tests/runDsh.test.ts
+++ b/cli/tests/runDsh.test.ts
@@ -1,0 +1,458 @@
+import { EventEmitter } from "node:events";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { executePluginMutation } from "../src/commands/mutate.js";
+import { beginProfileTransaction } from "../src/dsh/profileTransaction.js";
+import {
+  DshExecutionUncertainError,
+  runDsh,
+  type DshProcessTreeIdentity,
+} from "../src/dsh/runDsh.js";
+import { stageCatalogEntry, type StagedCatalogInstall } from "../src/dsh/staging.js";
+import type { InstallState, StagedInstall } from "../src/dsh/installState.js";
+import type { PublicCatalogEntry } from "../src/model.js";
+
+const roots: string[] = [];
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+function npmEntry(
+  overrides: Partial<PublicCatalogEntry> = {},
+): PublicCatalogEntry {
+  return {
+    schemaVersion: 1,
+    id: "vision-helper",
+    name: "Vision Helper",
+    description: { en: "A creator-built vision workflow for DSH users.", evidencePath: "README.md" },
+    unofficial: true,
+    kind: "plugin",
+    primaryCategory: "vision-audio-multimodal",
+    tags: ["vision"],
+    source: {
+      repository: "https://github.com/creator/vision-helper",
+      repositoryNodeId: "R_vision",
+      subpath: null,
+      commit: "b".repeat(40),
+    },
+    creator: { github: "creator" },
+    package: {
+      ecosystem: "npm",
+      name: "@creator/vision-helper",
+      version: "1.2.3",
+      integrity:
+        "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+    },
+    dsh: { profiles: ["web"], evidencePath: "package.json" },
+    repositoryScope: "dedicated",
+    popularity: { starsPolicy: "exact-repository", stars: 10 },
+    license: { spdx: "MIT" },
+    verification: {
+      status: "eligible",
+      checkedAt: "2026-08-16T00:00:00Z",
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+    canonicalKey: "R_vision:.",
+    ...overrides,
+  };
+}
+
+function exitingChild(code: number): EventEmitter {
+  const child = new EventEmitter();
+  queueMicrotask(() => child.emit("close", code, null));
+  return child;
+}
+
+describe("literal DSH delegation", () => {
+  it("passes injection-shaped profile and source values as argv with shell disabled", async () => {
+    const spawn = vi.fn(() => exitingChild(0));
+    expect(
+      await runDsh("web;touch /tmp/no", ["add", "pkg && whoami"], { spawn: spawn as never }),
+    ).toBe(0);
+    expect(spawn).toHaveBeenCalledWith(
+      "dsh",
+      ["plugin", "--profile", "web;touch /tmp/no", "add", "pkg && whoami"],
+      expect.objectContaining({ shell: false, stdio: "inherit" }),
+    );
+  });
+});
+
+describe("verified staging", () => {
+  it("downloads an allowlisted exact npm version and atomically stages only matching SHA-512", async () => {
+    const home = tempRoot("dsh-plugins-npm-");
+    const bytes = Buffer.from("fixture package tarball");
+    const integrity = `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+    const entry = npmEntry({
+      package: { ecosystem: "npm", name: "@creator/vision-helper", version: "1.2.3", integrity },
+    });
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("%40creator%2Fvision-helper")) {
+        return new Response(JSON.stringify({
+          versions: {
+            "1.2.3": {
+              dist: {
+                integrity,
+                tarball: "https://registry.npmjs.org/@creator/vision-helper/-/vision-helper-1.2.3.tgz",
+              },
+            },
+          },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(bytes, { status: 200, headers: { "content-length": String(bytes.length) } });
+    });
+
+    const staged = await stageCatalogEntry(entry, { dshHome: home, fetchImpl: fetchImpl as typeof fetch });
+    expect(staged.packageName).toBe("@creator/vision-helper");
+    expect(staged.installTarget.endsWith(".tgz")).toBe(true);
+    expect(readFileSync(staged.installTarget)).toEqual(bytes);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects checksum mismatch before publishing a cache target", async () => {
+    const home = tempRoot("dsh-plugins-checksum-");
+    const integrity = `sha512-${createHash("sha512").update("expected").digest("base64")}`;
+    const entry = npmEntry({
+      package: { ecosystem: "npm", name: "fixture", version: "1.0.0", integrity },
+    });
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      if (String(input).endsWith("/fixture")) {
+        return new Response(JSON.stringify({
+          versions: { "1.0.0": { dist: { integrity, tarball: "https://registry.npmjs.org/fixture/-/fixture-1.0.0.tgz" } } },
+        }), { status: 200 });
+      }
+      return new Response("different", { status: 200 });
+    });
+    await expect(
+      stageCatalogEntry(entry, { dshHome: home, fetchImpl: fetchImpl as typeof fetch }),
+    ).rejects.toThrow("checksum verification failed");
+  });
+
+  it("blocks non-GitHub source URLs, traversal and symlink escapes", async () => {
+    const home = tempRoot("dsh-plugins-source-");
+    const sourceBase = npmEntry({ package: { ecosystem: "source" } });
+    await expect(stageCatalogEntry({
+      ...sourceBase,
+      source: { ...sourceBase.source, repository: "https://example.com/creator/plugin" },
+    }, { dshHome: home })).rejects.toThrow("source repository is not allowlisted");
+    await expect(stageCatalogEntry({
+      ...sourceBase,
+      source: { ...sourceBase.source, subpath: "../escape" },
+    }, { dshHome: home })).rejects.toThrow("source subpath is unsafe");
+
+    const outside = tempRoot("dsh-plugins-outside-");
+    const runProcess = vi.fn(async (request: { args: readonly string[]; cwd: string }) => {
+      if (request.args.includes("checkout")) {
+        writeFileSync(join(request.cwd, "package.json"), JSON.stringify({ name: "source-plugin" }));
+        symlinkSync(outside, join(request.cwd, "escape"));
+      }
+      return request.args.includes("rev-parse") ? `${sourceBase.source.commit}\n` : "";
+    });
+    await expect(stageCatalogEntry(sourceBase, { dshHome: home, runProcess })).rejects.toThrow(
+      "source tree contains a symlink escape",
+    );
+  });
+});
+
+describe("profile transaction", () => {
+  it("restores the complete observable profile after a failed mutation", async () => {
+    const home = tempRoot("dsh-plugins-profile-");
+    const profile = join(home, "profiles", "web");
+    mkdirSync(profile, { recursive: true });
+    writeFileSync(join(profile, "package.json"), "before\n");
+    const transaction = await beginProfileTransaction(home, "web");
+    writeFileSync(join(profile, "package.json"), "after\n");
+    writeFileSync(join(profile, "pnpm-lock.yaml"), "changed\n");
+    await transaction.rollback();
+    expect(readFileSync(join(profile, "package.json"), "utf8")).toBe("before\n");
+    expect(existsSync(join(profile, "pnpm-lock.yaml"))).toBe(false);
+  });
+
+  it("rejects traversal-shaped profile names before touching disk", async () => {
+    const home = tempRoot("dsh-plugins-profile-name-");
+    await expect(beginProfileTransaction(home, "../outside")).rejects.toThrow("profile name is unsafe");
+  });
+});
+
+describe("idempotent mutation orchestration", () => {
+  const stagedInstall: StagedInstall = {
+    fingerprint: "sha256:fixture",
+    installTarget: "/safe/cache/plugin.tgz",
+    displayTarget: "$DSH_HOME/.dsh-plugins/cache/vision-helper/plugin.tgz",
+    packageName: "@creator/vision-helper",
+    cacheRelativePath: "vision-helper/fixture/plugin.tgz",
+  };
+
+  function fixtureDependencies(state: InstallState = { version: 1, installs: [] }) {
+    let stdout = "";
+    let stderr = "";
+    const artifactLease = {
+      recoveryReference: {
+        relativePath: ".dsh-plugins/artifact-leases/.lease-fixture/artifact.tgz",
+        sha512: `sha512-${"A".repeat(86)}==`,
+        bytes: 128,
+        packageName: "@creator/vision-helper",
+      },
+      revalidate: vi.fn(async () => undefined),
+      readVerifiedBytes: vi.fn(async () => Buffer.alloc(128)),
+      release: vi.fn(async () => undefined),
+    };
+    const staged: StagedCatalogInstall = { ...stagedInstall, artifactLease };
+    const transaction = {
+      recoveryReference: {
+        profile: "web",
+        fencingToken: 1,
+        existed: true,
+        journalRelativePath: "profiles/.dsh-plugins-transaction-web-fixture.json",
+        backupRelativePath: "profiles/.dsh-plugins-backup-web-fixture",
+      },
+      commit: vi.fn(async () => undefined),
+      rollback: vi.fn(async () => undefined),
+    };
+    const lock = {
+      canonicalHome: "/canonical/home",
+      profile: "web",
+      ownerToken: "mutation-owner",
+      fencingToken: 1,
+      assertOwned: vi.fn(async () => undefined),
+      heartbeat: vi.fn(async () => undefined),
+      release: vi.fn(async () => undefined),
+    };
+    const channel = {
+      installTarget: "http://127.0.0.1:43123/secret/artifact.tgz",
+      descriptor: {
+        kind: "loopback-buffer-v1" as const,
+        sha512: artifactLease.recoveryReference.sha512,
+        bytes: artifactLease.recoveryReference.bytes,
+        sourceFingerprint: staged.fingerprint,
+      },
+      close: vi.fn(async () => undefined),
+    };
+    const dependencies = {
+      dshHome: tempRoot("dsh-plugins-mutation-"),
+      acquireLock: vi.fn(async () => lock),
+      readRecoveryJournal: vi.fn(async () => null),
+      stageEntry: vi.fn(async () => staged),
+      runDsh: vi.fn(async () => 0),
+      readState: vi.fn(async () => state),
+      fingerprintActiveProfile: vi.fn(async () => artifactLease.recoveryReference.sha512),
+      writeState: vi.fn(async () => undefined),
+      beginTransaction: vi.fn(async () => transaction),
+      openArtifactChannel: vi.fn(async () => channel),
+      createRecoveryJournal: vi.fn(async (_home, input) => ({
+        version: 1 as const,
+        revision: 1,
+        status: "in_progress" as const,
+        phase: "needs_restore" as const,
+        ...input,
+      })),
+      updateRecoveryJournal: vi.fn(async (_home, current, patch) => ({
+        ...current,
+        ...patch,
+        revision: current.revision + 1,
+      })),
+      removeRecoveryJournal: vi.fn(async () => undefined),
+      stdout: (value: string) => { stdout += value; },
+      stderr: (value: string) => { stderr += value; },
+    };
+    return { dependencies, transaction, lock, artifactLease, output: () => ({ stdout, stderr }) };
+  }
+
+  it("makes dry-run process-free and requires explicit code-execution consent", async () => {
+    const dry = fixtureDependencies();
+    expect(await executePluginMutation({
+      operation: "add", entry: npmEntry(), profile: "web", dryRun: true, allowCodeExecution: false,
+    }, dry.dependencies)).toBe(0);
+    expect(dry.dependencies.stageEntry).not.toHaveBeenCalled();
+    expect(dry.dependencies.runDsh).not.toHaveBeenCalled();
+    expect(dry.output().stdout).toContain("Dry run: no files or processes changed.");
+
+    const blocked = fixtureDependencies();
+    expect(await executePluginMutation({
+      operation: "add", entry: npmEntry(), profile: "web", dryRun: false, allowCodeExecution: false,
+    }, blocked.dependencies)).toBe(2);
+    expect(blocked.dependencies.stageEntry).not.toHaveBeenCalled();
+    expect(blocked.dependencies.runDsh).not.toHaveBeenCalled();
+    expect(blocked.output().stderr).toContain("--allow-code-execution");
+  });
+
+  it("shows the unofficial notice in the pre-spawn code-execution consent message", async () => {
+    const test = fixtureDependencies();
+    expect(await executePluginMutation({
+      operation: "add", entry: npmEntry(), profile: "web", dryRun: false, allowCodeExecution: false,
+    }, test.dependencies)).toBe(2);
+    expect(test.dependencies.runDsh).not.toHaveBeenCalled();
+    expect(test.output().stderr).toBe(
+      "Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.\n" +
+        "Consent required: rerun with --allow-code-execution because DSH delegates to pnpm " +
+        "and may execute package lifecycle code.\n",
+    );
+  });
+
+  it("blocks quarantined and unavailable entries before staging", async () => {
+    for (const status of ["quarantined", "unavailable"] as const) {
+      const test = fixtureDependencies();
+      const entry = npmEntry({ verification: { ...npmEntry().verification, status } });
+      expect(await executePluginMutation({
+        operation: "add", entry, profile: "web", dryRun: false, allowCodeExecution: true,
+      }, test.dependencies)).toBe(1);
+      expect(test.dependencies.stageEntry).not.toHaveBeenCalled();
+      expect(test.output().stderr).toContain(`is ${status} and cannot be installed`);
+    }
+  });
+
+  it("does not spawn when the exact staged fingerprint is already installed", async () => {
+    const test = fixtureDependencies({
+      version: 1,
+      installs: [{
+        id: "vision-helper",
+        profile: "web",
+        packageName: stagedInstall.packageName,
+        fingerprint: stagedInstall.fingerprint,
+        cacheRelativePath: stagedInstall.cacheRelativePath,
+        installedAt: "2026-08-16T00:00:00.000Z",
+      }],
+    });
+    expect(await executePluginMutation({
+      operation: "update", entry: npmEntry(), profile: "web", dryRun: false, allowCodeExecution: true,
+    }, test.dependencies)).toBe(0);
+    expect(test.dependencies.runDsh).not.toHaveBeenCalled();
+    expect(test.dependencies.beginTransaction).not.toHaveBeenCalled();
+    expect(test.output().stdout).toContain("already matches the pinned catalog artifact");
+  });
+
+  it("rolls the profile back and leaves state untouched on DSH failure", async () => {
+    const test = fixtureDependencies();
+    test.dependencies.runDsh.mockResolvedValue(1);
+    expect(await executePluginMutation({
+      operation: "add", entry: npmEntry(), profile: "web", dryRun: false, allowCodeExecution: true,
+    }, test.dependencies)).toBe(1);
+    expect(test.transaction.rollback).toHaveBeenCalledOnce();
+    expect(test.transaction.commit).not.toHaveBeenCalled();
+    expect(test.dependencies.writeState).not.toHaveBeenCalled();
+    expect(test.artifactLease.release).toHaveBeenCalledOnce();
+    expect(test.lock.release).toHaveBeenCalledOnce();
+  });
+
+  it("rolls back an ambiguous timed-out DSH mutation and requires recovery", async () => {
+    const test = fixtureDependencies();
+    test.dependencies.runDsh.mockRejectedValue(new DshExecutionUncertainError("timeout", true));
+
+    expect(await executePluginMutation({
+      operation: "add", entry: npmEntry(), profile: "web", dryRun: false, allowCodeExecution: true,
+    }, test.dependencies)).toBe(1);
+
+    expect(test.transaction.rollback).toHaveBeenCalledOnce();
+    expect(test.transaction.commit).not.toHaveBeenCalled();
+    expect(test.dependencies.writeState).not.toHaveBeenCalled();
+    expect(test.artifactLease.release).toHaveBeenCalledOnce();
+    expect(test.lock.release).toHaveBeenCalledOnce();
+    expect(test.output().stderr).toBe(
+      "dsh execution timed out; result is ambiguous; recovery required\n",
+    );
+  });
+
+  it("revalidates the private artifact only after backup and immediately before DSH", async () => {
+    const test = fixtureDependencies();
+    const order: string[] = [];
+    test.dependencies.beginTransaction.mockImplementation(async () => {
+      order.push("backup");
+      return test.transaction;
+    });
+    test.artifactLease.revalidate.mockImplementation(async () => {
+      order.push("revalidate");
+    });
+    test.dependencies.runDsh.mockImplementation(async () => {
+      order.push("spawn");
+      return 0;
+    });
+    test.artifactLease.release.mockImplementation(async () => {
+      order.push("release");
+    });
+
+    expect(await executePluginMutation({
+      operation: "add", entry: npmEntry(), profile: "web", dryRun: false, allowCodeExecution: true,
+    }, test.dependencies)).toBe(0);
+    expect(order).toEqual(["backup", "revalidate", "spawn", "release"]);
+    expect(test.dependencies.runDsh).toHaveBeenCalledWith(
+      "web",
+      ["add", "http://127.0.0.1:43123/secret/artifact.tgz"],
+      expect.objectContaining({ onSpawn: expect.any(Function) }),
+    );
+  });
+
+  it.each(["timeout", "aborted"] as const)(
+    "retains every recovery resource when a %s leaves the DSH tree unreaped",
+    async (reason) => {
+      const test = fixtureDependencies({ version: 1, generation: 0, fencingToken: 0, installs: [] });
+      const processTree: DshProcessTreeIdentity = {
+        pid: 7_777,
+        processGroupId: 7_777,
+        treeIdentity: "linux:987654",
+        processStartIdentity: "linux:987654",
+        platform: "linux",
+      };
+      test.dependencies.runDsh.mockRejectedValue(
+        new DshExecutionUncertainError(reason, false, processTree),
+      );
+
+      expect(await executePluginMutation({
+        operation: "add", entry: npmEntry(), profile: "web", dryRun: false, allowCodeExecution: true,
+      }, test.dependencies)).toBe(1);
+
+      expect(test.transaction.rollback).not.toHaveBeenCalled();
+      expect(test.transaction.commit).not.toHaveBeenCalled();
+      expect(test.artifactLease.release).not.toHaveBeenCalled();
+      expect(test.lock.release).not.toHaveBeenCalled();
+      expect(test.dependencies.writeState).toHaveBeenCalledWith(
+        test.dependencies.dshHome,
+        expect.objectContaining({
+          recoveryRequired: expect.objectContaining({
+            status: "recovery_required",
+            profile: "web",
+            fencingToken: 1,
+            processTree,
+            artifact: test.artifactLease.recoveryReference,
+            transaction: test.transaction.recoveryReference,
+          }),
+        }),
+        expect.objectContaining({ expectedGeneration: 0, fencingToken: 1 }),
+      );
+    },
+  );
+
+  it("treats removal of an absent catalog-managed install as success", async () => {
+    const test = fixtureDependencies();
+    expect(await executePluginMutation({
+      operation: "remove", entry: npmEntry(), profile: "web", dryRun: false, allowCodeExecution: false,
+    }, test.dependencies)).toBe(0);
+    expect(test.dependencies.stageEntry).not.toHaveBeenCalled();
+    expect(test.dependencies.runDsh).not.toHaveBeenCalled();
+    expect(test.output().stdout).toContain("is not installed by dsh-plugins");
+  });
+});

--- a/cli/tests/staging-git-reap.test.ts
+++ b/cli/tests/staging-git-reap.test.ts
@@ -1,0 +1,98 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ChildSpawn, ProcessGroupSignaler } from "../src/dsh/childSupervisor.js";
+import { stageCatalogEntry } from "../src/dsh/staging.js";
+import type { PublicCatalogEntry } from "../src/model.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function sourceEntry(): PublicCatalogEntry {
+  return {
+    schemaVersion: 1,
+    id: "unreaped-source",
+    name: "Unreaped Source",
+    description: { en: "A source process fixture.", evidencePath: "README.md" },
+    unofficial: true,
+    kind: "plugin",
+    primaryCategory: "developer-tools",
+    tags: ["test"],
+    source: {
+      repository: "https://github.com/creator/unreaped-source",
+      repositoryNodeId: "R_unreaped",
+      subpath: null,
+      commit: "d".repeat(40),
+    },
+    creator: { github: "creator" },
+    package: { ecosystem: "source" },
+    dsh: { profiles: ["web"], evidencePath: "package.json" },
+    repositoryScope: "dedicated",
+    popularity: { starsPolicy: "exact-repository", stars: 1 },
+    license: { spdx: "MIT" },
+    verification: {
+      status: "eligible",
+      checkedAt: "2026-08-16T00:00:00Z",
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+    canonicalKey: "R_unreaped:.",
+  };
+}
+
+describe("source Git reap boundary", () => {
+  it("returns a bounded typed error and preserves the work area when the process tree never closes", async () => {
+    const home = mkdtempSync(join(tmpdir(), "dsh-staging-unreaped-"));
+    roots.push(home);
+    const events = new EventEmitter();
+    const child = Object.assign(events, {
+      pid: 7_777,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exitCode: null,
+      signalCode: null,
+      kill: () => true,
+      unref: () => undefined,
+    }) as unknown as ChildProcess;
+    const spawn = (() => child) as ChildSpawn;
+    const signals: Array<{ group: number; signal: NodeJS.Signals }> = [];
+    const signalProcessGroup: ProcessGroupSignaler = (group, signal) => {
+      signals.push({ group, signal });
+      return true;
+    };
+
+    const guarded = Promise.race([
+      stageCatalogEntry(sourceEntry(), {
+        dshHome: home,
+        budgets: { gitTimeoutMs: 10, killGraceMs: 10, gitReapTimeoutMs: 20 },
+        childSupervisor: { spawn, signalProcessGroup },
+      }),
+      new Promise<never>((_resolve, reject) => {
+        setTimeout(() => reject(new Error("source Git reap boundary stayed pending")), 250);
+      }),
+    ]);
+
+    await expect(guarded).rejects.toMatchObject({
+      name: "GitProcessUnreapedError",
+      reaped: false,
+      recoveryRequired: true,
+    });
+    expect(signals).toEqual([
+      { group: -7_777, signal: "SIGTERM" },
+      { group: -7_777, signal: "SIGKILL" },
+    ]);
+    const cacheRoot = join(home, ".dsh-plugins", "cache", "unreaped-source");
+    expect(readdirSync(cacheRoot).some((name) => name.startsWith(".unreaped-"))).toBe(true);
+    expect(readdirSync(cacheRoot).some((name) => name.startsWith(".stage-"))).toBe(false);
+  });
+});

--- a/cli/tests/staging-hardening.test.ts
+++ b/cli/tests/staging-hardening.test.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_STAGE_BUDGETS,
+  stageCatalogEntry,
+  type ProcessRequest,
+} from "../src/dsh/staging.js";
+import type { PublicCatalogEntry } from "../src/model.js";
+
+const roots: string[] = [];
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+function entryFor(
+  packageDescriptor: PublicCatalogEntry["package"],
+): PublicCatalogEntry {
+  return {
+    schemaVersion: 1,
+    id: "bounded-plugin",
+    name: "Bounded Plugin",
+    description: { en: "A bounded test plugin.", evidencePath: "README.md" },
+    unofficial: true,
+    kind: "plugin",
+    primaryCategory: "developer-tools",
+    tags: ["test"],
+    source: {
+      repository: "https://github.com/creator/bounded-plugin",
+      repositoryNodeId: "R_bounded",
+      subpath: null,
+      commit: "b".repeat(40),
+    },
+    creator: { github: "creator" },
+    package: packageDescriptor,
+    dsh: { profiles: ["web"], evidencePath: "package.json" },
+    repositoryScope: "dedicated",
+    popularity: { starsPolicy: "exact-repository", stars: 1 },
+    license: { spdx: "MIT" },
+    verification: {
+      status: "eligible",
+      checkedAt: "2026-08-16T00:00:00Z",
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+    canonicalKey: "R_bounded:.",
+  };
+}
+
+function npmFixture(bytes = Buffer.from("verified tarball")) {
+  const integrity = `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+  const entry = entryFor({
+    ecosystem: "npm",
+    name: "@creator/bounded-plugin",
+    version: "1.2.3",
+    integrity,
+  });
+  const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+    if (String(input).includes("%40creator%2Fbounded-plugin")) {
+      return new Response(JSON.stringify({
+        versions: {
+          "1.2.3": {
+            dist: {
+              integrity,
+              tarball:
+                "https://registry.npmjs.org/@creator/bounded-plugin/-/bounded-plugin-1.2.3.tgz",
+            },
+          },
+        },
+      }), { status: 200 });
+    }
+    return new Response(bytes, {
+      status: 200,
+      headers: { "content-length": String(bytes.length) },
+    });
+  });
+  return { bytes, entry, fetchImpl };
+}
+
+describe("immutable cache acceptance", () => {
+  it("rehashes a cached npm tarball and quarantines then refetches tampered content", async () => {
+    const home = tempRoot("dsh-cache-rehash-");
+    const fixture = npmFixture();
+    const first = await stageCatalogEntry(fixture.entry, {
+      dshHome: home,
+      fetchImpl: fixture.fetchImpl as typeof fetch,
+    });
+    writeFileSync(
+      join(home, ".dsh-plugins", "cache", first.cacheRelativePath),
+      "tampered-cache-content",
+    );
+
+    const second = await stageCatalogEntry(fixture.entry, {
+      dshHome: home,
+      fetchImpl: fixture.fetchImpl as typeof fetch,
+    });
+
+    expect(fixture.fetchImpl).toHaveBeenCalledTimes(4);
+    expect(readFileSync(second.installTarget)).toEqual(fixture.bytes);
+    expect(readdirSync(join(home, ".dsh-plugins", "cache", "bounded-plugin")))
+      .not.toContain(expect.stringContaining("quarantine"));
+  });
+
+  it("never accepts a tampered or symlinked npm cache while offline", async () => {
+    const home = tempRoot("dsh-cache-offline-");
+    const outside = join(tempRoot("dsh-cache-outside-"), "outside.tgz");
+    writeFileSync(outside, "attacker content");
+    const fixture = npmFixture();
+    const staged = await stageCatalogEntry(fixture.entry, {
+      dshHome: home,
+      fetchImpl: fixture.fetchImpl as typeof fetch,
+    });
+    const cachedArtifact = join(home, ".dsh-plugins", "cache", staged.cacheRelativePath);
+    rmSync(cachedArtifact);
+    symlinkSync(outside, cachedArtifact);
+    const fetchImpl = vi.fn(async () => new Response("must not fetch"));
+
+    await expect(stageCatalogEntry(fixture.entry, {
+      dshHome: home,
+      fetchImpl: fetchImpl as typeof fetch,
+      offline: true,
+    })).rejects.toThrow("cached artifact failed verification while offline");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rehashes the complete source cache and checks its commit pin metadata", async () => {
+    const home = tempRoot("dsh-source-cache-");
+    const entry = entryFor({ ecosystem: "source" });
+    const runProcess = vi.fn(async (request: ProcessRequest) => {
+      if (request.args.includes("checkout")) {
+        writeFileSync(join(request.cwd, "package.json"), JSON.stringify({ name: "source-plugin" }));
+        writeFileSync(join(request.cwd, "index.js"), "export default 1;\n");
+      }
+      return request.args.includes("rev-parse") ? `${entry.source.commit}\n` : "";
+    });
+    const staged = await stageCatalogEntry(entry, { dshHome: home, runProcess });
+    writeFileSync(
+      join(home, ".dsh-plugins", "cache", staged.cacheRelativePath, "index.js"),
+      "tampered\n",
+    );
+
+    await expect(stageCatalogEntry(entry, {
+      dshHome: home,
+      runProcess,
+      offline: true,
+    })).rejects.toThrow("cached artifact failed verification while offline");
+  });
+});
+
+describe("bounded downloads", () => {
+  it("cancels a chunked body immediately after the configured byte budget", async () => {
+    const home = tempRoot("dsh-stream-limit-");
+    const fixture = npmFixture();
+    let pulls = 0;
+    let cancellations = 0;
+    const fetchImpl = vi.fn(async () => new Response(new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(600));
+        if (pulls === 10) controller.close();
+      },
+      cancel() {
+        cancellations += 1;
+      },
+    }, { highWaterMark: 0 }), { status: 200 }));
+
+    await expect(stageCatalogEntry(fixture.entry, {
+      dshHome: home,
+      fetchImpl: fetchImpl as typeof fetch,
+      budgets: { metadataBytes: 1024 },
+    })).rejects.toThrow("download exceeds the safe size limit");
+    expect(pulls).toBeLessThanOrEqual(2);
+    expect(cancellations).toBe(1);
+  });
+
+  it("rejects malformed and understated Content-Length values", async () => {
+    for (const contentLength of ["invalid", "1"]) {
+      const home = tempRoot("dsh-content-length-");
+      const fixture = npmFixture();
+      const fetchImpl = vi.fn(async () => new Response("not-one-byte", {
+        status: 200,
+        headers: { "content-length": contentLength },
+      }));
+      await expect(stageCatalogEntry(fixture.entry, {
+        dshHome: home,
+        fetchImpl: fetchImpl as typeof fetch,
+      })).rejects.toThrow("download Content-Length is invalid");
+    }
+  });
+
+  it("aborts a fetch that never resolves within the configured deadline", async () => {
+    const home = tempRoot("dsh-fetch-deadline-");
+    const fixture = npmFixture();
+    let aborted = false;
+    const fetchImpl = vi.fn((_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          aborted = true;
+          reject(new DOMException("aborted", "AbortError"));
+        }, { once: true });
+      }));
+
+    await expect(stageCatalogEntry(fixture.entry, {
+      dshHome: home,
+      fetchImpl: fetchImpl as typeof fetch,
+      budgets: { fetchTimeoutMs: 20 },
+    })).rejects.toThrow("download timed out");
+    expect(aborted).toBe(true);
+  });
+});
+
+describe("bounded source materialization", () => {
+  it("enforces configured byte, file and path-depth budgets and cleans temporary staging", async () => {
+    const home = tempRoot("dsh-source-budget-");
+    const entry = entryFor({ ecosystem: "source" });
+    const runProcess = vi.fn(async (request: ProcessRequest) => {
+      if (request.args.includes("checkout")) {
+        writeFileSync(join(request.cwd, "package.json"), JSON.stringify({ name: "source-plugin" }));
+        mkdirSync(join(request.cwd, "a", "b", "c"), { recursive: true });
+        writeFileSync(join(request.cwd, "a", "b", "c", "large.bin"), Buffer.alloc(256));
+      }
+      return request.args.includes("rev-parse") ? `${entry.source.commit}\n` : "";
+    });
+
+    await expect(stageCatalogEntry(entry, {
+      dshHome: home,
+      runProcess,
+      budgets: { sourceBytes: 128, sourceFiles: 3, sourceDepth: 2 },
+    })).rejects.toThrow(/source tree exceeds the (byte|file|depth) limit/u);
+    const idRoot = join(home, ".dsh-plugins", "cache", "bounded-plugin");
+    expect(existsSync(idRoot) ? readdirSync(idRoot).some((name) => name.startsWith(".stage-")) : false)
+      .toBe(false);
+  });
+
+  it("rejects submodules and Git LFS pointer content", async () => {
+    const entry = entryFor({ ecosystem: "source" });
+    for (const unsafe of ["submodule", "lfs"] as const) {
+      const home = tempRoot(`dsh-source-${unsafe}-`);
+      const runProcess = vi.fn(async (request: ProcessRequest) => {
+        if (request.args.includes("checkout")) {
+          writeFileSync(join(request.cwd, "package.json"), JSON.stringify({ name: "source-plugin" }));
+          if (unsafe === "submodule") {
+            writeFileSync(join(request.cwd, ".gitmodules"), "[submodule \"x\"]\n");
+          } else {
+            writeFileSync(
+              join(request.cwd, "asset.bin"),
+              "version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 1\n",
+            );
+          }
+        }
+        return request.args.includes("rev-parse") ? `${entry.source.commit}\n` : "";
+      });
+      await expect(stageCatalogEntry(entry, { dshHome: home, runProcess })).rejects.toThrow(
+        unsafe === "submodule" ? "source tree contains submodules" : "source tree contains Git LFS content",
+      );
+    }
+  });
+
+  it("exports finite defaults for every network, process and source resource budget", () => {
+    expect(DEFAULT_STAGE_BUDGETS).toMatchObject({
+      metadataBytes: expect.any(Number),
+      tarballBytes: expect.any(Number),
+      sourceBytes: expect.any(Number),
+      sourceFiles: expect.any(Number),
+      sourceDepth: expect.any(Number),
+      fetchTimeoutMs: expect.any(Number),
+      gitTimeoutMs: expect.any(Number),
+      killGraceMs: expect.any(Number),
+      gitReapTimeoutMs: expect.any(Number),
+    });
+    for (const value of Object.values(DEFAULT_STAGE_BUDGETS)) {
+      expect(value).toBeGreaterThan(0);
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+});

--- a/cli/tests/windows-documentation-policy.test.ts
+++ b/cli/tests/windows-documentation-policy.test.ts
@@ -1,0 +1,58 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { doctorCommand } from "../src/commands/doctor.js";
+
+describe("native Windows mutation policy documentation", () => {
+  it("keeps CLI help and README aligned with the fail-closed v0.1.0 boundary", async () => {
+    const [app, readme, doctor] = await Promise.all([
+      readFile(new URL("../src/app.ts", import.meta.url), "utf8"),
+      readFile(new URL("../README.md", import.meta.url), "utf8"),
+      readFile(new URL("../src/commands/doctor.ts", import.meta.url), "utf8"),
+    ]);
+
+    for (const text of [app, readme, doctor]) {
+      expect(text).toMatch(/native Windows/iu);
+      expect(text).toMatch(/WSL/u);
+    }
+    expect(readme).not.toMatch(/Windows[^\n]*whole[- ]tree[^\n]*(?:safe|proof)/iu);
+  });
+
+  it("reports the native Windows mutation boundary without probing process-tree recovery", async () => {
+    const output: string[] = [];
+    const isProcessTreeAlive = vi.fn(async () => false);
+    const exitCode = await doctorCommand(
+      {
+        loadCatalog: async () => ({
+          source: { kind: "directory" },
+          entries: [],
+          diagnostics: [],
+        }),
+        stdout: (value) => output.push(value),
+        stderr: (value) => output.push(value),
+      },
+      undefined,
+      false,
+      {
+        platform: "win32",
+        nodeVersion: "20.0.0",
+        probeDsh: async () => ({ status: "present", version: "1.2.3" }),
+        resolveHome: () => "/unused",
+        readState: async () => ({
+          version: 1,
+          installs: [],
+          recoveryRequired: {
+            processTree: { platform: "win32" },
+          },
+        } as never),
+        isProcessTreeAlive,
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(output.join("")).toMatch(/native Windows.*WSL/iu);
+    expect(output.join("")).toMatch(/manual/iu);
+    expect(isProcessTreeAlive).not.toHaveBeenCalled();
+  });
+});

--- a/cli/tests/windows-mutation-policy.test.ts
+++ b/cli/tests/windows-mutation-policy.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executePluginMutation,
+  recoverPluginMutation,
+} from "../src/commands/mutate.js";
+import type { MutationRecoveryJournal } from "../src/dsh/mutationRecoveryJournal.js";
+import type { PublicCatalogEntry } from "../src/model.js";
+
+const entry: PublicCatalogEntry = {
+  schemaVersion: 1,
+  id: "fixture-plugin",
+  name: "Fixture Plugin",
+  description: { en: "Windows policy fixture.", evidencePath: "README.md" },
+  unofficial: true,
+  kind: "plugin",
+  primaryCategory: "developer-tools",
+  tags: ["fixture"],
+  source: {
+    repository: "https://github.com/creator/fixture-plugin",
+    repositoryNodeId: "R_fixture",
+    subpath: null,
+    commit: "a".repeat(40),
+  },
+  creator: { github: "creator" },
+  package: { ecosystem: "npm", name: "fixture-plugin", version: "1.0.0" },
+  dsh: { profiles: ["web"], evidencePath: "package.json" },
+  repositoryScope: "dedicated",
+  popularity: { starsPolicy: "exact-repository", stars: 1 },
+  license: { spdx: "MIT" },
+  verification: {
+    status: "eligible",
+    checkedAt: "2026-08-16T00:00:00.000Z",
+    repositoryIdentity: "resolved",
+    smokeTest: null,
+  },
+  provenance: { discussion: null, comment: null },
+  canonicalKey: "R_fixture:.",
+};
+
+describe("Windows mutation safety policy", () => {
+  it("blocks add/update/remove before lock, state, staging, or spawn and points to WSL", async () => {
+    for (const operation of ["add", "update", "remove"] as const) {
+      const stderr = vi.fn();
+      const acquireLock = vi.fn();
+      const readState = vi.fn();
+      const stageEntry = vi.fn();
+      const runDsh = vi.fn();
+      expect(await executePluginMutation({
+        operation,
+        ...(operation === "remove" ? { id: "fixture-plugin" } : { entry }),
+        profile: "web",
+        dryRun: false,
+        allowCodeExecution: true,
+      }, {
+        platform: "win32",
+        acquireLock,
+        readState,
+        stageEntry,
+        runDsh,
+        stdout: vi.fn(),
+        stderr,
+      })).toBe(1);
+      expect(acquireLock).not.toHaveBeenCalled();
+      expect(readState).not.toHaveBeenCalled();
+      expect(stageEntry).not.toHaveBeenCalled();
+      expect(runDsh).not.toHaveBeenCalled();
+      expect(stderr).toHaveBeenCalledWith(expect.stringMatching(/Windows.*WSL/iu));
+    }
+  });
+
+  it("keeps dry-run available without touching mutation dependencies", async () => {
+    const acquireLock = vi.fn();
+    expect(await executePluginMutation({
+      operation: "add",
+      entry,
+      profile: "web",
+      dryRun: true,
+      allowCodeExecution: false,
+    }, {
+      platform: "win32",
+      acquireLock,
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    })).toBe(0);
+    expect(acquireLock).not.toHaveBeenCalled();
+  });
+
+  it("never automatically clears a Windows recovery marker with incomplete membership proof", async () => {
+    const marker = {
+      version: 1,
+      revision: 4,
+      status: "recovery_required",
+      phase: "needs_restore",
+      ownerToken: "old-owner",
+      fencingToken: 7,
+      profile: "web",
+      transaction: {
+        profile: "web",
+        fencingToken: 7,
+        existed: true,
+        journalRelativePath: "profiles/.dsh-plugins-transaction-web-windows.json",
+        backupRelativePath: "profiles/.dsh-plugins-backup-web-windows",
+        backupFingerprint: `sha512-${"A".repeat(86)}==`,
+      },
+      artifact: null,
+      channel: null,
+      processTree: {
+        pid: 4_001,
+        processGroupId: null,
+        treeIdentity: "win32:incomplete",
+        processStartIdentity: "root-created",
+        platform: "win32",
+        members: [{ pid: 4_001, creationIdentity: "root-created" }],
+      },
+      createdAt: "2026-08-16T00:00:00.000Z",
+    } as MutationRecoveryJournal;
+    const recoverTransaction = vi.fn();
+    const removeRecoveryJournal = vi.fn();
+    const isProcessTreeAlive = vi.fn(async () => false);
+    const stderr = vi.fn();
+
+    expect(await recoverPluginMutation({
+      dshHome: "/canonical/home",
+      platform: "win32",
+      acquireLock: vi.fn(async () => ({
+        canonicalHome: "/canonical/home",
+        profile: "web",
+        ownerToken: "new-owner",
+        fencingToken: 8,
+        assertOwned: vi.fn(async () => undefined),
+        heartbeat: vi.fn(async () => undefined),
+        release: vi.fn(async () => undefined),
+      })),
+      readRecoveryJournal: vi.fn(async () => marker),
+      isProcessTreeAlive,
+      recoverTransaction,
+      removeRecoveryJournal,
+      stdout: vi.fn(),
+      stderr,
+    })).toBe(1);
+
+    expect(isProcessTreeAlive).not.toHaveBeenCalled();
+    expect(recoverTransaction).not.toHaveBeenCalled();
+    expect(removeRecoveryJournal).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(expect.stringMatching(/Windows.*manual/iu));
+  });
+});

--- a/cli/tests/windows-tree-proof.test.ts
+++ b/cli/tests/windows-tree-proof.test.ts
@@ -1,0 +1,94 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isDshProcessTreeAlive,
+  runDsh,
+  type DshProcessTreeIdentity,
+} from "../src/dsh/runDsh.js";
+
+interface FakeChild extends EventEmitter {
+  readonly pid: number;
+  readonly stdout: PassThrough;
+  readonly kill: ReturnType<typeof vi.fn>;
+}
+
+function child(pid: number): FakeChild {
+  const value = new EventEmitter() as FakeChild;
+  Object.defineProperties(value, {
+    pid: { value: pid },
+    stdout: { value: new PassThrough() },
+    kill: { value: vi.fn(() => true) },
+  });
+  return value;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const identity: DshProcessTreeIdentity = {
+  pid: 100,
+  processGroupId: null,
+  treeIdentity: "win32:100:root-created",
+  processStartIdentity: "root-created",
+  platform: "win32",
+  members: [
+    { pid: 100, creationIdentity: "root-created" },
+    { pid: 101, creationIdentity: "child-created" },
+  ],
+};
+
+describe("Windows whole-tree proof", () => {
+  it("reports alive when the root exited but a recorded descendant still has the same identity", async () => {
+    await expect(isDshProcessTreeAlive(identity, {
+      snapshotWindowsTree: vi.fn(async () => [
+        { pid: 101, creationIdentity: "child-created" },
+      ]),
+    })).resolves.toBe(true);
+  });
+
+  it("does not confuse a reused PID with the recorded process", async () => {
+    await expect(isDshProcessTreeAlive(identity, {
+      snapshotWindowsTree: vi.fn(async () => [
+        { pid: 100, creationIdentity: "different-creation" },
+        { pid: 101, creationIdentity: "different-child" },
+      ]),
+    })).resolves.toBe(false);
+  });
+
+  it.each(["pending", "failed"] as const)(
+    "returns reaped:false when taskkill is %s even if the root closes",
+    async (mode) => {
+      vi.useFakeTimers();
+      const root = child(200);
+      const killer = child(201);
+      const execution = runDsh("web", ["add", "http://127.0.0.1/artifact.tgz"], {
+        spawn: vi.fn(() => root) as never,
+        platform: "win32",
+        timeoutMs: 20,
+        terminationGraceMs: 10,
+        reapTimeoutMs: 10,
+        taskkillSpawn: vi.fn(() => killer) as never,
+        identifyProcessTree: async () => "win32:200:root-created",
+        snapshotWindowsTree: vi.fn(async () => [
+          { pid: 201, creationIdentity: "child-created" },
+        ]),
+      });
+      const rejection = expect(execution).rejects.toMatchObject({
+        name: "DshExecutionUncertainError",
+        reason: "timeout",
+        reaped: false,
+      });
+
+      await vi.advanceTimersByTimeAsync(20);
+      root.emit("close", null, "SIGKILL");
+      if (mode === "failed") killer.emit("close", 1, null);
+      await vi.advanceTimersByTimeAsync(30);
+      await rejection;
+    },
+  );
+});

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    // The CLI spawns real child processes and touches a temporary DSH home in several suites,
+    // so tests get room to finish rather than a default that trims the slowest honest ones.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
The CLI is how people install plugins from this catalog, so it belongs in the repository that holds the catalog — not in the private curation engine, which nobody needs access to in order to use a plugin.

## Why this is more than a move

npm **provenance attestation requires a public source repository**. From the engine the package could only ever ship unattested, and its README had to ask readers to take a private build on faith:

> built from a private source repository. It contains no private harvesting logic, candidate ledger, credentials or source maps.

Published from here, the binary carries an attestation tying it to the commit and workflow run that produced it — something a reader can verify instead of trust.

## What came along, and what did not

**Came:** the CLI sources and their 173 tests, plus the six modules that define what a catalog entry *is* — bundle marker, canonical keys, entry loading, the public schema and its validators (`cli/src/catalog/`).

**Did not:** everything that *curates* a catalog — which repository is a copy of another, duplicate ranking, sweep cursors, the harvest ledger, the publication orchestrator.

That boundary is not self-enforcing; vendoring "one more helper" from the same origin is exactly how an engine leaks into a client. `catalog-slice-boundary.test.ts` pins the allowed file list and asserts no curation identifier appears **either** in the vendored sources **or** in the bundle that actually ships — source purity alone would not be enough, since esbuild decides what survives.

## Three things the move corrected

- **Comments leaked private architecture.** The vendored files documented the engine's internals — package names, file paths, digest schemes. Useless to a CLI reader and no business being in a public repo; rewritten to describe the public contract.
- **Tests climbed between checkouts.** They reached the catalog schema via `../../../../awesome-omni-dsh-plugins/`. The schema is a sibling now.
- **`DEFAULT_CATALOG_REVISION` was stale** — it pointed at a 10-entry revision from before the catalog grew, so a fresh install defaulted to a nearly empty catalog. Now the current tip (160 entries).

## Release

`.github/workflows/release-npm.yml`: owner-dispatched, `main` only, OIDC trusted publishing with **no token anywhere**, exact four-file tarball verification, and a smoke that installs the packed tarball and **reads** what `--version` answers — running it without reading the output is what once let a build reach a release gate still calling itself by the previous version.

`.github/workflows/cli.yml` runs typecheck, tests, build and that same version assertion on every PR.

## Checks

`tsc --noEmit` clean · `vitest` **177/177** · `npm run build` clean · packed tarball is exactly 4 files · `node dist/bin.js --version` → `1.0.0`.

**Still blocked on you:** the npm trusted publisher must be configured to point at **this** repository and `release-npm.yml` before `1.0.0` can publish. The companion PR removing the CLI and its release workflow from the private engine follows after this merges.
