### PR TITLE
catalog: add fmlin0429712024-dsh-triage-plugin (community curation, created by @fmlin0429712024)

### DIFF
--- a/catalog/plugins/fmlin0429712024-dsh-triage-plugin.yaml
+++ b/catalog/plugins/fmlin0429712024-dsh-triage-plugin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: fmlin0429712024-dsh-triage-plugin
+name: dsh-triage-plugin
+description:
+  en: "DeepSeek Harness (DSH) plugin packaging of the LinkHealth intake-triage system: a hub skill that classifies/scores/routes inbound healthcare-sector business enquiries, three spoke role prompts that draft scoping notes, and a deterministic guardrail backstop that blocks any triage-log write violating phi involved = requ"
+  evidencePath: plugins/dsh-triage-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - bundle
+  - intake
+  - triage
+  - routing
+  - healthcare
+  - hub-and-spoke
+source:
+  repository: https://github.com/fmlin0429712024/linkhealth-dsh-platform
+  repositoryNodeId: R_kgDOT6mwFA
+  subpath: plugins/dsh-triage-plugin
+  commit: ac726ea9dcef9e8e6f90a8dcf512d09b4572a7d1
+creator:
+  github: fmlin0429712024
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: plugins/dsh-triage-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:12.570Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fmlin0429712024-dsh-triage-plugin`
- Submission type: community curation
- Created by `fmlin0429712024` — https://github.com/fmlin0429712024
- Original source repository: https://github.com/fmlin0429712024/linkhealth-dsh-platform
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.