### PR TITLE
catalog: add gou-gee-dsh-plugin-deepseek-vision (community curation, created by @GOU-GEE)

### DIFF
--- a/catalog/plugins/gou-gee-dsh-plugin-deepseek-vision.yaml
+++ b/catalog/plugins/gou-gee-dsh-plugin-deepseek-vision.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: gou-gee-dsh-plugin-deepseek-vision
+name: dsh-plugin-deepseek-vision
+description:
+  en: bash export VISION API KEY='你的智谱APIKey' npx -y @deepseek-ai/dsh@0.1.0-rc.6 plugin --profile web add dsh-plugin-deepseek-vision@0.4.1 npx -y @deepseek-ai/dsh@0.1.0-rc.6 web
+  evidencePath: plugins/dsh-plugin-deepseek-vision/README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - mcp
+  - vision
+  - image-analysis
+  - ocr
+  - glm-4-6v-flash
+source:
+  repository: https://github.com/GOU-GEE/deepseek-vision
+  repositoryNodeId: R_kgDOT4XZoA
+  subpath: plugins/dsh-plugin-deepseek-vision
+  commit: b524d6aedf7ba66e838dba1258f11463b8b7c987
+creator:
+  github: GOU-GEE
+package:
+  ecosystem: npm
+  name: dsh-plugin-deepseek-vision
+  version: 0.4.1
+  integrity: sha512-KiUixhMeIikwhTHiaxBGSWTiPFG9+0uI+o0Zgm9+Eex8/a8Y7OCli5yFlChLp1KwxtYHK6bditGAT/HnZsrrww==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-plugin-deepseek-vision/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:23.984Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gou-gee-dsh-plugin-deepseek-vision`
- Submission type: community curation
- Created by `GOU-GEE` — https://github.com/GOU-GEE
- Original source repository: https://github.com/GOU-GEE/deepseek-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.