### PR TITLE
catalog: add bwndlct-dsh-session-export (community curation, created by @bwndlct)

### DIFF
--- a/catalog/plugins/bwndlct-dsh-session-export.yaml
+++ b/catalog/plugins/bwndlct-dsh-session-export.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: bwndlct-dsh-session-export
+name: dsh-session-export
+description:
+  en: Export DeepSeek Harness sessions to portable, human-readable Markdown and JSON.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent
+  - session
+  - export
+  - markdown
+  - transcript
+source:
+  repository: https://github.com/bwndlct/dsh-session-export
+  repositoryNodeId: R_kgDOT4Ptog
+  subpath: null
+  commit: eb18389192e36934718877fd7c6eb397f5cf1cd4
+creator:
+  github: bwndlct
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:06.555Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bwndlct-dsh-session-export`
- Submission type: community curation
- Created by `bwndlct` — https://github.com/bwndlct
- Original source repository: https://github.com/bwndlct/dsh-session-export
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.