### PR TITLE
catalog: add haoku123-dsh-voice (community curation, created by @haoku123)

### DIFF
--- a/catalog/plugins/haoku123-dsh-voice.yaml
+++ b/catalog/plugins/haoku123-dsh-voice.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: haoku123-dsh-voice
+name: "@haoku123/dsh-voice"
+description:
+  en: "Full-duplex voice mode for DeepSeek Harness: streamed ASR - LLM - TTS with barge-in"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - full
+  - duplex
+  - voice
+  - mode
+  - streamed
+  - barge
+  - dsh
+source:
+  repository: https://github.com/haoku123/dsh-voice
+  repositoryNodeId: R_kgDOT5NOyw
+  subpath: null
+  commit: edccb0133766c3cde26ef5ee9b91c2388e8507e8
+creator:
+  github: haoku123
+package:
+  ecosystem: npm
+  name: "@haoku123/dsh-voice"
+  version: 0.7.0
+  integrity: sha512-MXTgcKEUwW0aeN+aKHj5+nWNwp7Grh6zATchVpJBTOzVL5+mPxqDJeNve2ia4pnMNU+6JjeWAGuPieMEVHLH3w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:29.865Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haoku123-dsh-voice`
- Submission type: community curation
- Created by `haoku123` — https://github.com/haoku123
- Original source repository: https://github.com/haoku123/dsh-voice
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.