### PR TITLE
catalog: add gitruozhi-dsh-github-mcp (community curation, created by @GitRuozhi)

### DIFF
--- a/catalog/plugins/gitruozhi-dsh-github-mcp.yaml
+++ b/catalog/plugins/gitruozhi-dsh-github-mcp.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: gitruozhi-dsh-github-mcp
+name: dsh-github-mcp
+description:
+  en: "GitHub official MCP server bridge for DeepSeek Harness: registers mcp github native tools via @deepseek-ai/dsh-mcp-client, plus a github file read tool that reads file contents over REST (fills the gap where the MCP bridge discards resource content)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - github-mcp-server
+source:
+  repository: https://github.com/GitRuozhi/dsh-github-mcp
+  repositoryNodeId: R_kgDOT5P2fQ
+  subpath: null
+  commit: fb03257c4c0dcfe4fa97c1c693d4eacd9184127c
+creator:
+  github: GitRuozhi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:20.343Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gitruozhi-dsh-github-mcp`
- Submission type: community curation
- Created by `GitRuozhi` — https://github.com/GitRuozhi
- Original source repository: https://github.com/GitRuozhi/dsh-github-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.