### PR TITLE
catalog: add gy-bai-dsh-anchored-subagent (community curation, created by @GY-Bai)

### DIFF
--- a/catalog/plugins/gy-bai-dsh-anchored-subagent.yaml
+++ b/catalog/plugins/gy-bai-dsh-anchored-subagent.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: gy-bai-dsh-anchored-subagent
+name: dsh-anchored-subagent
+description:
+  en: "Say the secret handshake: DSH subagents start on the Minimal two-tool condition to unlock DeepSeek's full RL-trained strength, then get the whole toolbox."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - agent-preset
+  - subagent
+  - minimal
+  - anchored
+  - trajectory
+source:
+  repository: https://github.com/GY-Bai/dsh-anchored-subagent
+  repositoryNodeId: R_kgDOT5zzdw
+  subpath: null
+  commit: 31fdd22a4265aef3107d9fca05854bea78a9af10
+creator:
+  github: GY-Bai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:26.994Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gy-bai-dsh-anchored-subagent`
- Submission type: community curation
- Created by `GY-Bai` — https://github.com/GY-Bai
- Original source repository: https://github.com/GY-Bai/dsh-anchored-subagent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.