### PR TITLE
catalog: add yflmq001-dsh-cost-tracker (community curation, created by @yflmq001)

### DIFF
--- a/catalog/plugins/yflmq001-dsh-cost-tracker.yaml
+++ b/catalog/plugins/yflmq001-dsh-cost-tracker.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: yflmq001-dsh-cost-tracker
+name: dsh-cost-tracker
+description:
+  en: Token cost tracking with per-model configurable pricing and peak/off-peak rates for the DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - token
+  - cost
+  - tracking
+  - model
+  - configurable
+  - pricing
+  - peak
+  - rates
+  - dsh
+source:
+  repository: https://github.com/yflmq001/dsh-cost-tracker
+  repositoryNodeId: R_kgDOT4D0qw
+  subpath: null
+  commit: dd8c57ce76d914eb72dd44544e7492f12d3ef105
+creator:
+  github: yflmq001
+package:
+  ecosystem: npm
+  name: dsh-cost-tracker
+  version: 1.0.0
+  integrity: sha512-R5NwiTHUwEfvGC9tCZCEZLf7tMIlPYnBIKGsniI3HD/kWOOVhmEABOT5xGAXD6flIS4y/cD7z76/m5Px75TF5A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:54.582Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yflmq001-dsh-cost-tracker`
- Submission type: community curation
- Created by `yflmq001` — https://github.com/yflmq001
- Original source repository: https://github.com/yflmq001/dsh-cost-tracker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.