### PR TITLE
catalog: add ganfabo123-cmyk-dsh-experience-memory (community curation, created by @ganfabo123-cmyk)

### DIFF
--- a/catalog/plugins/ganfabo123-cmyk-dsh-experience-memory.yaml
+++ b/catalog/plugins/ganfabo123-cmyk-dsh-experience-memory.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ganfabo123-cmyk-dsh-experience-memory
+name: dsh-experience-memory
+description:
+  en: Keyword-based reusable success and failure memory for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-memory
+  - llm-memory
+  - ai-agent
+  - dsh
+source:
+  repository: https://github.com/ganfabo123-cmyk/dsh-experience-memory
+  repositoryNodeId: R_kgDOT5voUQ
+  subpath: null
+  commit: abfb1ac62c790cb636602ba74bdd3e40d9482d26
+creator:
+  github: ganfabo123-cmyk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:18.839Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ganfabo123-cmyk-dsh-experience-memory`
- Submission type: community curation
- Created by `ganfabo123-cmyk` — https://github.com/ganfabo123-cmyk
- Original source repository: https://github.com/ganfabo123-cmyk/dsh-experience-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.