### PR TITLE
catalog: add sliverp-deepseek-harness-dingtalk (community curation, created by @sliverp)

### DIFF
--- a/catalog/plugins/sliverp-deepseek-harness-dingtalk.yaml
+++ b/catalog/plugins/sliverp-deepseek-harness-dingtalk.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: sliverp-deepseek-harness-dingtalk
+name: deepseek-harness-dingtalk
+description:
+  en: DingTalk Stream text, image, and file channel bridge for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dingtalk
+  - chatbot
+  - stream
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/sliverp/DeepSeek-harness-dingtalk
+  repositoryNodeId: R_kgDOT3ocqg
+  subpath: null
+  commit: 1cc1e0eaf15de62c373c7616b8fb588d6264cc97
+creator:
+  github: sliverp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:48.371Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sliverp-deepseek-harness-dingtalk`
- Submission type: community curation
- Created by `sliverp` — https://github.com/sliverp
- Original source repository: https://github.com/sliverp/DeepSeek-harness-dingtalk
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.