### PR TITLE
catalog: add yyh-001-dsh-expression-entry (community curation, created by @yyh-001)

### DIFF
--- a/catalog/plugins/yyh-001-dsh-expression-entry.yaml
+++ b/catalog/plugins/yyh-001-dsh-expression-entry.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: yyh-001-dsh-expression-entry
+name: dsh-expression-entry
+description:
+  en: bash dsh plugin --profile web add dsh-meme pnpm add dsh-meme
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - bash
+  - profile
+  - meme
+  - pnpm
+  - dsh
+source:
+  repository: https://github.com/yyh-001/dsh-meme
+  repositoryNodeId: R_kgDOT3eD3g
+  subpath: entry
+  commit: 5c83b91fe2942279b677ae537850e77504e26c7c
+creator:
+  github: yyh-001
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: entry/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:49:15.509Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yyh-001-dsh-expression-entry`
- Submission type: community curation
- Created by `yyh-001` — https://github.com/yyh-001
- Original source repository: https://github.com/yyh-001/dsh-meme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.