### PR TITLE
catalog: add azure5100-huahua-dsh-plugin-orchestra (community curation, created by @azure5100)

### DIFF
--- a/catalog/plugins/azure5100-huahua-dsh-plugin-orchestra.yaml
+++ b/catalog/plugins/azure5100-huahua-dsh-plugin-orchestra.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: azure5100-huahua-dsh-plugin-orchestra
+name: huahua-dsh-plugin-orchestra
+description:
+  en: bash dsh plugin --profile web add huahua-dsh-plugin-orchestra
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - plugin-management
+  - deepseek-harness
+  - plugin-orchestra
+source:
+  repository: https://github.com/azure5100/huahua-dsh-plugin-orchestra
+  repositoryNodeId: R_kgDOT6BCAg
+  subpath: null
+  commit: a128b7858c02fd4621593411b386d66f9f1400b0
+creator:
+  github: azure5100
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:54.763Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `azure5100-huahua-dsh-plugin-orchestra`
- Submission type: community curation
- Created by `azure5100` — https://github.com/azure5100
- Original source repository: https://github.com/azure5100/huahua-dsh-plugin-orchestra
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.