### PR TITLE
catalog: add haiziyao-dsh-vision-mix (community curation, created by @haiziyao)

### DIFF
--- a/catalog/plugins/haiziyao-dsh-vision-mix.yaml
+++ b/catalog/plugins/haiziyao-dsh-vision-mix.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: haiziyao-dsh-vision-mix
+name: dsh-vision-mix
+description:
+  en: A DeepSeek Harness Mix plugin for vision routing plus GPT Image generation and editing.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - vision
+  - vision-agent
+  - multimodal
+  - image-generation
+  - gpt-image-2
+  - dsh
+source:
+  repository: https://github.com/haiziyao/dsh-vision-mix
+  repositoryNodeId: R_kgDOT5PZ4w
+  subpath: null
+  commit: 6188b630c0c3be8d770bb6ffd660be3ee671190e
+creator:
+  github: haiziyao
+package:
+  ecosystem: npm
+  name: dsh-vision-mix
+  version: 0.2.2
+  integrity: sha512-3XBez9k/2DVfs37YwjjvUknnwgqHkuG/uawdvGNC+uFXIhl4hQ/weFYwRcD/DMeXB2eFdeBvoPsSTK4RW+zjLw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:00.130Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haiziyao-dsh-vision-mix`
- Submission type: community curation
- Created by `haiziyao` — https://github.com/haiziyao
- Original source repository: https://github.com/haiziyao/dsh-vision-mix
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.