### PR TITLE
catalog: add angeloszou-dsh-python-tempfile-shim (community curation, created by @AngelosZou)

### DIFF
--- a/catalog/plugins/angeloszou-dsh-python-tempfile-shim.yaml
+++ b/catalog/plugins/angeloszou-dsh-python-tempfile-shim.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: angeloszou-dsh-python-tempfile-shim
+name: dsh-python-tempfile-shim
+description:
+  en: "DeepSeek Harness plugin (temporary, pre-upstream-fix): automatically injects a CPython tempfile shim (PYTHONPATH - sitecustomize) into every confined shell command on the Windows sandbox, so python/pytest tempfile use works with zero extra tools, zero model-context overhead, and zero escalation."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - python
+  - tempfile
+  - pytest
+  - sandbox
+  - windows
+source:
+  repository: https://github.com/AngelosZou/dsh-python-tempfile-shim
+  repositoryNodeId: R_kgDOT50RVg
+  subpath: null
+  commit: 20b84cdc91516fbf51a782214ba8d88a3f083d34
+creator:
+  github: AngelosZou
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:03.157Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `angeloszou-dsh-python-tempfile-shim`
- Submission type: community curation
- Created by `AngelosZou` — https://github.com/AngelosZou
- Original source repository: https://github.com/AngelosZou/dsh-python-tempfile-shim
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.