### PR TITLE
catalog: add gptsapp-dsh-stylevault (community curation, created by @GptsApp)

### DIFF
--- a/catalog/plugins/gptsapp-dsh-stylevault.yaml
+++ b/catalog/plugins/gptsapp-dsh-stylevault.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: gptsapp-dsh-stylevault
+name: dsh-stylevault
+description:
+  en: StyleVault — classic open-source themes + full Style Settings + shareable config packs for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - theme
+  - stylevault
+  - catppuccin
+  - nord
+  - style-settings
+source:
+  repository: https://github.com/GptsApp/dsh-stylevault
+  repositoryNodeId: R_kgDOT5vbZQ
+  subpath: null
+  commit: b627f3a40c86cee9016d3749368479c08b5443b9
+creator:
+  github: GptsApp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:25.427Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gptsapp-dsh-stylevault`
- Submission type: community curation
- Created by `GptsApp` — https://github.com/GptsApp
- Original source repository: https://github.com/GptsApp/dsh-stylevault
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.