### PR TITLE
catalog: add hongming-huang-dsh-file-upload (community curation, created by @HongMing-Huang)

### DIFF
--- a/catalog/plugins/hongming-huang-dsh-file-upload.yaml
+++ b/catalog/plugins/hongming-huang-dsh-file-upload.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: hongming-huang-dsh-file-upload
+name: dsh-file-upload
+description:
+  en: "DeepSeek Harness dual-face plugin: Codex-style file references (@path), fully bundled document→Markdown (MarkItDown engine, 20+ formats), mature image handling (read image for multimodal routes, automatic vision descriptions for text-only models), read document tool."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - cordis
+  - upload
+  - drag-and-drop
+  - attachment
+  - markdown
+  - markitdown
+  - pdf
+  - docx
+  - xlsx
+source:
+  repository: https://github.com/HongMing-Huang/dsh-file-upload
+  repositoryNodeId: R_kgDOT5FImQ
+  subpath: null
+  commit: 0c86706305f40fd05e2c8dbf7853ac0bdcf7bcde
+creator:
+  github: HongMing-Huang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:11.481Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 13
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hongming-huang-dsh-file-upload`
- Submission type: community curation
- Created by `HongMing-Huang` — https://github.com/HongMing-Huang
- Original source repository: https://github.com/HongMing-Huang/dsh-file-upload
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.