### PR TITLE
catalog: add 2nd1st-dsh-plugin-open-app (community curation, created by @2nd1st)

### DIFF
--- a/catalog/plugins/2nd1st-dsh-plugin-open-app.yaml
+++ b/catalog/plugins/2nd1st-dsh-plugin-open-app.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: 2nd1st-dsh-plugin-open-app
+name: "@2nd1st/dsh-plugin-open-app"
+description:
+  en: "Brings open-mcp-apps into DeepSeek Harness (dsh): an Apps section in the sidebar, one container per app with its own workspace and conversation, an agent-presence strip under the app, and inline app rendering for MCP tool calls."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - mcp
+  - mcp-apps
+  - model-context-protocol
+  - open-mcp-apps
+  - cordis
+source:
+  repository: https://github.com/2nd1st/dsh-plugin-open-app
+  repositoryNodeId: R_kgDOT5MEFQ
+  subpath: null
+  commit: 01706d45221a1c98ac33be9c900a9dc3eec4f9af
+creator:
+  github: 2nd1st
+package:
+  ecosystem: npm
+  name: "@2nd1st/dsh-plugin-open-app"
+  version: 0.1.2
+  integrity: sha512-ObdVOyFDoCkvP8+57/gaUsTZVosl+i/MT7Zwzcw1FXAC/WzksP6+VflEV7fPPtrc8U48c29xmVI6GVnG0xKkHg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:24.094Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `2nd1st-dsh-plugin-open-app`
- Submission type: community curation
- Created by `2nd1st` — https://github.com/2nd1st
- Original source repository: https://github.com/2nd1st/dsh-plugin-open-app
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.