### PR TITLE
catalog: add alwaysgaurav1-dsh-session-export (community curation, created by @Alwaysgaurav1)

### DIFF
--- a/catalog/plugins/alwaysgaurav1-dsh-session-export.yaml
+++ b/catalog/plugins/alwaysgaurav1-dsh-session-export.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: alwaysgaurav1-dsh-session-export
+name: dsh-session-export
+description:
+  en: Export DeepSeek Harness sessions to Markdown, JSON, or self-contained HTML — slash commands /export-md, /export-json, /export-html
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - session-export
+  - markdown
+  - html
+  - json
+  - dsh
+source:
+  repository: https://github.com/Alwaysgaurav1/dsh-session-export
+  repositoryNodeId: R_kgDOT59r0g
+  subpath: null
+  commit: e1098096f87c9e8687c803ecd26e88a2b921141e
+creator:
+  github: Alwaysgaurav1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:47.971Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alwaysgaurav1-dsh-session-export`
- Submission type: community curation
- Created by `Alwaysgaurav1` — https://github.com/Alwaysgaurav1
- Original source repository: https://github.com/Alwaysgaurav1/dsh-session-export
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.