### PR TITLE
catalog: add fuyue521-dsh-desktop-shortcut (community curation, created by @fuyue521)

### DIFF
--- a/catalog/plugins/fuyue521-dsh-desktop-shortcut.yaml
+++ b/catalog/plugins/fuyue521-dsh-desktop-shortcut.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: fuyue521-dsh-desktop-shortcut
+name: dsh-desktop-shortcut
+description:
+  en: "DeepSeek Harness plugin: creates a Windows desktop shortcut that launches dsh web"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - desktop
+  - shortcut
+  - windows
+source:
+  repository: https://github.com/fuyue521/dsh-desktop-shortcut
+  repositoryNodeId: R_kgDOT5CApA
+  subpath: null
+  commit: 6bd601ca32a6faba617fc57b34c77892138a5279
+creator:
+  github: fuyue521
+package:
+  ecosystem: npm
+  name: dsh-desktop-shortcut
+  version: 0.2.6
+  integrity: sha512-ESzt8+jKdGFuCVooY3A41QL8hSjRT+Hgxcx/95cN9nx/wqtJGvBsdxnoOIIaQabbFxw0d3cHVnoMrQRHMxACfg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:57.281Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fuyue521-dsh-desktop-shortcut`
- Submission type: community curation
- Created by `fuyue521` — https://github.com/fuyue521
- Original source repository: https://github.com/fuyue521/dsh-desktop-shortcut
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.