### PR TITLE
catalog: add chongcyrus-dsh-vibe-math (community curation, created by @ChongCyrus)

### DIFF
--- a/catalog/plugins/chongcyrus-dsh-vibe-math.yaml
+++ b/catalog/plugins/chongcyrus-dsh-vibe-math.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: chongcyrus-dsh-vibe-math
+name: dsh-vibe-math
+description:
+  en: "Multi-agent mathematical problem-solving & verification frameworks for DeepSeek Harness — TWO agent presets in one install: vibe-math-v1 (classic pipeline: brainstorm → solver iteration → multi-verifier debate → Verified) and vibe-math-v2 (new probability-driven architecture: qs.json + Propos knowledge base + explorer→"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-preset
+  - multi-agent
+  - mathematics
+  - math
+  - theorem-proving
+  - verification
+  - solver
+  - llm-agents
+source:
+  repository: https://github.com/ChongCyrus/Vibe-Mathematics
+  repositoryNodeId: R_kgDOTqte0Q
+  subpath: null
+  commit: 2f628f4a106fd53da9bb7c21ac125aa762e3d55f
+creator:
+  github: ChongCyrus
+package:
+  ecosystem: npm
+  name: dsh-vibe-math
+  version: 0.3.19
+  integrity: sha512-462m5TWxxmF8oFMboeXPpu5toRxI/GjgWLgecT8zGjfGCZJun+xCMm6otMcblE3D0yuMJC6Q3mUSa2+RPD7dBQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:08.668Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chongcyrus-dsh-vibe-math`
- Submission type: community curation
- Created by `ChongCyrus` — https://github.com/ChongCyrus
- Original source repository: https://github.com/ChongCyrus/Vibe-Mathematics
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.