### PR TITLE
catalog: add baisama-cloud-dsh-session-mover (community curation, created by @baisama-cloud)

### DIFF
--- a/catalog/plugins/baisama-cloud-dsh-session-mover.yaml
+++ b/catalog/plugins/baisama-cloud-dsh-session-mover.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: baisama-cloud-dsh-session-mover
+name: dsh-session-mover
+description:
+  en: bash npm pack 生成 dsh-session-mover-0.1.0.tgz
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - workspace
+  - session
+  - drag-drop
+  - move
+  - web-ui
+source:
+  repository: https://github.com/baisama-cloud/dsh-session-mover
+  repositoryNodeId: R_kgDOT6BR9A
+  subpath: null
+  commit: bd6e0dbf71a07ea0fe979c121467b846e9b27acf
+creator:
+  github: baisama-cloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:09.544Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baisama-cloud-dsh-session-mover`
- Submission type: community curation
- Created by `baisama-cloud` — https://github.com/baisama-cloud
- Original source repository: https://github.com/baisama-cloud/dsh-session-mover
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.