### PR TITLE
catalog: add 1052326311-dsh-instruction-audit (community curation, created by @1052326311)

### DIFF
--- a/catalog/plugins/1052326311-dsh-instruction-audit.yaml
+++ b/catalog/plugins/1052326311-dsh-instruction-audit.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: 1052326311-dsh-instruction-audit
+name: dsh-instruction-audit
+description:
+  en: Privacy-minimal provenance receipts for DeepSeek Harness workspace instructions
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - privacy
+  - minimal
+  - provenance
+  - receipts
+  - workspace
+  - instructions
+  - dsh
+source:
+  repository: https://github.com/1052326311/dsh-instruction-audit
+  repositoryNodeId: R_kgDOT4l5hQ
+  subpath: null
+  commit: 8548400c1932a6a05d004189d5a9cf8deab3edd2
+creator:
+  github: "1052326311"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:56.809Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1052326311-dsh-instruction-audit`
- Submission type: community curation
- Created by `1052326311` — https://github.com/1052326311
- Original source repository: https://github.com/1052326311/dsh-instruction-audit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.