### PR TITLE
catalog: add freehul-dsh-sgme (community curation, created by @freehul)

### DIFF
--- a/catalog/plugins/freehul-dsh-sgme.yaml
+++ b/catalog/plugins/freehul-dsh-sgme.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: freehul-dsh-sgme
+name: dsh-sgme
+description:
+  en: SGME memory engine bridge for DeepSeek Harness — multi-agent shared long-term memory via HTTP.
+  evidencePath: adapters/dsh/sgme-bridge/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - sgme
+  - agent-memory
+  - persistent-memory
+  - multi-agent
+  - llm-memory
+  - cordis
+source:
+  repository: https://github.com/freehul/sgme
+  repositoryNodeId: R_kgDOT098uA
+  subpath: adapters/dsh/sgme-bridge
+  commit: d5d98a62b55a89d30c1f0206e3b59e82108633d0
+creator:
+  github: freehul
+package:
+  ecosystem: npm
+  name: dsh-sgme
+  version: 0.2.0
+  integrity: sha512-XNlXE4deejzgGI/YGno16PWvDB5rD1aLo9pwIkXQ91s022myhj7Go993FzY7MBWmENNFYFkrsjwOlOHnFqxr+A==
+dsh:
+  profiles:
+    - default
+  evidencePath: adapters/dsh/sgme-bridge/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:20.736Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `freehul-dsh-sgme`
- Submission type: community curation
- Created by `freehul` — https://github.com/freehul
- Original source repository: https://github.com/freehul/sgme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.