### PR TITLE
catalog: add dylan121322-llm-adaptive (community curation, created by @dylan121322)

### DIFF
--- a/catalog/plugins/dylan121322-llm-adaptive.yaml
+++ b/catalog/plugins/dylan121322-llm-adaptive.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: dylan121322-llm-adaptive
+name: llm-adaptive
+description:
+  en: "Adaptive model routing for DeepSeek Harness: per-request complexity classification with automatic provider routing."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - llm
+  - model-routing
+  - adaptive
+source:
+  repository: https://github.com/dylan121322/llm-adaptive
+  repositoryNodeId: R_kgDOT4JC0Q
+  subpath: null
+  commit: 305be1c75d094c2bfcee014b768906e2b5558b9f
+creator:
+  github: dylan121322
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:54.457Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dylan121322-llm-adaptive`
- Submission type: community curation
- Created by `dylan121322` — https://github.com/dylan121322
- Original source repository: https://github.com/dylan121322/llm-adaptive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.