### PR TITLE
catalog: add jiyr0119-dsh-workspace-explorer (community curation, created by @Jiyr0119)

### DIFF
--- a/catalog/plugins/jiyr0119-dsh-workspace-explorer.yaml
+++ b/catalog/plugins/jiyr0119-dsh-workspace-explorer.yaml
@@ -14,16 +14,7 @@ tags:
   - explorer
   - file-tree
   - ai-tools
-  - file
-  - files
-  - capsule
-  - button
-  - session
-  - header
-  - feature
-  - name
-  - folder
-  - icon
+  - dsh
 source:
   repository: https://github.com/Jiyr0119/dsh-workspace-explorer
   repositoryNodeId: R_kgDOT4N3SQ
@@ -45,7 +36,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:43.865Z
+  checkedAt: 2026-08-21T02:07:51.771Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/jiyr0119-dsh-workspace-explorer.yaml
+++ b/catalog/plugins/jiyr0119-dsh-workspace-explorer.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: jiyr0119-dsh-workspace-explorer
+name: "@jiyr0119/dsh-workspace-explorer"
+description:
+  en: "A workspace file explorer for the DeepSeek Harness Web UI: a “Workspace Files” capsule button in the session header (feature name + folder icon, beside the Session log button) opens an animated popup showing the current workspace's directory tree — click or drag a file to send its reference to the model."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - cordis
+  - workspace
+  - explorer
+  - file-tree
+  - ai-tools
+  - file
+  - files
+  - capsule
+  - button
+  - session
+  - header
+  - feature
+  - name
+  - folder
+  - icon
+source:
+  repository: https://github.com/Jiyr0119/dsh-workspace-explorer
+  repositoryNodeId: R_kgDOT4N3SQ
+  subpath: null
+  commit: f03b9547e9499377a0f9b5003d76d0a9e4507ce4
+creator:
+  github: Jiyr0119
+package:
+  ecosystem: npm
+  name: "@jiyr0119/dsh-workspace-explorer"
+  version: 0.5.2
+  integrity: sha512-pgWNi2TxVvyb2gAnrqMWU6Y71ycyP++O441138C1vDF7SR6f7s2N2zAccdparMsLTAdD3qQjvu+ByJVq0FldGA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:43.865Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiyr0119-dsh-workspace-explorer`
- Submission type: community curation
- Created by `Jiyr0119` — https://github.com/Jiyr0119
- Original source repository: https://github.com/Jiyr0119/dsh-workspace-explorer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.