### PR TITLE
catalog: add anil-matcha-dsh-plugin-muapi (community curation, created by @Anil-matcha)

### DIFF
--- a/catalog/plugins/anil-matcha-dsh-plugin-muapi.yaml
+++ b/catalog/plugins/anil-matcha-dsh-plugin-muapi.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: anil-matcha-dsh-plugin-muapi
+name: "@dsh-plugin/dsh-plugin-muapi"
+description:
+  en: DeepSeek Harness plugin that exposes MuApi's 100+ image, video, and audio generation models as an agent tool.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - muapi
+  - image-generation
+  - video-generation
+  - text-to-image
+  - text-to-video
+source:
+  repository: https://github.com/SamurAIGPT/dsh-plugin-muapi
+  repositoryNodeId: R_kgDOT60k_w
+  subpath: null
+  commit: 31c5a7a278634c5d3f6c5a5e4ab4f859ebd75b1d
+creator:
+  github: Anil-matcha
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:38.969Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `anil-matcha-dsh-plugin-muapi`
- Submission type: community curation
- Created by `Anil-matcha` — https://github.com/Anil-matcha
- Original source repository: https://github.com/SamurAIGPT/dsh-plugin-muapi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.