### PR TITLE
catalog: add chouyong-dsh-fork-graph (community curation, created by @chouyong)

### DIFF
--- a/catalog/plugins/chouyong-dsh-fork-graph.yaml
+++ b/catalog/plugins/chouyong-dsh-fork-graph.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: chouyong-dsh-fork-graph
+name: dsh-fork-graph
+description:
+  en: "Git-graph style conversation fork topology for DeepSeek Harness (dsh): see which session forked from which, and jump between branches."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - session
+  - fork
+  - graph
+  - visualization
+source:
+  repository: https://github.com/chouyong/dsh-fork-graph
+  repositoryNodeId: R_kgDOT5u2Cg
+  subpath: null
+  commit: bb162457a238eff0672f2bff7f180874fe90b377
+creator:
+  github: chouyong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:00.801Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chouyong-dsh-fork-graph`
- Submission type: community curation
- Created by `chouyong` — https://github.com/chouyong
- Original source repository: https://github.com/chouyong/dsh-fork-graph
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.