### PR TITLE
catalog: add gxx182-dsh-vision-bridge (community curation, created by @GXX182)

### DIFF
--- a/catalog/plugins/gxx182-dsh-vision-bridge.yaml
+++ b/catalog/plugins/gxx182-dsh-vision-bridge.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: gxx182-dsh-vision-bridge
+name: dsh-vision-bridge
+description:
+  en: DeepSeek Harness plugin that bridges images to external vision APIs and returns text-only analysis
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - cordis
+  - gemini
+  - vision
+  - dsh
+source:
+  repository: https://github.com/GXX182/dsh-vision-bridge
+  repositoryNodeId: R_kgDOT4P2lA
+  subpath: null
+  commit: 339efab1b87d65cf86ce573329317de06b95b2e7
+creator:
+  github: GXX182
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:21.083Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gxx182-dsh-vision-bridge`
- Submission type: community curation
- Created by `GXX182` — https://github.com/GXX182
- Original source repository: https://github.com/GXX182/dsh-vision-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.