### PR TITLE
catalog: add hrhrng-deepseek-harness-tui (community curation, created by @hrhrng)

### DIFF
--- a/catalog/plugins/hrhrng-deepseek-harness-tui.yaml
+++ b/catalog/plugins/hrhrng-deepseek-harness-tui.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: hrhrng-deepseek-harness-tui
+name: "@openma/deepseek-harness-tui"
+description:
+  en: Terminal-native ACP client UI; Cordis client tree, any ACP agent
+  evidencePath: npm/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - tui
+  - agent
+  - acp
+  - agent-client-protocol
+  - dsh
+source:
+  repository: https://github.com/openma-ai/Martty
+  repositoryNodeId: R_kgDOT3mJhA
+  subpath: npm
+  commit: ad3251f43083b12a6febe35108c2efb0a8599b7c
+creator:
+  github: hrhrng
+package:
+  ecosystem: npm
+  name: "@openma/deepseek-harness-tui"
+  version: 0.2.8
+  integrity: sha512-uRRII+T6o1xbpAJIgBGldfioTdswPIBs7Y+Zsr1tBd2xbjxgYyDeGIqvmlzj0svUE4GWn714LE1sI7j/K2T2FA==
+dsh:
+  profiles:
+    - default
+  evidencePath: npm/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:49:11.791Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hrhrng-deepseek-harness-tui`
- Submission type: community curation
- Created by `hrhrng` — https://github.com/hrhrng
- Original source repository: https://github.com/openma-ai/Martty
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.