### PR TITLE
catalog: add choi-peng-dsh-deepseek-balance (community curation, created by @Choi-Peng)

### DIFF
--- a/catalog/plugins/choi-peng-dsh-deepseek-balance.yaml
+++ b/catalog/plugins/choi-peng-dsh-deepseek-balance.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: choi-peng-dsh-deepseek-balance
+name: "@choi-p/dsh-deepseek-balance"
+description:
+  en: DeepSeek account balance in the dsh web sidebar footer, with live config hot reload and an editable Settings → Plugins card.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - balance
+source:
+  repository: https://github.com/Choi-Peng/dsh-deepseek-balance
+  repositoryNodeId: R_kgDOT4Nq7w
+  subpath: null
+  commit: 4920d1cf5cc9ab3d4b4b86b60bacfa34d89aba49
+creator:
+  github: Choi-Peng
+package:
+  ecosystem: npm
+  name: "@choi-p/dsh-deepseek-balance"
+  version: 0.4.0
+  integrity: sha512-ar4zBHKXqbMj0c1RMlrTVPuftXFgaSB9j+u7kxTI3o+93CwXINe7Nu/z+zDOHOuEIgSaekM6o7wuanu2bMNa9g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:14.082Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `choi-peng-dsh-deepseek-balance`
- Submission type: community curation
- Created by `Choi-Peng` — https://github.com/Choi-Peng
- Original source repository: https://github.com/Choi-Peng/dsh-deepseek-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.