### PR TITLE
catalog: add apodemakeles-dsh-token-dashboard (community curation, created by @apodemakeles)

### DIFF
--- a/catalog/plugins/apodemakeles-dsh-token-dashboard.yaml
+++ b/catalog/plugins/apodemakeles-dsh-token-dashboard.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: apodemakeles-dsh-token-dashboard
+name: "@apodemakeles/dsh-token-dashboard"
+description:
+  en: "DSH web GUI token-consumption heatmap: a daily/weekly total-token usage panel fed by session-log usage events"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - token-usage
+  - token-dashboard
+  - dashboard
+  - heatmap
+source:
+  repository: https://github.com/apodemakeles/dsh-token-dashboard
+  repositoryNodeId: R_kgDOT4apyQ
+  subpath: null
+  commit: dbd1c97ce8b316fa51172f52f78384c821d70a57
+creator:
+  github: apodemakeles
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:48.770Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `apodemakeles-dsh-token-dashboard`
- Submission type: community curation
- Created by `apodemakeles` — https://github.com/apodemakeles
- Original source repository: https://github.com/apodemakeles/dsh-token-dashboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.