### PR TITLE
catalog: add eddiehuang227-source-dsh-live-talk (community curation, created by @eddiehuang227-source)

### DIFF
--- a/catalog/plugins/eddiehuang227-source-dsh-live-talk.yaml
+++ b/catalog/plugins/eddiehuang227-source-dsh-live-talk.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: eddiehuang227-source-dsh-live-talk
+name: dsh-live-talk
+description:
+  en: Animate any photo into a responsive virtual girl. She talks, turns, smiles, and moves naturally in sync with your conversation. Low-lag, high-detail.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - live-talk
+  - virtual-girl
+  - conversational-ai
+  - digital-human
+  - tts
+  - asr
+  - dsh
+source:
+  repository: https://github.com/eddiehuang227-source/live-talk
+  repositoryNodeId: R_kgDOT6DE4w
+  subpath: null
+  commit: 86e342409ca620441fdea2b6cb9800d84c539d9e
+creator:
+  github: eddiehuang227-source
+package:
+  ecosystem: npm
+  name: dsh-live-talk
+  version: 0.6.0
+  integrity: sha512-KGcjYgj/mCXhaQQcBX2CEHbwBGFnQLDzDXpIBM4h2Q+KTrmQe/i1L+S9TDOCBe3dCp6XxgTg+wlWROXQcPTDRA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:09.738Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `eddiehuang227-source-dsh-live-talk`
- Submission type: community curation
- Created by `eddiehuang227-source` — https://github.com/eddiehuang227-source
- Original source repository: https://github.com/eddiehuang227-source/live-talk
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.