### PR TITLE
ci(release): publish verbosely so an OIDC rejection is distinguishable from a permission one

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -109,7 +109,13 @@ jobs:
       # --provenance is possible here and was not in the previous home: attestation requires a
       # public source repository, so moving the CLI beside the catalog is what lets an installer
       # trace this binary back to the commit and workflow run that built it.
+      # --loglevel verbose on purpose: without it npm prints only the final error, and the two
+      # failures that actually happen here are indistinguishable from it. A rejected OIDC
+      # exchange ("package not found" on /-/npm/v1/oidc/token/exchange) means no trusted
+      # publisher matches this repository and workflow; a 404 on the PUT afterwards means a
+      # credential was issued but may not write this package. A release that fails opaquely
+      # costs a round trip through a web UI nobody can read from here.
       - name: Publish
         run: |
           set -eu
-          npm publish "./$(cat /tmp/tarball-name)" --access public --provenance
+          npm publish "./$(cat /tmp/tarball-name)" --access public --provenance --loglevel verbose


### PR DESCRIPTION
The 1.0.0 publish failed with a bare `E404` on the PUT after every other step passed (tests, build, exact four-file tarball, packed-tarball smoke). Provenance was signed and logged to Sigstore, but that happens against GitHub's OIDC and Sigstore — it does **not** prove npm's trusted-publisher exchange succeeded.

Without `--loglevel verbose` npm prints only the final error, and two very different causes are indistinguishable:

- **no trusted publisher matches** this repository + workflow → the exchange is rejected (`/-/npm/v1/oidc/token/exchange … package not found`), which is what the previous attempt from the private repo showed;
- **a credential was issued but cannot write this package** → 404 on the PUT, which is what we see now.

The first is a settings change, the second a workflow change. Neither is readable from the logs as they stand, and the npm settings page is not reachable from CI.