### PR TITLE
catalog: add zimai233-dsh-adhd-copilot (community curation, created by @zimai233)

### DIFF
--- a/catalog/plugins/zimai233-dsh-adhd-copilot.yaml
+++ b/catalog/plugins/zimai233-dsh-adhd-copilot.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zimai233-dsh-adhd-copilot
+name: dsh-adhd-copilot
+description:
+  en: ADHD behavioral coaching skill for DeepSeek Harness. Guides readers through task execution - breaks tasks into micro-steps, manages overwhelm, provides launch rituals, calibrates time estimates, and recovers from self-blame.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - adhd
+  - coaching
+  - behavioral
+  - skill
+  - wellness
+  - mental-health
+source:
+  repository: https://github.com/zimai233/dsh-adhd-copilot
+  repositoryNodeId: R_kgDOT3-9iA
+  subpath: null
+  commit: 6527cb64b11b7265ba576e195bd008a5aa066be5
+creator:
+  github: zimai233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T04:48:58.840Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zimai233-dsh-adhd-copilot`
- Submission type: community curation
- Created by `zimai233` — https://github.com/zimai233
- Original source repository: https://github.com/zimai233/dsh-adhd-copilot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.