### PR TITLE
catalog: add bujue600-arch-dsh-testgen (community curation, created by @bujue600-arch)

### DIFF
--- a/catalog/plugins/bujue600-arch-dsh-testgen.yaml
+++ b/catalog/plugins/bujue600-arch-dsh-testgen.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: bujue600-arch-dsh-testgen
+name: dsh-testgen
+description:
+  en: "Automated unit-test generation for DeepSeek Harness: a /testgen command and generate tests tool that scaffold, run, and fix tests until they pass."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - testing
+  - unit-test
+  - test-generation
+  - vitest
+  - jest
+  - node-test
+  - coding-agent
+  - ai
+source:
+  repository: https://github.com/bujue600-arch/dsh-testgen
+  repositoryNodeId: R_kgDOT4QDHQ
+  subpath: null
+  commit: 1730f3927342dbbe75e981d81a0d64ae76a1f245
+creator:
+  github: bujue600-arch
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:31.334Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bujue600-arch-dsh-testgen`
- Submission type: community curation
- Created by `bujue600-arch` — https://github.com/bujue600-arch
- Original source repository: https://github.com/bujue600-arch/dsh-testgen
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.