### PR TITLE
catalog: add coolbreezecoin-dsh-wechat-mp (community curation, created by @coolbreezecoin)

### DIFF
--- a/catalog/plugins/coolbreezecoin-dsh-wechat-mp.yaml
+++ b/catalog/plugins/coolbreezecoin-dsh-wechat-mp.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: coolbreezecoin-dsh-wechat-mp
+name: dsh-wechat-mp
+description:
+  en: "DeepSeek Harness plugin: turn markdown into a typeset WeChat Official Account draft."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - wechat
+  - markdown
+  - dsh
+source:
+  repository: https://github.com/coolbreezecoin/dsh-wechat-mp
+  repositoryNodeId: R_kgDOT5OvJw
+  subpath: null
+  commit: 1f29cc14791e71fe8b32ac1e6eadf02abad4f0b3
+creator:
+  github: coolbreezecoin
+package:
+  ecosystem: npm
+  name: dsh-wechat-mp
+  version: 0.3.0
+  integrity: sha512-FbBN3D8YeP4suFzR2VQeDW1P3q7bgz8IW1wBKtB9GPzwd3mcnpm+MW6gWcVXDgEcfPYA4n+m6FAfqk4YUbPl8Q==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:03.830Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `coolbreezecoin-dsh-wechat-mp`
- Submission type: community curation
- Created by `coolbreezecoin` — https://github.com/coolbreezecoin
- Original source repository: https://github.com/coolbreezecoin/dsh-wechat-mp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.