### PR TITLE
catalog: add gezi-wen-sage-mem (community curation, created by @gezi-wen)

### DIFF
--- a/catalog/plugins/gezi-wen-sage-mem.yaml
+++ b/catalog/plugins/gezi-wen-sage-mem.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: gezi-wen-sage-mem
+name: sage-mem
+description:
+  en: File-based memory plugin for DeepSeek Harness (DSH) — cross-session memory in transparent markdown files
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - file
+  - memory
+  - cross
+  - session
+  - transparent
+  - markdown
+  - files
+source:
+  repository: https://github.com/gezi-wen/sage-mem
+  repositoryNodeId: R_kgDOT4IhIA
+  subpath: null
+  commit: a1916ea63bcd292fad2dc0309363ffeb31d37cbe
+creator:
+  github: gezi-wen
+package:
+  ecosystem: npm
+  name: sage-mem
+  version: 0.4.0
+  integrity: sha512-Dgu64BXVIW1t50IrriTsG10ksLVUibOVbqtemneQpdmSrQpv3j4Ej2ZWDAMy0rKLSpGApBWpSf3s/mipNUXO5w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:40.809Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/gezi-wen-sage-mem.yaml
+++ b/catalog/plugins/gezi-wen-sage-mem.yaml
@@ -10,13 +10,6 @@ primaryCategory: memory-rag
 tags:
   - dsh
   - deepseek-harness
-  - file
-  - memory
-  - cross
-  - session
-  - transparent
-  - markdown
-  - files
 source:
   repository: https://github.com/gezi-wen/sage-mem
   repositoryNodeId: R_kgDOT4IhIA
@@ -38,7 +31,7 @@ license:
   spdx: Apache-2.0
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:40.809Z
+  checkedAt: 2026-08-21T02:07:49.085Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gezi-wen-sage-mem`
- Submission type: community curation
- Created by `gezi-wen` — https://github.com/gezi-wen
- Original source repository: https://github.com/gezi-wen/sage-mem
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.