### PR TITLE
catalog: add glenngit-dsh-top (community curation, created by @glenngit)

### DIFF
--- a/catalog/plugins/glenngit-dsh-top.yaml
+++ b/catalog/plugins/glenngit-dsh-top.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: glenngit-dsh-top
+name: dsh-top
+description:
+  en: "System monitoring tool for the dsh web GUI: live CPU, RAM, disk, network, and top processes in a floating, collapsible panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - system-monitor
+  - web
+source:
+  repository: https://github.com/glenngit/dsh-top
+  repositoryNodeId: R_kgDOT61d7w
+  subpath: null
+  commit: 1843feb52c2321ac1f26b12be912b522b0800978
+creator:
+  github: glenngit
+package:
+  ecosystem: npm
+  name: dsh-top
+  version: 0.1.0
+  integrity: sha512-Fz4t7yOvzLo88fhWtICcVEE+DELNDSXuEEarHSb6ld76Jl07GZaVSuCdebj0WTt/yD6zECQNnW2yAj+AAEdipA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:22.395Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `glenngit-dsh-top`
- Submission type: community curation
- Created by `glenngit` — https://github.com/glenngit
- Original source repository: https://github.com/glenngit/dsh-top
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.