### PR TITLE
catalog: add fleg45-dsh-memoria (community curation, created by @fleg45)

### DIFF
--- a/catalog/plugins/fleg45-dsh-memoria.yaml
+++ b/catalog/plugins/fleg45-dsh-memoria.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: fleg45-dsh-memoria
+name: dsh-memoria
+description:
+  en: "Memoria long-term memory for DeepSeek Harness: one owned Python subprocess + native store/recall tools + auto recall injection"
+  evidencePath: memoria-dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - memoria
+  - long-term-memory
+  - agent
+  - dsh
+source:
+  repository: https://github.com/fleg45/memoria-framework
+  repositoryNodeId: R_kgDOT5oQ8Q
+  subpath: memoria-dsh-plugin
+  commit: 284dd5fa6cd32d23e36f1729fac6a2bc1c5d4d73
+creator:
+  github: fleg45
+package:
+  ecosystem: npm
+  name: dsh-memoria
+  version: 0.1.0
+  integrity: sha512-wspAiP9mki/IfWcpTtS6zmS2oqUUbaaDQFkzpYhrR6Z8iSXX/SyrhiuXphdxv7KL88PrTg67nGbiGz6tSAbJbA==
+dsh:
+  profiles:
+    - default
+  evidencePath: memoria-dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:11.201Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fleg45-dsh-memoria`
- Submission type: community curation
- Created by `fleg45` — https://github.com/fleg45
- Original source repository: https://github.com/fleg45/memoria-framework
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.