### PR TITLE
catalog: add tsonglew-dsh-workspace-search (community curation, created by @tsonglew)

### DIFF
--- a/catalog/plugins/tsonglew-dsh-workspace-search.yaml
+++ b/catalog/plugins/tsonglew-dsh-workspace-search.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: tsonglew-dsh-workspace-search
+name: dsh-workspace-search
+description:
+  en: VS Code-style workspace keyword search tab for the dsh web GUI, registered into dsh-better-sidebar
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - search
+  - workspace
+  - better-sidebar
+  - code
+  - style
+  - keyword
+  - registered
+  - better
+  - sidebar
+source:
+  repository: https://github.com/tsonglew/dsh-workspace-search
+  repositoryNodeId: R_kgDOT4WWHQ
+  subpath: null
+  commit: fc2ebaa9f998c592ecc725ca96519ea3b131408a
+creator:
+  github: tsonglew
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T01:51:48.716Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/tsonglew-dsh-workspace-search.yaml
+++ b/catalog/plugins/tsonglew-dsh-workspace-search.yaml
@@ -14,12 +14,6 @@ tags:
   - search
   - workspace
   - better-sidebar
-  - code
-  - style
-  - keyword
-  - registered
-  - better
-  - sidebar
 source:
   repository: https://github.com/tsonglew/dsh-workspace-search
   repositoryNodeId: R_kgDOT4WWHQ
@@ -38,7 +32,7 @@ license:
   spdx: MIT
 verification:
   status: eligible
-  checkedAt: 2026-08-21T01:51:48.716Z
+  checkedAt: 2026-08-21T02:07:55.734Z
   repositoryIdentity: resolved
   smokeTest: null
 popularity:


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tsonglew-dsh-workspace-search`
- Submission type: community curation
- Created by `tsonglew` — https://github.com/tsonglew
- Original source repository: https://github.com/tsonglew/dsh-workspace-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.