### PR TITLE
catalog: add hytime-dsh-thinking-effort (community curation, created by @hytime)

### DIFF
--- a/catalog/plugins/hytime-dsh-thinking-effort.yaml
+++ b/catalog/plugins/hytime-dsh-thinking-effort.yaml
@@ -13,17 +13,6 @@ tags:
   - reasoning-effort
   - thinking
   - llm-pi-ai
-  - adds
-  - configurable
-  - reasoning
-  - effort
-  - levels
-  - hand
-  - declared
-  - models
-  - sets
-  - default
-  - subagents
 source:
   repository: https://github.com/hytime/dsh-thinking-effort
   repositoryNodeId: R_kgDOT5CUHA
@@ -45,7 +34,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:42.256Z
+  checkedAt: 2026-08-21T02:07:50.302Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/hytime-dsh-thinking-effort.yaml
+++ b/catalog/plugins/hytime-dsh-thinking-effort.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: hytime-dsh-thinking-effort
+name: "@hytime/dsh-thinking-effort"
+description:
+  en: A DSH (DeepSeek Harness) plugin that adds configurable reasoning effort levels to hand-declared llm-pi-ai models and sets a default reasoning effort for subagents.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - reasoning-effort
+  - thinking
+  - llm-pi-ai
+  - adds
+  - configurable
+  - reasoning
+  - effort
+  - levels
+  - hand
+  - declared
+  - models
+  - sets
+  - default
+  - subagents
+source:
+  repository: https://github.com/hytime/dsh-thinking-effort
+  repositoryNodeId: R_kgDOT5CUHA
+  subpath: null
+  commit: 9573f728ce596117690baee725581a347646d262
+creator:
+  github: hytime
+package:
+  ecosystem: npm
+  name: "@hytime/dsh-thinking-effort"
+  version: 0.1.6
+  integrity: sha512-wmHjNrQtpp8rBIToYUFcG31DTzDuihpTRswccSxH2s9wLTi0NdQ0Vnz3lNjTHlnZD3p8j+thLCa3ijotehsXVA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:42.256Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hytime-dsh-thinking-effort`
- Submission type: community curation
- Created by `hytime` — https://github.com/hytime
- Original source repository: https://github.com/hytime/dsh-thinking-effort
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.