### PR TITLE
catalog: add sliverp-deepseek-harness-lark (community curation, created by @sliverp)

### DIFF
--- a/catalog/plugins/sliverp-deepseek-harness-lark.yaml
+++ b/catalog/plugins/sliverp-deepseek-harness-lark.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: sliverp-deepseek-harness-lark
+name: deepseek-harness-lark
+description:
+  en: Feishu and Lark text, image, and file channel bridge for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - feishu
+  - lark
+  - chatbot
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/sliverp/DeepSeek-harness-lark
+  repositoryNodeId: R_kgDOT3ocrg
+  subpath: null
+  commit: b8c6f6ed8eab67a5b99be9b430ef19bea631fd4d
+creator:
+  github: sliverp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:49.865Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sliverp-deepseek-harness-lark`
- Submission type: community curation
- Created by `sliverp` — https://github.com/sliverp
- Original source repository: https://github.com/sliverp/DeepSeek-harness-lark
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.