### PR TITLE
catalog: add claude-dsh-github-connect (community curation, created by @claude)

### DIFF
--- a/catalog/plugins/claude-dsh-github-connect.yaml
+++ b/catalog/plugins/claude-dsh-github-connect.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: claude-dsh-github-connect
+name: dsh-github-connect
+description:
+  en: GitHub connect service for the DeepSeek Harness — Device Flow authorization storing the token through the credentials seam, deterministic git flow-state detection driving the conversation PR status bar, and @Remote methods (connectStatus / startDeviceFlow / createPr / mergePr) for zero-model-turn UI buttons
+  evidencePath: packages/github/github-connect/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - connect
+  - service
+  - device
+  - flow
+  - authorization
+  - storing
+  - token
+  - through
+  - credentials
+  - seam
+  - deterministic
+  - state
+  - detection
+  - driving
+  - conversation
+  - status
+source:
+  repository: https://github.com/kaziii/dsh-github-connector
+  repositoryNodeId: R_kgDOT3ijLg
+  subpath: packages/github/github-connect
+  commit: 34117bfad325e47a30c5146d4b7c2421d07594b5
+creator:
+  github: claude
+package:
+  ecosystem: npm
+  name: dsh-github-connect
+  version: 0.1.3
+  integrity: sha512-LuJiNRHsIFj1HNK6u0/JdPMQSqKTZkyBUeq3YMyzee5lDGvX6WxqykJvC5Or/GgwsCNWEFy6TnQEdUPJDlHM2g==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/github/github-connect/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:02.937Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `claude-dsh-github-connect`
- Submission type: community curation
- Created by `claude` — https://github.com/claude
- Original source repository: https://github.com/kaziii/dsh-github-connector
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.