### PR TITLE
catalog: add a903067276-rgb-dsh-plan-switch (community curation, created by @a903067276-rgb)

### DIFF
--- a/catalog/plugins/a903067276-rgb-dsh-plan-switch.yaml
+++ b/catalog/plugins/a903067276-rgb-dsh-plan-switch.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: a903067276-rgb-dsh-plan-switch
+name: dsh-plan-switch
+description:
+  en: One-click enter/exit Plan mode for the DSH web input bar (a quick-click shortcut for /plan)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - plan
+  - web-ui
+source:
+  repository: https://github.com/a903067276-rgb/dsh-plan-switch
+  repositoryNodeId: R_kgDOT6kokg
+  subpath: null
+  commit: dc22a7885b66d2e5ffc283b15ec9f70a75817e69
+creator:
+  github: a903067276-rgb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:26.971Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `a903067276-rgb-dsh-plan-switch`
- Submission type: community curation
- Created by `a903067276-rgb` — https://github.com/a903067276-rgb
- Original source repository: https://github.com/a903067276-rgb/dsh-plan-switch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.