### PR TITLE
catalog: add scorp1o117-dsh-tool-vision (community curation, created by @Scorp1o117)

### DIFF
--- a/catalog/plugins/scorp1o117-dsh-tool-vision.yaml
+++ b/catalog/plugins/scorp1o117-dsh-tool-vision.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: scorp1o117-dsh-tool-vision
+name: dsh-tool-vision
+description:
+  en: Part of the DeepSeek Harness Enhancement Suite — Vision · Soul/Persona · Long-term Memory · Plugin Marketplace.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - multimodal
+  - image
+  - openai-compatible
+  - qwen-vl
+  - glm-4v
+  - ollama
+source:
+  repository: https://github.com/Scorp1o117/dsh-tool-vision
+  repositoryNodeId: R_kgDOT3e4Eg
+  subpath: null
+  commit: d161ddb920a52b735d1aca8bfa66b834d1630dfc
+creator:
+  github: Scorp1o117
+package:
+  ecosystem: npm
+  name: dsh-tool-vision
+  version: 0.5.0
+  integrity: sha512-UO3aQ04N09+KmOtGcmoiMFZ4C5CJfcDIebxfrUuxSkqrcwYpqcxos9d4z+n/PBz7JeO1eTBnHbLFwLfeqagCPQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:16.304Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `scorp1o117-dsh-tool-vision`
- Submission type: community curation
- Created by `Scorp1o117` — https://github.com/Scorp1o117
- Original source repository: https://github.com/Scorp1o117/dsh-tool-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.