### PR TITLE
catalog: add bjvgukv25842-cmyk-quotecite (community curation, created by @bjvgukv25842-cmyk)

### DIFF
--- a/catalog/plugins/bjvgukv25842-cmyk-quotecite.yaml
+++ b/catalog/plugins/bjvgukv25842-cmyk-quotecite.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: bjvgukv25842-cmyk-quotecite
+name: quotecite
+description:
+  en: https://github.com/user-attachments/assets/89fb0a27-1f38-48f6-8341-317b6d1f42bc
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - quotable
+  - quotecite
+  - quote
+  - citation
+  - context-engineering
+  - user
+  - attachments
+  - assets
+  - 89fb0a27
+  - 1f38
+  - 48f6
+  - "8341"
+  - 317b6d1f42bc
+source:
+  repository: https://github.com/bjvgukv25842-cmyk/Quotable-DeepSeek-Harness
+  repositoryNodeId: R_kgDOT5s5SA
+  subpath: null
+  commit: 613bcf8ff08accd1bd2e1ab8f6febc3667180572
+creator:
+  github: bjvgukv25842-cmyk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:39.172Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/bjvgukv25842-cmyk-quotecite.yaml
+++ b/catalog/plugins/bjvgukv25842-cmyk-quotecite.yaml
@@ -16,14 +16,6 @@ tags:
   - quote
   - citation
   - context-engineering
-  - user
-  - attachments
-  - assets
-  - 89fb0a27
-  - 1f38
-  - 48f6
-  - "8341"
-  - 317b6d1f42bc
 source:
   repository: https://github.com/bjvgukv25842-cmyk/Quotable-DeepSeek-Harness
   repositoryNodeId: R_kgDOT5s5SA
@@ -42,7 +34,7 @@ license:
   spdx: Apache-2.0
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:39.172Z
+  checkedAt: 2026-08-21T02:07:47.701Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bjvgukv25842-cmyk-quotecite`
- Submission type: community curation
- Created by `bjvgukv25842-cmyk` — https://github.com/bjvgukv25842-cmyk
- Original source repository: https://github.com/bjvgukv25842-cmyk/Quotable-DeepSeek-Harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.