### PR TITLE
catalog: add dreambe-dsh-desktop (community curation, created by @dreambe)

### DIFF
--- a/catalog/plugins/dreambe-dsh-desktop.yaml
+++ b/catalog/plugins/dreambe-dsh-desktop.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: dreambe-dsh-desktop
+name: "@deepseek-ai/dsh-desktop"
+description:
+  en: "dsh desktop application: the web client composition in an Electron shell, carried by a protocol handler instead of a server"
+  evidencePath: apps/desktop/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - desktop
+  - application
+  - client
+  - composition
+  - electron
+  - shell
+  - carried
+  - protocol
+  - handler
+  - instead
+  - server
+  - dsh
+source:
+  repository: https://github.com/dreambe/deepseek-harness-desktop
+  repositoryNodeId: R_kgDOT65Q5g
+  subpath: apps/desktop
+  commit: 6e3924ac011291ee74d739bf5b8b92fde0906cc5
+creator:
+  github: dreambe
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: apps/desktop/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:08.241Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dreambe-dsh-desktop`
- Submission type: community curation
- Created by `dreambe` — https://github.com/dreambe
- Original source repository: https://github.com/dreambe/deepseek-harness-desktop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.