### PR TITLE
catalog: add bobleer-deepseek-harness-plugin-mcp (community curation, created by @bobleer)

### DIFF
--- a/catalog/plugins/bobleer-deepseek-harness-plugin-mcp.yaml
+++ b/catalog/plugins/bobleer-deepseek-harness-plugin-mcp.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: bobleer-deepseek-harness-plugin-mcp
+name: deepseek-harness-plugin-mcp
+description:
+  en: MCP server that lets any agent discover, install, and run DeepSeek Harness plugins.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - mcp
+  - model-context-protocol
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+source:
+  repository: https://github.com/bobleer/deepseek-harness-plugin-mcp
+  repositoryNodeId: R_kgDOT3eryQ
+  subpath: null
+  commit: 8b292eb2e423efcbc8ed173015cfd0daafc482ca
+creator:
+  github: bobleer
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:29.867Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bobleer-deepseek-harness-plugin-mcp`
- Submission type: community curation
- Created by `bobleer` — https://github.com/bobleer
- Original source repository: https://github.com/bobleer/deepseek-harness-plugin-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.