### PR TITLE
ci(release): let the first publish authenticate with a token

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -105,6 +105,29 @@ jobs:
           fi
           "$SCRATCH/node_modules/.bin/dsh-plugins" --help > /dev/null
 
+      # Two authentication paths, in npm's own order of preference.
+      #
+      # Trusted publishing (no secret) is the destination: npm exchanges this workflow's OIDC
+      # token for a scoped credential and nothing long-lived exists anywhere. But it cannot be
+      # configured for a package that does not exist yet — the exchange answers
+      # "package not found", which is precisely how the first release of this name failed. So the
+      # FIRST publish needs NPM_TOKEN; once it has created the package, the trusted publisher can
+      # be attached and the secret deleted, and this step keeps working without it.
+      #
+      # `NODE_AUTH_TOKEN` is what the .npmrc written by setup-node reads. Absent secret means an
+      # empty value, which npm ignores in favour of the OIDC exchange — so removing the secret is
+      # all it takes to go back to trusted publishing.
+      - name: Report which credential path this run will take
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            echo "NPM_TOKEN present: publishing with the token (bootstrap path)."
+            echo "Delete the secret once the trusted publisher is configured."
+          else
+            echo "No NPM_TOKEN: publishing through trusted publishing (OIDC)."
+          fi
+
       # Trusted publishing: npm exchanges the workflow's OIDC token for a scoped credential.
       # --provenance is possible here and was not in the previous home: attestation requires a
       # public source repository, so moving the CLI beside the catalog is what lets an installer
@@ -116,6 +139,8 @@ jobs:
       # credential was issued but may not write this package. A release that fails opaquely
       # costs a round trip through a web UI nobody can read from here.
       - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -eu
           npm publish "./$(cat /tmp/tarball-name)" --access public --provenance --loglevel verbose


### PR DESCRIPTION
## The chicken and egg, confirmed

Trusted publishing **cannot be configured for a package that does not exist**. The exchange answers:

```
POST 404 /-/npm/v1/oidc/token/exchange/package/omni-dsh-plugins
OIDC token exchange error - package not found
```

That is exactly how every attempt failed — first under the scoped name, then again under `omni-dsh-plugins`. Something has to **create** the package before there is anything to attach a trusted publisher to.

## What changes

The publish step reads `NODE_AUTH_TOKEN` from an **optional** `NPM_TOKEN` secret:

- **secret present** → publishes with the token (bootstrap);
- **secret absent** → npm falls back to the OIDC exchange, which is the destination state.

Deleting the secret after the first release is the whole migration; no workflow change needed. A step before publish prints which path the run took, so the logs never leave it ambiguous which credential published a given version.

**Provenance is unaffected either way** — the attestation is signed against GitHub's OIDC and Sigstore, not against however npm was authenticated. Both failed runs already produced a signed statement in the transparency log (`logIndex=2539596080`) before the PUT was rejected.

## Steps after this merges

1. npm → **Access Tokens** → *Generate New Token* → **Granular Access Token**, with **Read and write** on packages. The package does not exist yet, so scope it to all packages for now — it can be narrowed to `omni-dsh-plugins` after the first release.
2. GitHub → this repo → **Settings → Secrets and variables → Actions** → new secret named `NPM_TOKEN`.
3. I dispatch `release-npm` with version `1.0.0`.
4. npm → the new package's **Settings → Trusted Publisher** → `diegosouzapw` / `awesome-omni-dsh-plugins` / `release-npm.yml` / environment `npm-release`.
5. Delete the `NPM_TOKEN` secret. Every later release goes through OIDC with nothing long-lived stored.