### PR TITLE
catalog: add lee259-dsh-workbench (community curation, created by @lee259)

### DIFF
--- a/catalog/plugins/lee259-dsh-workbench.yaml
+++ b/catalog/plugins/lee259-dsh-workbench.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: lee259-dsh-workbench
+name: dsh-workbench
+description:
+  en: A right-side file workspace for DeepSeek Harness Web.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - workbench
+  - file-preview
+  - file-tree
+  - diff
+  - right
+  - side
+  - file
+  - workspace
+source:
+  repository: https://github.com/lee259/dsh-workbench
+  repositoryNodeId: R_kgDOT4JjFA
+  subpath: null
+  commit: 5c4f6a66c600de3908e452be2355e27f1f9cb813
+creator:
+  github: lee259
+package:
+  ecosystem: npm
+  name: dsh-workbench
+  version: 0.8.0
+  integrity: sha512-1AzG/8xZPMRS1BgX2BRSoxc0XWct9TV0iNxww/Jah/wueaHkOs5188y9M9yGEFXnKXo+p5jGQ4fysYXr2j2PvA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:45.479Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/lee259-dsh-workbench.yaml
+++ b/catalog/plugins/lee259-dsh-workbench.yaml
@@ -16,10 +16,6 @@ tags:
   - file-preview
   - file-tree
   - diff
-  - right
-  - side
-  - file
-  - workspace
 source:
   repository: https://github.com/lee259/dsh-workbench
   repositoryNodeId: R_kgDOT4JjFA
@@ -41,7 +37,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:45.479Z
+  checkedAt: 2026-08-21T02:07:53.324Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lee259-dsh-workbench`
- Submission type: community curation
- Created by `lee259` — https://github.com/lee259
- Original source repository: https://github.com/lee259/dsh-workbench
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.