### PR TITLE
catalog: add bainianlaoyao-easy-archive (community curation, created by @bainianlaoyao)

### DIFF
--- a/catalog/plugins/bainianlaoyao-easy-archive.yaml
+++ b/catalog/plugins/bainianlaoyao-easy-archive.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: bainianlaoyao-easy-archive
+name: easy-archive
+description:
+  en: "A DSH (DeepSeek Harness) web plugin that moves session archiving out of the kebab (⋮) menu and onto the workspace sidebar row itself, as a two-step inline button:"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - archive
+  - sidebar
+  - workspace
+source:
+  repository: https://github.com/bainianlaoyao/easy-archive
+  repositoryNodeId: R_kgDOT6QrVw
+  subpath: null
+  commit: 9c9f6eb6e67a47dca7d351cf45efd82d4ce823be
+creator:
+  github: bainianlaoyao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:56.176Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bainianlaoyao-easy-archive`
- Submission type: community curation
- Created by `bainianlaoyao` — https://github.com/bainianlaoyao
- Original source repository: https://github.com/bainianlaoyao/easy-archive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.