### PR TITLE
catalog: add dd2673-dsh-wending-ssh-manager (community curation, created by @dd2673)

### DIFF
--- a/catalog/plugins/dd2673-dsh-wending-ssh-manager.yaml
+++ b/catalog/plugins/dd2673-dsh-wending-ssh-manager.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dd2673-dsh-wending-ssh-manager
+name: dsh-wending-ssh-manager
+description:
+  en: "Hardened multi-account SSH manager for DSH: profile-isolated storage, host-key pinning, Windows DPAPI secrets, pooled exec/SFTP, isolated tunnels, web terminal, cluster operations, and official agent tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - hardened
+  - multi
+  - account
+  - manager
+  - profile
+  - isolated
+  - storage
+  - host
+  - pinning
+  - windows
+  - dpapi
+  - secrets
+  - pooled
+  - exec
+  - sftp
+  - tunnels
+source:
+  repository: https://github.com/dd2673/dsh-wending-ssh-manager
+  repositoryNodeId: R_kgDOT5xaRw
+  subpath: null
+  commit: 6fa9f2a032319185591a52881f18f07ab6484ae5
+creator:
+  github: dd2673
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:06.702Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dd2673-dsh-wending-ssh-manager`
- Submission type: community curation
- Created by `dd2673` — https://github.com/dd2673
- Original source repository: https://github.com/dd2673/dsh-wending-ssh-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.