### PR TITLE
catalog: add minybear-dsh-pet (community curation, created by @minybear)

### DIFF
--- a/catalog/plugins/minybear-dsh-pet.yaml
+++ b/catalog/plugins/minybear-dsh-pet.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: minybear-dsh-pet
+name: "@minybear/dsh-pet"
+description:
+  en: "Codex-style desktop pet for the DSH web GUI: a floating animated sprite driven by the agent's running state"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - pet
+  - codex
+  - desktop-pet
+  - tamagotchi
+source:
+  repository: https://github.com/minybear/DeepSeek-Harness-Pet
+  repositoryNodeId: R_kgDOT4Axwg
+  subpath: null
+  commit: ed48a0bf74bef5ed9b575d4c796495f5aaf6777b
+creator:
+  github: minybear
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:14.715Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `minybear-dsh-pet`
- Submission type: community curation
- Created by `minybear` — https://github.com/minybear
- Original source repository: https://github.com/minybear/DeepSeek-Harness-Pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.