### PR TITLE
catalog: add foliotemp-dsh-claude-antidote (community curation, created by @FolioTemp)

### DIFF
--- a/catalog/plugins/foliotemp-dsh-claude-antidote.yaml
+++ b/catalog/plugins/foliotemp-dsh-claude-antidote.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: foliotemp-dsh-claude-antidote
+name: dsh-claude-antidote
+description:
+  en: "Compatibility antidote for dsh-claude-ux: keep its risk-control UI visibly enabled while neutralizing the actual debuffs."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - compatibility
+  - claude
+  - antidote
+source:
+  repository: https://github.com/FolioTemp/dsh-claude-antidote
+  repositoryNodeId: R_kgDOT5ynXg
+  subpath: null
+  commit: 44fa421609277870a62a2e34e4a6de75785e25e0
+creator:
+  github: FolioTemp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:19.277Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `foliotemp-dsh-claude-antidote`
- Submission type: community curation
- Created by `FolioTemp` — https://github.com/FolioTemp
- Original source repository: https://github.com/FolioTemp/dsh-claude-antidote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.