### PR TITLE
catalog: add akslcw-dsh-negative-ledger (community curation, created by @akslcw)

### DIFF
--- a/catalog/plugins/akslcw-dsh-negative-ledger.yaml
+++ b/catalog/plugins/akslcw-dsh-negative-ledger.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: akslcw-dsh-negative-ledger
+name: "@akslcw/dsh-negative-ledger"
+description:
+  en: "Agent negative-knowledge ledger for DeepSeek Harness: records failed paths with evidence hashes and retry conditions, auto-invalidates on evidence change."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - negative-knowledge
+  - agent-ledger
+  - coding-agent
+  - dsh
+source:
+  repository: https://github.com/akslcw/dsh-negative-ledger
+  repositoryNodeId: R_kgDOT4DxMQ
+  subpath: null
+  commit: f0ecad5ec8e2769c22c8f28cee0f9b9e5e754489
+creator:
+  github: akslcw
+package:
+  ecosystem: npm
+  name: "@akslcw/dsh-negative-ledger"
+  version: 0.1.1
+  integrity: sha512-vDsVQ8tADGziuZKO+FZr6ni//t04E2B6MHFkjbZBOEgbgZiwIiUmxTDOKclgPip6LHmZAQlQqFljDQemSyqDTw==
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:28.440Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `akslcw-dsh-negative-ledger`
- Submission type: community curation
- Created by `akslcw` — https://github.com/akslcw
- Original source repository: https://github.com/akslcw/dsh-negative-ledger
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.