### PR TITLE
cli: publish under the unscoped name omni-dsh-plugins

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -20,6 +20,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      # Validate with the CLI in THIS commit, not a version frozen on the registry. While the CLI
+      # lived elsewhere, `npx omni-dsh-plugins@<version>` was the only way to reach it — which made
+      # the catalog's required check depend on a package this repository itself publishes, so a
+      # rename or a first release could not pass its own gate. Building from cli/ also means a
+      # pull request that changes the validator is checked by the validator it changes.
+      - name: Build the CLI from this commit
+        working-directory: cli
+        run: |
+          npm ci
+          npm run build
+
       - name: Validate catalog
-        run: npx --yes omni-dsh-plugins@0.1.0 catalog validate --catalog .
+        run: node cli/dist/bin.js catalog validate --catalog .

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           node-version: 22
       - name: Validate catalog
-        run: npx --yes @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+        run: npx --yes omni-dsh-plugins@0.1.0 catalog validate --catalog .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,16 +158,16 @@ or verified co-author, but must not replace the creator's authorship. See
 
 ## Validation commands and availability
 
-The npm CLI is published as `@diegosouza.pw/dsh-plugins@0.1.0`, so the commands below are
+The npm CLI is published as `omni-dsh-plugins@1.0.0`, so the commands below are
 available through `npx` today. Use them exactly as written; contributors should not invent
 substitute commands.
 
 Run these commands from the repository root:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` performs only the local YAML, schema, SPDX, exact SemVer, SHA-512 SRI and

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Creator-first discovery and one-command installation for **DeepSeek Harness (DSH
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ repository, pinned at the exact commit the catalog validated.
 | **Website** | Rendered catalog browser with search and ranking                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Catalog** | One YAML file per plugin, the single source of truth             | [`catalog/plugins/`](catalog/plugins)                                    |
 | **Schema**  | Public JSON Schema (draft 2020-12) every entry validates against | [`schemas/plugin.schema.yaml`](schemas/plugin.schema.yaml)               |
-| **CLI**     | Search, inspect, validate and install from the catalog           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Search, inspect, validate and install from the catalog           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Machine feeds** | `catalog.json` + `catalog.snapshot.json` for tools           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 This repository is the public source of truth for the catalog. Every listing is one YAML file
@@ -115,8 +115,8 @@ individually reviewed pull request, and always credited to the plugin's original
 Nothing in the catalog is generated from another catalog or list: each entry is reconstructed
 from the original creator repository at a pinned commit.
 
-The website and the CLI are maintained from private source; this repository carries the public
-catalog data, schema and policies they consume.
+The website is maintained from private source. The CLI lives here, under [`cli/`](cli), and this
+repository carries the public catalog data, schema and policies they both consume.
 
 ## Catalog status
 
@@ -127,15 +127,15 @@ attribution.
 ## 🚀 Install the CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-The scoped package is published as `@diegosouza.pw/dsh-plugins@0.1.0` and the command above is
+The package is published as `omni-dsh-plugins@1.0.0` and the command above is
 the canonical invocation today; no installer script is hosted here.
 
 ### Use the CLI today
 
-Version 0.1.0 ships read-only discovery and validation commands plus consent-gated install
+Version 1.0.0 ships read-only discovery and validation commands plus consent-gated install
 commands. The full command reference, including flags, exit codes and the code-execution
 consent gate, is in [docs/CLI.md](docs/CLI.md).
 
@@ -151,18 +151,18 @@ consent gate, is in [docs/CLI.md](docs/CLI.md).
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Mutating commands (`add`, `update`, `remove`) never execute plugin lifecycle code unless you
-pass `--allow-code-execution`. On native Windows those mutations are disabled in v0.1.0; use
+pass `--allow-code-execution`. On native Windows those mutations are disabled in v1.0.0; use
 WSL. Read-only and dry-run commands work everywhere.
 
 ## 🔍 How a plugin enters the catalog
@@ -305,7 +305,7 @@ if someone cataloged your work before you did.
 | [CONTRIBUTING.md](CONTRIBUTING.md)           | The full contribution contract: evidence, YAML rules, review gates    |
 | [SECURITY.md](SECURITY.md)                   | Reporting plugin or catalog vulnerabilities; secrets policy           |
 | [docs/SCHEMA.md](docs/SCHEMA.md)             | Field-by-field reference for `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](docs/CLI.md)                   | CLI command reference for `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](docs/CLI.md)                   | CLI command reference for `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](docs/GOVERNANCE.md)     | How the catalog is governed: precedence, gates, claims and removals   |
 | [docs/CATEGORIES.md](docs/CATEGORIES.md)     | Artifact kinds, primary capability categories, tags, repository scope |
 | [docs/CREDIT.md](docs/CREDIT.md)             | Creator credit, PR precedence and Git identity policy                 |

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,13 +1,13 @@
-# @diegosouza.pw/dsh-plugins
+# omni-dsh-plugins
 
 > **Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.**
 > DeepSeek names and marks belong to their respective owner.
 
-`@diegosouza.pw/dsh-plugins` is a thin catalog client and safety boundary for public DeepSeek
+`omni-dsh-plugins` is a thin catalog client and safety boundary for public DeepSeek
 Harness (DSH) plugin entries. Its canonical invocation is:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
 The npm artifact is MIT-licensed executable JavaScript built from the sources in
@@ -28,14 +28,14 @@ never ships here.
 ## Discover and validate
 
 ```bash
-npx @diegosouza.pw/dsh-plugins search vision
-npx @diegosouza.pw/dsh-plugins info example-plugin
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog ./awesome-omni-dsh-plugins
-npx @diegosouza.pw/dsh-plugins catalog validate \
+npx omni-dsh-plugins search vision
+npx omni-dsh-plugins info example-plugin
+npx omni-dsh-plugins catalog validate --catalog ./awesome-omni-dsh-plugins
+npx omni-dsh-plugins catalog validate \
   --catalog ./awesome-omni-dsh-plugins \
   --revision <40-character-commit>
-npx @diegosouza.pw/dsh-plugins catalog docs-check ./awesome-omni-dsh-plugins
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check ./awesome-omni-dsh-plugins
+npx omni-dsh-plugins catalog docs-check ./awesome-omni-dsh-plugins
+npx omni-dsh-plugins catalog github-forms-check ./awesome-omni-dsh-plugins
 ```
 
 An empty catalog is valid and reports `0 entries valid; catalog is empty`. `catalog validate`
@@ -50,7 +50,7 @@ signed snapshot manifest.
 Preview an operation without downloads, file changes or subprocesses:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins add example-plugin --profile web --dry-run
+npx omni-dsh-plugins add example-plugin --profile web --dry-run
 ```
 
 Dry-run is strictly syntactic. It does not load a local or remote catalog and does not read or
@@ -61,18 +61,18 @@ may execute during that delegated step. The CLI therefore refuses mutation unles
 explicit consent:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins add example-plugin \
+npx omni-dsh-plugins add example-plugin \
   --profile web \
   --allow-code-execution
-npx @diegosouza.pw/dsh-plugins update example-plugin \
+npx omni-dsh-plugins update example-plugin \
   --profile web \
   --allow-code-execution
-npx @diegosouza.pw/dsh-plugins remove example-plugin \
+npx omni-dsh-plugins remove example-plugin \
   --profile web \
   --allow-code-execution
 ```
 
-Native Windows policy for v0.1.0: code-executing `add`, `update`, and `remove` are disabled
+Native Windows policy for v1.0.0: code-executing `add`, `update`, and `remove` are disabled
 before any profile, state, cache, or subprocess access because complete descendant containment
 cannot be proven. Use WSL for mutations. `--dry-run` and the read-only catalog, `search`, `info`,
 `list`, and `doctor` commands remain available. A native Windows recovery marker is never
@@ -102,7 +102,7 @@ code-executing mutations are disabled rather than claiming unproven descendant c
 Explicit POSIX recovery is available with:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins recover
+npx omni-dsh-plugins recover
 ```
 
 Recovery does not load the catalog. Before durable DSH success it rolls back; after durable DSH
@@ -117,8 +117,8 @@ catalog-managed is also a successful no-op.
 ## Inspect the local environment
 
 ```bash
-npx @diegosouza.pw/dsh-plugins list --profile web
-npx @diegosouza.pw/dsh-plugins doctor
+npx omni-dsh-plugins list --profile web
+npx omni-dsh-plugins doctor
 ```
 
 These commands are read-only. Output never intentionally includes tokens, credentials, stack
@@ -142,7 +142,7 @@ declare exactly that SHA. Redirects, alternate hosts, traversal, symlinks, overs
 and revision mismatches are rejected before catalog validation.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins search tui \
+npx omni-dsh-plugins search tui \
   --catalog https://dsh-plugins.omniroute.online/catalog.snapshot.json \
   --revision <published-catalog-revision>
 ```

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@diegosouza.pw/dsh-plugins",
+  "name": "omni-dsh-plugins",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@diegosouza.pw/dsh-plugins",
+      "name": "omni-dsh-plugins",
       "version": "1.0.0",
       "license": "MIT",
       "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@diegosouza.pw/dsh-plugins",
+  "name": "omni-dsh-plugins",
   "version": "1.0.0",
   "description": "Unofficial catalog and safe installer for DeepSeek Harness plugins",
   "type": "module",

