### PR TITLE
catalog: add 988hj7tczd-oss-dsh-computer-use (community curation, created by @988hj7tczd-oss)

### DIFF
--- a/catalog/plugins/988hj7tczd-oss-dsh-computer-use.yaml
+++ b/catalog/plugins/988hj7tczd-oss-dsh-computer-use.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: 988hj7tczd-oss-dsh-computer-use
+name: dsh-computer-use
+description:
+  en: "bash ./install.sh 预演: ./install.sh --dry-run ./uninstall.sh"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - computer-use
+  - cua-driver
+  - harness-desktop
+  - autopilot
+  - bash
+  - install
+  - uninstall
+source:
+  repository: https://github.com/988hj7tczd-oss/dsh-computer-use
+  repositoryNodeId: R_kgDOT5YX8A
+  subpath: null
+  commit: 5f94e234de98bde382b0a6df5e29c70023b38832
+creator:
+  github: 988hj7tczd-oss
+package:
+  ecosystem: npm
+  name: dsh-computer-use
+  version: 0.1.0
+  integrity: sha512-9NvuOfXtpMPECMgzTl1HmpZ50mhcAMZbNgG2eD3Now4me4rFMkDIZ+qXn+gJkbWDqACHdXbojhghC234qN+L5w==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:35.868Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/988hj7tczd-oss-dsh-computer-use.yaml
+++ b/catalog/plugins/988hj7tczd-oss-dsh-computer-use.yaml
@@ -13,9 +13,6 @@ tags:
   - cua-driver
   - harness-desktop
   - autopilot
-  - bash
-  - install
-  - uninstall
 source:
   repository: https://github.com/988hj7tczd-oss/dsh-computer-use
   repositoryNodeId: R_kgDOT5YX8A
@@ -38,7 +35,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:35.868Z
+  checkedAt: 2026-08-21T02:07:44.958Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `988hj7tczd-oss-dsh-computer-use`
- Submission type: community curation
- Created by `988hj7tczd-oss` — https://github.com/988hj7tczd-oss
- Original source repository: https://github.com/988hj7tczd-oss/dsh-computer-use
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.