### PR TITLE
catalog: add breezles-dsh-kb-rag (community curation, created by @Breezles)

### DIFF
--- a/catalog/plugins/breezles-dsh-kb-rag.yaml
+++ b/catalog/plugins/breezles-dsh-kb-rag.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: breezles-dsh-kb-rag
+name: dsh-kb-rag
+description:
+  en: "Local literature knowledge-base RAG tools for DSH: hybrid retrieval + rerank + cited answers over a SQLite index (bundled Python engine)."
+  evidencePath: npm-package/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - rag
+  - knowledge-base
+  - literature
+  - zotero
+  - sqlite
+  - embedding
+  - rerank
+source:
+  repository: https://github.com/Breeze136/dsh-kb-rag
+  repositoryNodeId: R_kgDOT57wiQ
+  subpath: npm-package
+  commit: ba12968e7e378c32e5e760fa415e7d2ea8c1119a
+creator:
+  github: Breezles
+package:
+  ecosystem: npm
+  name: dsh-kb-rag
+  version: 1.1.0
+  integrity: sha512-DRRs+4+yl3fECVBMYEG22AsoSRDoslTmlR/ZmwkNQNnJmpkgpFnnqYYL7ibUXwl2nvTzhFAuS1sYzdrNWXaWuw==
+dsh:
+  profiles:
+    - web
+  evidencePath: npm-package/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:59.264Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `breezles-dsh-kb-rag`
- Submission type: community curation
- Created by `Breezles` — https://github.com/Breezles
- Original source repository: https://github.com/Breeze136/dsh-kb-rag
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.