### PR TITLE
catalog: add gooodwei-arcana (community curation, created by @GooodWei)

### DIFF
--- a/catalog/plugins/gooodwei-arcana.yaml
+++ b/catalog/plugins/gooodwei-arcana.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: gooodwei-arcana
+name: arcana
+description:
+  en: "Arcana — a draggable, collapsible, usage-sorted floating deck of every slash command in DeepSeek Harness: hover for details, click to run"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - cordis
+  - slash-command
+  - command
+  - palette
+  - deck
+  - hud
+source:
+  repository: https://github.com/GooodWei/arcana
+  repositoryNodeId: R_kgDOT4Zr1Q
+  subpath: null
+  commit: 82f910c0b5e645c65c2a34be0b0e47035d0489a7
+creator:
+  github: GooodWei
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:58.679Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gooodwei-arcana`
- Submission type: community curation
- Created by `GooodWei` — https://github.com/GooodWei
- Original source repository: https://github.com/GooodWei/arcana
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.