### PR TITLE
catalog: add linglambda-dsh-undo (community curation, created by @LingLambda)

### DIFF
--- a/catalog/plugins/linglambda-dsh-undo.yaml
+++ b/catalog/plugins/linglambda-dsh-undo.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: linglambda-dsh-undo
+name: dsh-undo
+description:
+  en: Durable multi-level context undo/redo for DeepSeek Harness, with per-user-message WebUI actions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - undo
+  - redo
+  - context
+  - durable
+  - multi
+  - level
+  - user
+  - message
+  - webui
+  - actions
+source:
+  repository: https://github.com/LingLambda/dsh-undo
+  repositoryNodeId: R_kgDOT3bAJg
+  subpath: null
+  commit: 6948396fc0e71171fa26d9979c81bc7591571288
+creator:
+  github: LingLambda
+package:
+  ecosystem: npm
+  name: dsh-undo
+  version: 0.3.0-preview.1
+  integrity: sha512-mHBkCfrx0m5Tp/rWGB/xtMedLgqrRhRaPeoxg3i+bynALSNpKODibilmtBOZVXZ/Qrfd3QronrguZNTARPfFXA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:47.095Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/linglambda-dsh-undo.yaml
+++ b/catalog/plugins/linglambda-dsh-undo.yaml
@@ -14,13 +14,6 @@ tags:
   - undo
   - redo
   - context
-  - durable
-  - multi
-  - level
-  - user
-  - message
-  - webui
-  - actions
 source:
   repository: https://github.com/LingLambda/dsh-undo
   repositoryNodeId: R_kgDOT3bAJg
@@ -42,7 +35,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:47.095Z
+  checkedAt: 2026-08-21T02:07:54.540Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `linglambda-dsh-undo`
- Submission type: community curation
- Created by `LingLambda` — https://github.com/LingLambda
- Original source repository: https://github.com/LingLambda/dsh-undo
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.