### PR TITLE
catalog: add yuhui-sama-dsh-agentsoul (community curation, created by @yuhui-sama)

### DIFF
--- a/catalog/plugins/yuhui-sama-dsh-agentsoul.yaml
+++ b/catalog/plugins/yuhui-sama-dsh-agentsoul.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: yuhui-sama-dsh-agentsoul
+name: "@agentsoul/dsh-agentsoul"
+description:
+  en: AgentSoul for DeepSeek Harness — a local personality, identity, state and long-term memory layer. Auto-loads as a bundle plugin on every dsh startup.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - agentsoul
+  - local
+  - personality
+  - identity
+  - state
+  - long
+  - term
+  - memory
+  - layer
+  - auto
+  - loads
+  - bundle
+  - every
+  - startup
+  - dsh
+source:
+  repository: https://github.com/yuhui-sama/dsh-agentsoul
+  repositoryNodeId: R_kgDOT4gFBg
+  subpath: null
+  commit: 9cea3cfabeb9bfe2d9595c72020deadf8d77cfea
+creator:
+  github: yuhui-sama
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:55.985Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yuhui-sama-dsh-agentsoul`
- Submission type: community curation
- Created by `yuhui-sama` — https://github.com/yuhui-sama
- Original source repository: https://github.com/yuhui-sama/dsh-agentsoul
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.