### PR TITLE
catalog: add akqwpeter-skill-bartender (community curation, created by @akqwpeter)

### DIFF
--- a/catalog/plugins/akqwpeter-skill-bartender.yaml
+++ b/catalog/plugins/akqwpeter-skill-bartender.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: akqwpeter-skill-bartender
+name: skill-bartender
+description:
+  en: Task-to-skill pairing with a laziness ladder and a safe install cellar. Never overpours, never serves untasted. DSH · Claude Code · Codex
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - task
+  - skill
+  - pairing
+  - laziness
+  - ladder
+  - safe
+  - install
+  - cellar
+  - never
+  - overpours
+  - serves
+  - untasted
+  - claude
+  - code
+  - codex
+  - dsh
+source:
+  repository: https://github.com/MJorgin/skill-bartender
+  repositoryNodeId: R_kgDOT6G6bg
+  subpath: null
+  commit: 6beb7e0770661b5d08a9ae6a792041d185701fa9
+creator:
+  github: akqwpeter
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:47.814Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `akqwpeter-skill-bartender`
- Submission type: community curation
- Created by `akqwpeter` — https://github.com/akqwpeter
- Original source repository: https://github.com/MJorgin/skill-bartender
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.