### PR TITLE
catalog: add morgogh-widget-dock (community curation, created by @MorGogh)

### DIFF
--- a/catalog/plugins/morgogh-widget-dock.yaml
+++ b/catalog/plugins/morgogh-widget-dock.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: morgogh-widget-dock
+name: widget-dock
+description:
+  en: "DSH plugin: a draggable workbench of mini-cards (API balance, token usage, session stats, goal, cost estimate) beside the conversation"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - widget
+  - workbench
+  - ui
+source:
+  repository: https://github.com/MorGogh/widget-dock
+  repositoryNodeId: R_kgDOT3kH6A
+  subpath: null
+  commit: 65ed17e76c3d05fc3cdffa8e9a4f1856ba928ad8
+creator:
+  github: MorGogh
+package:
+  ecosystem: npm
+  name: widget-dock
+  version: 1.0.2
+  integrity: sha512-INl98iWAh1ra0aYYUiyWt1C7ehkcUy762xedjR0dQLMre0KRZxw0Zvfgm7j85crzbO9UcCoxyqQft1Ca996YVw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:22.505Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `morgogh-widget-dock`
- Submission type: community curation
- Created by `MorGogh` — https://github.com/MorGogh
- Original source repository: https://github.com/MorGogh/widget-dock
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.