### PR TITLE
catalog: add rakshith48-dsh-firecrawl (community curation, created by @rakshith48)

### DIFF
--- a/catalog/plugins/rakshith48-dsh-firecrawl.yaml
+++ b/catalog/plugins/rakshith48-dsh-firecrawl.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: rakshith48-dsh-firecrawl
+name: "@firecrawl/dsh-firecrawl"
+description:
+  en: Firecrawl-backed search and fetch providers for the DeepSeek Harness web capability seam (ctx.web)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - firecrawl
+  - web-search
+  - web-fetch
+  - scraping
+  - dsh
+source:
+  repository: https://github.com/firecrawl/dsh-firecrawl
+  repositoryNodeId: R_kgDOT6qzrA
+  subpath: null
+  commit: 2204a7ec9cbcf814601182de64204a6ce525b5ff
+creator:
+  github: rakshith48
+package:
+  ecosystem: npm
+  name: "@firecrawl/dsh-firecrawl"
+  version: 0.1.0
+  integrity: sha512-fV97A9KG1Dts5JBH0q/6cc1mDR7DMbQxFsd3g0/jiO1E8/S8JCswqDkL4yudYm8Gyem+eXvfGwKrOSYUy3fB/Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:19.576Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rakshith48-dsh-firecrawl`
- Submission type: community curation
- Created by `rakshith48` — https://github.com/rakshith48
- Original source repository: https://github.com/firecrawl/dsh-firecrawl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.