### PR TITLE
catalog: add a903067276-rgb-dsh-perm-guard (community curation, created by @a903067276-rgb)

### DIFF
--- a/catalog/plugins/a903067276-rgb-dsh-perm-guard.yaml
+++ b/catalog/plugins/a903067276-rgb-dsh-perm-guard.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: a903067276-rgb-dsh-perm-guard
+name: dsh-perm-guard
+description:
+  en: 'Auto-approval permission guard for DeepSeek Harness ( dsh ) web — the "middle tier" between workspace-write (asks too often) and danger-full-access (too open). Common operations like cross-directory edits, git commit / merge and builds run without approval prompts ; destructive operations (deletes, disk ops, privilege '
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - permission
+  - guard
+  - auto-approve
+  - dsh
+source:
+  repository: https://github.com/a903067276-rgb/dsh-perm-guard
+  repositoryNodeId: R_kgDOT6rvPQ
+  subpath: null
+  commit: 4139ff2393eca7112dba4b646b1a0a68692afd99
+creator:
+  github: a903067276-rgb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:39.306Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `a903067276-rgb-dsh-perm-guard`
- Submission type: community curation
- Created by `a903067276-rgb` — https://github.com/a903067276-rgb
- Original source repository: https://github.com/a903067276-rgb/dsh-perm-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.