### PR TITLE
catalog: add baisama-cloud-dsh-stt-input (community curation, created by @baisama-cloud)

### DIFF
--- a/catalog/plugins/baisama-cloud-dsh-stt-input.yaml
+++ b/catalog/plugins/baisama-cloud-dsh-stt-input.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: baisama-cloud-dsh-stt-input
+name: dsh-stt-input
+description:
+  en: Speech-to-text voice input for the DeepSeek Harness (DSH) web GUI.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - stt
+  - speech-to-text
+  - voice-input
+  - whisper
+  - groq
+  - openai
+  - web-speech-api
+  - web-ui
+source:
+  repository: https://github.com/baisama-cloud/dsh-stt-input
+  repositoryNodeId: R_kgDOT6FqbQ
+  subpath: null
+  commit: d2cc4790becb5a40521e17e1eaf3d24a1fb314ad
+creator:
+  github: baisama-cloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:11.182Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baisama-cloud-dsh-stt-input`
- Submission type: community curation
- Created by `baisama-cloud` — https://github.com/baisama-cloud
- Original source repository: https://github.com/baisama-cloud/dsh-stt-input
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.