### PR TITLE
catalog: add han-1413141-dsh-sticky-disclosure (community curation, created by @Han-1413141)

### DIFF
--- a/catalog/plugins/han-1413141-dsh-sticky-disclosure.yaml
+++ b/catalog/plugins/han-1413141-dsh-sticky-disclosure.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: han-1413141-dsh-sticky-disclosure
+name: dsh-sticky-disclosure
+description:
+  en: "DSH Web client plugin: collapse every expanded collapsible section in the conversation (Think / tool cards / command cards...) in one click, with a customizable hotkey."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - client-plugin
+  - ui
+  - sticky
+  - disclosure
+  - collapsible
+source:
+  repository: https://github.com/Han-1413141/dsh-sticky-disclosure
+  repositoryNodeId: R_kgDOT3eUBw
+  subpath: null
+  commit: 873bc91035e51dc598e5e60ad0c06df3a1a552d6
+creator:
+  github: Han-1413141
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:10.270Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `han-1413141-dsh-sticky-disclosure`
- Submission type: community curation
- Created by `Han-1413141` — https://github.com/Han-1413141
- Original source repository: https://github.com/Han-1413141/dsh-sticky-disclosure
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.