### PR TITLE
catalog: add happy2git-dsh-compass (community curation, created by @Happy2Git)

### DIFF
--- a/catalog/plugins/happy2git-dsh-compass.yaml
+++ b/catalog/plugins/happy2git-dsh-compass.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: happy2git-dsh-compass
+name: dsh-compass
+description:
+  en: "DSH web plugin: right-side context-and-files panel (directory browser, injected-context documents, read-only git commit graph) plus the session-log download action"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - right
+  - side
+  - context
+  - files
+  - panel
+  - directory
+  - browser
+  - injected
+  - documents
+  - read
+  - only
+  - commit
+  - graph
+  - plus
+  - session
+  - download
+source:
+  repository: https://github.com/Happy2Git/dsh-compass
+  repositoryNodeId: R_kgDOT5TKNQ
+  subpath: null
+  commit: 2676d15afb2b9d5a4a62715ea4c83fa7619081e0
+creator:
+  github: Happy2Git
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:39.669Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `happy2git-dsh-compass`
- Submission type: community curation
- Created by `Happy2Git` — https://github.com/Happy2Git
- Original source repository: https://github.com/Happy2Git/dsh-compass
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.