### PR TITLE
catalog: add 82c86b8z86-stack-dsh-engineering-workflow (community curation, created by @82c86b8z86-stack)

### DIFF
--- a/catalog/plugins/82c86b8z86-stack-dsh-engineering-workflow.yaml
+++ b/catalog/plugins/82c86b8z86-stack-dsh-engineering-workflow.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: 82c86b8z86-stack-dsh-engineering-workflow
+name: dsh-engineering-workflow
+description:
+  en: "Engineering workflow layer for DeepSeek Harness (dsh): a disciplined-engineer agent preset with five gated phases — requirements clarification, plan approval, TDD implementation, parallel subagent execution, and verified finishing. Skills adapted from the obra/superpowers workflow methodology."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - dsh-bundle
+  - deepseek-harness
+  - agent-preset
+  - skills
+  - workflow
+  - tdd
+  - subagents
+  - engineering
+source:
+  repository: https://github.com/82c86b8z86-stack/dsh-engineering-workflow
+  repositoryNodeId: R_kgDOT6GRfQ
+  subpath: null
+  commit: 3e251eb78002625bcc238a42d9926d87c3a38bfe
+creator:
+  github: 82c86b8z86-stack
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:00.178Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `82c86b8z86-stack-dsh-engineering-workflow`
- Submission type: community curation
- Created by `82c86b8z86-stack` — https://github.com/82c86b8z86-stack
- Original source repository: https://github.com/82c86b8z86-stack/dsh-engineering-workflow
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.