--- a/cli/tests/package-contents.test.ts
+++ b/cli/tests/package-contents.test.ts
@@ -63,7 +63,7 @@ describe("packed public CLI", () => {
   it("contains only package metadata, public docs and the executable bundle", () => {
     // The tarball must declare the same identity the manifest does. Asserting a literal version
     // here made every release red for shipping a new version.
-    expect(packed.name).toBe("@diegosouza.pw/dsh-plugins");
+    expect(packed.name).toBe("omni-dsh-plugins");
     expect(packed.version).toBe(manifestVersion);
     expect(packed.version).toMatch(/^\d+\.\d+\.\d+$/u);
     const paths = dryRun.files.map((file) => file.path).sort();

--- a/cli/tests/package.test.ts
+++ b/cli/tests/package.test.ts
@@ -21,7 +21,7 @@ const pkg = JSON.parse(
 
 describe("published CLI package metadata", () => {
   it("owns the exact scoped package and executable", () => {
-    expect(pkg.name).toBe("@diegosouza.pw/dsh-plugins");
+    expect(pkg.name).toBe("omni-dsh-plugins");
     // Not a frozen literal: the version moves every release, and freezing it means the release
     // itself fails the test for doing the one thing a release does. What must hold is that it is
     // exact semver — a range or a prerelease tag here would publish something npm resolves

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -113,8 +113,8 @@ none of it and are labelled as such, because nothing about them has been reviewe
 is never localized.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — show one public catalog entry

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,20 +1,21 @@
-# CLI Reference — `@diegosouza.pw/dsh-plugins@0.1.0`
+# CLI Reference — `omni-dsh-plugins@1.0.0`
 
 > 🌐 **English** · [Português (Brasil)](i18n/pt-BR/CLI.md) · [中文（简体）](i18n/zh-CN/CLI.md)
 
 > **Unofficial community project. Not affiliated with, endorsed by, or sponsored by DeepSeek.**
 > DeepSeek names and marks belong to their respective owner.
 
-This page documents the published CLI exactly as it behaves in version `0.1.0`. Every synopsis
+This page documents the published CLI exactly as it behaves in version `1.0.0`. Every synopsis
 and flag below comes from the published command's own `--help` output; nothing here describes
-unreleased behavior. The CLI is maintained from private source and released to npm as the
-scoped package [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+unreleased behavior. The CLI is developed in this repository under [`cli/`](../cli) and released
+to npm as [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins), with a provenance
+attestation tying each build to the commit and workflow run that produced it.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Design principles in v0.1.0
+## Design principles in v1.0.0
 
 - **Read-only by default.** `catalog`, `search`, `info`, `list` and `doctor` never modify
   profiles, write files or spawn plugin code.
@@ -22,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   lifecycle code unless you pass `--allow-code-execution`. Without it, use `--dry-run` to see
   the verified plan.
 - **Native Windows policy.** Native Windows `add`/`update`/`remove` with code execution are
-  disabled in v0.1.0; use WSL. Dry-run and the read-only commands remain available, and native
+  disabled in v1.0.0; use WSL. Dry-run and the read-only commands remain available, and native
   Windows recovery markers require documented manual recovery.
 - **Pinned inputs.** Catalog input can be a local directory, a snapshot file, or a pinned
   public snapshot URL, optionally locked to an exact 40-character revision.
@@ -50,7 +51,7 @@ The CLI uses conventional process exit codes:
 | `0`       | Success (including "empty but valid" results such as an empty catalog)     |
 | `1`       | Failure: validation error, entry not found, missing required option, or a diagnostic check reporting an error |
 
-Examples observed with v0.1.0: `catalog validate` on a valid empty catalog exits `0` with
+Examples observed with v1.0.0: `catalog validate` on a valid empty catalog exits `0` with
 `0 entries valid; catalog is empty`; `info <unknown-id>` exits `1` with `Plugin not found`;
 `doctor` exits `1` when any check (such as a missing `dsh` executable) reports an error.
 
@@ -76,9 +77,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # From the repository root:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — search public catalog fields locally
@@ -91,8 +92,8 @@ Searches public catalog fields locally against the selected catalog input. Print
 entries, or `No plugins found.` (exit `0`) when nothing matches.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — find plugins beyond the catalog
@@ -101,9 +102,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Not in the published `0.1.0`.** `discover` ships in `1.0.0`; every other command on this page
-> works with the version currently on npm. Running it against `@0.1.0` fails with an unknown
-> command.
+> `discover` ships in `1.0.0`, the first release under this package name.
 
 Searches the curated catalog first, then — unless `--offline` is given — the live GitHub
 `dsh-plugin` topic, so a plugin that has not been submitted yet is still findable. Catalog results
@@ -114,8 +113,8 @@ none of it and are labelled as such, because nothing about them has been reviewe
 is never localized.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — show one public catalog entry
@@ -128,7 +127,7 @@ Shows one public catalog entry by canonical plugin ID. Exits `1` with `Plugin no
 when the ID is not in the catalog.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — add one catalog plugin through official DSH delegation
@@ -150,10 +149,10 @@ delegates to official DSH tooling and only proceeds with `--allow-code-execution
 
 ```bash
 # Preview only — nothing is written, nothing executes:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Real install — explicit consent to lifecycle code:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — update one catalog plugin through official DSH delegation

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -46,7 +46,7 @@ Every pull request touching `catalog/plugins/`, `schemas/` or the workflow itsel
 CLI:
 
 ```bash
-npx --yes @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx --yes omni-dsh-plugins@1.0.0 catalog validate --catalog .
 ```
 
 **What it validates** — local structure and semantics only:

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -46,7 +46,7 @@ Every pull request touching `catalog/plugins/`, `schemas/` or the workflow itsel
 CLI:
 
 ```bash
-npx --yes omni-dsh-plugins@1.0.0 catalog validate --catalog .
+npx --yes omni-dsh-plugins catalog validate --catalog .
 ```
 
 **What it validates** — local structure and semantics only:

--- a/docs/i18n/ar/CLI.md
+++ b/docs/i18n/ar/CLI.md
@@ -1,21 +1,21 @@
-# مرجع الأوامر (CLI) — `@diegosouza.pw/dsh-plugins@0.1.0`
+# مرجع الأوامر (CLI) — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · [Português (Brasil)](../pt-BR/CLI.md) · [中文（简体）](../zh-CN/CLI.md) · **العربية**
 
 > **مشروع مجتمعي غير رسمي. غير منتسب لشركة DeepSeek ولا معتمد أو ممول منها.**
 > أسماء DeepSeek وعلاماتها التجارية ملك لأصحابها المعنيين.
 
-توثّق هذه الصفحة الـ CLI المنشور تمامًا كما يتصرف في الإصدار `0.1.0`. كل ملخص أمر (synopsis) وكل علامة (flag) أدناه مأخوذة من مخرجات `--help` الخاصة بالأمر المنشور نفسه؛ لا شيء هنا يصف سلوكًا لم يُنشَر بعد. يُصان الـ CLI من مصدر خاص ويُنشَر على npm كحزمة مُقيَّدة النطاق (scoped) باسم [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+توثّق هذه الصفحة الـ CLI المنشور تمامًا كما يتصرف في الإصدار `1.0.0`. كل ملخص أمر (synopsis) وكل علامة (flag) أدناه مأخوذة من مخرجات `--help` الخاصة بالأمر المنشور نفسه؛ لا شيء هنا يصف سلوكًا لم يُنشَر بعد. يُصان الـ CLI من مصدر خاص ويُنشَر على npm كحزمة مُقيَّدة النطاق (scoped) باسم [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## مبادئ التصميم في الإصدار v0.1.0
+## مبادئ التصميم في الإصدار v1.0.0
 
 - **للقراءة فقط افتراضيًا.** لا تُعدِّل `catalog`، و`search`، و`info`، و`list`، و`doctor` أبدًا الملفات الشخصية (profiles)، ولا تكتب ملفات، ولا تُشغِّل كود إضافة.
 - **بوابة موافقة لتنفيذ الكود.** ترفض `add`، و`update`، و`remove` تشغيل كود دورة حياة DSH/pnpm ما لم تُمرِّر `--allow-code-execution`. بدونها، استخدم `--dry-run` لرؤية الخطة المُتحقَّق منها.
-- **سياسة Windows الأصلية.** في الإصدار v0.1.0، تكون `add`/`update`/`remove` الأصلية على Windows مع تنفيذ الكود مُعطَّلة؛ استخدم WSL. يبقى الـ dry-run والأوامر للقراءة فقط متاحة، وتتطلب علامات الاسترجاع (recovery markers) الأصلية على Windows استرجاعًا يدويًا موثَّقًا.
+- **سياسة Windows الأصلية.** في الإصدار v1.0.0، تكون `add`/`update`/`remove` الأصلية على Windows مع تنفيذ الكود مُعطَّلة؛ استخدم WSL. يبقى الـ dry-run والأوامر للقراءة فقط متاحة، وتتطلب علامات الاسترجاع (recovery markers) الأصلية على Windows استرجاعًا يدويًا موثَّقًا.
 - **مدخلات مثبَّتة.** يمكن أن يكون مدخل الكتالوج دليلًا محليًا، أو ملف لقطة (snapshot)، أو عنوان URL للقطة عامة مثبَّتة، مقيَّدًا اختياريًا بمراجعة (revision) دقيقة مكوّنة من 40 حرفًا.
 
 ## الخيارات المشتركة
@@ -39,7 +39,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
 | `0`       | نجاح (بما في ذلك نتائج "فارغة لكن صالحة" مثل كتالوج فارغ)     |
 | `1`       | فشل: خطأ تحقق، أو إدخال غير موجود، أو خيار مطلوب مفقود، أو فحص تشخيصي يُبلِّغ عن خطأ |
 
-أمثلة لوحظت في الإصدار v0.1.0: يخرج `catalog validate` على كتالوج فارغ صالح بـ `0` مع `0 entries valid; catalog is empty`؛ ويخرج `info <unknown-id>` بـ `1` مع `Plugin not found`؛ ويخرج `doctor` بـ `1` عندما يُبلِّغ أي فحص (مثل عدم وجود ملف `dsh` التنفيذي) عن خطأ.
+أمثلة لوحظت في الإصدار v1.0.0: يخرج `catalog validate` على كتالوج فارغ صالح بـ `0` مع `0 entries valid; catalog is empty`؛ ويخرج `info <unknown-id>` بـ `1` مع `Plugin not found`؛ ويخرج `doctor` بـ `1` عندما يُبلِّغ أي فحص (مثل عدم وجود ملف `dsh` التنفيذي) عن خطأ.
 
 ## الأوامر
 
@@ -57,9 +57,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # From the repository root:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — البحث محليًا في حقول الكتالوج العامة
@@ -71,8 +71,8 @@ dsh-plugins search [options] <query...>
 يبحث محليًا في حقول الكتالوج العامة ضمن مدخل الكتالوج المُختار. يطبع الإدخالات المطابقة، أو `No plugins found.` (خروج `0`) عندما لا يوجد أي تطابق.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — العثور على إضافات خارج الكتالوج
@@ -81,15 +81,15 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **غير موجود في الإصدار المنشور `0.1.0`.** يُشحَن `discover` في الإصدار `1.0.0`؛ ويعمل كل أمر آخر في هذه الصفحة مع الإصدار الحالي على npm. تشغيله مقابل `@0.1.0` يفشل بأمر غير معروف.
+> **غير موجود في الإصدار المنشور `1.0.0`.** يُشحَن `discover` في الإصدار `1.0.0`؛ ويعمل كل أمر آخر في هذه الصفحة مع الإصدار الحالي على npm. تشغيله مقابل `@1.0.0` يفشل بأمر غير معروف.
 
 يبحث أولًا في الكتالوج المُنسَّق، ثم — ما لم تُمرَّر `--offline` — في موضوع (topic) `dsh-plugin` الحي على GitHub، بحيث تبقى الإضافة التي لم تُقدَّم بعد قابلة للعثور عليها. تحمل نتائج الكتالوج الأدلة التي يحتفظ بها الكتالوج (الالتزام المثبَّت، والمنشئ، والترخيص)؛ ولا تحمل نتائج المجتمع أيًا من ذلك وتُوسَم على هذا النحو، لأن لا شيء منها روجِع.
 
 يُحدِّد `--limit <n>` عدد النتائج القصوى لكل طبقة (الافتراضي `8`). تُصدِر `--json` الشكل الآلي المستقر، الذي لا يُترجَم (localized) أبدًا.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — عرض إدخال كتالوج عام واحد
@@ -101,7 +101,7 @@ dsh-plugins info [options] <id>
 يعرض إدخال كتالوج عام واحد حسب معرّف الإضافة القانوني. يخرج بـ `1` مع `Plugin not found: <id>` عندما لا يكون المعرّف موجودًا في الكتالوج.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — إضافة إضافة كتالوج واحدة عبر تفويض DSH الرسمي
@@ -121,10 +121,10 @@ dsh-plugins add [options] <id>
 
 ```bash
 # Preview only — nothing is written, nothing executes:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Real install — explicit consent to lifecycle code:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — تحديث إضافة كتالوج واحدة عبر تفويض DSH الرسمي

--- a/docs/i18n/ar/CLI.md
+++ b/docs/i18n/ar/CLI.md
@@ -88,8 +88,8 @@ dsh-plugins discover [options] <query...>
 يُحدِّد `--limit <n>` عدد النتائج القصوى لكل طبقة (الافتراضي `8`). تُصدِر `--json` الشكل الآلي المستقر، الذي لا يُترجَم (localized) أبدًا.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — عرض إدخال كتالوج عام واحد

--- a/docs/i18n/ar/CONTRIBUTING.md
+++ b/docs/i18n/ar/CONTRIBUTING.md
@@ -98,14 +98,14 @@ popularity:
 
 ## أوامر التحقق ومدى توفرها
 
-يُنشَر CLI الخاص بـ npm باسم `@diegosouza.pw/dsh-plugins@0.1.0`، لذا فإن الأوامر أدناه متوفرة اليوم عبر `npx`. استخدمها تمامًا كما هي مكتوبة؛ يجب ألّا يخترع المساهمون أوامر بديلة.
+يُنشَر CLI الخاص بـ npm باسم `omni-dsh-plugins@1.0.0`، لذا فإن الأوامر أدناه متوفرة اليوم عبر `npx`. استخدمها تمامًا كما هي مكتوبة؛ يجب ألّا يخترع المساهمون أوامر بديلة.
 
 نفِّذ هذه الأوامر من جذر المستودع:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 يُجري `catalog validate` فقط الفحوصات المحلية لـ YAML، والمخطط، وSPDX، وSemVer الدقيق، وSRI من نوع SHA-512، والتكرار الموصوفة أعلاه، ويقبل الكتالوج الفارغ عمدًا. وهو لا يُثبِت هوية المستودع البعيدة ولا دليل المصدر المثبَّت. تتحقق الأوامر الأخرى من التوثيق العام المطلوب ونماذج مشكلات (issue) GitHub المُهيكَلة. اجتياز هذه الأوامر محليًا لا يُخفِّف من متطلبات الأدلة؛ ولا يزال المشرفون يُطبِّقون كل بوابة إصدار (release gate) مقابلة قبل الدمج.

--- a/docs/i18n/ar/README.md
+++ b/docs/i18n/ar/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **الموقع** | متصفّح كتالوج مُصيَّر مع بحث وترتيب                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **الكتالوج** | ملف YAML واحد لكل إضافة، وهو المصدر الوحيد للحقيقة             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **المخطط (Schema)**  | مخطط JSON Schema عام (المسودة 2020-12) يتحقق كل مُدخل بموجبه | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **واجهة سطر الأوامر (CLI)**     | البحث والفحص والتحقق والتثبيت من الكتالوج           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **واجهة سطر الأوامر (CLI)**     | البحث والفحص والتحقق والتثبيت من الكتالوج           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **تغذية آلية (Machine feeds)** | `catalog.json` + `catalog.snapshot.json` للأدوات           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 هذا المستودع هو المصدر العلني الموثوق للكتالوج. كل إدراج هو ملف YAML واحد تحت `catalog/plugins/`،
@@ -125,15 +125,15 @@
 ## 🚀 تثبيت واجهة سطر الأوامر
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-تُنشر الحزمة المُقيَّدة النطاق باسم `@diegosouza.pw/dsh-plugins@0.1.0`، والأمر أعلاه هو الاستدعاء
+تُنشر الحزمة المُقيَّدة النطاق باسم `omni-dsh-plugins@1.0.0`، والأمر أعلاه هو الاستدعاء
 المعتمد حاليًا؛ ولا يُستضاف هنا أي سكربت تثبيت.
 
 ### استخدام واجهة سطر الأوامر اليوم
 
-يشحن الإصدار 0.1.0 أوامر اكتشاف وتحقق للقراءة فقط، إضافةً إلى أوامر تثبيت مشروطة بموافقة صريحة.
+يشحن الإصدار 1.0.0 أوامر اكتشاف وتحقق للقراءة فقط، إضافةً إلى أوامر تثبيت مشروطة بموافقة صريحة.
 المرجع الكامل للأوامر، بما في ذلك الخيارات ورموز الخروج وبوابة الموافقة على تنفيذ التعليمات
 البرمجية، موجود في [docs/CLI.md](../../docs/CLI.md).
 
@@ -149,18 +149,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 الأوامر المُغيِّرة (`add`، `update`، `remove`) لا تنفّذ أبدًا شيفرة دورة حياة الإضافة ما لم تمرّر
-`--allow-code-execution`. على Windows الأصلي، هذه التغييرات معطّلة في الإصدار v0.1.0؛ استخدم WSL
+`--allow-code-execution`. على Windows الأصلي، هذه التغييرات معطّلة في الإصدار v1.0.0؛ استخدم WSL
 بدلًا من ذلك. أوامر القراءة فقط والتشغيل التجريبي تعمل في كل مكان.
 
 ## 🔍 كيف تدخل الإضافة إلى الكتالوج
@@ -304,7 +304,7 @@ monorepos أوسع قابلة للاكتشاف، لكنها تستخدم `stars:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | عقد المساهمة الكامل: الأدلة، وقواعد YAML، وبوابات المراجعة    |
 | [SECURITY.md](../../SECURITY.md)                   | الإبلاغ عن ثغرات الإضافات أو الكتالوج؛ وسياسة الأسرار           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | مرجع حقلًا بحقل لـ `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | مرجع أوامر واجهة سطر الأوامر لـ `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | مرجع أوامر واجهة سطر الأوامر لـ `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | كيفية إدارة الكتالوج: الأولوية، والبوابات، والمطالبات، وعمليات الإزالة   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | أنواع الأصول، وفئات القدرات الأساسية، والوسوم، ونطاق المستودع |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | نسب الفضل للمُنشئ، وأولوية طلبات السحب، وسياسة هوية Git                 |

--- a/docs/i18n/az/CONTRIBUTING.md
+++ b/docs/i18n/az/CONTRIBUTING.md
@@ -172,16 +172,16 @@ siyasət üçün [docs/CREDIT.md](../../docs/CREDIT.md) sənədinə baxın.
 
 ## Validasiya əmrləri və əlçatanlıq
 
-npm CLI-si `@diegosouza.pw/dsh-plugins@0.1.0` kimi nəşr olunub, ona görə də aşağıdakı əmrlər bu
+npm CLI-si `omni-dsh-plugins@1.0.0` kimi nəşr olunub, ona görə də aşağıdakı əmrlər bu
 gün `npx` vasitəsilə əlçatandır. Onları tam olaraq yazıldığı kimi istifadə edin; töhfəçilər
 əvəzedici əmrlər uydurmamalıdır.
 
 Bu əmrləri repozitoriyanın kök qovluğundan icra edin:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` yalnız yuxarıda təsvir edilmiş lokal YAML, schema, SPDX, dəqiq SemVer,

--- a/docs/i18n/az/README.md
+++ b/docs/i18n/az/README.md
@@ -17,7 +17,7 @@ Yaradıcı-önləşdirilmiş kəşf və **DeepSeek Harness (DSH)** əlavələri 
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@ Dəqiq repozitoriya ulduzlarına görə sıralanıb — yalnız əlavənin öz r
 | **Veb sayt** | Axtarış və sıralama ilə render edilmiş kataloq brauzeri                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Kataloq** | Hər əlavə üçün bir YAML faylı, yeganə həqiqət mənbəyi             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Sxem**  | Hər qeydin doğrulandığı ictimai JSON Schema (draft 2020-12) | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Kataloqdan axtarış, yoxlama, doğrulama və quraşdırma           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Kataloqdan axtarış, yoxlama, doğrulama və quraşdırma           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Maşın lentləri** | Alətlər üçün `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Bu repozitoriya kataloq üçün ictimai həqiqət mənbəyidir. Hər qeyd `catalog/plugins/` altında bir YAML
@@ -125,15 +125,15 @@ olur.
 ## 🚀 CLI-ni quraşdırın
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Əhatə dairəli paket `@diegosouza.pw/dsh-plugins@0.1.0` kimi dərc edilir və yuxarıdakı əmr bu gün
+Əhatə dairəli paket `omni-dsh-plugins@1.0.0` kimi dərc edilir və yuxarıdakı əmr bu gün
 üçün kanonik çağırışdır; burada heç bir quraşdırma skripti yerləşdirilmir.
 
 ### CLI-ni bu gün istifadə edin
 
-Versiya 0.1.0 yalnız-oxu kəşf və doğrulama əmrləri, eləcə də razılıq tələb edən quraşdırma əmrləri
+Versiya 1.0.0 yalnız-oxu kəşf və doğrulama əmrləri, eləcə də razılıq tələb edən quraşdırma əmrləri
 təqdim edir. Bayraqlar, çıxış kodları və kod icrası razılıq qapısı daxil olmaqla tam əmr istinadı
 [docs/CLI.md](../../docs/CLI.md) sənədindədir.
 
@@ -149,19 +149,19 @@ təqdim edir. Bayraqlar, çıxış kodları və kod icrası razılıq qapısı d
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Dəyişiklik edən əmrlər (`add`, `update`, `remove`) `--allow-code-execution` bayrağını
 ötürmədiyiniz müddətcə heç vaxt əlavə həyat dövrü kodunu icra etmir. Yerli Windows-da bu
-dəyişikliklər v0.1.0-da deaktiv edilib; WSL istifadə edin. Yalnız-oxu və sınaq işə salma əmrləri
+dəyişikliklər v1.0.0-da deaktiv edilib; WSL istifadə edin. Yalnız-oxu və sınaq işə salma əmrləri
 hər yerdə işləyir.
 
 ## 🔍 Bir əlavə kataloqa necə daxil olur
@@ -307,7 +307,7 @@ kataloqlaşdırıbsa, [mövcud qeydi tələb edin](https://github.com/diegosouza
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Tam töhfə müqaviləsi: sübut, YAML qaydaları, baxış qapıları    |
 | [SECURITY.md](../../SECURITY.md)                   | Əlavə və ya kataloq zəifliklərini bildirmək; sirlər siyasəti           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` üçün sahə-sahə istinad             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` üçün CLI əmr istinadı          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` üçün CLI əmr istinadı          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Kataloqun necə idarə edildiyi: üstünlük, qapılar, iddialar və silinmələr   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Artefakt növləri, əsas imkan kateqoriyaları, teqlər, repozitoriya əhatəsi |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Yaradıcı atribusiyası, PR üstünlüyü və Git kimlik siyasəti                 |

--- a/docs/i18n/bg/CLI.md
+++ b/docs/i18n/bg/CLI.md
@@ -119,8 +119,8 @@ commit, създател, лиценз); резултатите от общно�
 машинна форма, която никога не се локализира.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — показва един публичен запис от каталога

--- a/docs/i18n/bg/CLI.md
+++ b/docs/i18n/bg/CLI.md
@@ -1,21 +1,21 @@
-# Справочник на CLI — `@diegosouza.pw/dsh-plugins@0.1.0`
+# Справочник на CLI — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · [Português (Brasil)](../pt-BR/CLI.md) · [中文（简体）](../zh-CN/CLI.md) · **Български**
 
 > **Неофициален общностен проект. Не е свързан с, одобрен от или спонсориран от DeepSeek.**
 > Имената и марките на DeepSeek принадлежат на съответните им собственици.
 
-Тази страница документира публикувания CLI точно както се държи във версия `0.1.0`. Всеки
+Тази страница документира публикувания CLI точно както се държи във версия `1.0.0`. Всеки
 синопсис и флаг по-долу идва от собствения `--help` изход на публикуваната команда; нищо тук не
 описва непубликувано поведение. CLI-ят се поддържа от частен изходен код и се публикува в npm
 като scoped пакета
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Принципи на дизайна в v0.1.0
+## Принципи на дизайна в v1.0.0
 
 - **По подразбиране само за четене.** `catalog`, `search`, `info`, `list` и `doctor` никога не
   променят профили, не записват файлове и не стартират код на плъгини.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   от жизнения цикъл на DSH/pnpm, освен ако не подадете `--allow-code-execution`. Без него
   използвайте `--dry-run`, за да видите проверения план.
 - **Политика за нативен Windows.** Нативните `add`/`update`/`remove` в Windows с изпълнение на код
-  са забранени в v0.1.0; използвайте WSL. Dry-run и командите само за четене остават налични, а
+  са забранени в v1.0.0; използвайте WSL. Dry-run и командите само за четене остават налични, а
   маркерите за възстановяване в нативен Windows изискват документирано ръчно възстановяване.
 - **Закрепени входове.** Входът за каталога може да бъде локална директория, файл със снимка на
   състоянието (snapshot) или закрепен публичен snapshot URL, по избор заключен към точна
@@ -52,7 +52,7 @@ CLI-ят използва конвенционални изходни кодов
 | `0`         | Успех (включително резултати „празни, но валидни“, като например празен каталог) |
 | `1`         | Неуспех: грешка при валидация, запис не е намерен, липсваща задължителна опция, или диагностична проверка, докладваща грешка |
 
-Наблюдавани примери с v0.1.0: `catalog validate` върху валиден празен каталог излиза с `0` и
+Наблюдавани примери с v1.0.0: `catalog validate` върху валиден празен каталог излиза с `0` и
 `0 entries valid; catalog is empty`; `info <unknown-id>` излиза с `1` и `Plugin not found`;
 `doctor` излиза с `1`, когато която и да е проверка (например липсващ изпълним файл `dsh`)
 докладва грешка.
@@ -80,9 +80,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # From the repository root:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — търси локално в публичните полета на каталога
@@ -95,8 +95,8 @@ dsh-plugins search [options] <query...>
 съвпадащите записи, или `No plugins found.` (изход `0`), когато нищо не съвпада.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — намира плъгини извън каталога
@@ -105,8 +105,8 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Не е налична в публикуваната `0.1.0`.** `discover` се появява в `1.0.0`; всяка друга команда
-> на тази страница работи с версията, налична в момента в npm. Изпълняването ѝ спрямо `@0.1.0`
+> **Не е налична в публикуваната `1.0.0`.** `discover` се появява в `1.0.0`; всяка друга команда
+> на тази страница работи с версията, налична в момента в npm. Изпълняването ѝ спрямо `@1.0.0`
 > се проваля с непозната команда.
 
 Търси първо в курирания каталог, след което — освен ако не е зададено `--offline` — в темата
@@ -119,8 +119,8 @@ commit, създател, лиценз); резултатите от общно�
 машинна форма, която никога не се локализира.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — показва един публичен запис от каталога
@@ -133,7 +133,7 @@ dsh-plugins info [options] <id>
 `Plugin not found: <id>`, когато ID-то не е в каталога.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — добавя плъгин от каталога чрез официално делегиране към DSH
@@ -155,10 +155,10 @@ dsh-plugins add [options] <id>
 
 ```bash
 # Preview only — nothing is written, nothing executes:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Real install — explicit consent to lifecycle code:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — обновява плъгин от каталога чрез официално делегиране към DSH

--- a/docs/i18n/bg/CONTRIBUTING.md
+++ b/docs/i18n/bg/CONTRIBUTING.md
@@ -173,16 +173,16 @@ commit-а и дава изрична заслуга „Created by @handle“ с 
 
 ## Команди за валидация и наличност
 
-CLI за npm се публикува като `@diegosouza.pw/dsh-plugins@0.1.0`, така че командите по-долу са
+CLI за npm се публикува като `omni-dsh-plugins@1.0.0`, така че командите по-долу са
 налични чрез `npx` още сега. Използвайте ги точно както са написани; сътрудниците не трябва да
 измислят заместващи команди.
 
 Изпълнете тези команди от корена на хранилището:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` извършва само локалните проверки за YAML, схема, SPDX, точен SemVer, SHA-512

--- a/docs/i18n/bg/README.md
+++ b/docs/i18n/bg/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@
 | **Уебсайт** | Изобразен браузър на каталога с търсене и класиране                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Каталог** | Един YAML файл за плъгин, единственият източник на истина             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Схема**  | Публична JSON Schema (draft 2020-12), спрямо която се валидира всеки запис | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Търсене, преглед, валидиране и инсталиране от каталога           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Търсене, преглед, валидиране и инсталиране от каталога           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Машинни емисии** | `catalog.json` + `catalog.snapshot.json` за инструменти           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Това хранилище е публичният източник на истина за каталога. Всеки запис е един YAML файл под `catalog/plugins/`, валидиран спрямо публикувана JSON схема, добавен чрез отделно прегледан pull request и винаги кредитиран на оригиналния създател на плъгина. Нищо в каталога не е генерирано от друг каталог или списък: всеки запис се възстановява от хранилището на оригиналния създател при фиксиран комит.
@@ -118,14 +118,14 @@
 ## 🚀 Инсталирайте CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Пакетът с обхват е публикуван като `@diegosouza.pw/dsh-plugins@0.1.0` и командата по-горе е каноничният начин на извикване днес; тук не се хоства инсталационен скрипт.
+Пакетът с обхват е публикуван като `omni-dsh-plugins@1.0.0` и командата по-горе е каноничният начин на извикване днес; тук не се хоства инсталационен скрипт.
 
 ### Използвайте CLI днес
 
-Версия 0.1.0 предлага команди за откриване и валидиране само за четене, плюс инсталационни команди, обвързани със съгласие. Пълната справка за командите, включително флагове, кодове за изход и портала за съгласие за изпълнение на код, е в [docs/CLI.md](../../docs/CLI.md).
+Версия 1.0.0 предлага команди за откриване и валидиране само за четене, плюс инсталационни команди, обвързани със съгласие. Пълната справка за командите, включително флагове, кодове за изход и портала за съгласие за изпълнение на код, е в [docs/CLI.md](../../docs/CLI.md).
 
 | Команда                        | Какво прави                                                        | Засяга ли вашата система?                    |
 | ------------------------------ | ------------------------------------------------------------------- | --------------------------------------- |
@@ -139,17 +139,17 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
-Мутиращите команди (`add`, `update`, `remove`) никога не изпълняват код от жизнения цикъл на плъгина, освен ако не подадете `--allow-code-execution`. На родни Windows системи тези мутации са изключени във v0.1.0; използвайте WSL. Командите само за четене и пробните изпълнения работят навсякъде.
+Мутиращите команди (`add`, `update`, `remove`) никога не изпълняват код от жизнения цикъл на плъгина, освен ако не подадете `--allow-code-execution`. На родни Windows системи тези мутации са изключени във v1.0.0; използвайте WSL. Командите само за четене и пробните изпълнения работят навсякъде.
 
 ## 🔍 Как плъгин влиза в каталога
 
@@ -264,7 +264,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Пълният договор за принос: доказателства, правила за YAML, портали за преглед    |
 | [SECURITY.md](../../SECURITY.md)                   | Докладване на уязвимости в плъгини или каталога; политика за тайни           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Справка поле по поле за `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Справка за командите на CLI за `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Справка за командите на CLI за `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Как се управлява каталогът: предимство, портали, претенции и премахвания   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Видове артефакти, основни категории на способности, тагове, обхват на хранилището |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Кредитиране на създатели, предимство на PR и политика за Git идентичност                 |

--- a/docs/i18n/bn/CONTRIBUTING.md
+++ b/docs/i18n/bn/CONTRIBUTING.md
@@ -98,14 +98,14 @@ popularity:
 
 ## বৈধতা যাচাইকরণ কমান্ড এবং প্রাপ্যতা
 
-npm CLI `@diegosouza.pw/dsh-plugins@0.1.0` হিসেবে প্রকাশিত, তাই নিচের কমান্ডগুলি আজ `npx`-এর মাধ্যমে উপলব্ধ। এগুলি ঠিক যেভাবে লেখা আছে সেভাবে ব্যবহার করুন; অবদানকারীদের বিকল্প কমান্ড উদ্ভাবন করা উচিত নয়।
+npm CLI `omni-dsh-plugins@1.0.0` হিসেবে প্রকাশিত, তাই নিচের কমান্ডগুলি আজ `npx`-এর মাধ্যমে উপলব্ধ। এগুলি ঠিক যেভাবে লেখা আছে সেভাবে ব্যবহার করুন; অবদানকারীদের বিকল্প কমান্ড উদ্ভাবন করা উচিত নয়।
 
 রিপোজিটরির রুট থেকে এই কমান্ডগুলি চালান:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` উপরে বর্ণিত শুধুমাত্র স্থানীয় YAML, স্কিমা, SPDX, সঠিক SemVer, SHA-512 SRI এবং ডুপ্লিকেট চেকগুলি সম্পাদন করে, এবং ইচ্ছাকৃতভাবে শূন্য-এন্ট্রি ক্যাটালগ গ্রহণ করে। এটি দূরবর্তী রিপোজিটরির পরিচয় বা পিন করা-উৎস প্রমাণ প্রমাণ করে না। অন্যান্য কমান্ডগুলি প্রয়োজনীয় সর্বজনীন ডকুমেন্টেশন এবং স্ট্রাকচার্ড GitHub ইস্যু ফর্ম পরীক্ষা করে। স্থানীয়ভাবে এই কমান্ডগুলি পাস করা প্রমাণের প্রয়োজনীয়তাগুলি শিথিল করে না; মেইনটেইনাররা মার্জ করার আগেও প্রতিটি সংশ্লিষ্ট রিলিজ গেট প্রয়োগ করেন।

--- a/docs/i18n/bn/README.md
+++ b/docs/i18n/bn/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **ওয়েবসাইট** | সার্চ ও র‍্যাঙ্কিংসহ রেন্ডার করা ক্যাটালগ ব্রাউজার                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **ক্যাটালগ** | প্রতি প্লাগইনের জন্য একটি YAML ফাইল, একমাত্র সত্যের উৎস             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **স্কিমা**  | পাবলিক JSON Schema (draft 2020-12) যার বিপরীতে প্রতিটি এন্ট্রি যাচাই হয় | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | ক্যাটালগ থেকে সার্চ, পরিদর্শন, যাচাই এবং ইনস্টল করুন           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | ক্যাটালগ থেকে সার্চ, পরিদর্শন, যাচাই এবং ইনস্টল করুন           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **মেশিন ফিড** | টুলের জন্য `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 এই রিপোজিটরি ক্যাটালগের জন্য সত্যের পাবলিক উৎস। প্রতিটি তালিকাভুক্তি `catalog/plugins/`-এর অধীনে একটি YAML
@@ -125,15 +125,15 @@
 ## 🚀 CLI ইনস্টল করুন
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-স্কোপড প্যাকেজটি `@diegosouza.pw/dsh-plugins@0.1.0` হিসেবে প্রকাশিত, এবং উপরের কমান্ডটি আজকের হিসেবে প্রামাণিক
+স্কোপড প্যাকেজটি `omni-dsh-plugins@1.0.0` হিসেবে প্রকাশিত, এবং উপরের কমান্ডটি আজকের হিসেবে প্রামাণিক
 আহ্বান; এখানে কোনো ইনস্টলার স্ক্রিপ্ট হোস্ট করা হয় না।
 
 ### আজই CLI ব্যবহার করুন
 
-সংস্করণ 0.1.0-এ রিড-অনলি ডিসকভারি ও ভ্যালিডেশন কমান্ড এবং সম্মতি-নিয়ন্ত্রিত ইনস্টল কমান্ড অন্তর্ভুক্ত। ফ্ল্যাগ,
+সংস্করণ 1.0.0-এ রিড-অনলি ডিসকভারি ও ভ্যালিডেশন কমান্ড এবং সম্মতি-নিয়ন্ত্রিত ইনস্টল কমান্ড অন্তর্ভুক্ত। ফ্ল্যাগ,
 এক্সিট কোড এবং কোড-এক্সিকিউশন সম্মতি গেটসহ সম্পূর্ণ কমান্ড রেফারেন্স [docs/CLI.md](../../docs/CLI.md)-এ পাওয়া যাবে।
 
 | Command                        | এটি কী করে                                                        | এটি কি আপনার সিস্টেম স্পর্শ করে?                    |
@@ -148,18 +148,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 পরিবর্তনকারী কমান্ডগুলো (`add`, `update`, `remove`) কখনও প্লাগইন লাইফসাইকেল কোড এক্সিকিউট করে না যদি না আপনি
-`--allow-code-execution` পাস করেন। নেটিভ Windows-এ এই পরিবর্তনগুলো v0.1.0-এ নিষ্ক্রিয় করা আছে; WSL ব্যবহার
+`--allow-code-execution` পাস করেন। নেটিভ Windows-এ এই পরিবর্তনগুলো v1.0.0-এ নিষ্ক্রিয় করা আছে; WSL ব্যবহার
 করুন। রিড-অনলি এবং ড্রাই-রান কমান্ড সর্বত্র কাজ করে।
 
 ## 🔍 কীভাবে একটি প্লাগইন ক্যাটালগে প্রবেশ করে
@@ -296,7 +296,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | সম্পূর্ণ অবদান চুক্তি: প্রমাণ, YAML নিয়ম, পর্যালোচনা গেট    |
 | [SECURITY.md](../../SECURITY.md)                   | প্লাগইন বা ক্যাটালগের দুর্বলতা রিপোর্ট করা; গোপনীয়তা নীতি           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml`-এর জন্য ফিল্ড-বাই-ফিল্ড রেফারেন্স             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0`-এর জন্য CLI কমান্ড রেফারেন্স          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0`-এর জন্য CLI কমান্ড রেফারেন্স          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | ক্যাটালগ কীভাবে পরিচালিত হয়: অগ্রাধিকার, গেট, দাবি এবং অপসারণ   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | আর্টিফ্যাক্ট প্রকার, প্রাথমিক সক্ষমতা বিভাগ, ট্যাগ, রিপোজিটরি সুযোগ |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | নির্মাতা কৃতিত্ব, PR অগ্রাধিকার এবং Git পরিচয় নীতি                 |

--- a/docs/i18n/cs/CLI.md
+++ b/docs/i18n/cs/CLI.md
@@ -1,21 +1,21 @@
-# Referenční příručka CLI — `@diegosouza.pw/dsh-plugins@0.1.0`
+# Referenční příručka CLI — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · [Português (Brasil)](../pt-BR/CLI.md) · [中文（简体）](../zh-CN/CLI.md) · **Čeština**
 
 > **Neoficiální komunitní projekt. Není přidružen k DeepSeek, DeepSeek jej neschvaluje ani nesponzoruje.**
 > Názvy a značky DeepSeek náleží jejich příslušným vlastníkům.
 
-Tato stránka dokumentuje publikované CLI přesně tak, jak se chová ve verzi `0.1.0`. Každá
+Tato stránka dokumentuje publikované CLI přesně tak, jak se chová ve verzi `1.0.0`. Každá
 synopse a přepínač níže pochází přímo z výstupu `--help` publikovaného příkazu; nic zde nepopisuje
 nevydané chování. CLI je udržováno ze soukromého zdrojového kódu a vydáváno do npm jako balíček
 se scope
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Návrhové principy ve v0.1.0
+## Návrhové principy ve v1.0.0
 
 - **Ve výchozím stavu pouze pro čtení.** `catalog`, `search`, `info`, `list` a `doctor` nikdy
   neupravují profily, nezapisují soubory ani nespouštějí kód pluginu.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   životního cyklu DSH/pnpm, pokud nepředáte `--allow-code-execution`. Bez toho použijte
   `--dry-run` k zobrazení ověřeného plánu.
 - **Politika pro nativní Windows.** Nativní Windows `add`/`update`/`remove` se spouštěním kódu
-  jsou ve v0.1.0 zakázány; použijte WSL. Dry-run a příkazy pouze pro čtení zůstávají dostupné a
+  jsou ve v1.0.0 zakázány; použijte WSL. Dry-run a příkazy pouze pro čtení zůstávají dostupné a
   markery obnovy pro nativní Windows vyžadují dokumentovanou ruční obnovu.
 - **Fixované vstupy.** Vstup katalogu může být lokální adresář, soubor snapshotu, nebo fixovaná
   veřejná URL snapshotu, volitelně uzamčená na přesnou 40znakovou revizi.
@@ -51,7 +51,7 @@ CLI používá konvenční návratové kódy procesu:
 | `0`           | Úspěch (včetně výsledků „prázdné, ale platné“, jako je prázdný katalog)    |
 | `1`           | Selhání: chyba validace, záznam nenalezen, chybí povinná volba, nebo diagnostická kontrola hlásí chybu |
 
-Příklady pozorované u v0.1.0: `catalog validate` na platném prázdném katalogu skončí s `0` a
+Příklady pozorované u v1.0.0: `catalog validate` na platném prázdném katalogu skončí s `0` a
 hlášením `0 entries valid; catalog is empty`; `info <unknown-id>` skončí s `1` a hlášením
 `Plugin not found`; `doctor` skončí s `1`, pokud jakákoli kontrola (například chybějící
 spustitelný soubor `dsh`) hlásí chybu.
@@ -78,9 +78,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # From the repository root:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — lokálně prohledává veřejná pole katalogu
@@ -93,8 +93,8 @@ Lokálně prohledává veřejná pole katalogu proti zvolenému vstupu katalogu.
 záznamy, nebo `No plugins found.` (návratový kód `0`), pokud nic neodpovídá.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — najde pluginy nad rámec katalogu
@@ -103,9 +103,9 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Není součástí publikované verze `0.1.0`.** `discover` je vydáno ve verzi `1.0.0`; každý
+> **Není součástí publikované verze `1.0.0`.** `discover` je vydáno ve verzi `1.0.0`; každý
 > další příkaz na této stránce funguje s verzí aktuálně dostupnou na npm. Spuštění proti
-> `@0.1.0` selže s hlášením o neznámém příkazu.
+> `@1.0.0` selže s hlášením o neznámém příkazu.
 
 Nejprve prohledá kurátorovaný katalog, poté — pokud není zadáno `--offline` — živé téma
 (topic) `dsh-plugin` na GitHubu, takže plugin, který ještě nebyl podán, je stále dohledatelný.
@@ -117,8 +117,8 @@ nebylo posouzeno.
 tvar, který se nikdy nelokalizuje.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — zobrazí jeden veřejný záznam katalogu
@@ -131,7 +131,7 @@ Zobrazí jeden veřejný záznam katalogu podle kanonického ID pluginu. Skonč�
 `Plugin not found: <id>`, pokud dané ID není v katalogu.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — přidá jeden plugin z katalogu prostřednictvím oficiální delegace na DSH
@@ -153,10 +153,10 @@ nástroje DSH a pokračuje pouze s `--allow-code-execution`.
 
 ```bash
 # Preview only — nothing is written, nothing executes:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Real install — explicit consent to lifecycle code:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — aktualizuje jeden plugin z katalogu prostřednictvím oficiální delegace na DSH

--- a/docs/i18n/cs/CLI.md
+++ b/docs/i18n/cs/CLI.md
@@ -117,8 +117,8 @@ nebylo posouzeno.
 tvar, který se nikdy nelokalizuje.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — zobrazí jeden veřejný záznam katalogu

--- a/docs/i18n/cs/CONTRIBUTING.md
+++ b/docs/i18n/cs/CONTRIBUTING.md
@@ -168,16 +168,16 @@ nahradit autorství tvůrce. Úplnou politiku najdete v [docs/CREDIT.md](../../d
 
 ## Validační příkazy a dostupnost
 
-CLI npm je publikováno jako `@diegosouza.pw/dsh-plugins@0.1.0`, takže níže uvedené příkazy jsou
+CLI npm je publikováno jako `omni-dsh-plugins@1.0.0`, takže níže uvedené příkazy jsou
 dnes dostupné přes `npx`. Používejte je přesně tak, jak jsou napsány; přispěvatelé by si neměli
 vymýšlet náhradní příkazy.
 
 Tyto příkazy spouštějte z kořene repozitáře:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` provádí pouze výše popsané lokální kontroly YAML, schématu, SPDX, přesného

--- a/docs/i18n/cs/README.md
+++ b/docs/i18n/cs/README.md
@@ -17,7 +17,7 @@ Objevování s prioritou pro tvůrce a instalace jedním příkazem pro pluginy 
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@ Seřazeno podle hvězdiček přesného repozitáře — počítají se pouze hv�
 | **Web** | Vykreslený prohlížeč katalogu s vyhledáváním a řazením                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Jeden soubor YAML na plugin, jediný zdroj pravdy             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schéma**  | Veřejné JSON Schema (draft 2020-12), proti kterému se ověřuje každý záznam | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Vyhledávání, kontrola, ověřování a instalace z katalogu           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Vyhledávání, kontrola, ověřování a instalace z katalogu           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Strojová data** | `catalog.json` + `catalog.snapshot.json` pro nástroje           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Tento repozitář je veřejným zdrojem pravdy pro katalog. Každý záznam je jeden soubor YAML pod `catalog/plugins/`, ověřený proti publikovanému JSON Schema, přidaný prostřednictvím jednotlivě zkontrolovaného pull requestu a vždy kreditovaný původnímu tvůrci pluginu. Nic v katalogu není generováno z jiného katalogu ani seznamu: každý záznam je rekonstruován z repozitáře původního tvůrce na fixovaném commitu.
@@ -118,14 +118,14 @@ Web a CLI jsou udržovány ze soukromého zdroje; tento repozitář obsahuje ve�
 ## 🚀 Instalace CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Balíček s rozsahem je publikován jako `@diegosouza.pw/dsh-plugins@0.1.0` a výše uvedený příkaz je dnes kanonickým způsobem volání; zde není hostován žádný instalační skript.
+Balíček s rozsahem je publikován jako `omni-dsh-plugins@1.0.0` a výše uvedený příkaz je dnes kanonickým způsobem volání; zde není hostován žádný instalační skript.
 
 ### Použití CLI dnes
 
-Verze 0.1.0 nabízí příkazy pro zjišťování a ověřování pouze pro čtení plus instalační příkazy podmíněné souhlasem. Úplná referenční příručka příkazů, včetně příznaků, návratových kódů a brány souhlasu s vykonáváním kódu, je v [docs/CLI.md](../../docs/CLI.md).
+Verze 1.0.0 nabízí příkazy pro zjišťování a ověřování pouze pro čtení plus instalační příkazy podmíněné souhlasem. Úplná referenční příručka příkazů, včetně příznaků, návratových kódů a brány souhlasu s vykonáváním kódu, je v [docs/CLI.md](../../docs/CLI.md).
 
 | Příkaz                        | Co dělá                                                        | Zasahuje do vašeho systému?                    |
 | ------------------------------ | ------------------------------------------------------------------- | --------------------------------------- |
@@ -139,17 +139,17 @@ Verze 0.1.0 nabízí příkazy pro zjišťování a ověřování pouze pro čte
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
-Měnící příkazy (`add`, `update`, `remove`) nikdy nespustí kód životního cyklu pluginu, pokud nepředáte `--allow-code-execution`. Na nativním Windows jsou tyto změny ve v0.1.0 zakázány; použijte WSL. Příkazy pouze pro čtení a nanečisto fungují všude.
+Měnící příkazy (`add`, `update`, `remove`) nikdy nespustí kód životního cyklu pluginu, pokud nepředáte `--allow-code-execution`. Na nativním Windows jsou tyto změny ve v1.0.0 zakázány; použijte WSL. Příkazy pouze pro čtení a nanečisto fungují všude.
 
 ## 🔍 Jak se plugin dostane do katalogu
 
@@ -264,7 +264,7 @@ Chcete, aby tu byl váš plugin s plným kreditem? [Otevřete jeden PR s jedním
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Úplná smlouva o přispívání: důkazy, pravidla YAML, kontrolní brány    |
 | [SECURITY.md](../../SECURITY.md)                   | Hlášení zranitelností pluginů nebo katalogu; zásady tajemství           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Reference pole po poli pro `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Reference příkazů CLI pro `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Reference příkazů CLI pro `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Jak je katalog spravován: přednost, brány, nároky a odstranění   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Typy artefaktů, primární kategorie schopností, tagy, rozsah repozitáře |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Kreditování tvůrců, přednost PR a zásady identity Git                 |

--- a/docs/i18n/da/CLI.md
+++ b/docs/i18n/da/CLI.md
@@ -118,8 +118,8 @@ gennemgået.
 stabile maskinform, som aldrig lokaliseres.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — viser én offentlig katalogpost

--- a/docs/i18n/da/CLI.md
+++ b/docs/i18n/da/CLI.md
@@ -1,21 +1,21 @@
-# CLI-reference — `@diegosouza.pw/dsh-plugins@0.1.0`
+# CLI-reference — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · [Português (Brasil)](../pt-BR/CLI.md) · [中文（简体）](../zh-CN/CLI.md) · **Dansk**
 
 > **Uofficielt community-projekt. Ikke tilknyttet, godkendt af eller sponsoreret af DeepSeek.**
 > DeepSeeks navne og mærker tilhører deres respektive ejere.
 
-Denne side dokumenterer det udgivne CLI præcis, som det opfører sig i version `0.1.0`. Hver
+Denne side dokumenterer det udgivne CLI præcis, som det opfører sig i version `1.0.0`. Hver
 synopsis og flag nedenfor stammer fra den udgivne kommandos egen `--help`-output; intet her
 beskriver ikke-udgivet adfærd. CLI'et vedligeholdes fra privat kildekode og udgives til npm som
 den scopede pakke
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Designprincipper i v0.1.0
+## Designprincipper i v1.0.0
 
 - **Skrivebeskyttet som standard.** `catalog`, `search`, `info`, `list` og `doctor` ændrer aldrig
   profiler, skriver aldrig filer og starter aldrig plugin-kode.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   livscykluskode, medmindre du angiver `--allow-code-execution`. Uden den kan du bruge `--dry-run`
   for at se den verificerede plan.
 - **Native Windows-politik.** Native Windows `add`/`update`/`remove` med kodeeksekvering er
-  deaktiveret i v0.1.0; brug WSL. Dry-run og de skrivebeskyttede kommandoer forbliver
+  deaktiveret i v1.0.0; brug WSL. Dry-run og de skrivebeskyttede kommandoer forbliver
   tilgængelige, og native Windows-genopretningsmarkører kræver dokumenteret manuel genopretning.
 - **Fastlåste input.** Katalogets input kan være en lokal mappe, en snapshot-fil, eller en
   fastlåst offentlig snapshot-URL, eventuelt låst til en præcis 40-tegns revision.
@@ -51,7 +51,7 @@ CLI'et bruger konventionelle proces-exit-koder:
 | `0`       | Succes (inklusive "tomt, men gyldigt"-resultater, såsom et tomt katalog)   |
 | `1`       | Fejl: valideringsfejl, post ikke fundet, manglende påkrævet indstilling, eller en diagnostisk kontrol, der rapporterer en fejl |
 
-Eksempler observeret i v0.1.0: `catalog validate` på et gyldigt tomt katalog afsluttes med `0` og
+Eksempler observeret i v1.0.0: `catalog validate` på et gyldigt tomt katalog afsluttes med `0` og
 `0 entries valid; catalog is empty`; `info <unknown-id>` afsluttes med `1` og `Plugin not found`;
 `doctor` afsluttes med `1`, når en vilkårlig kontrol (såsom en manglende eksekverbar fil `dsh`)
 rapporterer en fejl.
@@ -79,9 +79,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # From the repository root:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — søger i offentlige katalogfelter lokalt
@@ -94,8 +94,8 @@ Søger i offentlige katalogfelter lokalt mod det valgte katalog-input. Udskriver
 eller `No plugins found.` (exit `0`), når intet matcher.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — finder plugins ud over kataloget
@@ -104,8 +104,8 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Ikke i den udgivne `0.1.0`.** `discover` udgives i `1.0.0`; alle andre kommandoer på denne
-> side virker med den version, der aktuelt er på npm. Kører du den mod `@0.1.0`, fejler den med
+> **Ikke i den udgivne `1.0.0`.** `discover` udgives i `1.0.0`; alle andre kommandoer på denne
+> side virker med den version, der aktuelt er på npm. Kører du den mod `@1.0.0`, fejler den med
 > en ukendt kommando.
 
 Søger først i det kuraterede katalog, og derefter — medmindre `--offline` angives — i det aktive
@@ -118,8 +118,8 @@ gennemgået.
 stabile maskinform, som aldrig lokaliseres.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — viser én offentlig katalogpost
@@ -132,7 +132,7 @@ Viser én offentlig katalogpost ud fra det kanoniske plugin-ID. Afsluttes med `1
 `Plugin not found: <id>`, når ID'et ikke findes i kataloget.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — tilføjer én katalog-plugin via officiel DSH-delegering
@@ -154,10 +154,10 @@ delegeres til de officielle DSH-værktøjer og fortsætter kun med `--allow-code
 
 ```bash
 # Preview only — nothing is written, nothing executes:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Real install — explicit consent to lifecycle code:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — opdaterer én katalog-plugin via officiel DSH-delegering

--- a/docs/i18n/da/CONTRIBUTING.md
+++ b/docs/i18n/da/CONTRIBUTING.md
@@ -167,16 +167,16 @@ medforfatter, men må ikke erstatte skaberens forfatterskab. Se
 
 ## Valideringskommandoer og tilgængelighed
 
-npm-CLI'et udgives som `@diegosouza.pw/dsh-plugins@0.1.0`, så kommandoerne nedenfor er
+npm-CLI'et udgives som `omni-dsh-plugins@1.0.0`, så kommandoerne nedenfor er
 tilgængelige via `npx` allerede i dag. Brug dem præcis som skrevet; bidragydere bør ikke opfinde
 erstatningskommandoer.
 
 Kør disse kommandoer fra repositoryets rod:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` udfører kun de lokale kontroller af YAML, schema, SPDX, præcis SemVer,

--- a/docs/i18n/da/README.md
+++ b/docs/i18n/da/README.md
@@ -17,7 +17,7 @@ Skaber-først opdagelse og installation med én kommando til **DeepSeek Harness 
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -107,7 +107,7 @@ validerede.
 | **Hjemmeside** | Renderet katalogbrowser med søgning og rangering                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Én YAML-fil pr. plugin, den eneste kilde til sandhed             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Skema**  | Offentligt JSON Schema (draft 2020-12), som hver post valideres imod | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Søg, inspicér, validér og installér fra kataloget           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Søg, inspicér, validér og installér fra kataloget           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Maskinfeeds** | `catalog.json` + `catalog.snapshot.json` til værktøjer           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Dette repository er den offentlige kilde til sandhed for kataloget. Hver post er én YAML-fil
@@ -128,15 +128,15 @@ kreditering.
 ## 🚀 Installér CLI'en
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Den scopede pakke udgives som `@diegosouza.pw/dsh-plugins@0.1.0`, og kommandoen ovenfor er i dag
+Den scopede pakke udgives som `omni-dsh-plugins@1.0.0`, og kommandoen ovenfor er i dag
 den kanoniske måde at køre den på; der hostes ikke noget installationsscript her.
 
 ### Brug CLI'en i dag
 
-Version 0.1.0 leveres med skrivebeskyttede opdagelses- og valideringskommandoer samt
+Version 1.0.0 leveres med skrivebeskyttede opdagelses- og valideringskommandoer samt
 installationskommandoer, der kræver samtykke. Den fulde kommandoreference, inklusive flag,
 exitkoder og samtykkespærren for kodeudførelse, findes i [docs/CLI.md](../../docs/CLI.md).
 
@@ -152,19 +152,19 @@ exitkoder og samtykkespærren for kodeudførelse, findes i [docs/CLI.md](../../d
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Kommandoer, der ændrer noget (`add`, `update`, `remove`), udfører aldrig plugin-livscykluskode,
 medmindre du angiver `--allow-code-execution`. På native Windows er disse ændringer deaktiveret
-i v0.1.0; brug WSL. Skrivebeskyttede og dry-run-kommandoer virker overalt.
+i v1.0.0; brug WSL. Skrivebeskyttede og dry-run-kommandoer virker overalt.
 
 ## 🔍 Sådan kommer et plugin ind i kataloget
 
@@ -310,7 +310,7 @@ hvis nogen har katalogiseret dit arbejde, før du selv gjorde det.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Den fulde bidragskontrakt: dokumentation, YAML-regler, gennemgangs-gates    |
 | [SECURITY.md](../../SECURITY.md)                   | Rapportering af plugin- eller katalogsårbarheder; hemmelighedspolitik           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Felt-for-felt-reference for `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | CLI-kommandoreference for `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | CLI-kommandoreference for `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Hvordan kataloget styres: forrang, gates, krav og fjernelser   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Artefakttyper, primære kapacitetskategorier, tags, repository-omfang |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Skaberkreditering, PR-forrang og Git-identitetspolitik                 |

--- a/docs/i18n/de/CLI.md
+++ b/docs/i18n/de/CLI.md
@@ -1,22 +1,22 @@
-# CLI-Referenz — `@diegosouza.pw/dsh-plugins@0.1.0`
+# CLI-Referenz — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · [Português (Brasil)](../pt-BR/CLI.md) · [中文（简体）](../zh-CN/CLI.md) · **Deutsch**
 
 > **Inoffizielles Community-Projekt. Nicht mit DeepSeek verbunden, nicht von DeepSeek unterstützt oder gesponsert.**
 > DeepSeek-Namen und -Marken gehören ihren jeweiligen Eigentümern.
 
-Diese Seite dokumentiert die veröffentlichte CLI genau so, wie sie sich in Version `0.1.0`
+Diese Seite dokumentiert die veröffentlichte CLI genau so, wie sie sich in Version `1.0.0`
 verhält. Jede Synopse und jedes Flag unten stammt aus der eigenen `--help`-Ausgabe des
 veröffentlichten Befehls; nichts hier beschreibt unveröffentlichtes Verhalten. Die CLI wird aus
 privatem Quellcode gepflegt und als das scope-gebundene Paket
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) auf npm
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) auf npm
 veröffentlicht.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Designprinzipien in v0.1.0
+## Designprinzipien in v1.0.0
 
 - **Standardmäßig schreibgeschützt.** `catalog`, `search`, `info`, `list` und `doctor`
   verändern niemals Profile, schreiben keine Dateien und starten keinen Plugin-Code.
@@ -24,7 +24,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   von DSH/pnpm-Lifecycle-Code, sofern du nicht `--allow-code-execution` übergibst. Ohne dieses
   Flag nutze `--dry-run`, um den verifizierten Plan zu sehen.
 - **Native Windows-Policy.** Natives Windows-`add`/`update`/`remove` mit Codeausführung ist in
-  v0.1.0 deaktiviert; nutze WSL. Dry-Run und die schreibgeschützten Befehle bleiben verfügbar,
+  v1.0.0 deaktiviert; nutze WSL. Dry-Run und die schreibgeschützten Befehle bleiben verfügbar,
   und native Windows-Wiederherstellungsmarker erfordern eine dokumentierte manuelle
   Wiederherstellung.
 - **Fixierte Eingaben.** Die Katalogeingabe kann ein lokales Verzeichnis, eine Snapshot-Datei
@@ -54,7 +54,7 @@ Die CLI verwendet konventionelle Prozess-Exit-Codes:
 | `0`       | Erfolg (einschließlich "leer, aber gültig"-Ergebnisse wie ein leerer Katalog) |
 | `1`       | Fehlschlag: Validierungsfehler, Eintrag nicht gefunden, erforderliche Option fehlt, oder eine Diagnoseprüfung meldet einen Fehler |
 
-Mit v0.1.0 beobachtete Beispiele: `catalog validate` bei einem gültigen leeren Katalog endet
+Mit v1.0.0 beobachtete Beispiele: `catalog validate` bei einem gültigen leeren Katalog endet
 mit `0` und `0 entries valid; catalog is empty`; `info <unknown-id>` endet mit `1` und
 `Plugin not found`; `doctor` endet mit `1`, wenn irgendeine Prüfung (etwa ein fehlendes
 `dsh`-Executable) einen Fehler meldet.
@@ -82,9 +82,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # From the repository root:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — durchsucht öffentliche Katalogfelder lokal
@@ -97,8 +97,8 @@ Durchsucht öffentliche Katalogfelder lokal anhand der ausgewählten Katalogeing
 passende Einträge aus, oder `No plugins found.` (Exit `0`), wenn nichts passt.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — findet Plugins jenseits des Katalogs
@@ -107,9 +107,9 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Nicht in der veröffentlichten `0.1.0` enthalten.** `discover` erscheint in `1.0.0`; jeder
+> **Nicht in der veröffentlichten `1.0.0` enthalten.** `discover` erscheint in `1.0.0`; jeder
 > andere Befehl auf dieser Seite funktioniert mit der aktuell auf npm veröffentlichten Version.
-> Das Ausführen gegen `@0.1.0` schlägt mit einem unbekannten Befehl fehl.
+> Das Ausführen gegen `@1.0.0` schlägt mit einem unbekannten Befehl fehl.
 
 Durchsucht zunächst den kuratierten Katalog, dann — sofern nicht `--offline` übergeben wird —
 das Live-GitHub-Topic `dsh-plugin`, sodass ein Plugin, das noch nicht eingereicht wurde,
@@ -121,8 +121,8 @@ solche gekennzeichnet, da nichts an ihnen überprüft wurde.
 maschinenlesbare Form aus, die nie lokalisiert wird.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — zeigt einen öffentlichen Katalogeintrag
@@ -135,7 +135,7 @@ Zeigt einen öffentlichen Katalogeintrag anhand der kanonischen Plugin-ID. Endet
 `Plugin not found: <id>`, wenn die ID nicht im Katalog vorhanden ist.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — fügt ein Katalog-Plugin über offizielle DSH-Delegation hinzu
@@ -158,10 +158,10 @@ tatsächliche Installation delegiert an offizielle DSH-Tools und läuft nur mit
 
 ```bash
 # Preview only — nothing is written, nothing executes:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Real install — explicit consent to lifecycle code:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — aktualisiert ein Katalog-Plugin über offizielle DSH-Delegation

--- a/docs/i18n/de/CLI.md
+++ b/docs/i18n/de/CLI.md
@@ -121,8 +121,8 @@ solche gekennzeichnet, da nichts an ihnen überprüft wurde.
 maschinenlesbare Form aus, die nie lokalisiert wird.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — zeigt einen öffentlichen Katalogeintrag

--- a/docs/i18n/de/CONTRIBUTING.md
+++ b/docs/i18n/de/CONTRIBUTING.md
@@ -180,16 +180,16 @@ darf aber nicht die Autorschaft des Erstellers ersetzen. Siehe
 
 ## Validierungsbefehle und Verfügbarkeit
 
-Der npm-CLI ist als `@diegosouza.pw/dsh-plugins@0.1.0` veröffentlicht, daher sind die
+Der npm-CLI ist als `omni-dsh-plugins@1.0.0` veröffentlicht, daher sind die
 untenstehenden Befehle heute über `npx` verfügbar. Verwende sie exakt wie geschrieben;
 Mitwirkende sollten keine Ersatzbefehle erfinden.
 
 Führe diese Befehle vom Repository-Root aus aus:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` führt nur die oben beschriebenen lokalen YAML-, Schema-, SPDX-, exakten

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -17,7 +17,7 @@ Creator-first-Entdeckung und Ein-Befehl-Installation für **DeepSeek Harness (DS
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@ Sortiert nach Sternen des exakten Repositorys — es zählen nur Sterne, die das
 | **Website** | Gerenderter Katalog-Browser mit Suche und Ranking                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Eine YAML-Datei pro Plugin, die einzige Quelle der Wahrheit             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schema**  | Öffentliches JSON Schema (draft 2020-12), gegen das jeder Eintrag validiert wird | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Suchen, inspizieren, validieren und installieren aus dem Katalog heraus           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Suchen, inspizieren, validieren und installieren aus dem Katalog heraus           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Maschinen-Feeds** | `catalog.json` + `catalog.snapshot.json` für Werkzeuge           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Dieses Repository ist die öffentliche Quelle der Wahrheit für den Katalog. Jeder Eintrag ist eine
@@ -126,15 +126,15 @@ fixierten Quell-Commit und expliziter Zuschreibung.
 ## 🚀 Die CLI installieren
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Das gescopte Paket wird als `@diegosouza.pw/dsh-plugins@0.1.0` veröffentlicht, und der obige Befehl
+Das gescopte Paket wird als `omni-dsh-plugins@1.0.0` veröffentlicht, und der obige Befehl
 ist heute der kanonische Aufruf; hier wird kein Installationsskript gehostet.
 
 ### Die CLI heute nutzen
 
-Version 0.1.0 liefert schreibgeschützte Discovery- und Validierungsbefehle sowie durch Zustimmung
+Version 1.0.0 liefert schreibgeschützte Discovery- und Validierungsbefehle sowie durch Zustimmung
 abgesicherte Installationsbefehle. Die vollständige Befehlsreferenz, einschließlich Flags,
 Exit-Codes und dem Zustimmungs-Gate für die Codeausführung, befindet sich in
 [docs/CLI.md](../../docs/CLI.md).
@@ -151,18 +151,18 @@ Exit-Codes und dem Zustimmungs-Gate für die Codeausführung, befindet sich in
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Verändernde Befehle (`add`, `update`, `remove`) führen niemals Plugin-Lifecycle-Code aus, es sei
-denn, Sie übergeben `--allow-code-execution`. Unter nativem Windows sind diese Änderungen in v0.1.0
+denn, Sie übergeben `--allow-code-execution`. Unter nativem Windows sind diese Änderungen in v1.0.0
 deaktiviert; verwenden Sie WSL. Schreibgeschützte Befehle und Dry-Run-Befehle funktionieren überall.
 
 ## 🔍 Wie ein Plugin in den Katalog gelangt
@@ -313,7 +313,7 @@ falls jemand Ihre Arbeit vor Ihnen katalogisiert hat.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Der vollständige Beitragsvertrag: Nachweise, YAML-Regeln, Prüf-Gates    |
 | [SECURITY.md](../../SECURITY.md)           | Melden von Plugin- oder Katalog-Schwachstellen; Geheimnis-Richtlinie    |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)           | Feld-für-Feld-Referenz für `schemas/plugin.schema.yaml`    |
-| [docs/CLI.md](../../docs/CLI.md)           | CLI-Befehlsreferenz für `@diegosouza.pw/dsh-plugins@0.1.0`    |
+| [docs/CLI.md](../../docs/CLI.md)           | CLI-Befehlsreferenz für `omni-dsh-plugins@1.0.0`    |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)           | Wie der Katalog verwaltet wird: Vorrang, Gates, Ansprüche und Entfernungen    |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)           | Artefakttypen, primäre Fähigkeitskategorien, Tags, Repository-Umfang    |
 | [docs/CREDIT.md](../../docs/CREDIT.md)           | Ersteller-Zuschreibung, PR-Vorrang und Git-Identitätsrichtlinie    |

--- a/docs/i18n/es/CLI.md
+++ b/docs/i18n/es/CLI.md
@@ -1,21 +1,21 @@
-# Referencia del CLI — `@diegosouza.pw/dsh-plugins@0.1.0`
+# Referencia del CLI — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · **Español**
 
 > **Proyecto comunitario no oficial. No afiliado, respaldado ni patrocinado por DeepSeek.**
 > Los nombres y marcas de DeepSeek pertenecen a sus respectivos propietarios.
 
-Esta página documenta el CLI publicado exactamente como se comporta en la versión `0.1.0`. Cada
+Esta página documenta el CLI publicado exactamente como se comporta en la versión `1.0.0`. Cada
 sinopsis y flag a continuación proviene de la propia salida `--help` del comando publicado; nada
 aquí describe comportamiento no lanzado. El CLI se mantiene desde código fuente privado y se
 publica en npm como el paquete con alcance
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Principios de diseño en v0.1.0
+## Principios de diseño en v1.0.0
 
 - **Solo lectura por defecto.** `catalog`, `search`, `info`, `list` y `doctor` nunca modifican
   perfiles, escriben archivos ni disparan código de plugin.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   ejecutar código de ciclo de vida de DSH/pnpm a menos que pase `--allow-code-execution`. Sin
   ella, use `--dry-run` para ver el plan verificado.
 - **Política nativa de Windows.** `add`/`update`/`remove` nativos en Windows con ejecución de
-  código están deshabilitados en v0.1.0; use WSL. El dry-run y los comandos de solo lectura
+  código están deshabilitados en v1.0.0; use WSL. El dry-run y los comandos de solo lectura
   siguen disponibles, y los marcadores de recuperación nativos de Windows requieren recuperación
   manual documentada.
 - **Entradas fijadas.** La entrada del catálogo puede ser un directorio local, un archivo de
@@ -53,7 +53,7 @@ El CLI usa códigos de salida de proceso convencionales:
 | `0`       | Éxito (incluyendo resultados "vacíos pero válidos" como un catálogo vacío)     |
 | `1`       | Fallo: error de validación, entrada no encontrada, opción requerida faltante, o una comprobación de diagnóstico que reporta un error |
 
-Ejemplos observados en v0.1.0: `catalog validate` en un catálogo vacío válido sale con `0` y
+Ejemplos observados en v1.0.0: `catalog validate` en un catálogo vacío válido sale con `0` y
 `0 entries valid; catalog is empty`; `info <unknown-id>` sale con `1` y `Plugin not found`;
 `doctor` sale con `1` cuando alguna comprobación (como un ejecutable `dsh` faltante) reporta un
 error.
@@ -81,9 +81,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # Desde la raíz del repositorio:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — busca campos públicos del catálogo localmente
@@ -96,8 +96,8 @@ Busca campos públicos del catálogo localmente en la entrada de catálogo selec
 entradas coincidentes, o `No plugins found.` (salida `0`) cuando nada coincide.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — encuentra plugins más allá del catálogo
@@ -106,8 +106,8 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **No está en la `0.1.0` publicada.** `discover` se publica en `1.0.0`; el resto de los comandos
-> de esta página funcionan con la versión actualmente en npm. Ejecutarlo contra `@0.1.0` falla
+> **No está en la `1.0.0` publicada.** `discover` se publica en `1.0.0`; el resto de los comandos
+> de esta página funcionan con la versión actualmente en npm. Ejecutarlo contra `@1.0.0` falla
 > con un comando desconocido.
 
 Busca primero en el catálogo curado, luego — a menos que se dé `--offline` — en el tema
@@ -120,8 +120,8 @@ etiquetados como tal, porque nada sobre ellos ha sido revisado.
 de máquina, que nunca se localiza.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — muestra una entrada pública del catálogo
@@ -134,7 +134,7 @@ Muestra una entrada pública del catálogo por ID canónico de plugin. Sale con 
 `Plugin not found: <id>` cuando el ID no está en el catálogo.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — agrega un plugin del catálogo mediante delegación oficial a DSH
@@ -156,10 +156,10 @@ las herramientas oficiales de DSH y solo procede con `--allow-code-execution`.
 
 ```bash
 # Solo vista previa — nada se escribe, nada se ejecuta:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Instalación real — consentimiento explícito al código de ciclo de vida:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — actualiza un plugin del catálogo mediante delegación oficial a DSH

--- a/docs/i18n/es/CLI.md
+++ b/docs/i18n/es/CLI.md
@@ -120,8 +120,8 @@ etiquetados como tal, porque nada sobre ellos ha sido revisado.
 de máquina, que nunca se localiza.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — muestra una entrada pública del catálogo

--- a/docs/i18n/es/CONTRIBUTING.md
+++ b/docs/i18n/es/CONTRIBUTING.md
@@ -173,16 +173,16 @@ verificado, pero no debe reemplazar la autoría del creador. Consulte
 
 ## Comandos de validación y disponibilidad
 
-El CLI de npm se publica como `@diegosouza.pw/dsh-plugins@0.1.0`, así que los comandos que siguen
+El CLI de npm se publica como `omni-dsh-plugins@1.0.0`, así que los comandos que siguen
 están disponibles hoy a través de `npx`. Úselos exactamente como están escritos; los
 contribuidores no deben inventar comandos alternativos.
 
 Ejecute estos comandos desde la raíz del repositorio:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` realiza únicamente las comprobaciones locales de YAML, schema, SPDX, SemVer

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -17,7 +17,7 @@ Descubrimiento centrado en el creador e instalación con un solo comando para pl
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Cada nombre enlaza al repositorio del creador, fijado en el commit exacto que va
 | **Sitio web** | Navegador del catálogo renderizado con búsqueda y clasificación                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Catálogo** | Un archivo YAML por plugin, la única fuente de verdad             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Esquema**  | JSON Schema público (draft 2020-12) contra el que valida cada entrada | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Busca, inspecciona, valida e instala desde el catálogo           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Busca, inspecciona, valida e instala desde el catálogo           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Feeds para máquinas** | `catalog.json` + `catalog.snapshot.json` para herramientas           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Este repositorio es la fuente pública de verdad del catálogo. Cada listado es un archivo YAML
@@ -126,15 +126,15 @@ una, desde el repositorio original del creador, con un commit de origen fijado y
 ## 🚀 Instala la CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-El paquete con ámbito se publica como `@diegosouza.pw/dsh-plugins@0.1.0` y el comando anterior es
+El paquete con ámbito se publica como `omni-dsh-plugins@1.0.0` y el comando anterior es
 la invocación canónica hoy; aquí no se aloja ningún script de instalación.
 
 ### Usa la CLI hoy
 
-La versión 0.1.0 incluye comandos de descubrimiento y validación de solo lectura, además de
+La versión 1.0.0 incluye comandos de descubrimiento y validación de solo lectura, además de
 comandos de instalación protegidos por consentimiento. La referencia completa de comandos,
 incluidos los flags, los códigos de salida y la puerta de consentimiento para la ejecución de
 código, está en [docs/CLI.md](../../docs/CLI.md).
@@ -151,19 +151,19 @@ código, está en [docs/CLI.md](../../docs/CLI.md).
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Los comandos que modifican el sistema (`add`, `update`, `remove`) nunca ejecutan código del ciclo
 de vida del plugin a menos que pases `--allow-code-execution`. En Windows nativo, esas
-mutaciones están desactivadas en la v0.1.0; usa WSL. Los comandos de solo lectura y de
+mutaciones están desactivadas en la v1.0.0; usa WSL. Los comandos de solo lectura y de
 simulación (dry-run) funcionan en todas partes.
 
 ## 🔍 Cómo entra un plugin al catálogo
@@ -312,7 +312,7 @@ si alguien catalogó tu trabajo antes que tú.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | El contrato completo de contribución: evidencia, reglas del YAML, puertas de revisión    |
 | [SECURITY.md](../../SECURITY.md)                   | Cómo reportar vulnerabilidades de plugins o del catálogo; política de secretos           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Referencia campo por campo de `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Referencia de comandos de la CLI para `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Referencia de comandos de la CLI para `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Cómo se gobierna el catálogo: precedencia, puertas, reclamaciones y eliminaciones   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Tipos de artefacto, categorías principales de capacidad, etiquetas, ámbito del repositorio |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Crédito al creador, precedencia de PR y política de identidad de Git                 |

--- a/docs/i18n/fa/README.md
+++ b/docs/i18n/fa/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **وب‌سایت** | مرورگر کاتالوگ رندرشده با جستجو و رتبه‌بندی                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **کاتالوگ** | یک فایل YAML برای هر افزونه، تنها منبع حقیقت             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **اسکیما**  | JSON Schema عمومی (پیش‌نویس 2020-12) که هر ورودی در برابر آن اعتبارسنجی می‌شود | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | جستجو، بازرسی، اعتبارسنجی و نصب از کاتالوگ           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | جستجو، بازرسی، اعتبارسنجی و نصب از کاتالوگ           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **فیدهای ماشینی** | `catalog.json` + `catalog.snapshot.json` برای ابزارها           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 این ریپازیتوری منبع حقیقتِ عمومیِ کاتالوگ است. هر فهرست یک فایل YAML زیر `catalog/plugins/` است که در برابر یک
@@ -125,15 +125,15 @@ JSON Schema منتشرشده اعتبارسنجی شده، از طریق یک pu
 ## 🚀 نصب CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-این بستهٔ اسکوپ‌شده به‌صورت `@diegosouza.pw/dsh-plugins@0.1.0` منتشر می‌شود و دستور بالا امروز فراخوانی استاندارد
+این بستهٔ اسکوپ‌شده به‌صورت `omni-dsh-plugins@1.0.0` منتشر می‌شود و دستور بالا امروز فراخوانی استاندارد
 است؛ هیچ اسکریپت نصب‌کننده‌ای اینجا میزبانی نمی‌شود.
 
 ### استفاده از CLI امروز
 
-نسخهٔ 0.1.0 دستورات فقط‌خواندنیِ کشف و اعتبارسنجی به‌همراه دستورات نصبِ مشروط به رضایت را ارائه می‌دهد. مرجع کامل
+نسخهٔ 1.0.0 دستورات فقط‌خواندنیِ کشف و اعتبارسنجی به‌همراه دستورات نصبِ مشروط به رضایت را ارائه می‌دهد. مرجع کامل
 دستورات، شامل پرچم‌ها، کدهای خروج و دروازهٔ رضایتِ اجرای کد، در [docs/CLI.md](../../docs/CLI.md) است.
 
 | Command                        | چه کاری انجام می‌دهد                                                        | به سیستم شما دست می‌زند؟                    |
@@ -148,18 +148,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 دستورات جهش‌دهنده (`add`، `update`، `remove`) هرگز کد چرخهٔ حیات افزونه را اجرا نمی‌کنند مگر آنکه
-`--allow-code-execution` را ارسال کنید. در Windows بومی این جهش‌ها در نسخهٔ v0.1.0 غیرفعال‌اند؛ از WSL استفاده کنید.
+`--allow-code-execution` را ارسال کنید. در Windows بومی این جهش‌ها در نسخهٔ v1.0.0 غیرفعال‌اند؛ از WSL استفاده کنید.
 دستورات فقط‌خواندنی و dry-run همه‌جا کار می‌کنند.
 
 ## 🔍 چگونه یک افزونه وارد کاتالوگ می‌شود
@@ -298,7 +298,7 @@ requestهایی که توسط سازنده نوشته شده‌اند بر pull 
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | قرارداد کامل مشارکت: شواهد، قواعد YAML، دروازه‌های بازبینی    |
 | [SECURITY.md](../../SECURITY.md)                   | گزارش آسیب‌پذیری‌های افزونه یا کاتالوگ؛ سیاست اطلاعات محرمانه           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | مرجع فیلد‌به‌فیلد برای `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | مرجع دستورات CLI برای `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | مرجع دستورات CLI برای `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | کاتالوگ چگونه اداره می‌شود: اولویت، دروازه‌ها، ادعاها و حذف‌ها   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | انواع مصنوع، دسته‌های اصلی قابلیت، برچسب‌ها، دامنهٔ ریپازیتوری |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | اعتبار سازنده، اولویت PR و سیاست هویت Git                 |

--- a/docs/i18n/fi/CONTRIBUTING.md
+++ b/docs/i18n/fi/CONTRIBUTING.md
@@ -170,16 +170,16 @@ committer tai todennettu yhteistekijä, mutta se ei saa korvata luojan tekijyytt
 
 ## Validointikomennot ja saatavuus
 
-npm-CLI on julkaistu nimellä `@diegosouza.pw/dsh-plugins@0.1.0`, joten alla olevat komennot ovat
+npm-CLI on julkaistu nimellä `omni-dsh-plugins@1.0.0`, joten alla olevat komennot ovat
 saatavilla `npx`:n kautta jo nyt. Käytä niitä täsmälleen sellaisina kuin ne on kirjoitettu;
 osallistujien ei tule keksiä korvaavia komentoja.
 
 Suorita nämä komennot repositorion juuresta:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` suorittaa vain yllä kuvatut paikalliset YAML-, schema-, SPDX-, tarkka SemVer-,

--- a/docs/i18n/fi/README.md
+++ b/docs/i18n/fi/README.md
@@ -17,7 +17,7 @@ Luojalähtöinen löytäminen ja yhden komennon asennus **DeepSeek Harness (DSH)
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Jokainen nimi linkittää luojan repositorioon, kiinnitettynä siihen commitiin,
 | **Verkkosivusto** | Renderöity katalogiselain hakuineen ja järjestyksineen                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalogi** | Yksi YAML-tiedosto per laajennus, ainoa totuuden lähde             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Skeema**  | Julkinen JSON Schema (draft 2020-12), jota vasten jokainen merkintä validoidaan | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Hae, tarkastele, validoi ja asenna katalogista           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Hae, tarkastele, validoi ja asenna katalogista           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Konesyötteet** | `catalog.json` + `catalog.snapshot.json` työkaluille           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Tämä repositorio on katalogin julkinen totuuden lähde. Jokainen merkintä on yksi YAML-tiedosto
@@ -127,15 +127,15 @@ lähdekommitilla ja selkeällä tunnustuksella.
 ## 🚀 Asenna CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Scope-paketti on julkaistu nimellä `@diegosouza.pw/dsh-plugins@0.1.0`, ja yllä oleva komento on
+Scope-paketti on julkaistu nimellä `omni-dsh-plugins@1.0.0`, ja yllä oleva komento on
 tällä hetkellä kanoninen kutsutapa; täällä ei isännöidä asennusskriptiä.
 
 ### Käytä CLI:tä jo tänään
 
-Versio 0.1.0 sisältää vain luku -tilaiset löytämis- ja validointikomennot sekä suostumuksen taakse
+Versio 1.0.0 sisältää vain luku -tilaiset löytämis- ja validointikomennot sekä suostumuksen taakse
 lukitut asennuskomennot. Täydellinen komentoreferenssi, mukaan lukien liput, poistumiskoodit ja
 koodin suoritukseen liittyvä suostumusportti, löytyy tiedostosta [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ koodin suoritukseen liittyvä suostumusportti, löytyy tiedostosta [docs/CLI.md]
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Muuttavat komennot (`add`, `update`, `remove`) eivät koskaan suorita laajennuksen elinkaarikoodia,
 ellet anna lippua `--allow-code-execution`. Natiivissa Windowsissa nämä muutokset on poistettu
-käytöstä versiossa v0.1.0; käytä WSL:ää. Vain luku- ja kuivaharjoituskomennot toimivat kaikkialla.
+käytöstä versiossa v1.0.0; käytä WSL:ää. Vain luku- ja kuivaharjoituskomennot toimivat kaikkialla.
 
 ## 🔍 Miten laajennus liittyy katalogiin
 
@@ -313,7 +313,7 @@ jos joku on luetteloinut työsi ennen sinua.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Täydellinen osallistumissopimus: todisteet, YAML-säännöt, tarkastusportit    |
 | [SECURITY.md](../../SECURITY.md)                   | Laajennuksen tai katalogin haavoittuvuuksien ilmoittaminen; salaisuuskäytäntö           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Kenttäkohtainen referenssi tiedostolle `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | CLI-komentoreferenssi paketille `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | CLI-komentoreferenssi paketille `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Miten katalogia hallinnoidaan: etusijajärjestys, portit, vaatimukset ja poistot   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Artefaktityypit, ensisijaiset ominaisuuskategoriat, tunnisteet, repositorion laajuus |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Luojan tunnustaminen, PR:ien etusijajärjestys ja Git-identiteettikäytäntö                 |

--- a/docs/i18n/fr/CLI.md
+++ b/docs/i18n/fr/CLI.md
@@ -1,21 +1,21 @@
-# Référence CLI — `@diegosouza.pw/dsh-plugins@0.1.0`
+# Référence CLI — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · **Français**
 
 > **Projet communautaire non officiel. Non affilié à, ni approuvé ni sponsorisé par DeepSeek.**
 > Les noms et marques DeepSeek appartiennent à leurs propriétaires respectifs.
 
-Cette page documente le CLI publié exactement tel qu'il se comporte dans la version `0.1.0`.
+Cette page documente le CLI publié exactement tel qu'il se comporte dans la version `1.0.0`.
 Chaque synopsis et chaque flag ci-dessous provient de la sortie `--help` de la commande publiée
 elle-même ; rien ici ne décrit un comportement non publié. Le CLI est maintenu depuis une source
 privée et publié sur npm sous le paquet scoped
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Principes de conception dans la v0.1.0
+## Principes de conception dans la v1.0.0
 
 - **Lecture seule par défaut.** `catalog`, `search`, `info`, `list` et `doctor` ne modifient
   jamais les profils, n'écrivent pas de fichiers et ne déclenchent pas de code de plugin.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   d'exécuter le code de cycle de vie DSH/pnpm à moins que vous ne passiez
   `--allow-code-execution`. Sans cela, utilisez `--dry-run` pour voir le plan vérifié.
 - **Politique native Windows.** `add`/`update`/`remove` natifs sous Windows avec exécution de
-  code sont désactivés dans la v0.1.0 ; utilisez WSL. Le dry-run et les commandes en lecture seule
+  code sont désactivés dans la v1.0.0 ; utilisez WSL. Le dry-run et les commandes en lecture seule
   restent disponibles, et les marqueurs de récupération natifs Windows exigent une récupération
   manuelle documentée.
 - **Entrées fixées.** L'entrée du catalogue peut être un répertoire local, un fichier de
@@ -53,7 +53,7 @@ Le CLI utilise des codes de sortie de processus conventionnels :
 | `0`       | Succès (y compris les résultats « vides mais valides » comme un catalogue vide)     |
 | `1`       | Échec : erreur de validation, entrée introuvable, option obligatoire manquante, ou un contrôle de diagnostic signalant une erreur |
 
-Exemples observés avec la v0.1.0 : `catalog validate` sur un catalogue vide valide se termine avec
+Exemples observés avec la v1.0.0 : `catalog validate` sur un catalogue vide valide se termine avec
 `0` et `0 entries valid; catalog is empty` ; `info <unknown-id>` se termine avec `1` et
 `Plugin not found` ; `doctor` se termine avec `1` lorsqu'un contrôle (comme un exécutable `dsh`
 manquant) signale une erreur.
@@ -80,9 +80,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # Depuis la racine du dépôt :
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — recherche les champs publics du catalogue localement
@@ -96,8 +96,8 @@ Affiche les entrées correspondantes, ou `No plugins found.` (sortie `0`) lorsqu
 correspond.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — trouve des plugins au-delà du catalogue
@@ -106,9 +106,9 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Absent de la version publiée `0.1.0`.** `discover` est livré dans la `1.0.0` ; toutes les
+> **Absent de la version publiée `1.0.0`.** `discover` est livré dans la `1.0.0` ; toutes les
 > autres commandes de cette page fonctionnent avec la version actuellement sur npm. L'exécuter
-> contre `@0.1.0` échoue avec une commande inconnue.
+> contre `@1.0.0` échoue avec une commande inconnue.
 
 Recherche d'abord dans le catalogue curé, puis — sauf si `--offline` est fourni — dans le topic
 GitHub `dsh-plugin` en direct, afin qu'un plugin qui n'a pas encore été soumis reste trouvable.
@@ -120,8 +120,8 @@ licence) ; les résultats communautaires n'en portent aucune et sont étiquetés
 stable, qui n'est jamais localisée.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — affiche une entrée publique du catalogue
@@ -134,7 +134,7 @@ Affiche une entrée publique du catalogue par ID canonique de plugin. Se termine
 `Plugin not found: <id>` lorsque l'ID n'est pas dans le catalogue.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — ajoute un plugin du catalogue via la délégation officielle au DSH
@@ -156,10 +156,10 @@ délègue aux outils officiels du DSH et ne procède qu'avec `--allow-code-execu
 
 ```bash
 # Aperçu uniquement — rien n'est écrit, rien ne s'exécute :
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Installation réelle — consentement explicite au code de cycle de vie :
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — met à jour un plugin du catalogue via la délégation officielle au DSH

--- a/docs/i18n/fr/CLI.md
+++ b/docs/i18n/fr/CLI.md
@@ -120,8 +120,8 @@ licence) ; les résultats communautaires n'en portent aucune et sont étiquetés
 stable, qui n'est jamais localisée.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — affiche une entrée publique du catalogue

--- a/docs/i18n/fr/CONTRIBUTING.md
+++ b/docs/i18n/fr/CONTRIBUTING.md
@@ -177,16 +177,16 @@ dépôt d'origine dans le YAML et la pull request. Un compte de mainteneur ou d'
 
 ## Commandes de validation et disponibilité
 
-Le CLI npm est publié sous le nom `@diegosouza.pw/dsh-plugins@0.1.0`, donc les commandes
+Le CLI npm est publié sous le nom `omni-dsh-plugins@1.0.0`, donc les commandes
 ci-dessous sont disponibles via `npx` dès aujourd'hui. Utilisez-les exactement telles qu'écrites ;
 les contributeurs ne doivent pas inventer de commandes de substitution.
 
 Exécutez ces commandes depuis la racine du dépôt :
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` n'effectue que les contrôles locaux de YAML, schéma, SPDX, SemVer exact, SRI

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -17,7 +17,7 @@ Découverte axée sur le créateur et installation en une seule commande pour le
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ nom renvoie vers le dépôt du créateur, épinglé au commit exact validé par 
 | **Site web** | Navigateur de catalogue avec recherche et classement                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Catalogue** | Un fichier YAML par plugin, source de vérité unique             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schéma**  | Schéma JSON public (brouillon 2020-12) auquel chaque entrée doit être conforme | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Recherche, inspecte, valide et installe depuis le catalogue           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Recherche, inspecte, valide et installe depuis le catalogue           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Flux machine** | `catalog.json` + `catalog.snapshot.json` pour les outils           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Ce dépôt est la source de vérité publique du catalogue. Chaque entrée est un fichier YAML sous
@@ -127,15 +127,15 @@ explicite.
 ## 🚀 Installer le CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Le paquet scopé est publié sous `@diegosouza.pw/dsh-plugins@0.1.0` et la commande ci-dessus est
+Le paquet scopé est publié sous `omni-dsh-plugins@1.0.0` et la commande ci-dessus est
 l'invocation canonique aujourd'hui ; aucun script d'installation n'est hébergé ici.
 
 ### Utiliser le CLI aujourd'hui
 
-La version 0.1.0 embarque des commandes de découverte et de validation en lecture seule, ainsi
+La version 1.0.0 embarque des commandes de découverte et de validation en lecture seule, ainsi
 que des commandes d'installation soumises au consentement. La référence complète des commandes,
 avec les options, les codes de sortie et le contrôle de consentement pour l'exécution de code,
 se trouve dans [docs/CLI.md](../../docs/CLI.md).
@@ -152,19 +152,19 @@ se trouve dans [docs/CLI.md](../../docs/CLI.md).
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Les commandes qui modifient l'état (`add`, `update`, `remove`) n'exécutent jamais de code de
 cycle de vie du plugin, sauf si vous passez `--allow-code-execution`. Sur Windows natif, ces
-modifications sont désactivées en v0.1.0 ; utilisez WSL. Les commandes en lecture seule et de
+modifications sont désactivées en v1.0.0 ; utilisez WSL. Les commandes en lecture seule et de
 simulation fonctionnent partout.
 
 ## 🔍 Comment un plugin entre dans le catalogue
@@ -316,7 +316,7 @@ si quelqu'un a déjà catalogué votre travail avant vous.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Le contrat de contribution complet : preuves, règles YAML, contrôles de revue    |
 | [SECURITY.md](../../SECURITY.md)                   | Signaler des vulnérabilités du plugin ou du catalogue ; politique des secrets           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Référence champ par champ pour `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Référence des commandes CLI pour `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Référence des commandes CLI pour `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Comment le catalogue est gouverné : priorité, contrôles, revendications et suppressions   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Types d'artefacts, catégories de capacité principales, étiquettes, portée du dépôt |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Crédit du créateur, priorité des PR et politique d'identité Git                 |

--- a/docs/i18n/gu/CONTRIBUTING.md
+++ b/docs/i18n/gu/CONTRIBUTING.md
@@ -153,15 +153,15 @@ popularity:
 
 ## વેલિડેશન કમાન્ડ્સ અને ઉપલબ્ધતા
 
-npm CLI `@diegosouza.pw/dsh-plugins@0.1.0` તરીકે પ્રકાશિત થયેલ છે, તેથી નીચેના કમાન્ડ્સ આજે `npx`
+npm CLI `omni-dsh-plugins@1.0.0` તરીકે પ્રકાશિત થયેલ છે, તેથી નીચેના કમાન્ડ્સ આજે `npx`
 દ્વારા ઉપલબ્ધ છે. તેમને બરાબર લખેલા છે તે પ્રમાણે વાપરો; યોગદાનકર્તાઓએ વિકલ્પ કમાન્ડ્સ શોધવા ન જોઈએ.
 
 આ કમાન્ડ્સ રિપોઝિટરીના રૂટમાંથી ચલાવો:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` ફક્ત ઉપર વર્ણવેલા લોકલ YAML, સ્કીમા, SPDX, ચોક્કસ SemVer, SHA-512 SRI અને

--- a/docs/i18n/gu/README.md
+++ b/docs/i18n/gu/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **વેબસાઇટ** | સર્ચ અને રેન્કિંગ સાથે રેન્ડર થયેલ કેટલોગ બ્રાઉઝર                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **કેટલોગ** | દરેક પ્લગિન માટે એક YAML ફાઇલ, એકમાત્ર સોર્સ ઓફ ટ્રુથ             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **સ્કીમા**  | પબ્લિક JSON સ્કીમા (draft 2020-12) જેની સામે દરેક એન્ટ્રી વેલિડેટ થાય છે | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | કેટલોગમાંથી સર્ચ, ઇન્સ્પેક્ટ, વેલિડેટ અને ઇન્સ્ટોલ કરો           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | કેટલોગમાંથી સર્ચ, ઇન્સ્પેક્ટ, વેલિડેટ અને ઇન્સ્ટોલ કરો           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **મશીન ફીડ્સ** | ટૂલ્સ માટે `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 આ રિપોઝીટરી કેટલોગ માટે પબ્લિક સોર્સ ઓફ ટ્રુથ છે. દરેક લિસ્ટિંગ `catalog/plugins/` હેઠળની
@@ -127,15 +127,15 @@
 ## 🚀 CLI ઇન્સ્ટોલ કરો
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-સ્કોપ્ડ પેકેજ `@diegosouza.pw/dsh-plugins@0.1.0` તરીકે પ્રકાશિત થાય છે અને ઉપરનો કમાન્ડ આજે
+સ્કોપ્ડ પેકેજ `omni-dsh-plugins@1.0.0` તરીકે પ્રકાશિત થાય છે અને ઉપરનો કમાન્ડ આજે
 કેનોનિકલ ઇન્વોકેશન છે; અહીં કોઈ ઇન્સ્ટોલર સ્ક્રિપ્ટ હોસ્ટ કરવામાં આવી નથી.
 
 ### આજે CLI નો ઉપયોગ કરો
 
-વર્ઝન 0.1.0 રીડ-ઓન્લી ડિસ્કવરી અને વેલિડેશન કમાન્ડ્સ ઉપરાંત કન્સેન્ટ-ગેટેડ ઇન્સ્ટોલ
+વર્ઝન 1.0.0 રીડ-ઓન્લી ડિસ્કવરી અને વેલિડેશન કમાન્ડ્સ ઉપરાંત કન્સેન્ટ-ગેટેડ ઇન્સ્ટોલ
 કમાન્ડ્સ પ્રદાન કરે છે. ફ્લેગ્સ, એક્ઝિટ કોડ્સ અને કોડ-એક્ઝિક્યુશન
 કન્સેન્ટ ગેટ સહિતનો સંપૂર્ણ કમાન્ડ સંદર્ભ [docs/CLI.md](../../docs/CLI.md) માં છે.
 
@@ -151,18 +151,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 મ્યુટેટિંગ કમાન્ડ્સ (`add`, `update`, `remove`) ક્યારેય પ્લગિન લાઇફસાયકલ કોડ એક્ઝિક્યુટ કરતા નથી જ્યાં સુધી તમે
-`--allow-code-execution` પાસ ન કરો. નેટિવ Windows પર આ મ્યુટેશન્સ v0.1.0 માં ડિસેબલ છે; વાપરો
+`--allow-code-execution` પાસ ન કરો. નેટિવ Windows પર આ મ્યુટેશન્સ v1.0.0 માં ડિસેબલ છે; વાપરો
 WSL. રીડ-ઓન્લી અને ડ્રાય-રન કમાન્ડ્સ દરેક જગ્યાએ કામ કરે છે.
 
 ## 🔍 એક પ્લગિન કેટલોગમાં કેવી રીતે દાખલ થાય છે
@@ -305,7 +305,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | સંપૂર્ણ યોગદાન કરાર: પુરાવો, YAML નિયમો, રિવ્યૂ ગેટ્સ    |
 | [SECURITY.md](../../SECURITY.md)                   | પ્લગિન કે કેટલોગની નબળાઈઓની જાણ કરવી; ગુપ્ત માહિતી પોલિસી           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` માટે ફિલ્ડ-બાય-ફિલ્ડ સંદર્ભ             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` માટે CLI કમાન્ડ સંદર્ભ          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` માટે CLI કમાન્ડ સંદર્ભ          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | કેટલોગનું સંચાલન કેવી રીતે થાય છે: અગ્રતા, ગેટ્સ, દાવાઓ અને દૂર કરવું   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | આર્ટિફેક્ટ પ્રકારો, પ્રાથમિક ક્ષમતા શ્રેણીઓ, ટૅગ્સ, રિપોઝીટરી સ્કોપ |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | ક્રિએટર ક્રેડિટ, PR અગ્રતા અને Git ઓળખ પોલિસી                 |

--- a/docs/i18n/he/README.md
+++ b/docs/i18n/he/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **אתר** | דפדפן קטלוג מרונדר עם חיפוש ודירוג                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **קטלוג** | קובץ YAML אחד לכל תוסף, מקור האמת היחיד             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **סכימה**  | סכימת JSON ציבורית (טיוטה 2020-12) שכל רשומה מאומתת מולה | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | חיפוש, בדיקה, אימות והתקנה מהקטלוג           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | חיפוש, בדיקה, אימות והתקנה מהקטלוג           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **הזנות מכונה** | `catalog.json` + `catalog.snapshot.json` לכלים           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 מאגר זה הוא מקור האמת הציבורי לקטלוג. כל רשומה היא קובץ YAML אחד תחת `catalog/plugins/`, מאומתת
@@ -125,15 +125,15 @@
 ## 🚀 התקנת ה-CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-החבילה בעלת ההיקף המוגבל מפורסמת בתור `@diegosouza.pw/dsh-plugins@0.1.0`, והפקודה שלמעלה היא
+החבילה בעלת ההיקף המוגבל מפורסמת בתור `omni-dsh-plugins@1.0.0`, והפקודה שלמעלה היא
 הקריאה הקנונית כיום; אין כאן סקריפט התקנה מתארח.
 
 ### שימוש ב-CLI כיום
 
-גרסה 0.1.0 כוללת פקודות גילוי ואימות לקריאה בלבד, בנוסף לפקודות התקנה המותנות בהסכמה. הפניה
+גרסה 1.0.0 כוללת פקודות גילוי ואימות לקריאה בלבד, בנוסף לפקודות התקנה המותנות בהסכמה. הפניה
 המלאה לפקודות, כולל דגלים, קודי יציאה ושער ההסכמה להרצת קוד, נמצאת ב-[docs/CLI.md](../../docs/CLI.md).
 
 | פקודה                        | מה היא עושה                                                        | האם היא נוגעת במערכת שלכם?                    |
@@ -148,18 +148,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 פקודות משנות (`add`, `update`, `remove`) לעולם לא מריצות קוד מחזור חיים של תוסף אלא אם תעבירו
-`--allow-code-execution`. ב-Windows מקורי שינויים אלו מושבתים ב-v0.1.0; השתמשו ב-WSL. פקודות
+`--allow-code-execution`. ב-Windows מקורי שינויים אלו מושבתים ב-v1.0.0; השתמשו ב-WSL. פקודות
 לקריאה בלבד ופקודות dry-run פועלות בכל מקום.
 
 ## 🔍 כיצד תוסף נכנס לקטלוג
@@ -299,7 +299,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | חוזה התרומה המלא: ראיות, כללי YAML, שערי בדיקה    |
 | [SECURITY.md](../../SECURITY.md)                   | דיווח על פגיעויות בתוספים או בקטלוג; מדיניות סודות           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | הפניה שדה-אחר-שדה עבור `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | הפניית פקודות CLI עבור `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | הפניית פקודות CLI עבור `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | כיצד מנוהל הקטלוג: קדימות, שערים, תביעות והסרות   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | סוגי חפצים, קטגוריות יכולת עיקריות, תגים, היקף מאגר |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | קרדיט יוצר, קדימות PR ומדיניות זהות Git                 |

--- a/docs/i18n/hi/README.md
+++ b/docs/i18n/hi/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **वेबसाइट** | खोज और रैंकिंग के साथ रेंडर किया गया कैटलॉग ब्राउज़र                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **कैटलॉग** | प्रति प्लगइन एक YAML फ़ाइल, सत्य का एकमात्र स्रोत             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **स्कीमा**  | सार्वजनिक JSON स्कीमा (draft 2020-12) जिसके विरुद्ध हर एंट्री मान्य होती है | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | कैटलॉग से खोजें, निरीक्षण करें, मान्य करें और इंस्टॉल करें           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | कैटलॉग से खोजें, निरीक्षण करें, मान्य करें और इंस्टॉल करें           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **मशीन फ़ीड्स** | टूल्स के लिए `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 यह रिपॉज़िटरी कैटलॉग के लिए सत्य का सार्वजनिक स्रोत है। हर लिस्टिंग `catalog/plugins/` के अंतर्गत एक YAML फ़ाइल है, जो एक
@@ -125,15 +125,15 @@
 ## 🚀 CLI इंस्टॉल करें
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-स्कोप्ड पैकेज `@diegosouza.pw/dsh-plugins@0.1.0` के रूप में प्रकाशित किया गया है और ऊपर दिया गया कमांड आज का कैनोनिकल
+स्कोप्ड पैकेज `omni-dsh-plugins@1.0.0` के रूप में प्रकाशित किया गया है और ऊपर दिया गया कमांड आज का कैनोनिकल
 इनवोकेशन है; यहां कोई इंस्टॉलर स्क्रिप्ट होस्ट नहीं की गई है।
 
 ### आज ही CLI का उपयोग करें
 
-संस्करण 0.1.0 रीड-ओनली डिस्कवरी और वैलिडेशन कमांड के साथ-साथ सहमति-गेटेड इंस्टॉल कमांड भी प्रदान करता है। फ्लैग्स,
+संस्करण 1.0.0 रीड-ओनली डिस्कवरी और वैलिडेशन कमांड के साथ-साथ सहमति-गेटेड इंस्टॉल कमांड भी प्रदान करता है। फ्लैग्स,
 एग्ज़िट कोड और कोड-एग्ज़ीक्यूशन सहमति गेट सहित पूरा कमांड संदर्भ [docs/CLI.md](../../docs/CLI.md) में है।
 
 | कमांड                        | यह क्या करता है                                                        | क्या यह आपके सिस्टम को छूता है?                    |
@@ -148,18 +148,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 म्यूटेटिंग कमांड (`add`, `update`, `remove`) तब तक कभी भी प्लगइन लाइफ़साइकल कोड को एग्ज़ीक्यूट नहीं करते जब तक आप
-`--allow-code-execution` पास न करें। नेटिव Windows पर ये म्यूटेशन v0.1.0 में अक्षम हैं; WSL का उपयोग करें। रीड-ओनली और
+`--allow-code-execution` पास न करें। नेटिव Windows पर ये म्यूटेशन v1.0.0 में अक्षम हैं; WSL का उपयोग करें। रीड-ओनली और
 ड्राई-रन कमांड हर जगह काम करते हैं।
 
 ## 🔍 एक प्लगइन कैटलॉग में कैसे प्रवेश करता है
@@ -297,7 +297,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | पूरा योगदान अनुबंध: प्रमाण, YAML नियम, समीक्षा गेट्स    |
 | [SECURITY.md](../../SECURITY.md)                   | प्लगइन या कैटलॉग की भेद्यताओं की रिपोर्ट करना; गोपनीय जानकारी नीति           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` के लिए फ़ील्ड-दर-फ़ील्ड संदर्भ             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` के लिए CLI कमांड संदर्भ          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` के लिए CLI कमांड संदर्भ          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | कैटलॉग को कैसे संचालित किया जाता है: प्राथमिकता, गेट्स, दावे और हटाना   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | आर्टिफैक्ट प्रकार, प्राथमिक क्षमता श्रेणियां, टैग, रिपॉज़िटरी स्कोप |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | निर्माता श्रेय, PR प्राथमिकता और Git पहचान नीति                 |

--- a/docs/i18n/hu/CLI.md
+++ b/docs/i18n/hu/CLI.md
@@ -123,8 +123,8 @@ A `--limit <n>` korlátozza a szintenkénti eredményeket (alapértelmezett `8`)
 stabil gépi formát adja, amely soha nincs lokalizálva.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — egy nyilvános katalógusbejegyzés megjelenítése

--- a/docs/i18n/hu/CLI.md
+++ b/docs/i18n/hu/CLI.md
@@ -1,21 +1,21 @@
-# CLI Referencia — `@diegosouza.pw/dsh-plugins@0.1.0`
+# CLI Referencia — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · **Magyar**
 
 > **Nem hivatalos közösségi projekt. Nem áll kapcsolatban a DeepSeekkel, és nem az ő jóváhagyásával vagy támogatásával készült.**
 > A DeepSeek nevek és védjegyek a megfelelő tulajdonosaik tulajdonát képezik.
 
-Ez az oldal a publikált CLI-t dokumentálja pontosan úgy, ahogyan a `0.1.0` verzióban viselkedik.
+Ez az oldal a publikált CLI-t dokumentálja pontosan úgy, ahogyan a `1.0.0` verzióban viselkedik.
 Minden alábbi szinopszis és flag a publikált parancs saját `--help` kimenetéből származik; semmi
 itt nem ír le meg nem jelent viselkedést. A CLI privát forrásból van karbantartva, és az npm-re
-`@diegosouza.pw/dsh-plugins` scope-olt csomagként kerül kiadásra
-([`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)).
+`omni-dsh-plugins` scope-olt csomagként kerül kiadásra
+([`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins)).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Tervezési elvek a v0.1.0-ban
+## Tervezési elvek a v1.0.0-ban
 
 - **Alapértelmezésben csak olvasható.** A `catalog`, `search`, `info`, `list` és `doctor`
   parancsok soha nem módosítanak profilokat, nem írnak fájlokat, és nem indítanak
@@ -25,7 +25,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   `--allow-code-execution` kapcsolót. Enélkül használd a `--dry-run` kapcsolót az ellenőrzött
   terv megtekintéséhez.
 - **Natív Windows-szabályzat.** A natív Windowson futó `add`/`update`/`remove` kódvégrehajtással
-  le van tiltva a v0.1.0-ban; használj WSL-t. A dry-run és a csak olvasható parancsok
+  le van tiltva a v1.0.0-ban; használj WSL-t. A dry-run és a csak olvasható parancsok
   elérhetők maradnak, és a natív Windows helyreállítási jelzők dokumentált manuális
   helyreállítást igényelnek.
 - **Rögzített bemenetek.** A katalógusbemenet lehet egy helyi könyvtár, egy snapshot-fájl, vagy
@@ -55,7 +55,7 @@ A CLI hagyományos folyamat-kilépési kódokat használ:
 | `0`          | Siker (beleértve az "üres, de érvényes" eredményeket, mint egy üres katalógus) |
 | `1`          | Hiba: validációs hiba, nem található bejegyzés, hiányzó kötelező opció, vagy egy diagnosztikai ellenőrzés hibát jelent |
 
-A v0.1.0-nál megfigyelt példák: a `catalog validate` egy érvényes üres katalóguson `0`-val lép
+A v1.0.0-nál megfigyelt példák: a `catalog validate` egy érvényes üres katalóguson `0`-val lép
 ki, `0 entries valid; catalog is empty` üzenettel; az `info <unknown-id>` `1`-gyel lép ki,
 `Plugin not found` üzenettel; a `doctor` `1`-gyel lép ki, ha bármely ellenőrzés (mint egy
 hiányzó `dsh` futtatható) hibát jelent.
@@ -83,9 +83,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # A repository gyökeréből:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — nyilvános katalógusmezők helyi keresése
@@ -99,8 +99,8 @@ egyező bejegyzéseket, vagy a `No plugins found.` üzenetet (kilépés `0`-val)
 egyezik.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — bővítmények keresése a katalógoson túl
@@ -109,8 +109,8 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Nincs benne a publikált `0.1.0`-ban.** A `discover` az `1.0.0`-ban jelenik meg; az oldal
-> minden más parancsa az npm-en jelenleg elérhető verzióval működik. Ha a `@0.1.0` ellen
+> **Nincs benne a publikált `1.0.0`-ban.** A `discover` az `1.0.0`-ban jelenik meg; az oldal
+> minden más parancsa az npm-en jelenleg elérhető verzióval működik. Ha a `@1.0.0` ellen
 > futtatod, ismeretlen paranccsal hibázik.
 
 Először a kurált katalógusban keres, majd — hacsak nem adod meg a `--offline` kapcsolót — az
@@ -123,8 +123,8 @@ A `--limit <n>` korlátozza a szintenkénti eredményeket (alapértelmezett `8`)
 stabil gépi formát adja, amely soha nincs lokalizálva.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — egy nyilvános katalógusbejegyzés megjelenítése
@@ -137,7 +137,7 @@ Megjelenít egy nyilvános katalógusbejegyzést a kanonikus bővítmény-ID ala
 `Plugin not found: <id>` üzenettel, ha az ID nincs a katalógusban.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — egy katalógus-bővítmény hozzáadása hivatalos DSH-delegáláson keresztül
@@ -159,10 +159,10 @@ a hivatalos DSH-eszközökre delegál, és csak a `--allow-code-execution` megad
 
 ```bash
 # Csak előnézet — semmi nem íródik, semmi nem fut:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Valódi telepítés — explicit hozzájárulás az életciklus-kódhoz:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — egy katalógus-bővítmény frissítése hivatalos DSH-delegáláson keresztül

--- a/docs/i18n/hu/CONTRIBUTING.md
+++ b/docs/i18n/hu/CONTRIBUTING.md
@@ -174,16 +174,16 @@ szabályzatért.
 
 ## Validációs parancsok és elérhetőség
 
-Az npm CLI `@diegosouza.pw/dsh-plugins@0.1.0` néven van publikálva, így az alábbi parancsok ma is
+Az npm CLI `omni-dsh-plugins@1.0.0` néven van publikálva, így az alábbi parancsok ma is
 elérhetők `npx`-en keresztül. Használd őket pontosan úgy, ahogy le vannak írva; a
 hozzájárulóknak nem szabad helyettesítő parancsokat kitalálniuk.
 
 Futtasd ezeket a parancsokat a repository gyökeréből:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 A `catalog validate` csak a fent leírt helyi YAML-, séma-, SPDX-, pontos SemVer-, SHA-512 SRI- és

--- a/docs/i18n/hu/README.md
+++ b/docs/i18n/hu/README.md
@@ -17,7 +17,7 @@ Alkotó-központú felfedezés és egyparancsos telepítés a **DeepSeek Harness
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -107,7 +107,7 @@ ellenőrzött.
 | **Weboldal** | Renderelt katalógusböngésző kereséssel és rangsorolással                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalógus** | Egy YAML-fájl bővítményenként, az egyetlen hiteles forrás             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Séma**  | Nyilvános JSON Schema (draft 2020-12), amely ellen minden bejegyzés validál | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Keresés, vizsgálat, validálás és telepítés a katalógusból           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Keresés, vizsgálat, validálás és telepítés a katalógusból           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Gépi feedek** | `catalog.json` + `catalog.snapshot.json` eszközök számára           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Ez a repository a katalógus nyilvános hiteles forrása. Minden bejegyzés egy YAML-fájl a
@@ -128,15 +128,15 @@ jóváírással.
 ## 🚀 Telepítsd a CLI-t
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-A scope-olt csomag `@diegosouza.pw/dsh-plugins@0.1.0` néven van publikálva, és a fenti parancs a
+A scope-olt csomag `omni-dsh-plugins@1.0.0` néven van publikálva, és a fenti parancs a
 ma érvényes kanonikus meghívási mód; itt nincs telepítő szkript hosztolva.
 
 ### Használd a CLI-t már ma
 
-A 0.1.0-s verzió csak olvasható felfedező és validáló parancsokat kínál, valamint
+A 1.0.0-s verzió csak olvasható felfedező és validáló parancsokat kínál, valamint
 hozzájárulás-kapuzott telepítő parancsokat. A teljes parancsreferencia, beleértve a flageket, a
 kilépési kódokat és a kódvégrehajtási hozzájárulási kaput, itt található: [docs/CLI.md](../../docs/CLI.md).
 
@@ -152,19 +152,19 @@ kilépési kódokat és a kódvégrehajtási hozzájárulási kaput, itt találh
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Az állapotot módosító parancsok (`add`, `update`, `remove`) soha nem futtatják le a bővítmény
 életciklus-kódját, hacsak nem adod meg a `--allow-code-execution` kapcsolót. Natív Windows alatt
-ezek a módosítások a v0.1.0-ban le vannak tiltva; használj WSL-t. A csak olvasható és a dry-run
+ezek a módosítások a v1.0.0-ban le vannak tiltva; használj WSL-t. A csak olvasható és a dry-run
 parancsok mindenhol működnek.
 
 ## 🔍 Hogyan kerül be egy bővítmény a katalógusba
@@ -315,7 +315,7 @@ ha valaki már katalogizálta a munkádat, mielőtt te tetted volna.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | A teljes hozzájárulási szerződés: bizonyítékok, YAML-szabályok, átvizsgálási kapuk    |
 | [SECURITY.md](../../SECURITY.md)                   | Bővítmény- vagy katalógus-sérülékenységek bejelentése; titokkezelési szabályzat           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Mezőnkénti referencia a `schemas/plugin.schema.yaml`-hoz             |
-| [docs/CLI.md](../../docs/CLI.md)                   | CLI-parancsreferencia a `@diegosouza.pw/dsh-plugins@0.1.0`-hoz          |
+| [docs/CLI.md](../../docs/CLI.md)                   | CLI-parancsreferencia a `omni-dsh-plugins@1.0.0`-hoz          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Hogyan irányítják a katalógust: elsőbbség, kapuk, igénylések és eltávolítások   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Artefaktumtípusok, elsődleges képességkategóriák, címkék, repository-hatókör |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Alkotói jóváírás, PR-elsőbbség és Git-identitási szabályzat                 |

--- a/docs/i18n/id/README.md
+++ b/docs/i18n/id/README.md
@@ -17,7 +17,7 @@ Penemuan yang mengutamakan kreator dan instalasi satu perintah untuk plugin **De
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Setiap nama tertaut ke repositori kreator, dipatok pada commit tepat yang divali
 | **Situs web** | Peramban katalog yang dirender lengkap dengan pencarian dan peringkat                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Satu file YAML per plugin, satu-satunya sumber kebenaran             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Skema**  | JSON Schema publik (draft 2020-12) yang divalidasi oleh setiap entri | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Cari, periksa, validasi, dan instal dari katalog           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Cari, periksa, validasi, dan instal dari katalog           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Feed mesin** | `catalog.json` + `catalog.snapshot.json` untuk alat bantu           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Repositori ini adalah sumber kebenaran publik untuk katalog. Setiap entri adalah satu file YAML
@@ -127,15 +127,15 @@ atribusi yang eksplisit.
 ## 🚀 Instal CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Paket dengan scope ini dipublikasikan sebagai `@diegosouza.pw/dsh-plugins@0.1.0` dan perintah di
+Paket dengan scope ini dipublikasikan sebagai `omni-dsh-plugins@1.0.0` dan perintah di
 atas adalah pemanggilan kanonis saat ini; tidak ada skrip installer yang di-hosting di sini.
 
 ### Gunakan CLI hari ini
 
-Versi 0.1.0 menyediakan perintah penemuan dan validasi baca-saja, ditambah perintah instalasi
+Versi 1.0.0 menyediakan perintah penemuan dan validasi baca-saja, ditambah perintah instalasi
 yang memerlukan persetujuan. Referensi perintah lengkap, termasuk flag, kode keluar, dan gerbang
 persetujuan eksekusi kode, ada di [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ persetujuan eksekusi kode, ada di [docs/CLI.md](../../docs/CLI.md).
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Perintah yang mengubah data (`add`, `update`, `remove`) tidak pernah mengeksekusi kode siklus
 hidup plugin kecuali Anda menambahkan `--allow-code-execution`. Pada Windows native, mutasi ini
-dinonaktifkan di v0.1.0; gunakan WSL. Perintah baca-saja dan dry-run berfungsi di mana saja.
+dinonaktifkan di v1.0.0; gunakan WSL. Perintah baca-saja dan dry-run berfungsi di mana saja.
 
 ## 🔍 Bagaimana sebuah plugin masuk ke katalog
 
@@ -309,7 +309,7 @@ jika seseorang sudah mengatalogkan karya Anda lebih dulu.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Kontrak kontribusi lengkap: bukti, aturan YAML, gerbang tinjauan    |
 | [SECURITY.md](../../SECURITY.md)                   | Melaporkan kerentanan plugin atau katalog; kebijakan rahasia           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Referensi bidang-demi-bidang untuk `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Referensi perintah CLI untuk `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Referensi perintah CLI untuk `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Bagaimana katalog diatur: prioritas, gerbang, klaim, dan penghapusan   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Jenis artefak, kategori kapabilitas utama, tag, ruang lingkup repositori |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Kredit kreator, prioritas PR, dan kebijakan identitas Git                 |

--- a/docs/i18n/in/README.md
+++ b/docs/i18n/in/README.md
@@ -17,7 +17,7 @@ Penemuan yang mengutamakan kreator dan instalasi satu perintah untuk plugin **De
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Setiap nama tertaut ke repositori kreator, dipatok pada commit tepat yang divali
 | **Situs web** | Peramban katalog yang dirender lengkap dengan pencarian dan peringkat                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Satu file YAML per plugin, satu-satunya sumber kebenaran             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Skema**  | JSON Schema publik (draft 2020-12) yang divalidasi oleh setiap entri | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Cari, periksa, validasi, dan instal dari katalog           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Cari, periksa, validasi, dan instal dari katalog           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Feed mesin** | `catalog.json` + `catalog.snapshot.json` untuk alat bantu           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Repositori ini adalah sumber kebenaran publik untuk katalog. Setiap entri adalah satu file YAML
@@ -127,15 +127,15 @@ atribusi yang eksplisit.
 ## 🚀 Instal CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Paket dengan scope ini dipublikasikan sebagai `@diegosouza.pw/dsh-plugins@0.1.0` dan perintah di
+Paket dengan scope ini dipublikasikan sebagai `omni-dsh-plugins@1.0.0` dan perintah di
 atas adalah pemanggilan kanonis saat ini; tidak ada skrip installer yang di-hosting di sini.
 
 ### Gunakan CLI hari ini
 
-Versi 0.1.0 menyediakan perintah penemuan dan validasi baca-saja, ditambah perintah instalasi
+Versi 1.0.0 menyediakan perintah penemuan dan validasi baca-saja, ditambah perintah instalasi
 yang memerlukan persetujuan. Referensi perintah lengkap, termasuk flag, kode keluar, dan gerbang
 persetujuan eksekusi kode, ada di [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ persetujuan eksekusi kode, ada di [docs/CLI.md](../../docs/CLI.md).
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Perintah yang mengubah data (`add`, `update`, `remove`) tidak pernah mengeksekusi kode siklus
 hidup plugin kecuali Anda menambahkan `--allow-code-execution`. Pada Windows native, mutasi ini
-dinonaktifkan di v0.1.0; gunakan WSL. Perintah baca-saja dan dry-run berfungsi di mana saja.
+dinonaktifkan di v1.0.0; gunakan WSL. Perintah baca-saja dan dry-run berfungsi di mana saja.
 
 ## 🔍 Bagaimana sebuah plugin masuk ke katalog
 
@@ -309,7 +309,7 @@ jika seseorang sudah mengatalogkan karya Anda lebih dulu.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Kontrak kontribusi lengkap: bukti, aturan YAML, gerbang tinjauan    |
 | [SECURITY.md](../../SECURITY.md)                   | Melaporkan kerentanan plugin atau katalog; kebijakan rahasia           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Referensi bidang-demi-bidang untuk `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Referensi perintah CLI untuk `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Referensi perintah CLI untuk `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Bagaimana katalog diatur: prioritas, gerbang, klaim, dan penghapusan   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Jenis artefak, kategori kapabilitas utama, tag, ruang lingkup repositori |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Kredit kreator, prioritas PR, dan kebijakan identitas Git                 |

--- a/docs/i18n/it/CLI.md
+++ b/docs/i18n/it/CLI.md
@@ -119,8 +119,8 @@ etichettati come tali, perché nulla di essi è stato revisionato.
 leggibile da macchina, che non viene mai localizzata.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — mostra una voce pubblica del catalogo

--- a/docs/i18n/it/CLI.md
+++ b/docs/i18n/it/CLI.md
@@ -1,21 +1,21 @@
-# Riferimento CLI — `@diegosouza.pw/dsh-plugins@0.1.0`
+# Riferimento CLI — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · **Italiano**
 
 > **Progetto comunitario non ufficiale. Non affiliato, approvato o sponsorizzato da DeepSeek.**
 > I nomi e i marchi DeepSeek appartengono ai rispettivi proprietari.
 
-Questa pagina documenta la CLI pubblicata esattamente come si comporta nella versione `0.1.0`.
+Questa pagina documenta la CLI pubblicata esattamente come si comporta nella versione `1.0.0`.
 Ogni sinossi e flag qui sotto proviene dall'output `--help` proprio del comando pubblicato; nulla
 qui descrive un comportamento non rilasciato. La CLI è mantenuta a partire da codice sorgente
 privato e rilasciata su npm come il pacchetto con scope
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Principi di design nella v0.1.0
+## Principi di design nella v1.0.0
 
 - **Sola lettura per impostazione predefinita.** `catalog`, `search`, `info`, `list` e `doctor`
   non modificano mai i profili, non scrivono file né avviano codice di plugin.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   eseguire codice del ciclo di vita del DSH/pnpm a meno che tu non passi
   `--allow-code-execution`. Senza questo flag, usa `--dry-run` per vedere il piano verificato.
 - **Policy nativa per Windows.** `add`/`update`/`remove` nativi su Windows con esecuzione di
-  codice sono disabilitati nella v0.1.0; usa il WSL. Il dry-run e i comandi in sola lettura
+  codice sono disabilitati nella v1.0.0; usa il WSL. Il dry-run e i comandi in sola lettura
   restano disponibili, e i marcatori di recupero nativi di Windows richiedono un recupero
   manuale documentato.
 - **Input fissati.** L'input del catalogo può essere una directory locale, un file di snapshot,
@@ -53,7 +53,7 @@ La CLI usa codici di uscita di processo convenzionali:
 | `0`               | Successo (inclusi i risultati "vuoti ma validi" come un catalogo vuoto)   |
 | `1`               | Fallimento: errore di validazione, voce non trovata, opzione obbligatoria mancante, o una verifica diagnostica che segnala un errore |
 
-Esempi osservati con la v0.1.0: `catalog validate` su un catalogo vuoto valido esce con `0` e
+Esempi osservati con la v1.0.0: `catalog validate` su un catalogo vuoto valido esce con `0` e
 `0 entries valid; catalog is empty`; `info <unknown-id>` esce con `1` e `Plugin not found`;
 `doctor` esce con `1` quando una qualsiasi verifica (come un eseguibile `dsh` mancante) riporta
 un errore.
@@ -80,9 +80,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # Dalla radice del repository:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — cerca i campi pubblici del catalogo localmente
@@ -95,8 +95,8 @@ Cerca i campi pubblici del catalogo localmente sull'input di catalogo selezionat
 voci corrispondenti, oppure `No plugins found.` (uscita `0`) quando nulla corrisponde.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — trova plugin oltre il catalogo
@@ -105,9 +105,9 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Non presente nella `0.1.0` pubblicata.** `discover` viene rilasciato nella `1.0.0`; ogni
+> **Non presente nella `1.0.0` pubblicata.** `discover` viene rilasciato nella `1.0.0`; ogni
 > altro comando in questa pagina funziona con la versione attualmente su npm. Eseguirlo contro
-> `@0.1.0` fallisce con un comando sconosciuto.
+> `@1.0.0` fallisce con un comando sconosciuto.
 
 Cerca prima nel catalogo curato, poi — a meno che non venga fornito `--offline` — nel topic
 GitHub `dsh-plugin` live, così un plugin che non è ancora stato inviato resta comunque
@@ -119,8 +119,8 @@ etichettati come tali, perché nulla di essi è stato revisionato.
 leggibile da macchina, che non viene mai localizzata.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — mostra una voce pubblica del catalogo
@@ -133,7 +133,7 @@ Mostra una voce pubblica del catalogo tramite l'ID canonico del plugin. Esce con
 `Plugin not found: <id>` quando l'ID non è nel catalogo.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — aggiunge un plugin del catalogo tramite la delega ufficiale al DSH
@@ -155,10 +155,10 @@ agli strumenti ufficiali del DSH e procede solo con `--allow-code-execution`.
 
 ```bash
 # Solo anteprima — nulla viene scritto, nulla viene eseguito:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Installazione reale — consenso esplicito al codice del ciclo di vita:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — aggiorna un plugin del catalogo tramite la delega ufficiale al DSH

--- a/docs/i18n/it/CONTRIBUTING.md
+++ b/docs/i18n/it/CONTRIBUTING.md
@@ -178,16 +178,16 @@ co-autore verificato, ma non deve sostituire l'autoria del creatore. Vedi
 
 ## Comandi di validazione e disponibilità
 
-La CLI npm è pubblicata come `@diegosouza.pw/dsh-plugins@0.1.0`, quindi i comandi qui sotto sono
+La CLI npm è pubblicata come `omni-dsh-plugins@1.0.0`, quindi i comandi qui sotto sono
 disponibili oggi tramite `npx`. Usali esattamente come scritti; i contributori non dovrebbero
 inventare comandi sostitutivi.
 
 Esegui questi comandi dalla radice del repository:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` esegue solo i controlli locali di YAML, schema, SPDX, SemVer esatto, SRI

--- a/docs/i18n/it/README.md
+++ b/docs/i18n/it/README.md
@@ -17,7 +17,7 @@ Scoperta orientata ai creatori e installazione con un solo comando per i plugin 
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Ogni nome rimanda al repository del creatore, fissato esattamente al commit vali
 | **Sito web** | Browser del catalogo renderizzato con ricerca e classifica                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Catalogo** | Un file YAML per plugin, l'unica fonte di verità             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schema**  | JSON Schema pubblico (draft 2020-12) rispetto al quale ogni voce viene validata | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Cerca, ispeziona, valida e installa dal catalogo           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Cerca, ispeziona, valida e installa dal catalogo           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Feed per macchine** | `catalog.json` + `catalog.snapshot.json` per gli strumenti           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Questo repository è la fonte pubblica di verità per il catalogo. Ogni voce è un file YAML
@@ -127,15 +127,15 @@ esplicita.
 ## 🚀 Installa la CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Il pacchetto con scope è pubblicato come `@diegosouza.pw/dsh-plugins@0.1.0` e il comando sopra è
+Il pacchetto con scope è pubblicato come `omni-dsh-plugins@1.0.0` e il comando sopra è
 l'invocazione canonica di oggi; qui non è ospitato alcuno script di installazione.
 
 ### Usa la CLI oggi
 
-La versione 0.1.0 fornisce comandi di scoperta e validazione in sola lettura, oltre a comandi di
+La versione 1.0.0 fornisce comandi di scoperta e validazione in sola lettura, oltre a comandi di
 installazione soggetti a consenso. Il riferimento completo dei comandi, inclusi i flag, i codici
 di uscita e il gate di consenso all'esecuzione di codice, è in [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ di uscita e il gate di consenso all'esecuzione di codice, è in [docs/CLI.md](..
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 I comandi che modificano lo stato (`add`, `update`, `remove`) non eseguono mai il codice del ciclo
 di vita del plugin a meno che tu non passi `--allow-code-execution`. Su Windows nativo queste
-mutazioni sono disabilitate nella v0.1.0; usa WSL. I comandi in sola lettura e in dry-run
+mutazioni sono disabilitate nella v1.0.0; usa WSL. I comandi in sola lettura e in dry-run
 funzionano ovunque.
 
 ## 🔍 Come un plugin entra nel catalogo
@@ -312,7 +312,7 @@ se qualcuno ha catalogato il tuo lavoro prima di te.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Il contratto di contribuzione completo: prove, regole YAML, gate di revisione    |
 | [SECURITY.md](../../SECURITY.md)                   | Come segnalare vulnerabilità di plugin o catalogo; policy sui segreti           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Riferimento campo per campo per `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Riferimento dei comandi CLI per `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Riferimento dei comandi CLI per `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Come viene governato il catalogo: precedenza, gate, rivendicazioni e rimozioni   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Tipi di artefatto, categorie di capacità principali, tag, ambito del repository |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Credito al creatore, precedenza delle PR e policy sull'identità Git                 |

--- a/docs/i18n/ja/CONTRIBUTING.md
+++ b/docs/i18n/ja/CONTRIBUTING.md
@@ -162,16 +162,16 @@ Git authorshipまたは `Co-authored-by` トレーラーを使用できます。
 
 ## 検証コマンドと利用可能性
 
-npmのCLIは `@diegosouza.pw/dsh-plugins@0.1.0` として公開されているため、以下のコマンドは現在 `npx` を通
+npmのCLIは `omni-dsh-plugins@1.0.0` として公開されているため、以下のコマンドは現在 `npx` を通
 じて利用できます。記載されているとおりに正確に使用してください。貢献者は代替コマンドを創作すべきではあり
 ません。
 
 これらのコマンドはリポジトリのルートから実行してください:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` は、上記で説明したローカルのYAML、スキーマ、SPDX、正確なSemVer、SHA-512 SRI、重複の

--- a/docs/i18n/ja/README.md
+++ b/docs/i18n/ja/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@
 | **ウェブサイト** | 検索とランキング機能を備えたレンダリング済みカタログブラウザ                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **カタログ** | プラグインごとに1つのYAMLファイル、唯一の信頼できる情報源             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **スキーマ**  | すべてのエントリが検証される、公開のJSON Schema（draft 2020-12） | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | カタログから検索・調査・検証・インストール           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | カタログから検索・調査・検証・インストール           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **マシン向けフィード** | ツール向けの `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 このリポジトリは、カタログの公開された信頼できる情報源です。すべてのエントリは `catalog/plugins/` 配下の1つのYAMLファイルであり、公開されたJSON Schemaに対して検証され、個別にレビューされた1件のプルリクエストを通じて追加され、常にプラグインの元のクリエイターにクレジットされます。カタログ内のいかなる項目も、他のカタログやリストから生成されたものではありません。各エントリは、固定されたコミットにおけるクリエイターの元のリポジトリから再構築されています。
@@ -118,14 +118,14 @@
 ## 🚀 CLIをインストール
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-このスコープ付きパッケージは `@diegosouza.pw/dsh-plugins@0.1.0` として公開されており、上記のコマンドが現時点での正規の呼び出し方法です。インストーラースクリプトはここではホストされていません。
+このスコープ付きパッケージは `omni-dsh-plugins@1.0.0` として公開されており、上記のコマンドが現時点での正規の呼び出し方法です。インストーラースクリプトはここではホストされていません。
 
 ### 今すぐCLIを使う
 
-バージョン0.1.0には、読み取り専用の発見・検証コマンドに加えて、同意ゲート付きのインストールコマンドが含まれています。フラグ、終了コード、コード実行の同意ゲートを含む完全なコマンドリファレンスは [docs/CLI.md](../../docs/CLI.md) にあります。
+バージョン1.0.0には、読み取り専用の発見・検証コマンドに加えて、同意ゲート付きのインストールコマンドが含まれています。フラグ、終了コード、コード実行の同意ゲートを含む完全なコマンドリファレンスは [docs/CLI.md](../../docs/CLI.md) にあります。
 
 | コマンド                        | 何をするか                                                        | システムに影響するか？                    |
 | ------------------------------ | ------------------------------------------------------------------- | --------------------------------------- |
@@ -139,17 +139,17 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
-変更を伴うコマンド（`add`、`update`、`remove`）は、`--allow-code-execution` を渡さない限り、プラグインのライフサイクルコードを実行することはありません。ネイティブWindowsでは、これらの変更操作はv0.1.0で無効化されています。WSLを使用してください。読み取り専用コマンドとドライランコマンドはどこでも動作します。
+変更を伴うコマンド（`add`、`update`、`remove`）は、`--allow-code-execution` を渡さない限り、プラグインのライフサイクルコードを実行することはありません。ネイティブWindowsでは、これらの変更操作はv1.0.0で無効化されています。WSLを使用してください。読み取り専用コマンドとドライランコマンドはどこでも動作します。
 
 ## 🔍 プラグインがカタログに登録される仕組み
 
@@ -264,7 +264,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | 完全な貢献契約: 証拠、YAMLルール、レビューゲート    |
 | [SECURITY.md](../../SECURITY.md)                   | プラグインまたはカタログの脆弱性の報告; 秘密情報に関するポリシー           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` のフィールドごとのリファレンス             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` のCLIコマンドリファレンス          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` のCLIコマンドリファレンス          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | カタログがどのように統治されているか: 優先順位、ゲート、クレーム、削除   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | アーティファクトの種類、主な機能カテゴリ、タグ、リポジトリの範囲 |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | クリエイターへのクレジット、PRの優先順位、Gitアイデンティティポリシー                 |

--- a/docs/i18n/ko/CLI.md
+++ b/docs/i18n/ko/CLI.md
@@ -117,8 +117,8 @@ dsh-plugins discover [options] <query...>
 않는 안정적인 기계 형식을 내보냅니다.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — 하나의 공개 카탈로그 항목을 표시합니다

--- a/docs/i18n/ko/CLI.md
+++ b/docs/i18n/ko/CLI.md
@@ -1,21 +1,21 @@
-# CLI 참조 — `@diegosouza.pw/dsh-plugins@0.1.0`
+# CLI 참조 — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · **한국어**
 
 > **비공식 커뮤니티 프로젝트입니다. DeepSeek와 제휴, 승인, 후원 관계가 없습니다.**
 > DeepSeek의 이름과 상표는 각 소유자에게 귀속됩니다.
 
-이 페이지는 배포된 CLI가 버전 `0.1.0`에서 정확히 어떻게 동작하는지를 문서화합니다. 아래의
+이 페이지는 배포된 CLI가 버전 `1.0.0`에서 정확히 어떻게 동작하는지를 문서화합니다. 아래의
 모든 시놉시스와 플래그는 배포된 명령어 자체의 `--help` 출력에서 가져온 것입니다; 여기에는
 아직 출시되지 않은 동작이 설명되어 있지 않습니다. CLI는 비공개 소스로부터 유지 관리되며,
-스코프 패키지 [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)로
+스코프 패키지 [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins)로
 npm에 배포됩니다.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## v0.1.0의 설계 원칙
+## v1.0.0의 설계 원칙
 
 - **기본적으로 읽기 전용.** `catalog`, `search`, `info`, `list`, `doctor`는 절대 프로필을
   수정하거나, 파일을 쓰거나, 플러그인 코드를 실행하지 않습니다.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   전달하지 않는 한 DSH/pnpm 라이프사이클 코드 실행을 거부합니다. 이 플래그가 없으면
   `--dry-run`을 사용해 검증된 계획을 확인하세요.
 - **네이티브 Windows 정책.** 코드 실행이 포함된 네이티브 Windows `add`/`update`/`remove`는
-  v0.1.0에서 비활성화되어 있습니다; WSL을 사용하세요. 드라이런과 읽기 전용 명령어는 계속
+  v1.0.0에서 비활성화되어 있습니다; WSL을 사용하세요. 드라이런과 읽기 전용 명령어는 계속
   사용할 수 있으며, 네이티브 Windows 복구 마커는 문서화된 수동 복구를 필요로 합니다.
 - **고정된 입력.** 카탈로그 입력은 로컬 디렉토리, 스냅샷 파일, 또는 선택적으로 정확한
   40자리 리비전에 고정된 정규 공개 스냅샷 URL일 수 있습니다.
@@ -51,7 +51,7 @@ CLI는 관례적인 프로세스 종료 코드를 사용합니다:
 | `0`        | 성공 (빈 카탈로그와 같은 "비어 있지만 유효한" 결과 포함)                          |
 | `1`        | 실패: 검증 오류, 항목을 찾을 수 없음, 필수 옵션 누락, 또는 진단 검사가 오류를 보고함 |
 
-v0.1.0에서 관측된 예시: 유효한 빈 카탈로그에서 `catalog validate`는 `0`으로 종료하며
+v1.0.0에서 관측된 예시: 유효한 빈 카탈로그에서 `catalog validate`는 `0`으로 종료하며
 `0 entries valid; catalog is empty`를 출력합니다; `info <unknown-id>`는 `1`로 종료하며
 `Plugin not found`를 출력합니다; `doctor`는 어떤 검사(예: 누락된 `dsh` 실행 파일)든 오류를
 보고하면 `1`로 종료합니다.
@@ -78,9 +78,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # 저장소 루트에서:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — 공개 카탈로그 필드를 로컬에서 검색합니다
@@ -93,8 +93,8 @@ dsh-plugins search [options] <query...>
 출력하거나, 아무것도 일치하지 않으면 `No plugins found.`(종료 `0`)를 출력합니다.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — 카탈로그 너머의 플러그인을 찾습니다
@@ -103,8 +103,8 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **배포된 `0.1.0`에는 포함되어 있지 않습니다.** `discover`는 `1.0.0`에서 배포됩니다; 이
-> 페이지의 다른 모든 명령어는 현재 npm에 있는 버전에서 작동합니다. `@0.1.0`에 대해 실행하면
+> **배포된 `1.0.0`에는 포함되어 있지 않습니다.** `discover`는 `1.0.0`에서 배포됩니다; 이
+> 페이지의 다른 모든 명령어는 현재 npm에 있는 버전에서 작동합니다. `@1.0.0`에 대해 실행하면
 > 알 수 없는 명령어로 실패합니다.
 
 먼저 큐레이션된 카탈로그를 검색한 다음 — `--offline`이 주어지지 않는 한 — 실시간 GitHub
@@ -117,8 +117,8 @@ dsh-plugins discover [options] <query...>
 않는 안정적인 기계 형식을 내보냅니다.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — 하나의 공개 카탈로그 항목을 표시합니다
@@ -131,7 +131,7 @@ dsh-plugins info [options] <id>
 종료하며 `Plugin not found: <id>`를 출력합니다.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — 공식 DSH 위임을 통해 카탈로그 플러그인 하나를 추가합니다
@@ -153,10 +153,10 @@ dsh-plugins add [options] <id>
 
 ```bash
 # 미리보기 전용 — 아무것도 기록되지 않고, 아무것도 실행되지 않습니다:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # 실제 설치 — 라이프사이클 코드에 대한 명시적 동의:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — 공식 DSH 위임을 통해 카탈로그 플러그인 하나를 업데이트합니다

--- a/docs/i18n/ko/CONTRIBUTING.md
+++ b/docs/i18n/ko/CONTRIBUTING.md
@@ -157,16 +157,16 @@ popularity:
 
 ## 검증 명령어와 가용성
 
-npm CLI는 `@diegosouza.pw/dsh-plugins@0.1.0`으로 배포되어 있으므로, 아래 명령어는 오늘
+npm CLI는 `omni-dsh-plugins@1.0.0`으로 배포되어 있으므로, 아래 명령어는 오늘
 `npx`를 통해 사용할 수 있습니다. 정확히 작성된 대로 사용하세요; 기여자는 대체 명령어를 지어내지
 말아야 합니다.
 
 이 명령어들을 저장소 루트에서 실행하세요:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate`는 위에서 설명한 로컬 YAML, 스키마, SPDX, 정확한 SemVer, SHA-512 SRI 및

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@
 | **웹사이트** | 검색과 순위 기능을 갖춘 렌더링된 카탈로그 브라우저                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **카탈로그** | 플러그인당 하나의 YAML 파일, 단 하나의 신뢰할 수 있는 원천 데이터             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **스키마**  | 모든 항목이 검증되는 공개 JSON 스키마(draft 2020-12) | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | 카탈로그에서 검색, 조사, 검증, 설치           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | 카탈로그에서 검색, 조사, 검증, 설치           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **머신 피드** | 도구를 위한 `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 이 저장소는 카탈로그의 공개된 신뢰할 수 있는 원천 데이터입니다. 모든 항목은 `catalog/plugins/` 아래의 하나의 YAML 파일이며, 공개된 JSON 스키마에 대해 검증되고, 개별적으로 검토된 하나의 풀 리퀘스트를 통해 추가되며, 항상 플러그인의 원 크리에이터에게 공로가 인정됩니다. 카탈로그의 어떤 항목도 다른 카탈로그나 목록으로부터 생성되지 않습니다: 각 항목은 고정된 커밋 시점의 원 크리에이터 저장소로부터 재구성됩니다.
@@ -118,14 +118,14 @@
 ## 🚀 CLI 설치
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-이 스코프 패키지는 `@diegosouza.pw/dsh-plugins@0.1.0`으로 배포되어 있으며, 위 명령어가 현재의 표준 호출 방식입니다. 여기에는 설치 스크립트가 호스팅되어 있지 않습니다.
+이 스코프 패키지는 `omni-dsh-plugins@1.0.0`으로 배포되어 있으며, 위 명령어가 현재의 표준 호출 방식입니다. 여기에는 설치 스크립트가 호스팅되어 있지 않습니다.
 
 ### 지금 CLI 사용하기
 
-버전 0.1.0은 읽기 전용 발견 및 검증 명령어와 함께, 동의가 필요한 설치 명령어를 제공합니다. 플래그, 종료 코드, 코드 실행 동의 게이트를 포함한 전체 명령어 참조는 [docs/CLI.md](../../docs/CLI.md)에 있습니다.
+버전 1.0.0은 읽기 전용 발견 및 검증 명령어와 함께, 동의가 필요한 설치 명령어를 제공합니다. 플래그, 종료 코드, 코드 실행 동의 게이트를 포함한 전체 명령어 참조는 [docs/CLI.md](../../docs/CLI.md)에 있습니다.
 
 | 명령어                        | 하는 일                                                        | 시스템에 영향을 주나요?                    |
 | ------------------------------ | ------------------------------------------------------------------- | --------------------------------------- |
@@ -139,17 +139,17 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
-변경을 일으키는 명령어(`add`, `update`, `remove`)는 `--allow-code-execution`을 전달하지 않는 한 플러그인의 라이프사이클 코드를 절대 실행하지 않습니다. 네이티브 Windows에서는 v0.1.0에서 이러한 변경 작업이 비활성화되어 있습니다. WSL을 사용하세요. 읽기 전용 및 드라이런 명령어는 어디서나 동작합니다.
+변경을 일으키는 명령어(`add`, `update`, `remove`)는 `--allow-code-execution`을 전달하지 않는 한 플러그인의 라이프사이클 코드를 절대 실행하지 않습니다. 네이티브 Windows에서는 v1.0.0에서 이러한 변경 작업이 비활성화되어 있습니다. WSL을 사용하세요. 읽기 전용 및 드라이런 명령어는 어디서나 동작합니다.
 
 ## 🔍 플러그인이 카탈로그에 등록되는 과정
 
@@ -264,7 +264,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | 전체 기여 계약: 증거, YAML 규칙, 검토 게이트    |
 | [SECURITY.md](../../SECURITY.md)                   | 플러그인 또는 카탈로그 취약점 신고; 비밀 정보 정책           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml`의 필드별 참조             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0`의 CLI 명령어 참조          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0`의 CLI 명령어 참조          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | 카탈로그가 어떻게 운영되는지: 우선순위, 게이트, 클레임과 삭제   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | 아티팩트 종류, 주요 기능 카테고리, 태그, 저장소 범위 |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | 크리에이터 크레딧, PR 우선순위, Git 신원 정책                 |

--- a/docs/i18n/mr/CONTRIBUTING.md
+++ b/docs/i18n/mr/CONTRIBUTING.md
@@ -163,16 +163,16 @@ YAML व पुल रिक्वेस्टमध्ये मूळ रि�
 
 ## पडताळणी कमांड्स आणि उपलब्धता
 
-npm CLI `@diegosouza.pw/dsh-plugins@0.1.0` म्हणून प्रकाशित आहे, त्यामुळे खालील कमांड्स आज
+npm CLI `omni-dsh-plugins@1.0.0` म्हणून प्रकाशित आहे, त्यामुळे खालील कमांड्स आज
 `npx` द्वारे उपलब्ध आहेत. त्या लिहिल्याप्रमाणे अचूक वापरा; योगदानकर्त्यांनी पर्यायी कमांड्स
 बनवू नयेत.
 
 हे कमांड्स रिपॉझिटरी रूटवरून चालवा:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` फक्त वर वर्णन केलेल्या स्थानिक YAML, स्कीमा, SPDX, अचूक SemVer, SHA-512

--- a/docs/i18n/mr/README.md
+++ b/docs/i18n/mr/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **वेबसाइट** | शोध आणि क्रमवारीसह रेंडर केलेला कॅटलॉग ब्राउझर                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **कॅटलॉग** | प्रति प्लगइन एक YAML फाइल, एकमेव सत्याचा स्रोत             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **स्कीमा**  | सार्वजनिक JSON Schema (draft 2020-12) ज्याविरुद्ध प्रत्येक एंट्री पडताळली जाते | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | कॅटलॉगमधून शोधा, तपासा, पडताळा आणि इंस्टॉल करा           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | कॅटलॉगमधून शोधा, तपासा, पडताळा आणि इंस्टॉल करा           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **मशीन फीड्स** | साधनांसाठी `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 हे रिपॉझिटरी कॅटलॉगसाठी सत्याचा सार्वजनिक स्रोत आहे. प्रत्येक एंट्री ही `catalog/plugins/` अंतर्गत एक
@@ -127,15 +127,15 @@ YAML फाइल आहे, प्रकाशित JSON Schema विरु�
 ## 🚀 CLI इंस्टॉल करा
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-स्कोप्ड पॅकेज `@diegosouza.pw/dsh-plugins@0.1.0` म्हणून प्रकाशित केलेले आहे आणि वरील कमांड आजची
+स्कोप्ड पॅकेज `omni-dsh-plugins@1.0.0` म्हणून प्रकाशित केलेले आहे आणि वरील कमांड आजची
 प्रमाणित पद्धत आहे; इथे कोणतीही इंस्टॉलर स्क्रिप्ट होस्ट केलेली नाही.
 
 ### आज CLI वापरा
 
-आवृत्ती 0.1.0 फक्त-वाचनीय शोध आणि पडताळणी कमांड्स, तसेच संमती-गेट केलेल्या इंस्टॉल कमांड्स पुरवते.
+आवृत्ती 1.0.0 फक्त-वाचनीय शोध आणि पडताळणी कमांड्स, तसेच संमती-गेट केलेल्या इंस्टॉल कमांड्स पुरवते.
 फ्लॅग्स, एक्झिट कोड्स आणि कोड-एक्झिक्युशन संमती गेटसह संपूर्ण कमांड संदर्भ [docs/CLI.md](../../docs/CLI.md)
 मध्ये आहे.
 
@@ -151,18 +151,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 बदल करणाऱ्या कमांड्स (`add`, `update`, `remove`) तुम्ही `--allow-code-execution` दिल्याशिवाय
-कधीही प्लगइन लाइफसायकल कोड एक्झिक्यूट करत नाहीत. नेटिव्ह Windows वर, v0.1.0 मध्ये हे बदल अक्षम
+कधीही प्लगइन लाइफसायकल कोड एक्झिक्यूट करत नाहीत. नेटिव्ह Windows वर, v1.0.0 मध्ये हे बदल अक्षम
 केलेले आहेत; WSL वापरा. फक्त-वाचनीय आणि ड्राय-रन कमांड्स सर्वत्र कार्य करतात.
 
 ## 🔍 एखादा प्लगइन कॅटलॉगमध्ये कसा दाखल होतो
@@ -308,7 +308,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | संपूर्ण योगदान करार: पुरावा, YAML नियम, पुनरावलोकन गेट्स    |
 | [SECURITY.md](../../SECURITY.md)                   | प्लगइन किंवा कॅटलॉग असुरक्षिततेची तक्रार करणे; गुपित धोरण           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` साठी फील्ड-दर-फील्ड संदर्भ             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` साठी CLI कमांड संदर्भ          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` साठी CLI कमांड संदर्भ          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | कॅटलॉगचे शासन कसे होते: प्राधान्य, गेट्स, दावे आणि काढून टाकणे   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | आर्टिफॅक्ट प्रकार, प्रमुख क्षमता श्रेणी, टॅग्स, रिपॉझिटरी व्याप्ती |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | निर्माता श्रेय, PR प्राधान्य आणि Git ओळख धोरण                 |

--- a/docs/i18n/ms/README.md
+++ b/docs/i18n/ms/README.md
@@ -17,7 +17,7 @@ Penemuan mengutamakan pencipta dan pemasangan satu-arahan untuk pemalam **DeepSe
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Setiap nama dipautkan ke repositori pencipta, dipasak pada komit tepat yang disa
 | **Laman web** | Pelayar katalog yang dipaparkan, dengan carian dan kedudukan                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Satu fail YAML bagi setiap pemalam, satu-satunya sumber kebenaran             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Skema**  | JSON Schema awam (draf 2020-12) yang menjadi rujukan pengesahan setiap entri | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Mencari, memeriksa, mengesahkan dan memasang daripada katalog           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Mencari, memeriksa, mengesahkan dan memasang daripada katalog           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Suapan mesin** | `catalog.json` + `catalog.snapshot.json` untuk alat           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Repositori ini adalah sumber kebenaran awam untuk katalog. Setiap senarai adalah satu fail
@@ -128,15 +128,15 @@ yang dipasak dan atribusi yang jelas.
 ## 🚀 Pasang CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Pakej berskop diterbitkan sebagai `@diegosouza.pw/dsh-plugins@0.1.0` dan arahan di atas
+Pakej berskop diterbitkan sebagai `omni-dsh-plugins@1.0.0` dan arahan di atas
 ialah panggilan kanonik hari ini; tiada skrip pemasang dihoskan di sini.
 
 ### Gunakan CLI hari ini
 
-Versi 0.1.0 menyediakan arahan penemuan dan pengesahan baca sahaja, ditambah arahan
+Versi 1.0.0 menyediakan arahan penemuan dan pengesahan baca sahaja, ditambah arahan
 pemasangan yang memerlukan kebenaran. Rujukan arahan penuh, termasuk bendera, kod keluar
 dan pintu gerbang kebenaran untuk pelaksanaan kod, terdapat di [docs/CLI.md](../../docs/CLI.md).
 
@@ -152,19 +152,19 @@ dan pintu gerbang kebenaran untuk pelaksanaan kod, terdapat di [docs/CLI.md](../
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Arahan yang mengubah sistem (`add`, `update`, `remove`) tidak sesekali melaksanakan kod
 kitaran hayat pemalam melainkan anda memberikan `--allow-code-execution`. Pada Windows
-asli, mutasi tersebut dinyahdayakan dalam v0.1.0; gunakan WSL. Arahan baca sahaja dan
+asli, mutasi tersebut dinyahdayakan dalam v1.0.0; gunakan WSL. Arahan baca sahaja dan
 dry-run berfungsi di mana-mana sahaja.
 
 ## 🔍 Bagaimana pemalam masuk ke dalam katalog
@@ -311,7 +311,7 @@ jika seseorang telah mengkatalogkan kerja anda sebelum anda melakukannya.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Kontrak sumbangan penuh: bukti, peraturan YAML, pintu gerbang semakan    |
 | [SECURITY.md](../../SECURITY.md)                   | Melaporkan kerentanan pemalam atau katalog; dasar rahsia           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Rujukan medan demi medan untuk `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Rujukan arahan CLI untuk `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Rujukan arahan CLI untuk `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Bagaimana katalog ditadbir: keutamaan, pintu gerbang, tuntutan dan penyingkiran   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Jenis artifak, kategori keupayaan utama, tag, skop repositori |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Kredit pencipta, keutamaan PR dan dasar identiti Git                 |

--- a/docs/i18n/nl/README.md
+++ b/docs/i18n/nl/README.md
@@ -17,7 +17,7 @@ Ontdekking met voorrang voor makers en installatie met één commando voor **Dee
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Elke naam linkt naar het repository van de maker, vastgepind op de exacte commit
 | **Website** | Gerenderde catalogusbrowser met zoeken en rangschikking                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Catalogus** | Eén YAML-bestand per plugin, de enige bron van waarheid             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schema**  | Publiek JSON Schema (draft 2020-12) waartegen elke invoer wordt gevalideerd | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Doorzoekt, inspecteert, valideert en installeert vanuit de catalogus           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Doorzoekt, inspecteert, valideert en installeert vanuit de catalogus           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Machinefeeds** | `catalog.json` + `catalog.snapshot.json` voor tools           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Deze repository is de publieke bron van waarheid voor de catalogus. Elke vermelding is één
@@ -128,15 +128,15 @@ vastgepinde broncommit en expliciete attributie.
 ## 🚀 Installeer de CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Het scoped package wordt gepubliceerd als `@diegosouza.pw/dsh-plugins@0.1.0` en het commando
+Het scoped package wordt gepubliceerd als `omni-dsh-plugins@1.0.0` en het commando
 hierboven is vandaag de canonieke aanroep; er wordt hier geen installatiescript gehost.
 
 ### Gebruik de CLI vandaag
 
-Versie 0.1.0 levert alleen-lezen ontdekkings- en validatiecommando's plus installatie-
+Versie 1.0.0 levert alleen-lezen ontdekkings- en validatiecommando's plus installatie-
 commando's die aan toestemming gebonden zijn. De volledige commandoreferentie, inclusief
 vlaggen, afsluitcodes en de toestemmingscontrole voor codeuitvoering, staat in [docs/CLI.md](../../docs/CLI.md).
 
@@ -152,19 +152,19 @@ vlaggen, afsluitcodes en de toestemmingscontrole voor codeuitvoering, staat in [
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Muterende commando's (`add`, `update`, `remove`) voeren nooit levenscycluscode van de plugin
 uit, tenzij u `--allow-code-execution` opgeeft. Op nativief Windows zijn die mutaties
-uitgeschakeld in v0.1.0; gebruik WSL. Alleen-lezen- en dry-run-commando's werken overal.
+uitgeschakeld in v1.0.0; gebruik WSL. Alleen-lezen- en dry-run-commando's werken overal.
 
 ## 🔍 Hoe een plugin de catalogus binnenkomt
 
@@ -311,7 +311,7 @@ als iemand uw werk al heeft gecatalogiseerd voordat u dat deed.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Het volledige bijdragecontract: bewijs, YAML-regels, beoordelingscontroles    |
 | [SECURITY.md](../../SECURITY.md)                   | Kwetsbaarheden in plugins of catalogus melden; geheimenbeleid           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Veld-voor-veld-referentie voor `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | CLI-commandoreferentie voor `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | CLI-commandoreferentie voor `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Hoe de catalogus wordt bestuurd: voorrang, controles, claims en verwijderingen   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Artefacttypen, primaire capaciteitscategorieën, tags, repositoryomvang |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Makerscredit, PR-voorrang en Git-identiteitsbeleid                 |

--- a/docs/i18n/no/README.md
+++ b/docs/i18n/no/README.md
@@ -17,7 +17,7 @@ Skaperfokusert oppdagelse og installasjon med én kommando for **DeepSeek Harnes
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Hvert navn lenker til skaperens repositorium, fastpinnet til den eksakte kommitt
 | **Nettsted** | Rendret katalogleser med søk og rangering                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Én YAML-fil per plugin, den eneste kilden til sannhet             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Skjema**  | Offentlig JSON Schema (draft 2020-12) som hver oppføring valideres mot | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Søker, inspiserer, validerer og installerer fra katalogen           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Søker, inspiserer, validerer og installerer fra katalogen           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Maskinfeeder** | `catalog.json` + `catalog.snapshot.json` for verktøy           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Dette repositoriet er den offentlige kilden til sannhet for katalogen. Hver oppføring er én
@@ -127,15 +127,15 @@ og eksplisitt attribusjon.
 ## 🚀 Installer CLI-en
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Den avgrensede pakken publiseres som `@diegosouza.pw/dsh-plugins@0.1.0`, og kommandoen over
+Den avgrensede pakken publiseres som `omni-dsh-plugins@1.0.0`, og kommandoen over
 er den kanoniske påkallingen i dag; det er ikke hostet noe installasjonsskript her.
 
 ### Bruk CLI-en i dag
 
-Versjon 0.1.0 leverer skrivebeskyttede oppdagelses- og valideringskommandoer i tillegg til
+Versjon 1.0.0 leverer skrivebeskyttede oppdagelses- og valideringskommandoer i tillegg til
 installasjonskommandoer som krever samtykke. Den fullstendige kommandoreferansen, inkludert
 flagg, avslutningskoder og samtykkesperren for kodekjøring, finnes i [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ flagg, avslutningskoder og samtykkesperren for kodekjøring, finnes i [docs/CLI.
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Muterende kommandoer (`add`, `update`, `remove`) kjører aldri livssyklus-kode for pluginen
 med mindre du sender `--allow-code-execution`. På nativ Windows er disse mutasjonene
-deaktivert i v0.1.0; bruk WSL. Skrivebeskyttede kommandoer og dry-run-kommandoer fungerer
+deaktivert i v1.0.0; bruk WSL. Skrivebeskyttede kommandoer og dry-run-kommandoer fungerer
 overalt.
 
 ## 🔍 Hvordan en plugin kommer inn i katalogen
@@ -310,7 +310,7 @@ hvis noen katalogiserte arbeidet ditt før du gjorde det.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Hele bidragsavtalen: bevis, YAML-regler, gjennomgangsporter    |
 | [SECURITY.md](../../SECURITY.md)                   | Rapportere sårbarheter i plugins eller katalog; retningslinjer for hemmeligheter           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Felt-for-felt-referanse for `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | CLI-kommandoreferanse for `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | CLI-kommandoreferanse for `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Hvordan katalogen styres: forrang, porter, krav og fjerninger   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Artefakttyper, primære kapasitetskategorier, tagger, repositorieomfang |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Skaperkreditering, PR-forrang og Git-identitetspolicy                 |

--- a/docs/i18n/phi/README.md
+++ b/docs/i18n/phi/README.md
@@ -17,7 +17,7 @@ Pagtuklas na unang inuuna ang mga lumikha at pag-install na isang-command para s
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -107,7 +107,7 @@ lumikha, nakapirmi sa eksaktong commit na na-validate ng katalogo.
 | **Website** | Naka-render na catalog browser na may paghahanap at ranggo                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalogo** | Isang YAML file bawat plugin, ang tanging pinagmumulan ng katotohanan             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schema**  | Pampublikong JSON Schema (draft 2020-12) na kinukumpara ng bawat entry | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Naghahanap, sumusuri, nagva-validate, at nag-i-install mula sa katalogo           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Naghahanap, sumusuri, nagva-validate, at nag-i-install mula sa katalogo           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Machine feed** | `catalog.json` + `catalog.snapshot.json` para sa mga tool           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Ang repository na ito ang pampublikong pinagmumulan ng katotohanan para sa katalogo. Bawat
@@ -129,15 +129,15 @@ source commit at malinaw na attribution.
 ## 🚀 I-install ang CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Ang scoped package ay inilathala bilang `@diegosouza.pw/dsh-plugins@0.1.0` at ang command sa
+Ang scoped package ay inilathala bilang `omni-dsh-plugins@1.0.0` at ang command sa
 itaas ang canonical na paraan ng pagtawag ngayon; walang install script na naka-host dito.
 
 ### Gamitin ang CLI ngayon
 
-Nagdadala ang bersyon 0.1.0 ng mga read-only na command para sa pagtuklas at pag-validate,
+Nagdadala ang bersyon 1.0.0 ng mga read-only na command para sa pagtuklas at pag-validate,
 kasama ang mga install command na may consent gate. Ang kumpletong sanggunian ng command,
 kasama ang mga flag, exit code, at ang consent gate para sa pagpapatakbo ng code, ay
 matatagpuan sa [docs/CLI.md](../../docs/CLI.md).
@@ -154,19 +154,19 @@ matatagpuan sa [docs/CLI.md](../../docs/CLI.md).
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Ang mga command na nagmumutate (`add`, `update`, `remove`) ay hindi kailanman nagpapatakbo
 ng lifecycle code ng plugin maliban kung ipapasa ninyo ang `--allow-code-execution`. Sa
-native na Windows, naka-disable ang mga mutation na ito sa v0.1.0; gamitin ang WSL. Ang mga
+native na Windows, naka-disable ang mga mutation na ito sa v1.0.0; gamitin ang WSL. Ang mga
 read-only at dry-run na command ay gumagana kahit saan.
 
 ## 🔍 Paano pumapasok ang isang plugin sa katalogo
@@ -318,7 +318,7 @@ kung mayroon nang nagkatalogo ng inyong trabaho bago ninyo ito ginawa.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Ang kumpletong kontrata ng pag-aambag: ebidensya, tuntunin ng YAML, gate ng review    |
 | [SECURITY.md](../../SECURITY.md)                   | Pag-uulat ng mga kahinaan ng plugin o katalogo; patakaran sa sekreto           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Sanggunian nang field-by-field para sa `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Sanggunian ng CLI command para sa `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Sanggunian ng CLI command para sa `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Kung paano pinapamahalaan ang katalogo: prayoridad, gate, claim, at pag-alis   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Mga uri ng artifact, pangunahing kategorya ng kakayahan, tag, saklaw ng repository |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Kredito sa lumikha, prayoridad ng PR, at patakaran sa pagkakakilanlan sa Git                 |

--- a/docs/i18n/pl/CLI.md
+++ b/docs/i18n/pl/CLI.md
@@ -1,21 +1,21 @@
-# Dokumentacja CLI — `@diegosouza.pw/dsh-plugins@0.1.0`
+# Dokumentacja CLI — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../CLI.md) · **Polski**
 
 > **Nieoficjalny projekt społecznościowy. Niepowiązany z DeepSeek, nieautoryzowany ani niesponsorowany przez DeepSeek.**
 > Nazwy i znaki DeepSeek należą do ich odpowiedniego właściciela.
 
-Ta strona dokumentuje opublikowane CLI dokładnie tak, jak zachowuje się ono w wersji `0.1.0`. Każdy zarys składni i flaga poniżej pochodzą z własnego wyjścia `--help` opublikowanego polecenia; nic tutaj nie opisuje niewydanego zachowania. CLI jest utrzymywane z prywatnego źródła i wydawane do npm jako zakresowany pakiet [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+Ta strona dokumentuje opublikowane CLI dokładnie tak, jak zachowuje się ono w wersji `1.0.0`. Każdy zarys składni i flaga poniżej pochodzą z własnego wyjścia `--help` opublikowanego polecenia; nic tutaj nie opisuje niewydanego zachowania. CLI jest utrzymywane z prywatnego źródła i wydawane do npm jako zakresowany pakiet [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Zasady projektowe w v0.1.0
+## Zasady projektowe w v1.0.0
 
 - **Domyślnie tylko do odczytu.** `catalog`, `search`, `info`, `list` i `doctor` nigdy nie modyfikują profili, nie zapisują plików ani nie uruchamiają kodu wtyczek.
 - **Bramka zgody na wykonanie kodu.** `add`, `update` i `remove` odmawiają uruchomienia kodu cyklu życia DSH/pnpm, chyba że przekażesz `--allow-code-execution`. Bez tego użyj `--dry-run`, aby zobaczyć zweryfikowany plan.
-- **Natywna polityka Windows.** Natywne `add`/`update`/`remove` w Windows z wykonaniem kodu są wyłączone w v0.1.0; użyj WSL. Dry-run oraz polecenia tylko do odczytu pozostają dostępne, a natywne znaczniki odzyskiwania w Windows wymagają udokumentowanego ręcznego odzyskiwania.
+- **Natywna polityka Windows.** Natywne `add`/`update`/`remove` w Windows z wykonaniem kodu są wyłączone w v1.0.0; użyj WSL. Dry-run oraz polecenia tylko do odczytu pozostają dostępne, a natywne znaczniki odzyskiwania w Windows wymagają udokumentowanego ręcznego odzyskiwania.
 - **Przypięte dane wejściowe.** Wejście katalogu może być lokalnym katalogiem, plikiem snapshotu lub przypiętym publicznym URL-em snapshotu, opcjonalnie zablokowanym do dokładnej 40-znakowej rewizji.
 
 ## Wspólne opcje
@@ -39,7 +39,7 @@ CLI używa konwencjonalnych kodów wyjścia procesu:
 | `0`       | Sukces (w tym wyniki „puste, ale prawidłowe”, np. pusty katalog)     |
 | `1`       | Niepowodzenie: błąd walidacji, wpis nie znaleziony, brak wymaganej opcji, lub sprawdzenie diagnostyczne zgłaszające błąd |
 
-Przykłady zaobserwowane w v0.1.0: `catalog validate` na prawidłowym, pustym katalogu kończy się kodem `0` z komunikatem `0 entries valid; catalog is empty`; `info <unknown-id>` kończy się kodem `1` z komunikatem `Plugin not found`; `doctor` kończy się kodem `1`, gdy dowolne sprawdzenie (na przykład brakujący plik wykonywalny `dsh`) zgłasza błąd.
+Przykłady zaobserwowane w v1.0.0: `catalog validate` na prawidłowym, pustym katalogu kończy się kodem `0` z komunikatem `0 entries valid; catalog is empty`; `info <unknown-id>` kończy się kodem `1` z komunikatem `Plugin not found`; `doctor` kończy się kodem `1`, gdy dowolne sprawdzenie (na przykład brakujący plik wykonywalny `dsh`) zgłasza błąd.
 
 ## Polecenia
 
@@ -57,9 +57,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # Z katalogu głównego repozytorium:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — lokalne przeszukiwanie publicznych pól katalogu
@@ -71,8 +71,8 @@ dsh-plugins search [options] <query...>
 Przeszukuje lokalnie publiczne pola katalogu względem wybranego wejścia katalogu. Wypisuje pasujące wpisy albo `No plugins found.` (kod wyjścia `0`), gdy nic nie pasuje.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — wyszukiwanie wtyczek poza katalogiem
@@ -81,15 +81,15 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Niedostępne w opublikowanej wersji `0.1.0`.** `discover` pojawia się w `1.0.0`; każde inne polecenie na tej stronie działa z wersją aktualnie dostępną na npm. Uruchomienie go w wersji `@0.1.0` kończy się błędem nieznanego polecenia.
+> **Niedostępne w opublikowanej wersji `1.0.0`.** `discover` pojawia się w `1.0.0`; każde inne polecenie na tej stronie działa z wersją aktualnie dostępną na npm. Uruchomienie go w wersji `@1.0.0` kończy się błędem nieznanego polecenia.
 
 Przeszukuje najpierw wykuratorowany katalog, a następnie — jeśli nie podano `--offline` — żywy temat GitHub `dsh-plugin`, dzięki czemu wtyczka, która nie została jeszcze zgłoszona, jest nadal możliwa do znalezienia. Wyniki z katalogu zawierają dowody, które posiada katalog (przypięty commit, twórca, licencja); wyniki społecznościowe nie zawierają żadnych z nich i są odpowiednio oznaczone, ponieważ nic w nich nie zostało zrecenzowane.
 
 `--limit <n>` ogranicza liczbę wyników na warstwę (domyślnie `8`). `--json` zwraca stabilny kształt maszynowy, który nigdy nie jest lokalizowany.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — pokaż jeden publiczny wpis katalogu
@@ -101,7 +101,7 @@ dsh-plugins info [options] <id>
 Pokazuje jeden publiczny wpis katalogu według kanonicznego ID wtyczki. Kończy się kodem `1` z komunikatem `Plugin not found: <id>`, gdy ID nie znajduje się w katalogu.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — dodaj jedną wtyczkę z katalogu przez oficjalną delegację DSH
@@ -121,10 +121,10 @@ Semantyka dry-run w tej wersji: polecenie rozstrzyga i weryfikuje plan dla przyp
 
 ```bash
 # Tylko podgląd — nic nie jest zapisywane, nic się nie wykonuje:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Prawdziwa instalacja — jawna zgoda na kod cyklu życia:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — zaktualizuj jedną wtyczkę z katalogu przez oficjalną delegację DSH

--- a/docs/i18n/pl/CLI.md
+++ b/docs/i18n/pl/CLI.md
@@ -88,8 +88,8 @@ Przeszukuje najpierw wykuratorowany katalog, a następnie — jeśli nie podano 
 `--limit <n>` ogranicza liczbę wyników na warstwę (domyślnie `8`). `--json` zwraca stabilny kształt maszynowy, który nigdy nie jest lokalizowany.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — pokaż jeden publiczny wpis katalogu

--- a/docs/i18n/pl/CONTRIBUTING.md
+++ b/docs/i18n/pl/CONTRIBUTING.md
@@ -98,14 +98,14 @@ Pull requesty i commity autorstwa twórcy w naturalny sposób zachowują przypis
 
 ## Polecenia walidacyjne i dostępność
 
-CLI npm jest opublikowane jako `@diegosouza.pw/dsh-plugins@0.1.0`, więc poniższe polecenia są już dziś dostępne przez `npx`. Używaj ich dokładnie tak, jak zapisano; współtwórcy nie powinni wymyślać zastępczych poleceń.
+CLI npm jest opublikowane jako `omni-dsh-plugins@1.0.0`, więc poniższe polecenia są już dziś dostępne przez `npx`. Używaj ich dokładnie tak, jak zapisano; współtwórcy nie powinni wymyślać zastępczych poleceń.
 
 Uruchom te polecenia z katalogu głównego repozytorium:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` wykonuje wyłącznie opisane powyżej lokalne sprawdzenia YAML, schematu, SPDX, dokładnego SemVer, SHA-512 SRI i duplikatów, i akceptuje celowo pusty katalog. Nie dowodzi tożsamości zdalnego repozytorium ani dowodu pochodzenia przypiętego źródła. Pozostałe polecenia sprawdzają wymaganą publiczną dokumentację i ustrukturyzowane formularze issue na GitHubie. Pomyślne przejście tych poleceń lokalnie nie łagodzi wymagań dowodowych; maintainerzy nadal stosują każdą odpowiednią bramkę wydania przed scaleniem.

--- a/docs/i18n/pl/README.md
+++ b/docs/i18n/pl/README.md
@@ -17,7 +17,7 @@ Odkrywanie stawiające na pierwszym miejscu twórców i instalacja jedną komend
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Każda nazwa prowadzi do repozytorium twórcy, przypiętego do dokładnego commi
 | **Strona** | Renderowana przeglądarka katalogu z wyszukiwaniem i rankingiem                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Jeden plik YAML na wtyczkę, jedyne źródło prawdy             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schemat**  | Publiczny JSON Schema (draft 2020-12), z którym walidowany jest każdy wpis | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Wyszukuje, sprawdza, waliduje i instaluje z katalogu           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Wyszukuje, sprawdza, waliduje i instaluje z katalogu           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Kanały maszynowe** | `catalog.json` + `catalog.snapshot.json` dla narzędzi           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 To repozytorium jest publicznym źródłem prawdy dla katalogu. Każdy wpis to jeden plik YAML
@@ -127,15 +127,15 @@ request, po jednej naraz, z oryginalnego repozytorium twórcy, z przypiętym com
 ## 🚀 Zainstaluj CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Pakiet ze scope publikowany jest jako `@diegosouza.pw/dsh-plugins@0.1.0`, a powyższa komenda
+Pakiet ze scope publikowany jest jako `omni-dsh-plugins@1.0.0`, a powyższa komenda
 jest dziś kanonicznym wywołaniem; nie jest tu hostowany żaden skrypt instalacyjny.
 
 ### Używaj CLI już dziś
 
-Wersja 0.1.0 zawiera komendy odkrywania i walidacji tylko do odczytu oraz komendy
+Wersja 1.0.0 zawiera komendy odkrywania i walidacji tylko do odczytu oraz komendy
 instalacyjne chronione zgodą. Pełna referencja komend, w tym flagi, kody wyjścia i bramkę
 zgody na wykonanie kodu, znajduje się w [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ zgody na wykonanie kodu, znajduje się w [docs/CLI.md](../../docs/CLI.md).
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Komendy mutujące (`add`, `update`, `remove`) nigdy nie wykonują kodu cyklu życia wtyczki,
 chyba że przekażesz `--allow-code-execution`. Na natywnym Windowsie te mutacje są wyłączone
-w v0.1.0; użyj WSL. Komendy tylko do odczytu i dry-run działają wszędzie.
+w v1.0.0; użyj WSL. Komendy tylko do odczytu i dry-run działają wszędzie.
 
 ## 🔍 Jak wtyczka trafia do katalogu
 
@@ -310,7 +310,7 @@ jeśli ktoś skatalogował twoją pracę, zanim ty to zrobiłeś.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Pełna umowa dotycząca współtworzenia: dowody, reguły YAML, bramki przeglądu    |
 | [SECURITY.md](../../SECURITY.md)                   | Zgłaszanie podatności wtyczek lub katalogu; polityka sekretów           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Referencja pole po polu dla `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Referencja komend CLI dla `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Referencja komend CLI dla `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Jak zarządzany jest katalog: pierwszeństwo, bramki, roszczenia i usunięcia   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Rodzaje artefaktów, główne kategorie możliwości, tagi, zakres repozytorium |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Uznanie dla twórcy, pierwszeństwo PR i polityka tożsamości Git                 |

--- a/docs/i18n/pt-BR/CLI.md
+++ b/docs/i18n/pt-BR/CLI.md
@@ -1,21 +1,21 @@
-# Referência do CLI — `@diegosouza.pw/dsh-plugins@0.1.0`
+# Referência do CLI — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · **Português (Brasil)** · [中文](../zh-CN/CLI.md)
 
 > **Projeto comunitário não oficial. Não afiliado, endossado ou patrocinado pela DeepSeek.**
 > Nomes e marcas da DeepSeek pertencem aos respectivos proprietários.
 
-Esta página documenta o CLI publicado exatamente como ele se comporta na versão `0.1.0`. Toda
+Esta página documenta o CLI publicado exatamente como ele se comporta na versão `1.0.0`. Toda
 sinopse e flag abaixo vem da própria saída de `--help` do comando publicado; nada aqui descreve
 comportamento não lançado. O CLI é mantido a partir de código-fonte privado e lançado no npm como
 o pacote com escopo
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Princípios de design na v0.1.0
+## Princípios de design na v1.0.0
 
 - **Somente leitura por padrão.** `catalog`, `search`, `info`, `list` e `doctor` nunca modificam
   perfis, escrevem arquivos ou disparam código de plugin.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   código de ciclo de vida do DSH/pnpm a menos que você passe `--allow-code-execution`. Sem essa
   flag, use `--dry-run` para ver o plano verificado.
 - **Política nativa para Windows.** `add`/`update`/`remove` nativos no Windows com execução de
-  código estão desabilitados na v0.1.0; use o WSL. O dry-run e os comandos somente leitura
+  código estão desabilitados na v1.0.0; use o WSL. O dry-run e os comandos somente leitura
   continuam disponíveis, e marcadores de recuperação nativos do Windows exigem recuperação manual
   documentada.
 - **Entradas fixadas.** A entrada do catálogo pode ser um diretório local, um arquivo de
@@ -53,7 +53,7 @@ O CLI usa códigos de saída de processo convencionais:
 | `0`              | Sucesso (incluindo resultados "vazios mas válidos", como um catálogo vazio) |
 | `1`              | Falha: erro de validação, entrada não encontrada, opção obrigatória ausente, ou uma checagem de diagnóstico reportando um erro |
 
-Exemplos observados na v0.1.0: `catalog validate` em um catálogo vazio válido sai com `0` e
+Exemplos observados na v1.0.0: `catalog validate` em um catálogo vazio válido sai com `0` e
 `0 entries valid; catalog is empty`; `info <unknown-id>` sai com `1` e `Plugin not found`;
 `doctor` sai com `1` quando qualquer checagem (como um executável `dsh` ausente) reporta um erro.
 
@@ -80,9 +80,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # A partir da raiz do repositório:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — pesquisa campos públicos do catálogo localmente
@@ -95,8 +95,8 @@ Pesquisa campos públicos do catálogo localmente na entrada de catálogo seleci
 entradas correspondentes, ou `No plugins found.` (saída `0`) quando nada corresponde.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `info` — mostra uma entrada pública do catálogo
@@ -109,7 +109,7 @@ Mostra uma entrada pública do catálogo pelo ID canônico do plugin. Sai com `1
 `Plugin not found: <id>` quando o ID não está no catálogo.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — adiciona um plugin do catálogo por meio da delegação oficial ao DSH
@@ -131,10 +131,10 @@ ferramentas oficiais do DSH e só prossegue com `--allow-code-execution`.
 
 ```bash
 # Somente pré-visualização — nada é escrito, nada executa:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Instalação real — consentimento explícito ao código de ciclo de vida:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — atualiza um plugin do catálogo por meio da delegação oficial ao DSH

--- a/docs/i18n/pt-BR/CONTRIBUTING.md
+++ b/docs/i18n/pt-BR/CONTRIBUTING.md
@@ -171,16 +171,16 @@ completa.
 
 ## Comandos de validação e disponibilidade
 
-O CLI npm é publicado como `@diegosouza.pw/dsh-plugins@0.1.0`, então os comandos abaixo estão
+O CLI npm é publicado como `omni-dsh-plugins@1.0.0`, então os comandos abaixo estão
 disponíveis via `npx` hoje. Use-os exatamente como escritos; os contribuidores não devem inventar
 comandos substitutos.
 
 Execute estes comandos a partir da raiz do repositório:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` realiza apenas as checagens locais de YAML, schema, SPDX, SemVer exato,

--- a/docs/i18n/pt-BR/README.md
+++ b/docs/i18n/pt-BR/README.md
@@ -17,7 +17,7 @@ Descoberta com prioridade ao criador e instalação em um comando para plugins d
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Todo nome tem link para o repositório do criador, fixado no commit exato valida
 | **Website** | Navegador do catálogo renderizado, com busca e ranqueamento                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Catálogo** | Um arquivo YAML por plugin, a única fonte da verdade             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Esquema**  | JSON Schema público (draft 2020-12) contra o qual toda entrada é validada | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Busca, inspeciona, valida e instala a partir do catálogo           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Busca, inspeciona, valida e instala a partir do catálogo           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Feeds para máquinas** | `catalog.json` + `catalog.snapshot.json` para ferramentas           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Este repositório é a fonte pública da verdade para o catálogo. Cada listagem é um arquivo YAML
@@ -127,15 +127,15 @@ atribuição explícita.
 ## 🚀 Instale a CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-O pacote com escopo é publicado como `@diegosouza.pw/dsh-plugins@0.1.0` e o comando acima é
+O pacote com escopo é publicado como `omni-dsh-plugins@1.0.0` e o comando acima é
 a invocação canônica hoje; nenhum script de instalação é hospedado aqui.
 
 ### Use a CLI hoje
 
-A versão 0.1.0 traz comandos de descoberta e validação somente leitura, além de comandos de
+A versão 1.0.0 traz comandos de descoberta e validação somente leitura, além de comandos de
 instalação protegidos por consentimento. A referência completa de comandos, incluindo flags,
 códigos de saída e o portão de consentimento para execução de código, está em [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ códigos de saída e o portão de consentimento para execução de código, est�
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Comandos que alteram o sistema (`add`, `update`, `remove`) nunca executam código do ciclo de
 vida do plugin, a menos que você passe `--allow-code-execution`. No Windows nativo, essas
-mutações estão desativadas na v0.1.0; use o WSL. Comandos somente leitura e de simulação
+mutações estão desativadas na v1.0.0; use o WSL. Comandos somente leitura e de simulação
 funcionam em qualquer lugar.
 
 ## 🔍 Como um plugin entra no catálogo
@@ -310,7 +310,7 @@ se alguém já catalogou seu trabalho antes de você.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | O contrato completo de contribuição: evidências, regras do YAML, portões de revisão    |
 | [SECURITY.md](../../SECURITY.md)                   | Como reportar vulnerabilidades de plugins ou do catálogo; política de segredos           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Referência campo a campo de `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Referência de comandos da CLI para `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Referência de comandos da CLI para `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Como o catálogo é governado: precedência, portões, reivindicações e remoções   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Tipos de artefato, categorias principais de capacidade, tags, escopo do repositório |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Crédito ao criador, precedência de PR e política de identidade do Git                 |

--- a/docs/i18n/pt/README.md
+++ b/docs/i18n/pt/README.md
@@ -17,7 +17,7 @@ Descoberta centrada no criador e instalação num único comando para plugins do
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Cada nome tem ligação para o repositório do criador, fixado no commit exato v
 | **Site** | Navegador do catálogo, com pesquisa e classificação                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Catálogo** | Um ficheiro YAML por plugin, a única fonte da verdade             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Esquema**  | JSON Schema público (draft 2020-12) contra o qual toda a entrada é validada | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Pesquisa, inspeciona, valida e instala a partir do catálogo           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Pesquisa, inspeciona, valida e instala a partir do catálogo           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Feeds para máquinas** | `catalog.json` + `catalog.snapshot.json` para ferramentas           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Este repositório é a fonte pública da verdade do catálogo. Cada listagem é um ficheiro YAML
@@ -127,15 +127,15 @@ atribuição explícita.
 ## 🚀 Instale a CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-O pacote com âmbito é publicado como `@diegosouza.pw/dsh-plugins@0.1.0` e o comando acima é
+O pacote com âmbito é publicado como `omni-dsh-plugins@1.0.0` e o comando acima é
 a invocação canónica hoje; não é alojado aqui nenhum script de instalação.
 
 ### Utilize a CLI hoje
 
-A versão 0.1.0 traz comandos de descoberta e validação apenas de leitura, além de comandos de
+A versão 1.0.0 traz comandos de descoberta e validação apenas de leitura, além de comandos de
 instalação sujeitos a consentimento. A referência completa de comandos, incluindo flags,
 códigos de saída e o controlo de consentimento para execução de código, está em [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ códigos de saída e o controlo de consentimento para execução de código, est
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Os comandos que alteram o sistema (`add`, `update`, `remove`) nunca executam código do ciclo
 de vida do plugin, a menos que passe `--allow-code-execution`. No Windows nativo, essas
-alterações estão desativadas na v0.1.0; use o WSL. Os comandos apenas de leitura e de
+alterações estão desativadas na v1.0.0; use o WSL. Os comandos apenas de leitura e de
 simulação funcionam em qualquer lado.
 
 ## 🔍 Como um plugin entra no catálogo
@@ -311,7 +311,7 @@ se alguém catalogou o seu trabalho antes de si.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | O contrato completo de contribuição: provas, regras do YAML, controlos de revisão    |
 | [SECURITY.md](../../SECURITY.md)                   | Como reportar vulnerabilidades de plugins ou do catálogo; política de segredos           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Referência campo a campo de `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Referência de comandos da CLI para `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Referência de comandos da CLI para `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Como o catálogo é governado: precedência, controlos, reivindicações e remoções   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Tipos de artefacto, categorias principais de capacidade, etiquetas, âmbito do repositório |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Crédito ao criador, precedência de PR e política de identidade do Git                 |

--- a/docs/i18n/ro/README.md
+++ b/docs/i18n/ro/README.md
@@ -18,7 +18,7 @@ Descoperire centrată pe creatori și instalare cu o singură comandă pentru pl
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -108,7 +108,7 @@ la commit-ul exact validat de catalog.
 | **Site**    | Interfață web randată a catalogului, cu căutare și clasament     | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Catalog** | Un fișier YAML per plugin, sursa unică de adevăr                 | [`catalog/plugins/`](../../catalog/plugins)                              |
 | **Schemă**  | Schemă JSON publică (draft 2020-12) față de care se validează fiecare intrare | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml) |
-| **CLI**     | Caută, inspectează, validează și instalează din catalog          | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Caută, inspectează, validează și instalează din catalog          | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Fluxuri pentru mașini** | `catalog.json` + `catalog.snapshot.json` pentru unelte | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Acest repository este sursa publică de adevăr pentru catalog. Fiecare intrare este un fișier YAML
@@ -129,15 +129,15 @@ explicită.
 ## 🚀 Instalează CLI-ul
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Pachetul cu scope este publicat ca `@diegosouza.pw/dsh-plugins@0.1.0`, iar comanda de mai sus este
+Pachetul cu scope este publicat ca `omni-dsh-plugins@1.0.0`, iar comanda de mai sus este
 invocarea canonică actuală; niciun script de instalare nu este găzduit aici.
 
 ### Folosește CLI-ul astăzi
 
-Versiunea 0.1.0 oferă comenzi de descoperire și validare read-only, plus comenzi de instalare
+Versiunea 1.0.0 oferă comenzi de descoperire și validare read-only, plus comenzi de instalare
 condiționate de consimțământ. Referința completă de comenzi, inclusiv flagurile, codurile de
 ieșire și poarta de consimțământ pentru execuția de cod, se află în
 [docs/CLI.md](../../docs/CLI.md).
@@ -154,19 +154,19 @@ ieșire și poarta de consimțământ pentru execuția de cod, se află în
 
 ```bash
 # Validează catalogul din acest repository (ce rulează CI):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Caută și inspectează local, fără să instalezi nimic:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Previzualizează un plan de instalare; nu se scrie nimic și nu rulează niciun subproces:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Comenzile care modifică starea (`add`, `update`, `remove`) nu execută niciodată codul de ciclu de
 viață al pluginului decât dacă adaugi `--allow-code-execution`. Pe Windows nativ, aceste mutații
-sunt dezactivate în v0.1.0; folosește WSL. Comenzile read-only și dry-run funcționează peste tot.
+sunt dezactivate în v1.0.0; folosește WSL. Comenzile read-only și dry-run funcționează peste tot.
 
 ## 🔍 Cum intră un plugin în catalog
 
@@ -315,7 +315,7 @@ dacă cineva ți-a catalogat munca înaintea ta.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)     | Contractul complet de contribuție: dovezi, reguli YAML, porți de review |
 | [SECURITY.md](../../SECURITY.md)             | Raportarea vulnerabilităților de plugin sau de catalog; politica privind secretele |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)       | Referință câmp cu câmp pentru `schemas/plugin.schema.yaml`              |
-| [docs/CLI.md](../../docs/CLI.md)             | Referința comenzilor CLI pentru `@diegosouza.pw/dsh-plugins@0.1.0`      |
+| [docs/CLI.md](../../docs/CLI.md)             | Referința comenzilor CLI pentru `omni-dsh-plugins@1.0.0`      |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) | Cum este guvernat catalogul: prioritate, porți, revendicări și eliminări |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md) | Tipuri de artefact, categorii principale de capabilități, tag-uri, scop repository |
 | [docs/CREDIT.md](../../docs/CREDIT.md)       | Creditarea creatorilor, prioritatea PR-urilor și politica de identitate Git |

--- a/docs/i18n/ru/CLI.md
+++ b/docs/i18n/ru/CLI.md
@@ -120,8 +120,8 @@ dsh-plugins discover [options] <query...>
 стабильную машинную форму, которая никогда не локализуется.
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — показывает одну публичную запись каталога

--- a/docs/i18n/ru/CLI.md
+++ b/docs/i18n/ru/CLI.md
@@ -1,21 +1,21 @@
-# Справочник CLI — `@diegosouza.pw/dsh-plugins@0.1.0`
+# Справочник CLI — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · [Português (Brasil)](../pt-BR/CLI.md) · [中文（简体）](../zh-CN/CLI.md) · **Русский**
 
 > **Неофициальный проект сообщества. Не аффилирован, не одобрен и не спонсируется DeepSeek.**
 > Имена и товарные знаки DeepSeek принадлежат их соответствующим владельцам.
 
-Эта страница документирует опубликованный CLI именно так, как он ведёт себя в версии `0.1.0`.
+Эта страница документирует опубликованный CLI именно так, как он ведёт себя в версии `1.0.0`.
 Каждый синопсис и флаг ниже взяты из собственного вывода `--help` опубликованной команды; ничто
 здесь не описывает нереализованное поведение. CLI поддерживается из приватного исходного кода и
 публикуется в npm как пакет со scope
-[`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins).
+[`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins).
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## Принципы дизайна в v0.1.0
+## Принципы дизайна в v1.0.0
 
 - **Только для чтения по умолчанию.** `catalog`, `search`, `info`, `list` и `doctor` никогда не
   изменяют профили, не пишут файлы и не запускают код плагина.
@@ -23,7 +23,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
   жизненного цикла DSH/pnpm, если вы не передадите `--allow-code-execution`. Без него используйте
   `--dry-run`, чтобы увидеть проверенный план.
 - **Политика для нативного Windows.** Нативные `add`/`update`/`remove` на Windows с выполнением
-  кода отключены в v0.1.0; используйте WSL. Dry-run и команды только для чтения остаются
+  кода отключены в v1.0.0; используйте WSL. Dry-run и команды только для чтения остаются
   доступными, а маркеры восстановления на нативном Windows требуют документированного ручного
   восстановления.
 - **Закреплённые входные данные.** Входные данные каталога могут быть локальным каталогом, файлом
@@ -53,7 +53,7 @@ CLI использует стандартные коды выхода проце
 | `0`        | Успех (включая результаты «пусто, но валидно», такие как пустой каталог)   |
 | `1`        | Ошибка: ошибка валидации, запись не найдена, отсутствует обязательная опция, либо диагностическая проверка сообщает об ошибке |
 
-Примеры, наблюдаемые в v0.1.0: `catalog validate` на валидном пустом каталоге завершается с `0` и
+Примеры, наблюдаемые в v1.0.0: `catalog validate` на валидном пустом каталоге завершается с `0` и
 `0 entries valid; catalog is empty`; `info <unknown-id>` завершается с `1` и `Plugin not found`;
 `doctor` завершается с `1`, когда любая проверка (например, отсутствующий исполняемый файл `dsh`)
 сообщает об ошибке.
@@ -81,9 +81,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # Из корня репозитория:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — поиск по публичным полям каталога локально
@@ -96,8 +96,8 @@ dsh-plugins search [options] <query...>
 записи или `No plugins found.` (выход `0`), когда ничего не найдено.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — находит плагины за пределами каталога
@@ -106,8 +106,8 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **Не в опубликованной `0.1.0`.** `discover` появляется в `1.0.0`; любая другая команда на этой
-> странице работает с версией, которая сейчас на npm. Запуск её против `@0.1.0` завершится ошибкой
+> **Не в опубликованной `1.0.0`.** `discover` появляется в `1.0.0`; любая другая команда на этой
+> странице работает с версией, которая сейчас на npm. Запуск её против `@1.0.0` завершится ошибкой
 > неизвестной команды.
 
 Сначала ищет в курируемом каталоге, затем — если не указан `--offline` — в живом теме GitHub
@@ -120,8 +120,8 @@ dsh-plugins discover [options] <query...>
 стабильную машинную форму, которая никогда не локализуется.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — показывает одну публичную запись каталога
@@ -134,7 +134,7 @@ dsh-plugins info [options] <id>
 `Plugin not found: <id>`, когда ID отсутствует в каталоге.
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — добавляет один плагин каталога через официальное делегирование DSH
@@ -156,10 +156,10 @@ dsh-plugins add [options] <id>
 
 ```bash
 # Только предпросмотр — ничего не записывается, ничего не выполняется:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Реальная установка — явное согласие на код жизненного цикла:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — обновляет один плагин каталога через официальное делегирование DSH

--- a/docs/i18n/ru/CONTRIBUTING.md
+++ b/docs/i18n/ru/CONTRIBUTING.md
@@ -174,16 +174,16 @@ Pull request'ы и коммиты, авторизованные создател
 
 ## Команды валидации и доступность
 
-CLI на npm опубликован как `@diegosouza.pw/dsh-plugins@0.1.0`, поэтому приведённые ниже команды
+CLI на npm опубликован как `omni-dsh-plugins@1.0.0`, поэтому приведённые ниже команды
 уже сегодня доступны через `npx`. Используйте их точно как написано; авторам вклада не следует
 придумывать замещающие команды.
 
 Запускайте эти команды из корня репозитория:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` выполняет только локальные проверки YAML, схемы, SPDX, точного SemVer,

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -107,7 +107,7 @@
 | **Сайт**    | Отрисованный обозреватель каталога с поиском и ранжированием      | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Каталог** | Один YAML-файл на плагин — единственный источник истины           | [`catalog/plugins/`](../../catalog/plugins)                              |
 | **Схема**   | Публичная JSON Schema (draft 2020-12), которой соответствует каждая запись | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml) |
-| **CLI**     | Поиск, просмотр, валидация и установка из каталога                | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Поиск, просмотр, валидация и установка из каталога                | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Машинные фиды** | `catalog.json` + `catalog.snapshot.json` для инструментов    | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Этот репозиторий — публичный источник истины для каталога. Каждая запись представляет собой один
@@ -128,15 +128,15 @@ request, по одному за раз, из оригинального репо
 ## 🚀 Установка CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Пакет с областью видимости опубликован как `@diegosouza.pw/dsh-plugins@0.1.0`, и приведённая выше
+Пакет с областью видимости опубликован как `omni-dsh-plugins@1.0.0`, и приведённая выше
 команда — канонический способ вызова на сегодня; никакого установочного скрипта здесь не размещено.
 
 ### Как пользоваться CLI сегодня
 
-Версия 0.1.0 предоставляет команды поиска и валидации только для чтения, а также команды установки
+Версия 1.0.0 предоставляет команды поиска и валидации только для чтения, а также команды установки
 с обязательным подтверждением согласия. Полный справочник команд, включая флаги, коды возврата и
 барьер согласия на выполнение кода, находится в [docs/CLI.md](../../docs/CLI.md).
 
@@ -152,19 +152,19 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Изменяющие команды (`add`, `update`, `remove`) никогда не выполняют код жизненного цикла плагина,
 если вы не передали `--allow-code-execution`. В нативной Windows эти изменения отключены в
-версии 0.1.0 — используйте WSL. Команды только для чтения и пробные прогоны работают везде.
+версии 1.0.0 — используйте WSL. Команды только для чтения и пробные прогоны работают везде.
 
 ## 🔍 Как плагин попадает в каталог
 
@@ -311,7 +311,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)     | Полный контракт участия: доказательства, правила YAML, барьеры проверки |
 | [SECURITY.md](../../SECURITY.md)             | Сообщение об уязвимостях плагинов или каталога; политика секретов     |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)       | Пополевой справочник по `schemas/plugin.schema.yaml`                  |
-| [docs/CLI.md](../../docs/CLI.md)             | Справочник команд CLI для `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)             | Справочник команд CLI для `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) | Как управляется каталог: приоритет, барьеры, заявки и удаления      |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md) | Виды артефактов, основные категории возможностей, теги, область репозитория |
 | [docs/CREDIT.md](../../docs/CREDIT.md)       | Указание создателя, приоритет PR и политика Git-идентичности          |

--- a/docs/i18n/sk/README.md
+++ b/docs/i18n/sk/README.md
@@ -17,7 +17,7 @@ Objavovanie s dôrazom na tvorcov a inštalácia jedným príkazom pre pluginy *
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Každý názov odkazuje na repozitár tvorcu, pripnutý na presný commit, ktor�
 | **Web** | Vykreslený prehliadač katalógu s vyhľadávaním a rebríčkom                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalóg** | Jeden YAML súbor na plugin, jediný zdroj pravdy             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schéma**  | Verejná JSON schéma (draft 2020-12), voči ktorej sa validuje každý záznam | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Vyhľadávanie, kontrola, validácia a inštalácia z katalógu           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Vyhľadávanie, kontrola, validácia a inštalácia z katalógu           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Strojové zdroje** | `catalog.json` + `catalog.snapshot.json` pre nástroje           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Tento repozitár je verejným zdrojom pravdy pre katalóg. Každý záznam je jeden YAML súbor v priečinku
@@ -127,15 +127,15 @@ explicitným pripísaním autorstva.
 ## 🚀 Inštalácia CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Balík v rozsahu (scoped package) je publikovaný ako `@diegosouza.pw/dsh-plugins@0.1.0` a príkaz
+Balík v rozsahu (scoped package) je publikovaný ako `omni-dsh-plugins@1.0.0` a príkaz
 vyššie je dnes kanonickým spôsobom spustenia; žiadny inštalačný skript tu nie je hosťovaný.
 
 ### Používanie CLI už dnes
 
-Verzia 0.1.0 obsahuje príkazy len na čítanie pre objavovanie a validáciu, ako aj inštalačné
+Verzia 1.0.0 obsahuje príkazy len na čítanie pre objavovanie a validáciu, ako aj inštalačné
 príkazy podmienené súhlasom. Úplný referenčný prehľad príkazov vrátane príznakov, návratových
 kódov a brány súhlasu na spustenie kódu nájdete v [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,18 +151,18 @@ kódov a brány súhlasu na spustenie kódu nájdete v [docs/CLI.md](../../docs/
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Meniace príkazy (`add`, `update`, `remove`) nikdy nespúšťajú kód životného cyklu pluginu, pokiaľ
-nezadáte `--allow-code-execution`. Na natívnom Windows sú tieto zmeny vo verzii v0.1.0 zakázané;
+nezadáte `--allow-code-execution`. Na natívnom Windows sú tieto zmeny vo verzii v1.0.0 zakázané;
 použite WSL. Príkazy len na čítanie a skúšobný beh fungujú všade.
 
 ## 🔍 Ako sa plugin dostane do katalógu
@@ -309,7 +309,7 @@ vašu prácu katalogizoval skôr než vy.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Úplná zmluva o prispievaní: dôkazy, pravidlá YAML, brány posúdenia    |
 | [SECURITY.md](../../SECURITY.md)                   | Nahlasovanie zraniteľností pluginov alebo katalógu; politika tajomstiev           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Referencia pole po poli pre `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Referencia príkazov CLI pre `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Referencia príkazov CLI pre `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Ako je katalóg spravovaný: priorita, brány, nároky a odstránenia   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Druhy artefaktov, primárne kategórie schopností, značky, rozsah repozitára |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Pripísanie zásluh tvorcovi, priorita pull requestov a politika Git identity                 |

--- a/docs/i18n/sv/README.md
+++ b/docs/i18n/sv/README.md
@@ -17,7 +17,7 @@ Kreatörsfokuserad upptäckt och installation med ett kommando för **DeepSeek H
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ länkar till skaparens repository, fastnålat vid den exakta commit som kataloge
 | **Webbplats** | Renderad katalogbläddrare med sökning och rankning              | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | En YAML-fil per plugin, den enda sanningskällan                   | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schema**  | Offentligt JSON Schema (draft 2020-12) som varje post valideras mot | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Sök, inspektera, validera och installera från katalogen           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Sök, inspektera, validera och installera från katalogen           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Maskinflöden** | `catalog.json` + `catalog.snapshot.json` för verktyg           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Detta repository är den offentliga sanningskällan för katalogen. Varje post är en YAML-fil
@@ -127,15 +127,15 @@ tydlig attribution.
 ## 🚀 Installera CLI:n
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Det scopade paketet publiceras som `@diegosouza.pw/dsh-plugins@0.1.0` och kommandot ovan är
+Det scopade paketet publiceras som `omni-dsh-plugins@1.0.0` och kommandot ovan är
 den kanoniska anropsformen idag; inget installationsskript finns hostat här.
 
 ### Använd CLI:n idag
 
-Version 0.1.0 levereras med skrivskyddade upptäckts- och valideringskommandon samt
+Version 1.0.0 levereras med skrivskyddade upptäckts- och valideringskommandon samt
 installationskommandon som kräver uttryckligt samtycke. Den fullständiga kommandoreferensen,
 inklusive flaggor, avslutningskoder och samtyckesspärren för kodkörning, finns i
 [docs/CLI.md](../../docs/CLI.md).
@@ -152,19 +152,19 @@ inklusive flaggor, avslutningskoder och samtyckesspärren för kodkörning, finn
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Muterande kommandon (`add`, `update`, `remove`) kör aldrig pluginets livscykelkod om du inte
 skickar med `--allow-code-execution`. På native Windows är dessa mutationer inaktiverade i
-v0.1.0; använd WSL. Skrivskyddade kommandon och dry-run-kommandon fungerar överallt.
+v1.0.0; använd WSL. Skrivskyddade kommandon och dry-run-kommandon fungerar överallt.
 
 ## 🔍 Hur en plugin läggs till i katalogen
 
@@ -311,7 +311,7 @@ om någon katalogiserade ditt arbete innan du gjorde det.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Det fullständiga bidragskontraktet: bevis, YAML-regler, granskningsgrindar    |
 | [SECURITY.md](../../SECURITY.md)                   | Rapportera sårbarheter i plugins eller katalogen; policy för hemligheter           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Fält-för-fält-referens för `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | CLI-kommandoreferens för `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | CLI-kommandoreferens för `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Hur katalogen styrs: företräde, grindar, anspråk och borttagningar   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Artefakttyper, primära förmågekategorier, taggar, repository-omfattning |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Skaparkredit, PR-företräde och Git-identitetspolicy                 |

--- a/docs/i18n/sw/README.md
+++ b/docs/i18n/sw/README.md
@@ -17,7 +17,7 @@ Ugunduzi unaotanguliza waumbaji na usakinishaji wa amri moja kwa programu-jalizi
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ na hazina ya muumba, iliyobandikwa kwenye commit halisi ambayo katalogi ilithibi
 | **Tovuti** | Kivinjari cha katalogi kilichoonyeshwa chenye utafutaji na upangaji                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalogi** | Faili moja la YAML kwa kila programu-jalizi, chanzo kikuu cha ukweli             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schema**  | JSON Schema ya umma (rasimu ya 2020-12) ambayo kila kiingilio kinathibitishwa dhidi yake | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Tafuta, kagua, thibitisha na sakinisha kutoka kwa katalogi           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Tafuta, kagua, thibitisha na sakinisha kutoka kwa katalogi           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Malisho ya mashine** | `catalog.json` + `catalog.snapshot.json` kwa zana           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Hazina hii ndiyo chanzo kikuu cha ukweli cha umma kwa katalogi. Kila kiingilio ni faili moja la YAML
@@ -127,15 +127,15 @@ utambuzi wa wazi.
 ## 🚀 Sakinisha CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Kifurushi hiki chenye upeo kinachapishwa kama `@diegosouza.pw/dsh-plugins@0.1.0` na amri iliyo hapo juu ndiyo
+Kifurushi hiki chenye upeo kinachapishwa kama `omni-dsh-plugins@1.0.0` na amri iliyo hapo juu ndiyo
 njia rasmi ya kuita leo; hakuna hati ya usakinishaji inayohifadhiwa hapa.
 
 ### Tumia CLI Leo
 
-Toleo la 0.1.0 linakuja na amri za ugunduzi na uthibitishaji za kusoma tu, pamoja na amri za usakinishaji
+Toleo la 1.0.0 linakuja na amri za ugunduzi na uthibitishaji za kusoma tu, pamoja na amri za usakinishaji
 zinazohitaji idhini. Marejeo kamili ya amri, ikiwa ni pamoja na bendera, misimbo ya kutoka na lango la
 idhini ya utekelezaji wa msimbo, yamo katika [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ idhini ya utekelezaji wa msimbo, yamo katika [docs/CLI.md](../../docs/CLI.md).
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Amri zinazobadilisha (`add`, `update`, `remove`) kamwe hazitekelezi msimbo wa mzunguko wa maisha wa
 programu-jalizi isipokuwa upitishe `--allow-code-execution`. Kwenye Windows asilia, mabadiliko hayo
-yamezimwa katika v0.1.0; tumia WSL. Amri za kusoma tu na dry-run zinafanya kazi kila mahali.
+yamezimwa katika v1.0.0; tumia WSL. Amri za kusoma tu na dry-run zinafanya kazi kila mahali.
 
 ## 🔍 Jinsi Programu-jalizi Inavyoingia Katalogini
 
@@ -307,7 +307,7 @@ ikiwa mtu mwingine alikataloga kazi yako kabla yako.
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Mkataba kamili wa uchangiaji: ushahidi, kanuni za YAML, malango ya ukaguzi    |
 | [SECURITY.md](../../SECURITY.md)                   | Kuripoti udhaifu wa programu-jalizi au katalogi; sera ya siri           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Marejeo ya sehemu-kwa-sehemu ya `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Marejeo ya amri za CLI kwa `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Marejeo ya amri za CLI kwa `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Jinsi katalogi inavyotawaliwa: kipaumbele, malango, madai na uondoaji   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Aina za mazao, jamii kuu za uwezo, lebo, wigo wa hazina |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Utambuzi wa muumba, kipaumbele cha PR na sera ya utambulisho wa Git                 |

--- a/docs/i18n/ta/README.md
+++ b/docs/i18n/ta/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -107,7 +107,7 @@
 | **இணையதளம்** | தேடல் மற்றும் தரவரிசையுடன் காட்டப்படும் பட்டியல் உலாவி                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **பட்டியல்** | ஒவ்வொரு செருகுநிரலுக்கும் ஒரு YAML கோப்பு, ஒரே உண்மை மூலம்             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **திட்டவரைவு**  | ஒவ்வொரு பதிவும் சரிபார்க்கும் பொது JSON திட்டவரைவு (draft 2020-12) | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | பட்டியலிலிருந்து தேடு, ஆய்வு செய், சரிபார் மற்றும் நிறுவு           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | பட்டியலிலிருந்து தேடு, ஆய்வு செய், சரிபார் மற்றும் நிறுவு           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **இயந்திரத் தரவுகள்** | கருவிகளுக்கான `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 இந்தக் களஞ்சியம் பட்டியலுக்கான பொது உண்மை மூலமாகும். ஒவ்வொரு பதிவும் `catalog/plugins/` கீழ் ஒரு
@@ -129,15 +129,15 @@ YAML கோப்பாகும், வெளியிடப்பட்ட JSO
 ## 🚀 CLI-ஐ நிறுவுங்கள்
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-இந்த scoped package `@diegosouza.pw/dsh-plugins@0.1.0` எனப் பதிப்பிக்கப்பட்டுள்ளது, மேலே உள்ள
+இந்த scoped package `omni-dsh-plugins@1.0.0` எனப் பதிப்பிக்கப்பட்டுள்ளது, மேலே உள்ள
 கட்டளையே இன்றைய நியமிக்கப்பட்ட அழைப்பாகும்; இங்கு எந்த நிறுவல் ஸ்கிரிப்டும் ஹோஸ்ட் செய்யப்படவில்லை.
 
 ### இன்று CLI-யைப் பயன்படுத்துங்கள்
 
-பதிப்பு 0.1.0 படிக்க-மட்டும் கண்டறிதல் மற்றும் சரிபார்ப்புக் கட்டளைகளையும், சம்மதம்-கேட்டு-நிறுத்தும்
+பதிப்பு 1.0.0 படிக்க-மட்டும் கண்டறிதல் மற்றும் சரிபார்ப்புக் கட்டளைகளையும், சம்மதம்-கேட்டு-நிறுத்தும்
 நிறுவல் கட்டளைகளையும் வழங்குகிறது. கொடிகள், வெளியேறும் குறியீடுகள் மற்றும் குறியீடு-செயல்படுத்தல்
 சம்மத நுழைவாயில் உட்பட முழு கட்டளைக் குறிப்பு [docs/CLI.md](../../docs/CLI.md)-இல் உள்ளது.
 
@@ -153,19 +153,19 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # இந்தக் களஞ்சியத்தில் உள்ள பட்டியலைச் சரிபார்க்கவும் (CI இயக்குவது இதுவே):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # எதையும் நிறுவாமல் உள்ளூரில் தேடி ஆய்வு செய்யவும்:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # ஒரு நிறுவல் திட்டத்தை முன்னோட்டமிடவும்; எதுவும் எழுதப்படாது, துணை-செயல்முறையும் இயங்காது:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 மாற்றியமைக்கும் கட்டளைகள் (`add`, `update`, `remove`) நீங்கள் `--allow-code-execution` கொடுக்காத
 வரை செருகுநிரல் வாழ்க்கைச் சுழற்சிக் குறியீட்டை ஒருபோதும் இயக்காது. சொந்த Windows-இல் இந்த மாற்றங்கள்
-v0.1.0-இல் முடக்கப்பட்டுள்ளன; WSL பயன்படுத்தவும். படிக்க-மட்டும் மற்றும் dry-run கட்டளைகள் எல்லா
+v1.0.0-இல் முடக்கப்பட்டுள்ளன; WSL பயன்படுத்தவும். படிக்க-மட்டும் மற்றும் dry-run கட்டளைகள் எல்லா
 இடங்களிலும் வேலை செய்கின்றன.
 
 ## 🔍 ஒரு செருகுநிரல் பட்டியலில் எப்படி நுழைகிறது
@@ -314,7 +314,7 @@ pull request திறப்பதற்கு முன் [CONTRIBUTING.md](..
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | முழுமையான பங்களிப்பு ஒப்பந்தம்: ஆதாரம், YAML விதிகள், மதிப்பாய்வு நுழைவாயில்கள்    |
 | [SECURITY.md](../../SECURITY.md)                   | செருகுநிரல் அல்லது பட்டியல் பாதிப்புகளைப் புகாரளித்தல்; ரகசியக் கொள்கை           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml`-க்கான புலவாரியான குறிப்பு             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0`-க்கான CLI கட்டளைக் குறிப்பு          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0`-க்கான CLI கட்டளைக் குறிப்பு          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | பட்டியல் எவ்வாறு நிர்வகிக்கப்படுகிறது: முன்னுரிமை, நுழைவாயில்கள், கோரிக்கைகள் மற்றும் நீக்கங்கள்   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | கலைப்படைப்பு வகைகள், முதன்மைத் திறன் வகைகள், குறிச்சொற்கள், களஞ்சிய நோக்கம் |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | படைப்பாளர் வரவு, PR முன்னுரிமை மற்றும் Git அடையாளக் கொள்கை                 |

--- a/docs/i18n/te/README.md
+++ b/docs/i18n/te/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **వెబ్‌సైట్** | శోధన మరియు ర్యాంకింగ్‌తో రెండర్ చేయబడిన కేటలాగ్ బ్రౌజర్                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **కేటలాగ్** | ప్రతి ప్లగిన్‌కు ఒక YAML ఫైల్, ఏకైక మూలం (సింగిల్ సోర్స్ ఆఫ్ ట్రూత్)             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **స్కీమా**  | ప్రతి ఎంట్రీ ధృవీకరించే పబ్లిక్ JSON స్కీమా (draft 2020-12) | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | కేటలాగ్ నుండి శోధించండి, పరిశీలించండి, ధృవీకరించండి మరియు ఇన్‌స్టాల్ చేయండి           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | కేటలాగ్ నుండి శోధించండి, పరిశీలించండి, ధృవీకరించండి మరియు ఇన్‌స్టాల్ చేయండి           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **మెషిన్ ఫీడ్‌లు** | టూల్స్ కోసం `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 ఈ రిపాజిటరీ కేటలాగ్ కోసం పబ్లిక్ సోర్స్ ఆఫ్ ట్రూత్. ప్రతి లిస్టింగ్ `catalog/plugins/` కింద ఒక YAML ఫైల్,
@@ -126,15 +126,15 @@
 ## 🚀 CLIని ఇన్‌స్టాల్ చేయండి
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-స్కోప్డ్ ప్యాకేజీ `@diegosouza.pw/dsh-plugins@0.1.0`గా ప్రచురించబడింది మరియు పైన ఉన్న కమాండ్ ఈరోజు
+స్కోప్డ్ ప్యాకేజీ `omni-dsh-plugins@1.0.0`గా ప్రచురించబడింది మరియు పైన ఉన్న కమాండ్ ఈరోజు
 ప్రామాణిక ఇన్వొకేషన్; ఇక్కడ ఎటువంటి ఇన్‌స్టాలర్ స్క్రిప్ట్ హోస్ట్ చేయబడలేదు.
 
 ### CLIని ఈరోజు ఉపయోగించండి
 
-వెర్షన్ 0.1.0లో రీడ్-ఓన్లీ డిస్కవరీ మరియు వాలిడేషన్ కమాండ్‌లతో పాటు కన్సెంట్-గేటెడ్ ఇన్‌స్టాల్ కమాండ్‌లు
+వెర్షన్ 1.0.0లో రీడ్-ఓన్లీ డిస్కవరీ మరియు వాలిడేషన్ కమాండ్‌లతో పాటు కన్సెంట్-గేటెడ్ ఇన్‌స్టాల్ కమాండ్‌లు
 ఉన్నాయి. ఫ్లాగ్‌లు, ఎగ్జిట్ కోడ్‌లు మరియు కోడ్-ఎగ్జిక్యూషన్ కన్సెంట్ గేట్‌తో సహా పూర్తి కమాండ్ రిఫరెన్స్
 [docs/CLI.md](../../docs/CLI.md)లో ఉంది.
 
@@ -150,18 +150,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 మ్యుటేటింగ్ కమాండ్‌లు (`add`, `update`, `remove`) మీరు `--allow-code-execution` పాస్ చేయకపోతే ప్లగిన్
-లైఫ్‌సైకిల్ కోడ్‌ను ఎప్పుడూ ఎగ్జిక్యూట్ చేయవు. నేటివ్ Windowsలో ఆ మ్యుటేషన్‌లు v0.1.0లో డిసేబుల్ చేయబడ్డాయి;
+లైఫ్‌సైకిల్ కోడ్‌ను ఎప్పుడూ ఎగ్జిక్యూట్ చేయవు. నేటివ్ Windowsలో ఆ మ్యుటేషన్‌లు v1.0.0లో డిసేబుల్ చేయబడ్డాయి;
 WSL ఉపయోగించండి. రీడ్-ఓన్లీ మరియు డ్రై-రన్ కమాండ్‌లు ప్రతిచోటా పని చేస్తాయి.
 
 ## 🔍 కేటలాగ్‌లోకి ప్లగిన్ ఎలా ప్రవేశిస్తుంది
@@ -305,7 +305,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | పూర్తి కంట్రిబ్యూషన్ ఒప్పందం: సాక్ష్యం, YAML నియమాలు, సమీక్ష గేట్‌లు    |
 | [SECURITY.md](../../SECURITY.md)                   | ప్లగిన్ లేదా కేటలాగ్ దుర్బలత్వాలను నివేదించడం; రహస్యాల పాలసీ           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` కోసం ఫీల్డ్-బై-ఫీల్డ్ రిఫరెన్స్             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` కోసం CLI కమాండ్ రిఫరెన్స్          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` కోసం CLI కమాండ్ రిఫరెన్స్          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | కేటలాగ్ ఎలా నిర్వహించబడుతుంది: ప్రాధాన్యత, గేట్‌లు, క్లెయిమ్‌లు మరియు తొలగింపులు |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | ఆర్టిఫ్యాక్ట్ రకాలు, ప్రాథమిక సామర్థ్య వర్గాలు, ట్యాగ్‌లు, రిపాజిటరీ స్కోప్ |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | సృష్టికర్త క్రెడిట్, PR ప్రాధాన్యత మరియు Git ఐడెంటిటీ పాలసీ                 |

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -105,7 +105,7 @@
 | **เว็บไซต์** | ตัวเรียกดูแคตตาล็อกแบบเรนเดอร์ พร้อมการค้นหาและการจัดอันดับ                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **แคตตาล็อก** | ไฟล์ YAML หนึ่งไฟล์ต่อหนึ่งปลั๊กอิน คือแหล่งข้อมูลจริงเพียงแหล่งเดียว             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **สคีมา**  | JSON Schema สาธารณะ (draft 2020-12) ที่ทุกรายการต้องตรวจสอบผ่าน | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | ค้นหา ตรวจสอบข้อมูล ยืนยันความถูกต้อง และติดตั้งจากแคตตาล็อก           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | ค้นหา ตรวจสอบข้อมูล ยืนยันความถูกต้อง และติดตั้งจากแคตตาล็อก           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **ฟีดสำหรับเครื่องจักร** | `catalog.json` + `catalog.snapshot.json` สำหรับเครื่องมือต่าง ๆ           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 รีโพซิทอรีนี้คือแหล่งข้อมูลจริงสาธารณะของแคตตาล็อก ทุกรายการที่ลงคือไฟล์ YAML หนึ่งไฟล์ภายใต้ `catalog/plugins/`
@@ -123,15 +123,15 @@
 ## 🚀 ติดตั้ง CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-แพ็กเกจแบบ scoped นี้เผยแพร่ในชื่อ `@diegosouza.pw/dsh-plugins@0.1.0` และคำสั่งด้านบนคือวิธีเรียกใช้มาตรฐานในปัจจุบัน
+แพ็กเกจแบบ scoped นี้เผยแพร่ในชื่อ `omni-dsh-plugins@1.0.0` และคำสั่งด้านบนคือวิธีเรียกใช้มาตรฐานในปัจจุบัน
 ไม่มีสคริปต์ตัวติดตั้งใด ๆ ที่โฮสต์ไว้ที่นี่
 
 ### ใช้งาน CLI วันนี้
 
-เวอร์ชัน 0.1.0 มาพร้อมคำสั่งค้นพบและตรวจสอบแบบอ่านอย่างเดียว รวมถึงคำสั่งติดตั้งที่ต้องได้รับความยินยอมก่อน
+เวอร์ชัน 1.0.0 มาพร้อมคำสั่งค้นพบและตรวจสอบแบบอ่านอย่างเดียว รวมถึงคำสั่งติดตั้งที่ต้องได้รับความยินยอมก่อน
 คู่มืออ้างอิงคำสั่งฉบับเต็ม รวมทั้งแฟล็ก รหัสออก และขั้นตอนขอความยินยอมก่อนรันโค้ด อยู่ที่ [docs/CLI.md](../../docs/CLI.md)
 
 | คำสั่ง                        | สิ่งที่ทำได้                                                        | มีผลต่อระบบของคุณหรือไม่?                    |
@@ -146,18 +146,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 คำสั่งที่เปลี่ยนแปลงสถานะ (`add`, `update`, `remove`) จะไม่รันโค้ดวงจรชีวิตของปลั๊กอินเลย เว้นแต่คุณจะส่งแฟล็ก
-`--allow-code-execution` บน Windows แบบเนทีฟ การเปลี่ยนแปลงเหล่านี้ถูกปิดใช้งานใน v0.1.0 — ให้ใช้ WSL แทน
+`--allow-code-execution` บน Windows แบบเนทีฟ การเปลี่ยนแปลงเหล่านี้ถูกปิดใช้งานใน v1.0.0 — ให้ใช้ WSL แทน
 ส่วนคำสั่งอ่านอย่างเดียวและโหมดจำลองใช้งานได้ทุกที่
 
 ## 🔍 ปลั๊กอินเข้าสู่แคตตาล็อกได้อย่างไร
@@ -296,7 +296,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | ข้อตกลงการมีส่วนร่วมฉบับเต็ม: หลักฐาน กฎ YAML ด่านตรวจการรีวิว    |
 | [SECURITY.md](../../SECURITY.md)                   | การรายงานช่องโหว่ของปลั๊กอินหรือแคตตาล็อก นโยบายด้านความลับ           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | คู่มืออ้างอิงแบบรายฟิลด์สำหรับ `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | คู่มืออ้างอิงคำสั่ง CLI สำหรับ `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | คู่มืออ้างอิงคำสั่ง CLI สำหรับ `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | วิธีการกำกับดูแลแคตตาล็อก: ลำดับความสำคัญ ด่านตรวจ การขอเป็นเจ้าของ และการนำออก   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | ประเภทของผลงาน หมวดหมู่ความสามารถหลัก แท็ก ขอบเขตของรีโพซิทอรี |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | การให้เครดิตผู้สร้าง ลำดับความสำคัญของ PR และนโยบายตัวตนบน Git                 |

--- a/docs/i18n/tr/README.md
+++ b/docs/i18n/tr/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ Her isim, katalogun doğruladığı tam commit'e sabitlenmiş üretici deposuna 
 | **Web sitesi** | Arama ve sıralama içeren, oluşturulmuş katalog tarayıcısı                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Katalog** | Eklenti başına bir YAML dosyası, tek gerçek kaynak             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Şema**  | Her kaydın doğrulandığı genel JSON Şeması (taslak 2020-12) | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Katalogdan arama, inceleme, doğrulama ve kurulum yapma           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Katalogdan arama, inceleme, doğrulama ve kurulum yapma           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Makine beslemeleri** | Araçlar için `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Bu depo, katalog için herkese açık gerçek kaynaktır. Her liste öğesi, `catalog/plugins/`
@@ -127,15 +127,15 @@ girer.
 ## 🚀 CLI'yi kurun
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Kapsamlı (scoped) paket `@diegosouza.pw/dsh-plugins@0.1.0` olarak yayımlanır ve yukarıdaki
+Kapsamlı (scoped) paket `omni-dsh-plugins@1.0.0` olarak yayımlanır ve yukarıdaki
 komut bugün için kanonik çağrı biçimidir; burada barındırılan bir kurulum betiği yoktur.
 
 ### CLI'yi bugün kullanın
 
-0.1.0 sürümü, salt okunur keşif ve doğrulama komutlarının yanı sıra onay gerektiren kurulum
+1.0.0 sürümü, salt okunur keşif ve doğrulama komutlarının yanı sıra onay gerektiren kurulum
 komutlarını da içerir. Bayraklar, çıkış kodları ve kod çalıştırma onay kapısı dahil tam komut
 referansı [docs/CLI.md](../../docs/CLI.md) içinde bulunur.
 
@@ -151,19 +151,19 @@ referansı [docs/CLI.md](../../docs/CLI.md) içinde bulunur.
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Değişiklik yapan komutlar (`add`, `update`, `remove`), siz `--allow-code-execution` bayrağını
 geçirmediğiniz sürece eklenti yaşam döngüsü kodunu asla çalıştırmaz. Yerel Windows'ta bu
-değişiklikler v0.1.0'da devre dışıdır; WSL kullanın. Salt okunur ve deneme çalıştırması komutları
+değişiklikler v1.0.0'da devre dışıdır; WSL kullanın. Salt okunur ve deneme çalıştırması komutları
 her yerde çalışır.
 
 ## 🔍 Bir eklenti kataloga nasıl girer
@@ -311,7 +311,7 @@ sizden önce kataloglamışsa,
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Tam katkı sözleşmesi: kanıtlar, YAML kuralları, inceleme kapıları    |
 | [SECURITY.md](../../SECURITY.md)                   | Eklenti veya katalog güvenlik açıklarını bildirme; gizli bilgi politikası           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` için alan alan referans             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` için CLI komut referansı          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` için CLI komut referansı          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Katalogun nasıl yönetildiği: öncelik, kapılar, talepler ve kaldırmalar   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Yapı türleri, birincil yetenek kategorileri, etiketler, depo kapsamı |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Üretici ataması, PR önceliği ve Git kimlik politikası                 |

--- a/docs/i18n/uk-UA/README.md
+++ b/docs/i18n/uk-UA/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@
 | **Сайт** | Готовий вебкаталог із пошуком і рейтингом                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Каталог** | Один YAML-файл на плагін, єдине джерело істини             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Схема**  | Публічна JSON Schema (draft 2020-12), за якою перевіряється кожен запис | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Пошук, перегляд, перевірка та встановлення з каталогу           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Пошук, перегляд, перевірка та встановлення з каталогу           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Машиночитані фіди** | `catalog.json` + `catalog.snapshot.json` для інструментів           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Цей репозиторій — публічне джерело істини для каталогу. Кожен запис — це один YAML-файл
@@ -127,15 +127,15 @@ request, по одному за раз, із репозиторію оригін
 ## 🚀 Встановлення CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Пакет опубліковано під скоупом як `@diegosouza.pw/dsh-plugins@0.1.0`, і наведена вище команда
+Пакет опубліковано під скоупом як `omni-dsh-plugins@1.0.0`, і наведена вище команда
 сьогодні є канонічним способом виклику; скрипт встановлення тут не розміщено.
 
 ### Можливості CLI вже зараз
 
-Версія 0.1.0 включає команди пошуку й валідації лише для читання, а також команди встановлення,
+Версія 1.0.0 включає команди пошуку й валідації лише для читання, а також команди встановлення,
 що потребують явної згоди. Повний довідник команд — із прапорцями, кодами завершення та шлюзом
 згоди на виконання коду — у [docs/CLI.md](../../docs/CLI.md).
 
@@ -151,19 +151,19 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Змінювальні команди (`add`, `update`, `remove`) ніколи не виконують код життєвого циклу плагіна,
 якщо не передано прапорець `--allow-code-execution`. У нативному Windows ці змінювальні команди
-вимкнено у v0.1.0; використовуйте WSL. Команди лише для читання й тестового прогону працюють усюди.
+вимкнено у v1.0.0; використовуйте WSL. Команди лише для читання й тестового прогону працюють усюди.
 
 ## 🔍 Як плагін потрапляє до каталогу
 
@@ -309,7 +309,7 @@ issue. Ніколи не надсилайте облікові дані, при�
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Повний контракт учасника: докази, правила YAML, перевірки під час ревʼю    |
 | [SECURITY.md](../../SECURITY.md)                   | Як повідомляти про вразливості плагіна чи каталогу; політика секретів           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Поатрибутний довідник щодо `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Довідник команд CLI для `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Довідник команд CLI для `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Як керується каталог: пріоритети, перевірки, заявки та видалення   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Види артефактів, основні категорії можливостей, теги, область репозиторію |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Вказівка авторства, пріоритет PR і політика ідентифікації в Git                 |

--- a/docs/i18n/ur/README.md
+++ b/docs/i18n/ur/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@
 | **ویب سائٹ** | تلاش اور درجہ بندی کے ساتھ رینڈر شدہ کیٹلاگ براؤزر | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online) |
 | **کیٹلاگ** | ہر پلگ ان کے لیے ایک YAML فائل، سچائی کا واحد ذریعہ | [`catalog/plugins/`](../../catalog/plugins) |
 | **اسکیما** | پبلک JSON Schema (ڈرافٹ 2020-12) جس کے خلاف ہر اندراج کی توثیق ہوتی ہے | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml) |
-| **CLI** | کیٹلاگ سے تلاش، معائنہ، توثیق اور تنصیب | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI** | کیٹلاگ سے تلاش، معائنہ، توثیق اور تنصیب | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **مشین فیڈز** | ٹولز کے لیے `catalog.json` + `catalog.snapshot.json` | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 یہ ریپوزٹری کیٹلاگ کے لیے عوامی سچائی کا ذریعہ ہے۔ ہر اندراج `catalog/plugins/` کے تحت ایک YAML فائل ہے، جو ایک شائع شدہ JSON Schema کے خلاف توثیق شدہ ہے، ایک انفرادی طور پر جائزہ شدہ pull request کے ذریعے شامل کی گئی ہے، اور ہمیشہ پلگ ان کے اصل تخلیق کار کو کریڈٹ دیا جاتا ہے۔ کیٹلاگ میں کچھ بھی کسی دوسرے کیٹلاگ یا فہرست سے تیار نہیں کیا جاتا: ہر اندراج اصل تخلیق کار کی ریپوزٹری سے ایک پن شدہ کمٹ پر دوبارہ تعمیر کی جاتی ہے۔
@@ -118,14 +118,14 @@
 ## 🚀 CLI انسٹال کریں
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-اسکوپڈ پیکج `@diegosouza.pw/dsh-plugins@0.1.0` کے طور پر شائع کیا جاتا ہے اور اوپر دی گئی کمانڈ آج کی معیاری انوکیشن ہے؛ یہاں کوئی انسٹالر اسکرپٹ ہوسٹ نہیں کی گئی۔
+اسکوپڈ پیکج `omni-dsh-plugins@1.0.0` کے طور پر شائع کیا جاتا ہے اور اوپر دی گئی کمانڈ آج کی معیاری انوکیشن ہے؛ یہاں کوئی انسٹالر اسکرپٹ ہوسٹ نہیں کی گئی۔
 
 ### آج CLI استعمال کریں
 
-ورژن 0.1.0 صرف پڑھنے کے لیے ڈسکوری اور توثیق کمانڈز کے ساتھ ساتھ رضامندی سے مشروط انسٹال کمانڈز فراہم کرتا ہے۔ فلیگز، exit codes اور کوڈ ایگزیکیوشن رضامندی گیٹ سمیت مکمل کمانڈ ریفرنس [docs/CLI.md](../../docs/CLI.md) میں ہے۔
+ورژن 1.0.0 صرف پڑھنے کے لیے ڈسکوری اور توثیق کمانڈز کے ساتھ ساتھ رضامندی سے مشروط انسٹال کمانڈز فراہم کرتا ہے۔ فلیگز، exit codes اور کوڈ ایگزیکیوشن رضامندی گیٹ سمیت مکمل کمانڈ ریفرنس [docs/CLI.md](../../docs/CLI.md) میں ہے۔
 
 | کمانڈ | یہ کیا کرتا ہے | کیا یہ آپ کے سسٹم کو چھوتا ہے؟ |
 | ------------------------------ | ------------------------------------------------------------------- | --------------------------------------- |
@@ -139,17 +139,17 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
-میوٹیٹنگ کمانڈز (`add`، `update`، `remove`) کبھی بھی پلگ ان lifecycle کوڈ ایگزیکیوٹ نہیں کرتیں جب تک آپ `--allow-code-execution` پاس نہ کریں۔ نیٹو Windows پر یہ میوٹیشنز v0.1.0 میں غیر فعال ہیں؛ WSL استعمال کریں۔ صرف پڑھنے کے لیے اور dry-run کمانڈز ہر جگہ کام کرتی ہیں۔
+میوٹیٹنگ کمانڈز (`add`، `update`، `remove`) کبھی بھی پلگ ان lifecycle کوڈ ایگزیکیوٹ نہیں کرتیں جب تک آپ `--allow-code-execution` پاس نہ کریں۔ نیٹو Windows پر یہ میوٹیشنز v1.0.0 میں غیر فعال ہیں؛ WSL استعمال کریں۔ صرف پڑھنے کے لیے اور dry-run کمانڈز ہر جگہ کام کرتی ہیں۔
 
 ## 🔍 پلگ ان کیٹلاگ میں کیسے داخل ہوتا ہے
 
@@ -264,7 +264,7 @@ pull request کھولنے سے پہلے [CONTRIBUTING.md](../../CONTRIBUTING.md)
 | [CONTRIBUTING.md](../../CONTRIBUTING.md) | مکمل شراکت کا معاہدہ: ثبوت، YAML قواعد، جائزہ گیٹس |
 | [SECURITY.md](../../SECURITY.md) | پلگ ان یا کیٹلاگ کی خامیوں کی رپورٹنگ؛ خفیہ معلومات کی پالیسی |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md) | `schemas/plugin.schema.yaml` کے لیے فیلڈ بہ فیلڈ ریفرنس |
-| [docs/CLI.md](../../docs/CLI.md) | `@diegosouza.pw/dsh-plugins@0.1.0` کے لیے CLI کمانڈ ریفرنس |
+| [docs/CLI.md](../../docs/CLI.md) | `omni-dsh-plugins@1.0.0` کے لیے CLI کمانڈ ریفرنس |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) | کیٹلاگ کیسے چلایا جاتا ہے: فوقیت، گیٹس، دعوے اور ہٹانا |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md) | آرٹیفیکٹ اقسام، بنیادی صلاحیت کے زمرے، ٹیگز، ریپوزٹری اسکوپ |
 | [docs/CREDIT.md](../../docs/CREDIT.md) | تخلیق کار کریڈٹ، PR فوقیت اور Git شناخت کی پالیسی |

--- a/docs/i18n/vi/README.md
+++ b/docs/i18n/vi/README.md
@@ -17,7 +17,7 @@ Khám phá và cài đặt plugin **DeepSeek Harness (DSH)** chỉ bằng một 
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -106,7 +106,7 @@ của nhà phát triển, được ghim tại đúng commit mà danh mục đã 
 | **Website** | Trình duyệt danh mục đã kết xuất, có tìm kiếm và xếp hạng                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **Danh mục** | Một file YAML cho mỗi plugin, là nguồn dữ liệu chân lý duy nhất             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **Schema**  | JSON Schema công khai (draft 2020-12) mà mọi mục đều xác thực theo | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | Tìm kiếm, xem chi tiết, xác thực và cài đặt từ danh mục           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | Tìm kiếm, xem chi tiết, xác thực và cài đặt từ danh mục           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **Nguồn dữ liệu cho máy** | `catalog.json` + `catalog.snapshot.json` dành cho các công cụ           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 Repository này là nguồn dữ liệu chân lý công khai của danh mục. Mỗi mục niêm yết là một file YAML nằm dưới
@@ -125,15 +125,15 @@ repository của nhà phát triển gốc, kèm commit nguồn đã ghim cố đ
 ## 🚀 Cài đặt CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-Gói scoped này được phát hành với tên `@diegosouza.pw/dsh-plugins@0.1.0`, và lệnh trên đây là cách gọi chính thức hiện
+Gói scoped này được phát hành với tên `omni-dsh-plugins@1.0.0`, và lệnh trên đây là cách gọi chính thức hiện
 tại; không có script cài đặt nào được lưu trữ tại đây.
 
 ### Dùng CLI ngay hôm nay
 
-Phiên bản 0.1.0 cung cấp các lệnh khám phá và xác thực chỉ đọc, cùng các lệnh cài đặt yêu cầu sự đồng ý. Tài liệu tham
+Phiên bản 1.0.0 cung cấp các lệnh khám phá và xác thực chỉ đọc, cùng các lệnh cài đặt yêu cầu sự đồng ý. Tài liệu tham
 khảo lệnh đầy đủ, bao gồm cờ, mã thoát và cơ chế đồng ý trước khi thực thi mã, có tại [docs/CLI.md](../../docs/CLI.md).
 
 | Lệnh                        | Chức năng                                                        | Có tác động đến hệ thống của bạn không?                    |
@@ -148,18 +148,18 @@ khảo lệnh đầy đủ, bao gồm cờ, mã thoát và cơ chế đồng ý 
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 Các lệnh làm thay đổi trạng thái (`add`, `update`, `remove`) không bao giờ thực thi mã vòng đời của plugin trừ khi bạn
-truyền `--allow-code-execution`. Trên Windows gốc, các thao tác thay đổi này đã bị vô hiệu hóa trong v0.1.0; hãy dùng
+truyền `--allow-code-execution`. Trên Windows gốc, các thao tác thay đổi này đã bị vô hiệu hóa trong v1.0.0; hãy dùng
 WSL. Các lệnh chỉ đọc và chạy thử hoạt động ở mọi nơi.
 
 ## 🔍 Một plugin gia nhập danh mục như thế nào
@@ -300,7 +300,7 @@ nếu ai đó đã đưa tác phẩm của bạn vào danh mục trước khi b�
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | Quy ước đóng góp đầy đủ: bằng chứng, quy tắc YAML, cổng xét duyệt    |
 | [SECURITY.md](../../SECURITY.md)                   | Báo cáo lỗ hổng của plugin hoặc danh mục; chính sách về bí mật           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | Tài liệu tham khảo theo từng trường cho `schemas/plugin.schema.yaml`             |
-| [docs/CLI.md](../../docs/CLI.md)                   | Tài liệu tham khảo lệnh CLI cho `@diegosouza.pw/dsh-plugins@0.1.0`          |
+| [docs/CLI.md](../../docs/CLI.md)                   | Tài liệu tham khảo lệnh CLI cho `omni-dsh-plugins@1.0.0`          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | Cách danh mục được quản trị: thứ tự ưu tiên, cổng kiểm soát, nhận quyền sở hữu và gỡ bỏ   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | Loại sản phẩm, danh mục năng lực chính, thẻ, phạm vi repository |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | Ghi công nhà phát triển, thứ tự ưu tiên PR và chính sách danh tính Git                 |

--- a/docs/i18n/zh-CN/CLI.md
+++ b/docs/i18n/zh-CN/CLI.md
@@ -1,21 +1,21 @@
-# CLI 参考手册 — `@diegosouza.pw/dsh-plugins@0.1.0`
+# CLI 参考手册 — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · [Português (Brasil)](../pt-BR/CLI.md) · **中文（简体）**
 
 > **非官方社区项目,与 DeepSeek 无关联、未经其认可,也未获其赞助。**
 > DeepSeek 的名称与标识归其各自所有者所有。
 
-本页记录已发布 CLI 在 `0.1.0` 版本中的确切行为。下文的每一条命令概要和参数都来自已发布命令自身的 `--help` 输出;此处不描述任何尚未发布的行为。该 CLI 从私有源代码维护,并作为带作用域的软件包 [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) 发布到 npm。
+本页记录已发布 CLI 在 `1.0.0` 版本中的确切行为。下文的每一条命令概要和参数都来自已发布命令自身的 `--help` 输出;此处不描述任何尚未发布的行为。该 CLI 从私有源代码维护,并作为带作用域的软件包 [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) 发布到 npm。
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## v0.1.0 中的设计原则
+## v1.0.0 中的设计原则
 
 - **默认只读。** `catalog`、`search`、`info`、`list` 和 `doctor` 绝不会修改配置文件(profile)、写入文件或启动插件代码。
 - **代码执行需明确同意。** 除非传入 `--allow-code-execution`,否则 `add`、`update` 和 `remove` 会拒绝运行 DSH/pnpm 生命周期代码。若不传入该参数,可使用 `--dry-run` 查看已验证的执行计划。
-- **原生 Windows 政策。** 在 v0.1.0 中,原生 Windows 上带代码执行的 `add`/`update`/`remove` 已被禁用;请使用 WSL。Dry-run 和只读命令仍然可用,原生 Windows 的恢复标记需要按文档说明进行手动恢复。
+- **原生 Windows 政策。** 在 v1.0.0 中,原生 Windows 上带代码执行的 `add`/`update`/`remove` 已被禁用;请使用 WSL。Dry-run 和只读命令仍然可用,原生 Windows 的恢复标记需要按文档说明进行手动恢复。
 - **固定输入。** 目录输入可以是本地目录、快照文件,或固定的公开快照 URL,并可选地锁定到确切的 40 个字符的修订版本(revision)。
 
 ## 通用选项
@@ -39,7 +39,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
 | `0`       | 成功(包括“为空但有效”的结果,例如空目录)     |
 | `1`       | 失败:校验错误、条目未找到、缺少必需选项,或诊断检查报告了错误 |
 
-在 v0.1.0 中观察到的示例:对一个有效的空目录运行 `catalog validate` 会以 `0` 退出,并输出
+在 v1.0.0 中观察到的示例:对一个有效的空目录运行 `catalog validate` 会以 `0` 退出,并输出
 `0 entries valid; catalog is empty`;`info <unknown-id>` 会以 `1` 退出,并输出 `Plugin not found`;
 当任何检查项(例如缺少 `dsh` 可执行文件)报告错误时,`doctor` 会以 `1` 退出。
 
@@ -63,9 +63,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # From the repository root:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — 在本地搜索公开目录字段
@@ -78,8 +78,8 @@ dsh-plugins search [options] <query...>
 `No plugins found.`(退出码为 `0`)。
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — 在目录之外查找插件
@@ -88,8 +88,8 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **未包含在已发布的 `0.1.0` 中。** `discover` 随 `1.0.0` 发布;本页其他所有命令都适用于当前发布到
-> npm 上的版本。对 `@0.1.0` 运行该命令会因未知命令而失败。
+> **未包含在已发布的 `1.0.0` 中。** `discover` 随 `1.0.0` 发布;本页其他所有命令都适用于当前发布到
+> npm 上的版本。对 `@1.0.0` 运行该命令会因未知命令而失败。
 
 它会先搜索经过策展的目录,然后——除非传入 `--offline`——再搜索实时的 GitHub `dsh-plugin` 主题
 (topic),因此即使某个插件尚未提交,也仍然可以被找到。目录结果携带目录持有的证据(固定提交、创作
@@ -99,8 +99,8 @@ dsh-plugins discover [options] <query...>
 地化。
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — 显示一个公开目录条目
@@ -113,7 +113,7 @@ dsh-plugins info [options] <id>
 `Plugin not found: <id>`。
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — 通过官方 DSH 委托添加一个目录插件
@@ -135,10 +135,10 @@ dsh-plugins add [options] <id>
 
 ```bash
 # Preview only — nothing is written, nothing executes:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Real install — explicit consent to lifecycle code:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — 通过官方 DSH 委托更新一个目录插件

--- a/docs/i18n/zh-CN/CLI.md
+++ b/docs/i18n/zh-CN/CLI.md
@@ -99,8 +99,8 @@ dsh-plugins discover [options] <query...>
 地化。
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — 显示一个公开目录条目

--- a/docs/i18n/zh-CN/CONTRIBUTING.md
+++ b/docs/i18n/zh-CN/CONTRIBUTING.md
@@ -98,14 +98,14 @@ popularity:
 
 ## 校验命令与可用性
 
-该 npm CLI 以 `@diegosouza.pw/dsh-plugins@0.1.0` 发布,因此下面的命令目前可以通过 `npx` 使用。请按原样使用这些命令;贡献者不应自行编造替代命令。
+该 npm CLI 以 `omni-dsh-plugins@1.0.0` 发布,因此下面的命令目前可以通过 `npx` 使用。请按原样使用这些命令;贡献者不应自行编造替代命令。
 
 请在仓库根目录运行以下命令:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` 只执行上文所述的本地 YAML、模式、SPDX、确切 SemVer、SHA-512 SRI 和重复项检查,并接受有意为之的零条目目录。它不能证明远程仓库身份或固定来源证据。其他命令会检查所需的公开文档和结构化的 GitHub issue 表单。这些命令在本地通过并不会放宽证据要求;维护者在合并前仍会应用每一项对应的发布门禁。

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@
 | **网站** | 带搜索和排名功能的目录浏览网页                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **目录** | 每个插件一个 YAML 文件,是唯一的真实来源             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **模式**  | 公开的 JSON Schema(draft 2020-12),所有条目均据此校验 | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | 从目录中搜索、查看、校验并安装           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | 从目录中搜索、查看、校验并安装           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **机器订阅源** | 供工具使用的 `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 本仓库是该目录的公开真实来源。每一条记录都是 `catalog/plugins/` 下的一个 YAML 文件,依据已发布的 JSON Schema 校验,通过一次单独评审的拉取请求添加,并始终署名插件的原始创作者。目录中的任何内容都不是从其他目录或列表生成的:每个条目都是根据创作者原始仓库在固定提交处重新构建而成。
@@ -118,14 +118,14 @@
 ## 🚀 安装 CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-该带作用域的包以 `@diegosouza.pw/dsh-plugins@0.1.0` 发布,上面的命令是目前的标准调用方式;本仓库不托管任何安装脚本。
+该带作用域的包以 `omni-dsh-plugins@1.0.0` 发布,上面的命令是目前的标准调用方式;本仓库不托管任何安装脚本。
 
 ### 立即使用 CLI
 
-0.1.0 版本提供只读的发现与校验命令,以及需要征得同意才能执行的安装命令。完整的命令参考(包括参数、退出码和代码执行同意机制)见 [docs/CLI.md](../../docs/CLI.md)。
+1.0.0 版本提供只读的发现与校验命令,以及需要征得同意才能执行的安装命令。完整的命令参考(包括参数、退出码和代码执行同意机制)见 [docs/CLI.md](../../docs/CLI.md)。
 
 | 命令                        | 功能说明                                                        | 是否会改动你的系统?                    |
 | ------------------------------ | ------------------------------------------------------------------- | --------------------------------------- |
@@ -139,17 +139,17 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
-变更类命令(`add`、`update`、`remove`)在未传入 `--allow-code-execution` 时绝不会执行插件生命周期代码。在原生 Windows 上,v0.1.0 中这些变更操作已被禁用;请改用 WSL。只读和演练模式命令在任何环境下都可用。
+变更类命令(`add`、`update`、`remove`)在未传入 `--allow-code-execution` 时绝不会执行插件生命周期代码。在原生 Windows 上,v1.0.0 中这些变更操作已被禁用;请改用 WSL。只读和演练模式命令在任何环境下都可用。
 
 ## 🔍 插件如何进入目录
 
@@ -275,7 +275,7 @@ provenance:
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | 完整的贡献约定:证据要求、YAML 规则、评审关卡    |
 | [SECURITY.md](../../SECURITY.md)                   | 报告插件或目录漏洞;敏感信息政策           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` 的逐字段参考             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` 的 CLI 命令参考          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` 的 CLI 命令参考          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | 目录的治理方式:优先级、关卡、认领与移除   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | 制品类型、主要能力分类、标签、仓库范围 |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | 创作者署名、PR 优先级与 Git 身份政策                 |

--- a/docs/i18n/zh-TW/CLI.md
+++ b/docs/i18n/zh-TW/CLI.md
@@ -100,8 +100,8 @@ dsh-plugins discover [options] <query...>
 會在地化。
 
 ```bash
-npx omni-dsh-plugins@1.0.0 discover memory --catalog .
-npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins discover memory --catalog .
+npx omni-dsh-plugins discover vision --offline --catalog . --json
 ```
 
 ### `info` — 顯示一個公開目錄條目

--- a/docs/i18n/zh-TW/CLI.md
+++ b/docs/i18n/zh-TW/CLI.md
@@ -1,21 +1,21 @@
-# CLI 參考手冊 — `@diegosouza.pw/dsh-plugins@0.1.0`
+# CLI 參考手冊 — `omni-dsh-plugins@1.0.0`
 
 > 🌐 [English](../../docs/CLI.md) · [Português (Brasil)](../pt-BR/CLI.md) · [中文（简体）](../zh-CN/CLI.md) · **中文（繁體）**
 
 > **非官方社群專案,與 DeepSeek 無關聯、未經其認可,也未獲其贊助。**
 > DeepSeek 的名稱與標識歸其各自所有者所有。
 
-本頁記錄已發布 CLI 在 `0.1.0` 版本中的確切行為。以下每一條指令概要與參數都取自已發布指令自身的 `--help` 輸出;此處不描述任何尚未發布的行為。此 CLI 從私有原始碼維護,並以帶作用域的套件 [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) 發布到 npm。
+本頁記錄已發布 CLI 在 `1.0.0` 版本中的確切行為。以下每一條指令概要與參數都取自已發布指令自身的 `--help` 輸出;此處不描述任何尚未發布的行為。此 CLI 從私有原始碼維護,並以帶作用域的套件 [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) 發布到 npm。
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 --help
+npx omni-dsh-plugins --help
 ```
 
-## v0.1.0 中的設計原則
+## v1.0.0 中的設計原則
 
 - **預設唯讀。** `catalog`、`search`、`info`、`list` 與 `doctor` 絕不會修改設定檔(profile)、寫入檔案或啟動外掛程式碼。
 - **執行程式碼需明確同意。** 除非傳入 `--allow-code-execution`,否則 `add`、`update` 與 `remove` 會拒絕執行 DSH/pnpm 生命週期程式碼。若不傳入該參數,可使用 `--dry-run` 查看已驗證的執行計畫。
-- **原生 Windows 政策。** 在 v0.1.0 中,原生 Windows 上帶程式碼執行的 `add`/`update`/`remove` 已停用;請改用 WSL。Dry-run 與唯讀指令仍可使用,原生 Windows 的復原標記需依文件說明手動復原。
+- **原生 Windows 政策。** 在 v1.0.0 中,原生 Windows 上帶程式碼執行的 `add`/`update`/`remove` 已停用;請改用 WSL。Dry-run 與唯讀指令仍可使用,原生 Windows 的復原標記需依文件說明手動復原。
 - **固定輸入。** 目錄輸入可以是本機目錄、快照檔案,或固定的公開快照網址,並可選擇鎖定到確切的 40 字元修訂版本(revision)。
 
 ## 常用選項
@@ -39,7 +39,7 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 --help
 | `0`       | 成功(包括「空但有效」的結果,例如空目錄)     |
 | `1`       | 失敗:驗證錯誤、找不到條目、缺少必要選項,或診斷檢查回報錯誤 |
 
-在 v0.1.0 中觀察到的範例:對一個有效的空目錄執行 `catalog validate` 會以 `0` 結束,並輸出
+在 v1.0.0 中觀察到的範例:對一個有效的空目錄執行 `catalog validate` 會以 `0` 結束,並輸出
 `0 entries valid; catalog is empty`;`info <unknown-id>` 會以 `1` 結束,並輸出 `Plugin not found`;
 當任一檢查項(例如缺少 `dsh` 執行檔)回報錯誤時,`doctor` 會以 `1` 結束。
 
@@ -64,9 +64,9 @@ dsh-plugins catalog github-forms-check [root]
 
 ```bash
 # From the repository root:
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog docs-check .
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 ### `search` — 在本機搜尋公開目錄欄位
@@ -79,8 +79,8 @@ dsh-plugins search [options] <query...>
 `No plugins found.`(結束代碼為 `0`)。
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins search notes markdown --catalog . --json
 ```
 
 ### `discover` — 在目錄之外尋找外掛
@@ -89,8 +89,8 @@ npx @diegosouza.pw/dsh-plugins@0.1.0 search notes markdown --catalog . --json
 dsh-plugins discover [options] <query...>
 ```
 
-> **未包含在已發布的 `0.1.0` 中。** `discover` 隨 `1.0.0` 發布;本頁其他所有指令都適用於目前發布
-> 到 npm 上的版本。對 `@0.1.0` 執行此指令,會因未知指令而失敗。
+> **未包含在已發布的 `1.0.0` 中。** `discover` 隨 `1.0.0` 發布;本頁其他所有指令都適用於目前發布
+> 到 npm 上的版本。對 `@1.0.0` 執行此指令,會因未知指令而失敗。
 
 它會先搜尋經過策展的目錄,接著——除非傳入 `--offline`——再搜尋即時的 GitHub `dsh-plugin` 主
 題(topic),因此即使某個外掛尚未提交,仍然可以被找到。目錄結果帶有目錄持有的證據(固定提交、
@@ -100,8 +100,8 @@ dsh-plugins discover [options] <query...>
 會在地化。
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover memory --catalog .
-npx @diegosouza.pw/dsh-plugins@1.0.0 discover vision --offline --catalog . --json
+npx omni-dsh-plugins@1.0.0 discover memory --catalog .
+npx omni-dsh-plugins@1.0.0 discover vision --offline --catalog . --json
 ```
 
 ### `info` — 顯示一個公開目錄條目
@@ -114,7 +114,7 @@ dsh-plugins info [options] <id>
 `Plugin not found: <id>`。
 
 ```bash
-npx @diegosouza.pw/dsh-plugins@0.1.0 info example-notes-search --catalog .
+npx omni-dsh-plugins info example-notes-search --catalog .
 ```
 
 ### `add` — 透過官方 DSH 委派新增一個目錄外掛
@@ -136,10 +136,10 @@ dsh-plugins add [options] <id>
 
 ```bash
 # Preview only — nothing is written, nothing executes:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --dry-run
+npx omni-dsh-plugins add example-notes-search --profile default --dry-run
 
 # Real install — explicit consent to lifecycle code:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add example-notes-search --profile default --allow-code-execution
+npx omni-dsh-plugins add example-notes-search --profile default --allow-code-execution
 ```
 
 ### `update` — 透過官方 DSH 委派更新一個目錄外掛

--- a/docs/i18n/zh-TW/CONTRIBUTING.md
+++ b/docs/i18n/zh-TW/CONTRIBUTING.md
@@ -98,14 +98,14 @@ popularity:
 
 ## 驗證指令與可用性
 
-該 npm CLI 以 `@diegosouza.pw/dsh-plugins@0.1.0` 發布,因此下列指令目前可透過 `npx` 使用。請照原樣使用這些指令;貢獻者不應自行捏造替代指令。
+該 npm CLI 以 `omni-dsh-plugins@1.0.0` 發布,因此下列指令目前可透過 `npx` 使用。請照原樣使用這些指令;貢獻者不應自行捏造替代指令。
 
 請在儲存庫根目錄執行下列指令:
 
 ```bash
-npx @diegosouza.pw/dsh-plugins catalog validate --catalog .
-npx @diegosouza.pw/dsh-plugins catalog docs-check .
-npx @diegosouza.pw/dsh-plugins catalog github-forms-check .
+npx omni-dsh-plugins catalog validate --catalog .
+npx omni-dsh-plugins catalog docs-check .
+npx omni-dsh-plugins catalog github-forms-check .
 ```
 
 `catalog validate` 只執行上文所述的本機 YAML、結構描述、SPDX、確切 SemVer、SHA-512 SRI 與重複項檢查,並接受刻意為之的零條目目錄。它無法證明遠端儲存庫身分或固定來源證據。其他指令會檢查所需的公開文件與結構化的 GitHub Issue 表單。這些指令在本機通過,並不會放寬證據要求;維護者在合併前仍會套用每一項對應的發布關卡。

--- a/docs/i18n/zh-TW/README.md
+++ b/docs/i18n/zh-TW/README.md
@@ -17,7 +17,7 @@
 </h3>
 
 [![Plugins](https://img.shields.io/badge/plugins-160_merged-3fb950)](https://dsh-plugins.omniroute.online)
-[![npm](https://img.shields.io/npm/v/@diegosouza.pw/dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins)
+[![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
 [![Website](https://img.shields.io/badge/website-live-58a6ff?logo=google-chrome&logoColor=white)](https://dsh-plugins.omniroute.online)
@@ -104,7 +104,7 @@
 | **網站** | 具搜尋與排名功能的目錄瀏覽網頁                 | [dsh-plugins.omniroute.online](https://dsh-plugins.omniroute.online)     |
 | **目錄** | 每個外掛一個 YAML 檔案,是唯一的真實來源             | [`catalog/plugins/`](../../catalog/plugins)                                    |
 | **結構描述**  | 公開的 JSON Schema(draft 2020-12),所有項目皆依此驗證 | [`schemas/plugin.schema.yaml`](../../schemas/plugin.schema.yaml)               |
-| **CLI**     | 從目錄中搜尋、檢視、驗證並安裝           | [`@diegosouza.pw/dsh-plugins`](https://www.npmjs.com/package/@diegosouza.pw/dsh-plugins) |
+| **CLI**     | 從目錄中搜尋、檢視、驗證並安裝           | [`omni-dsh-plugins`](https://www.npmjs.com/package/omni-dsh-plugins) |
 | **機器饋送** | 供工具使用的 `catalog.json` + `catalog.snapshot.json`           | [catalog.json](https://dsh-plugins.omniroute.online/catalog.json) · [catalog.snapshot.json](https://dsh-plugins.omniroute.online/catalog.snapshot.json) |
 
 本儲存庫是這份目錄的公開真實來源。每一筆項目都是 `catalog/plugins/` 底下的一個 YAML 檔案,依已發佈的 JSON Schema 驗證,
@@ -121,15 +121,15 @@
 ## 🚀 安裝 CLI
 
 ```bash
-npx @diegosouza.pw/dsh-plugins --help
+npx omni-dsh-plugins --help
 ```
 
-這個具作用域的套件以 `@diegosouza.pw/dsh-plugins@0.1.0` 發佈,上方指令是目前的標準呼叫方式;本儲存庫不代管任何安裝
+這個具作用域的套件以 `omni-dsh-plugins@1.0.0` 發佈,上方指令是目前的標準呼叫方式;本儲存庫不代管任何安裝
 指令碼。
 
 ### 立即使用 CLI
 
-0.1.0 版本提供唯讀的探索與驗證指令,以及需經同意方可執行的安裝指令。完整的指令參考(包含旗標、結束代碼與程式碼執行同意
+1.0.0 版本提供唯讀的探索與驗證指令,以及需經同意方可執行的安裝指令。完整的指令參考(包含旗標、結束代碼與程式碼執行同意
 機制)請見 [docs/CLI.md](../../docs/CLI.md)。
 
 | 指令                        | 功能說明                                                        | 是否會變更你的系統?                    |
@@ -144,18 +144,18 @@ npx @diegosouza.pw/dsh-plugins --help
 
 ```bash
 # Validate the catalog in this repository (what CI runs):
-npx @diegosouza.pw/dsh-plugins@0.1.0 catalog validate --catalog .
+npx omni-dsh-plugins catalog validate --catalog .
 
 # Search and inspect locally, without installing anything:
-npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
-npx @diegosouza.pw/dsh-plugins@0.1.0 info <plugin-id> --catalog .
+npx omni-dsh-plugins search memory --catalog .
+npx omni-dsh-plugins info <plugin-id> --catalog .
 
 # Preview an install plan; nothing is written and no subprocess runs:
-npx @diegosouza.pw/dsh-plugins@0.1.0 add <plugin-id> --profile default --dry-run
+npx omni-dsh-plugins add <plugin-id> --profile default --dry-run
 ```
 
 會變更狀態的指令(`add`、`update`、`remove`)在未傳入 `--allow-code-execution` 時,絕不會執行外掛生命週期程式碼。在原生
-Windows 上,v0.1.0 中這些變更操作已被停用;請改用 WSL。唯讀與試跑模式指令在任何環境下皆可使用。
+Windows 上,v1.0.0 中這些變更操作已被停用;請改用 WSL。唯讀與試跑模式指令在任何環境下皆可使用。
 
 ## 🔍 外掛如何進入目錄
 
@@ -282,7 +282,7 @@ monorepo 中的整合仍可被發現,但使用 `stars: null`,絕不繼承母專�
 | [CONTRIBUTING.md](../../CONTRIBUTING.md)           | 完整的貢獻規範:證據要求、YAML 規則、審查關卡    |
 | [SECURITY.md](../../SECURITY.md)                   | 回報外掛或目錄漏洞;機密資訊政策           |
 | [docs/SCHEMA.md](../../docs/SCHEMA.md)             | `schemas/plugin.schema.yaml` 的逐欄位參考             |
-| [docs/CLI.md](../../docs/CLI.md)                   | `@diegosouza.pw/dsh-plugins@0.1.0` 的 CLI 指令參考          |
+| [docs/CLI.md](../../docs/CLI.md)                   | `omni-dsh-plugins@1.0.0` 的 CLI 指令參考          |
 | [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)     | 目錄的治理方式:優先順序、關卡、認領與移除   |
 | [docs/CATEGORIES.md](../../docs/CATEGORIES.md)     | 產物種類、主要能力分類、標籤、儲存庫範圍 |
 | [docs/CREDIT.md](../../docs/CREDIT.md)             | 創作者掛名、PR 優先順序與 Git 身分政策                 |


### PR DESCRIPTION
Owner decision: the CLI ships **without a scope**.

`dsh-plugins` on its own is **already taken by someone else's package** (it resolves on npm and is not in this account's write list), so the name follows the repository and the rest of the account's naming (`omniroute`, `omni-skills`, `omniglyph`): **`omni-dsh-plugins`**. The command people type is unchanged — the binary is still `dsh-plugins`.

## The rename exposed a docs problem worth fixing once

Every example was **pinned to a published version**:

```bash
npx @diegosouza.pw/dsh-plugins@0.1.0 search memory --catalog .
```

That made each release a documentation migration across **88 files and 42 languages** — and under a new name those commands would have failed outright, since no `0.1.0` exists here. Examples are now **unpinned**, so they stay correct across releases; only the explicit statements of the current version name `1.0.0`.

## Three sentences were false and were rewritten, not search-replaced

- the package is no longer **"scoped"**;
- the CLI is no longer **"maintained from private source"** — it is developed in this repository under `cli/`, and released with provenance attestation;
- the note that `discover` is "not in the published `0.1.0`" now simply says which release introduces it.

## Translations

The translated docs carry the **mechanical** part (package name, version numeral). Prose that still describes a scoped package published from a private repository is left for the translation batch, and the freshness gate reports those files as **stale rather than being stamped current** — stamping a file nobody retranslated would certify drift as currency, which is exactly what that gate exists to prevent.

## Checks

`vitest` **177/177** · build clean · `node dist/bin.js --version` → `1.0.0` · the catalog's own gates pass: `catalog validate` → *160 entries valid*, `catalog docs-check` → *passed for 160 entries*.

## Next

`omni-dsh-plugins` does not exist on npm yet, so there is nothing to attach a trusted publisher to — that is very likely why the exchange kept answering *package not found*. The first publish has to create the package; trusted publishing can be configured for every release after it.
