### PR TITLE
catalog: add anyuer678-dsh-logtimeline (community curation, created by @anyuer678)

### DIFF
--- a/catalog/plugins/anyuer678-dsh-logtimeline.yaml
+++ b/catalog/plugins/anyuer678-dsh-logtimeline.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: anyuer678-dsh-logtimeline
+name: dsh-logtimeline
+description:
+  en: Query local log files with Chinese natural-language time expressions — LogTimeline for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - query
+  - local
+  - files
+  - chinese
+  - natural
+  - language
+  - time
+  - expressions
+  - logtimeline
+  - dsh
+source:
+  repository: https://github.com/anyuer678/dsh-logtimeline
+  repositoryNodeId: R_kgDOT66PGA
+  subpath: null
+  commit: d4950af4b2301c5992774c951ab1a2f52f170fea
+creator:
+  github: anyuer678
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: GPL-3.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:06.430Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `anyuer678-dsh-logtimeline`
- Submission type: community curation
- Created by `anyuer678` — https://github.com/anyuer678
- Original source repository: https://github.com/anyuer678/dsh-logtimeline
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.