### PR TITLE
catalog: add 97shjbz78z-ai-dsh-mcp-connect (community curation, created by @97shjbz78z-ai)

### DIFF
--- a/catalog/plugins/97shjbz78z-ai-dsh-mcp-connect.yaml
+++ b/catalog/plugins/97shjbz78z-ai-dsh-mcp-connect.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: 97shjbz78z-ai-dsh-mcp-connect
+name: dsh-mcp-connect
+description:
+  en: "Zero-dependency MCP client bridge for DeepSeek Harness: connects stdio/HTTP MCP servers and auto-registers their tools for the agent."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - mcp
+  - model-context-protocol
+  - cordis
+  - agent
+  - tools
+source:
+  repository: https://github.com/Chhlafiu4312/dsh-mcp-bridge
+  repositoryNodeId: R_kgDOT54SOA
+  subpath: null
+  commit: 0e04cd340031f3c46c3bd889e5eac90aa2afd013
+creator:
+  github: 97shjbz78z-ai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:12.666Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `97shjbz78z-ai-dsh-mcp-connect`
- Submission type: community curation
- Created by `97shjbz78z-ai` — https://github.com/97shjbz78z-ai
- Original source repository: https://github.com/Chhlafiu4312/dsh-mcp-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.