### PR TITLE
catalog: add biociao-dsh-model-tier (community curation, created by @biociao)

### DIFF
--- a/catalog/plugins/biociao-dsh-model-tier.yaml
+++ b/catalog/plugins/biociao-dsh-model-tier.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: biociao-dsh-model-tier
+name: dsh-model-tier
+description:
+  en: "Tiered model router for DeepSeek Harness: routes auxiliary calls (session title, compaction) and subtasks to light models, escalates hard tasks to strong ones — automatically, per request, across providers."
+  evidencePath: packages/dsh-model-tier/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - model-router
+  - tiered-routing
+  - llm
+  - routing
+  - cost-optimization
+source:
+  repository: https://github.com/biociao/dsh-science
+  repositoryNodeId: R_kgDOT382Zw
+  subpath: packages/dsh-model-tier
+  commit: 23767ab2f8d7bcf84a0820daa4c6ae79549da000
+creator:
+  github: biociao
+package:
+  ecosystem: npm
+  name: dsh-model-tier
+  version: 0.1.0
+  integrity: sha512-xLfvANHei1KT5GL32EazIx6rbs4vVy+zCdaAQokIM9IX5gQWRAtnKH0BAR56zTr8wKACwjwyroo4GEanvd7IDg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: packages/dsh-model-tier/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:49:07.425Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `biociao-dsh-model-tier`
- Submission type: community curation
- Created by `biociao` — https://github.com/biociao
- Original source repository: https://github.com/biociao/dsh-science
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.