### PR TITLE
catalog: add huajuan404-dsh-diagram (community curation, created by @huajuan404)

### DIFF
--- a/catalog/plugins/huajuan404-dsh-diagram.yaml
+++ b/catalog/plugins/huajuan404-dsh-diagram.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: huajuan404-dsh-diagram
+name: dsh-diagram
+description:
+  en: Turn articles in DeepSeek Harness into editable Excalidraw canvases
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-bundle
+  - canvas
+  - diagram
+  - diagram-editor
+  - excalidraw
+  - flowchart
+  - visualization
+  - web-ui
+source:
+  repository: https://github.com/hanzhangzzz/dsh-diagram
+  repositoryNodeId: R_kgDOT4_eiQ
+  subpath: null
+  commit: 04ed56051cf577a72f8599865eb1810fdd647fe1
+creator:
+  github: huajuan404
+package:
+  ecosystem: npm
+  name: dsh-diagram
+  version: 0.2.1
+  integrity: sha512-a4biumcp4FjkdNtpGPzK826gmraVrhskDIazfWWCgri+a8RWuE5Jl03tCJOhI/inYM8gUapgYvJIpOuG6kNwcw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:37.706Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huajuan404-dsh-diagram`
- Submission type: community curation
- Created by `huajuan404` — https://github.com/huajuan404
- Original source repository: https://github.com/hanzhangzzz/dsh-diagram
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.