### PR TITLE
catalog: add anweat-dsh-voice-webspeech (community curation, created by @anweat)

### DIFF
--- a/catalog/plugins/anweat-dsh-voice-webspeech.yaml
+++ b/catalog/plugins/anweat-dsh-voice-webspeech.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: anweat-dsh-voice-webspeech
+name: dsh-voice-webspeech
+description:
+  en: sh pnpm dsh plugin --profile web add github:anweat/dsh-voice-webspeech
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - voice
+  - speech-to-text
+  - webspeech
+  - client-plugin
+source:
+  repository: https://github.com/anweat/dsh-voice-webspeech
+  repositoryNodeId: R_kgDOT331-A
+  subpath: null
+  commit: eb6a51ff9428c051304d978cc238a54aff782e19
+creator:
+  github: anweat
+package:
+  ecosystem: npm
+  name: dsh-voice-webspeech
+  version: 0.1.0
+  integrity: sha512-w59LNVHvikM0Wf5SKxtedJNywDu/bzyAQIy50kNFbcXVS9TExQ1ZLKXd+mGEe5FcrcIbFvouf8YPx3sD0QEa1Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:04.748Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `anweat-dsh-voice-webspeech`
- Submission type: community curation
- Created by `anweat` — https://github.com/anweat
- Original source repository: https://github.com/anweat/dsh-voice-webspeech
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.