### PR TITLE
catalog: add bugmaker2-dsh-plugin-template (community curation, created by @bugmaker2)

### DIFF
--- a/catalog/plugins/bugmaker2-dsh-plugin-template.yaml
+++ b/catalog/plugins/bugmaker2-dsh-plugin-template.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: bugmaker2-dsh-plugin-template
+name: dsh-plugin-template
+description:
+  en: Minimal Hello World plugin template for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+source:
+  repository: https://github.com/bugmaker2/dsh-plugin-template
+  repositoryNodeId: R_kgDOT3mwrg
+  subpath: null
+  commit: 114f75999d8d477951cbd91ee4d1e0f5360d6627
+creator:
+  github: bugmaker2
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:17.781Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bugmaker2-dsh-plugin-template`
- Submission type: community curation
- Created by `bugmaker2` — https://github.com/bugmaker2
- Original source repository: https://github.com/bugmaker2/dsh-plugin-template
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.