### PR TITLE
catalog: add baisama-cloud-dsh-omni-bridge (community curation, created by @baisama-cloud)

### DIFF
--- a/catalog/plugins/baisama-cloud-dsh-omni-bridge.yaml
+++ b/catalog/plugins/baisama-cloud-dsh-omni-bridge.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: baisama-cloud-dsh-omni-bridge
+name: dsh-omni-bridge
+description:
+  en: "Multi-channel message bridge for DeepSeek Harness (DSH): route WeChat (ClawBot/iLink), QQ, and Feishu (Lark) chat messages to a DSH agent and relay its replies back. 多通道桥接：微信 ClawBot / QQ / 飞书消息接入 DSH agent 并回传回复。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - bridge
+  - wechat
+  - clawbot
+  - qq
+  - feishu
+  - lark
+  - chat-bot
+source:
+  repository: https://github.com/baisama-cloud/dsh-omni-bridge
+  repositoryNodeId: R_kgDOT54YxQ
+  subpath: null
+  commit: cdb51787173ba9b46e0e8ee4ebfc38b9ae0f2dcd
+creator:
+  github: baisama-cloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:07.890Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baisama-cloud-dsh-omni-bridge`
- Submission type: community curation
- Created by `baisama-cloud` — https://github.com/baisama-cloud
- Original source repository: https://github.com/baisama-cloud/dsh-omni-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.