### PR TITLE
catalog: add april-jk-dsh-mobile (community curation, created by @april-jk)

### DIFF
--- a/catalog/plugins/april-jk-dsh-mobile.yaml
+++ b/catalog/plugins/april-jk-dsh-mobile.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: april-jk-dsh-mobile
+name: "@april-jk/dsh-mobile"
+description:
+  en: Installable DSH bundle and remote companion for mobile access
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - remote-access
+  - mobile
+  - dsh
+source:
+  repository: https://github.com/april-jk/dsh-mobile-plugin
+  repositoryNodeId: R_kgDOT6IPTQ
+  subpath: null
+  commit: fafd12c4866de6d14d84e6c6386293ce8c5390ca
+creator:
+  github: april-jk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:53.337Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `april-jk-dsh-mobile`
- Submission type: community curation
- Created by `april-jk` — https://github.com/april-jk
- Original source repository: https://github.com/april-jk/dsh-mobile-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.