### PR TITLE
catalog: add 2006spy-dsh-token-billing (community curation, created by @2006spy)

### DIFF
--- a/catalog/plugins/2006spy-dsh-token-billing.yaml
+++ b/catalog/plugins/2006spy-dsh-token-billing.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: 2006spy-dsh-token-billing
+name: dsh-token-billing
+description:
+  en: DeepSeek Harness (dsh) 实时 token 计费插件 · Real-time token billing for DSH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - token
+  - real
+  - time
+  - billing
+  - dsh
+source:
+  repository: https://github.com/2006spy/dsh-token-billing
+  repositoryNodeId: R_kgDOT5SeFA
+  subpath: null
+  commit: c520e744477f8e67d567594c359c662ee2892bd9
+creator:
+  github: 2006spy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:45.657Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `2006spy-dsh-token-billing`
- Submission type: community curation
- Created by `2006spy` — https://github.com/2006spy
- Original source repository: https://github.com/2006spy/dsh-token-billing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.