### PR TITLE
catalog: add 2008924-dsh-progress-viz-plugin (community curation, created by @2008924)

### DIFF
--- a/catalog/plugins/2008924-dsh-progress-viz-plugin.yaml
+++ b/catalog/plugins/2008924-dsh-progress-viz-plugin.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: 2008924-dsh-progress-viz-plugin
+name: dsh-progress-viz-plugin
+description:
+  en: bash cd publish/dsh-progress-viz/plugin pnpm install --registry https://registry.npmmirror.com pnpm build dsh plugin --profile headless add <本插件目录绝对路径
+  evidencePath: plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - progress
+  - dashboard
+source:
+  repository: https://github.com/2008924/dsh-progress-viz
+  repositoryNodeId: R_kgDOT4qT8Q
+  subpath: plugin
+  commit: 736909845ac33cf5ac671e1a4b6beecc814d983f
+creator:
+  github: "2008924"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:30.944Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `2008924-dsh-progress-viz-plugin`
- Submission type: community curation
- Created by `2008924` — https://github.com/2008924
- Original source repository: https://github.com/2008924/dsh-progress-viz
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.