### PR TITLE
catalog: add chloride233-dsh-cot-profile (community curation, created by @Chloride233)

### DIFF
--- a/catalog/plugins/chloride233-dsh-cot-profile.yaml
+++ b/catalog/plugins/chloride233-dsh-cot-profile.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: chloride233-dsh-cot-profile
+name: dsh-cot-profile
+description:
+  en: "Real-time chain-of-thought trajectory profiling for DeepSeek Harness: live wording indicators, profile-family judgment, and per-session measurement records"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - reasoning
+  - chain-of-thought
+  - trajectory
+  - monitoring
+  - dsh-plugin
+source:
+  repository: https://github.com/Chloride233/dsh-cot-profile
+  repositoryNodeId: R_kgDOT5UCyQ
+  subpath: null
+  commit: c6b5bb6ae56727c4c5c330f94f4ac5c09506e0ca
+creator:
+  github: Chloride233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:32.933Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chloride233-dsh-cot-profile`
- Submission type: community curation
- Created by `Chloride233` — https://github.com/Chloride233
- Original source repository: https://github.com/Chloride233/dsh-cot-profile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.