### PR TITLE
catalog: add tomowang-dsh-tui (community curation, created by @tomowang)

### DIFF
--- a/catalog/plugins/tomowang-dsh-tui.yaml
+++ b/catalog/plugins/tomowang-dsh-tui.yaml
@@ -12,14 +12,6 @@ tags:
   - deepseek-harness
   - tui
   - agent
-  - terminal
-  - front
-  - door
-  - tree
-  - mode
-  - bundle
-  - over
-  - base
   - dsh
 source:
   repository: https://github.com/tomowang/dsh-tui
@@ -43,7 +35,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:37.457Z
+  checkedAt: 2026-08-21T02:07:46.146Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:

--- a/catalog/plugins/tomowang-dsh-tui.yaml
+++ b/catalog/plugins/tomowang-dsh-tui.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: tomowang-dsh-tui
+name: "@tomowang/dsh-tui"
+description:
+  en: "Terminal front door for DeepSeek Harness (dsh): an out-of-tree TUI mode bundle over dsh-base"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - tui
+  - agent
+  - terminal
+  - front
+  - door
+  - tree
+  - mode
+  - bundle
+  - over
+  - base
+  - dsh
+source:
+  repository: https://github.com/tomowang/dsh-tui
+  repositoryNodeId: R_kgDOT4XSDw
+  subpath: null
+  commit: 689bb8496cd35e7019360c5c8faf82407ab2758c
+creator:
+  github: tomowang
+package:
+  ecosystem: npm
+  name: "@tomowang/dsh-tui"
+  version: 0.4.0
+  integrity: sha512-VG8VhKWEydZmLMsvwzy0J7DoCyJsmMlBy3HewHrxw/mcrWd6YyDoKgoosg0M1D/mXR9l+ku4tlTTJyFmOhVYuQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:37.457Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tomowang-dsh-tui`
- Submission type: community curation
- Created by `tomowang` — https://github.com/tomowang
- Original source repository: https://github.com/tomowang/dsh-tui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.