### PR TITLE
catalog: add jasonrale-dsh-archive-manager (community curation, created by @jasonrale)

### DIFF
--- a/catalog/plugins/jasonrale-dsh-archive-manager.yaml
+++ b/catalog/plugins/jasonrale-dsh-archive-manager.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: jasonrale-dsh-archive-manager
+name: dsh-archive-manager
+description:
+  en: "Archived-session manager for DSH Web: sidebar footer entry, grouped archive panel, restore/delete with full agent teardown"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - archive
+source:
+  repository: https://github.com/jasonrale/dsh-archive-manager
+  repositoryNodeId: R_kgDOT5ZJWg
+  subpath: null
+  commit: a57fa2733a2481efb640a99b208c77f2583c9772
+creator:
+  github: jasonrale
+package:
+  ecosystem: npm
+  name: dsh-archive-manager
+  version: 1.1.1
+  integrity: sha512-jox5HYMvQW5yMpXqD3r9CdpXlKPbqRgLryr13SJ9pi/c2HX7fzYI7e/4Dr+K/dZRJlKOXhDcSdQFawl+dgpstQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:42.610Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jasonrale-dsh-archive-manager`
- Submission type: community curation
- Created by `jasonrale` — https://github.com/jasonrale
- Original source repository: https://github.com/jasonrale/dsh-archive-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.