### PR TITLE
catalog: add como44-dsh-zh-more (community curation, created by @Como44)

### DIFF
--- a/catalog/plugins/como44-dsh-zh-more.yaml
+++ b/catalog/plugins/como44-dsh-zh-more.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: como44-dsh-zh-more
+name: dsh-zh-more
+description:
+  en: "Translates the English that the official DSH Chinese UI can't reach: slash-command names and the Settings → Plugins inventory cards — with three display modes."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - chinese
+  - zh
+  - i18n
+  - localization
+  - translate
+source:
+  repository: https://github.com/Como44/dsh-zh-more
+  repositoryNodeId: R_kgDOT6-h6Q
+  subpath: null
+  commit: c8f37b7c99315b70b307b6d3f3416ed8d2d290c7
+creator:
+  github: Como44
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:02.445Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `como44-dsh-zh-more`
- Submission type: community curation
- Created by `Como44` — https://github.com/Como44
- Original source repository: https://github.com/Como44/dsh-zh-more
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.