### PR TITLE
catalog: add cikeseven-dsh-tui (community curation, created by @CikeSeven)

### DIFF
--- a/catalog/plugins/cikeseven-dsh-tui.yaml
+++ b/catalog/plugins/cikeseven-dsh-tui.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: cikeseven-dsh-tui
+name: "@deepseek-harness-tui/dsh-tui"
+description:
+  en: Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - claude
+  - code
+  - style
+  - interactive
+  - front
+  - door
+  - agents
+  - built
+  - ported
+  - core
+  - dsh
+source:
+  repository: https://github.com/ccch1mneyyy/dsh-TUI
+  repositoryNodeId: R_kgDOT3WsVQ
+  subpath: null
+  commit: 01f06531ea499f21d23bbef4c1104dfb090b0282
+creator:
+  github: CikeSeven
+package:
+  ecosystem: npm
+  name: "@deepseek-harness-tui/dsh-tui"
+  version: 0.8.3
+  integrity: sha512-QYhUKMy+5nra0qb6EK4PcWGqF6UQ+FrhSavhMlhoq95eSe/3rbisPZoEbRmPu0NDp+SlLrSA5cHnfFk1vbGHWA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:33.895Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2188
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/cikeseven-dsh-tui.yaml
+++ b/catalog/plugins/cikeseven-dsh-tui.yaml
@@ -40,12 +40,12 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:33.895Z
+  checkedAt: 2026-08-21T02:07:42.901Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:
   starsPolicy: exact-repository
-  stars: 2188
+  stars: 2189
 provenance:
   discussion: null
   comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cikeseven-dsh-tui`
- Submission type: community curation
- Created by `CikeSeven` — https://github.com/CikeSeven
- Original source repository: https://github.com/ccch1mneyyy/dsh-TUI
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.