### PR TITLE
catalog: add benhuhuan-dsh-tui (community curation, created by @BenHuHuan)

### DIFF
--- a/catalog/plugins/benhuhuan-dsh-tui.yaml
+++ b/catalog/plugins/benhuhuan-dsh-tui.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: benhuhuan-dsh-tui
+name: "@deepseek-ai/dsh-tui"
+description:
+  en: Interactive pi-tui terminal front door for DeepSeek Harness agents
+  evidencePath: packages/ui/tui/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - interactive
+  - terminal
+  - front
+  - door
+  - agents
+  - dsh
+source:
+  repository: https://github.com/BenHuHuan/dhs-tuicode
+  repositoryNodeId: R_kgDOT4KNkw
+  subpath: packages/ui/tui
+  commit: 06900f6932bde3d593bda420809196b75fc6e30b
+creator:
+  github: BenHuHuan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: packages/ui/tui/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:49:01.839Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `benhuhuan-dsh-tui`
- Submission type: community curation
- Created by `BenHuHuan` — https://github.com/BenHuHuan
- Original source repository: https://github.com/BenHuHuan/dhs-tuicode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.