### PR TITLE
catalog: add 111111aaa111111-dsh-premise-guard-cn (community curation, created by @111111AAA111111)

### DIFF
--- a/catalog/plugins/111111aaa111111-dsh-premise-guard-cn.yaml
+++ b/catalog/plugins/111111aaa111111-dsh-premise-guard-cn.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 111111aaa111111-dsh-premise-guard-cn
+name: dsh-premise-guard-cn
+description:
+  en: bash dsh plugin --profile web add "github:111111AAA111111/dsh-premise-guard-cn" dsh plugin --profile web add "file:/path/to/dsh-premise-guard-cn"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - premise-guard
+  - memory
+  - chinese
+source:
+  repository: https://github.com/111111AAA111111/dsh-premise-guard-cn
+  repositoryNodeId: R_kgDOT49t6w
+  subpath: null
+  commit: 6c8ed6ea445d7a32ebd16c40ad4cdd0ca78f2660
+creator:
+  github: 111111AAA111111
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:29.331Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `111111aaa111111-dsh-premise-guard-cn`
- Submission type: community curation
- Created by `111111AAA111111` — https://github.com/111111AAA111111
- Original source repository: https://github.com/111111AAA111111/dsh-premise-guard-cn
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.