### PR TITLE
catalog: add ultronen-dsh-archived-chats (community curation, created by @Ultronen)

### DIFF
--- a/catalog/plugins/ultronen-dsh-archived-chats.yaml
+++ b/catalog/plugins/ultronen-dsh-archived-chats.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ultronen-dsh-archived-chats
+name: dsh-archived-chats
+description:
+  en: ⚡ Deletion takes effect immediately — no restart. Even sessions still resident in the background are torn down safely along the official lifecycle and wiped from disk the moment you click delete, instead of being "parked until the next restart".
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - archive
+  - sessions
+  - web-ui
+source:
+  repository: https://github.com/Ultronen/dsh-archived-chats
+  repositoryNodeId: R_kgDOT5pXsw
+  subpath: null
+  commit: 2fbbdefdf0fda0d5e414d9c0278a87c7cfdb9e8c
+creator:
+  github: Ultronen
+package:
+  ecosystem: npm
+  name: dsh-archived-chats
+  version: 0.7.0
+  integrity: sha512-2XSIJYRdOET9tsQ/0R6541iXPjYJfXgdF316Ot61G26uocB1V48WlUxsLR/8/XY/qhwLko/5arVggbwCg27Lkg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:51.667Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ultronen-dsh-archived-chats`
- Submission type: community curation
- Created by `Ultronen` — https://github.com/Ultronen
- Original source repository: https://github.com/Ultronen/dsh-archived-chats
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.