### PR TITLE
catalog: add fenghuolinshan-dsh-plugin-llm-balance (community curation, created by @FengHuoLinShan)

### DIFF
--- a/catalog/plugins/fenghuolinshan-dsh-plugin-llm-balance.yaml
+++ b/catalog/plugins/fenghuolinshan-dsh-plugin-llm-balance.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: fenghuolinshan-dsh-plugin-llm-balance
+name: dsh-plugin-llm-balance
+description:
+  en: "🏷️ Part of the DSH official plugin ecosystem (git tag: dsh-official-plugin ; GitHub topics: dsh-plugin · deepseek-harness ). English 中文"
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - dsh-bundle
+  - deepseek-harness
+  - moonshot
+  - kimi
+  - openai-codex
+  - codex
+  - chatgpt
+  - oauth
+  - opencode
+  - opencode-go
+  - api-balance
+  - quota
+  - billing
+source:
+  repository: https://github.com/FengHuoLinShan/dsh-plugin-llm-balance
+  repositoryNodeId: R_kgDOT4bZnQ
+  subpath: null
+  commit: 4d8368214c359a9f9628541f2983459bd2250012
+creator:
+  github: FengHuoLinShan
+package:
+  ecosystem: npm
+  name: dsh-plugin-llm-balance
+  version: 0.2.4
+  integrity: sha512-bzAtDOchL5ib6VCX5z45jpIj33RwsBkfQoWqTNfQSp8ZGVvr37w7Jjt77UIDgZVPHueYxqLVzGe5NCub94lttA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:34.631Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fenghuolinshan-dsh-plugin-llm-balance`
- Submission type: community curation
- Created by `FengHuoLinShan` — https://github.com/FengHuoLinShan
- Original source repository: https://github.com/FengHuoLinShan/dsh-plugin-llm-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.