### PR TITLE
catalog: add dely0-dsh-personal-workbench (community curation, created by @Dely0)

### DIFF
--- a/catalog/plugins/dely0-dsh-personal-workbench.yaml
+++ b/catalog/plugins/dely0-dsh-personal-workbench.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: dely0-dsh-personal-workbench
+name: "@dely0/dsh-personal-workbench"
+description:
+  en: A personal workbench plugin for DeepSeek Harness (DSH) Web. Turn your DSH into a calendar + task list + AI assistant workbench .
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - workbench
+  - task-management
+  - calendar
+  - ai-agent
+source:
+  repository: https://github.com/Dely0/dsh-personal-workbench
+  repositoryNodeId: R_kgDOT5c12A
+  subpath: null
+  commit: 3cda91f6a1d6c235574b2e6994eb412d1abd5c2a
+creator:
+  github: Dely0
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:15.636Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dely0-dsh-personal-workbench`
- Submission type: community curation
- Created by `Dely0` — https://github.com/Dely0
- Original source repository: https://github.com/Dely0/dsh-personal-workbench
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.