### PR TITLE
catalog: add xiaoyuyu6420-dsh-backup (community curation, created by @xiaoyuyu6420)

### DIFF
--- a/catalog/plugins/xiaoyuyu6420-dsh-backup.yaml
+++ b/catalog/plugins/xiaoyuyu6420-dsh-backup.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: xiaoyuyu6420-dsh-backup
+name: dsh-backup
+description:
+  en: "Backup, restore, download and GitHub-sync DeepSeek Harness user data (~/.dsh): /backup, scheduled auto-backup that survives restarts, sha256 checksums, integrity verify, rotation and a visual Settings panel. Cross-platform (macOS/Linux/Windows). 一键备份与恢复 DSH 数据：定时自动备份、完整性校验、下载与 GitHub 同步，附 Settings 可视面板。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - backup
+  - restore
+  - schedule
+  - cross-platform
+source:
+  repository: https://github.com/xiaoyuyu6420/dsh-backup
+  repositoryNodeId: R_kgDOT4KrQQ
+  subpath: null
+  commit: e1b94e43a19f654a23179cbd00fea5fad44c88d6
+creator:
+  github: xiaoyuyu6420
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:53.113Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaoyuyu6420-dsh-backup`
- Submission type: community curation
- Created by `xiaoyuyu6420` — https://github.com/xiaoyuyu6420
- Original source repository: https://github.com/xiaoyuyu6420/dsh-backup
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.