### PR TITLE
catalog: add qt-chen-dsh-mic-input (community curation, created by @QT-Chen)

### DIFF
--- a/catalog/plugins/qt-chen-dsh-mic-input.yaml
+++ b/catalog/plugins/qt-chen-dsh-mic-input.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: qt-chen-dsh-mic-input
+name: dsh-mic-input
+description:
+  en: Microphone voice input for the DeepSeek Harness (DSH) Web UI — in the browser, no server, no keys.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - voice
+  - voice-input
+  - speech-to-text
+  - microphone
+  - webspeech
+  - client-plugin
+source:
+  repository: https://github.com/QT-Chen/dsh-mic-input
+  repositoryNodeId: R_kgDOT4QS4g
+  subpath: null
+  commit: 92d6dec9ad8226cc2fd38a91c628bdf47e71a95f
+creator:
+  github: QT-Chen
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:46.854Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qt-chen-dsh-mic-input`
- Submission type: community curation
- Created by `QT-Chen` — https://github.com/QT-Chen
- Original source repository: https://github.com/QT-Chen/dsh-mic-input
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.