### PR TITLE
catalog: add jtdaugh-chatnode-wechat (community curation, created by @jtdaugh)

### DIFF
--- a/catalog/plugins/jtdaugh-chatnode-wechat.yaml
+++ b/catalog/plugins/jtdaugh-chatnode-wechat.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: jtdaugh-chatnode-wechat
+name: "@dsh-cowork/chatnode-wechat"
+description:
+  en: Chat with, monitor, and approve your DSH agents from WeChat — an iLink gateway + conversation node bundle for DeepSeek Harness
+  evidencePath: packages/chatnode-wechat/README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - chat
+  - monitor
+  - approve
+  - agents
+  - wechat
+  - ilink
+  - gateway
+  - conversation
+  - node
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/Jesse-njx/dsh-cowork
+  repositoryNodeId: R_kgDOT3iSxQ
+  subpath: packages/chatnode-wechat
+  commit: 2ae5cf755c4294a1e988eebf3b12dd062425d84c
+creator:
+  github: jtdaugh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/chatnode-wechat/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:49:09.469Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jtdaugh-chatnode-wechat`
- Submission type: community curation
- Created by `jtdaugh` — https://github.com/jtdaugh
- Original source repository: https://github.com/Jesse-njx/dsh-cowork
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.