### PR TITLE
catalog: add 534119219-chicheng-gate (community curation, created by @534119219)

### DIFF
--- a/catalog/plugins/534119219-chicheng-gate.yaml
+++ b/catalog/plugins/534119219-chicheng-gate.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: 534119219-chicheng-gate
+name: chicheng-gate
+description:
+  en: dsh plugin --profile web add github:534119219/chicheng-gate
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - chicheng-gate
+  - lan
+  - frp
+  - frpc
+  - tunnel
+  - remote-access
+  - mobile
+source:
+  repository: https://github.com/534119219/chicheng-gate
+  repositoryNodeId: R_kgDOT5Bhlg
+  subpath: null
+  commit: 6a98288eb6faa91e8beefcc1be06d30451a3962a
+creator:
+  github: "534119219"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:25.604Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `534119219-chicheng-gate`
- Submission type: community curation
- Created by `534119219` — https://github.com/534119219
- Original source repository: https://github.com/534119219/chicheng-gate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.