### PR TITLE
catalog: add adithya-hmt-fullstack-expert (community curation, created by @adithya-hmt)

### DIFF
--- a/catalog/plugins/adithya-hmt-fullstack-expert.yaml
+++ b/catalog/plugins/adithya-hmt-fullstack-expert.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: adithya-hmt-fullstack-expert
+name: "@deepseek-ai/fullstack-expert"
+description:
+  en: Cordis-native, evidence-driven full-stack engineering discipline for DeepSeek Harness agents
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - coding-agent
+  - full-stack
+  - verification
+  - supabase
+  - dsh
+source:
+  repository: https://github.com/adithya-hmt/fullstack-expert
+  repositoryNodeId: R_kgDOT6JyUg
+  subpath: null
+  commit: 1419bb6f77e5f08fca41b6bdc75cc2dcdc49b6a5
+creator:
+  github: adithya-hmt
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:40.841Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `adithya-hmt-fullstack-expert`
- Submission type: community curation
- Created by `adithya-hmt` — https://github.com/adithya-hmt
- Original source repository: https://github.com/adithya-hmt/fullstack-expert
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.