### PR TITLE
catalog: add hjqcan-dsh-goodmemory (community curation, created by @hjqcan)

### DIFF
--- a/catalog/plugins/hjqcan-dsh-goodmemory.yaml
+++ b/catalog/plugins/hjqcan-dsh-goodmemory.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: hjqcan-dsh-goodmemory
+name: dsh-goodmemory
+description:
+  en: Automatic cross-session GoodMemory recall and writeback for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - goodmemory
+  - memory
+  - agent
+  - dsh
+source:
+  repository: https://github.com/hjqcan/dsh-goodmemory
+  repositoryNodeId: R_kgDOT5QDyA
+  subpath: null
+  commit: 5b80ddd077eddc1bb164c563fdd2bfe2f94341d9
+creator:
+  github: hjqcan
+package:
+  ecosystem: npm
+  name: dsh-goodmemory
+  version: 0.1.0
+  integrity: sha512-qj/PmJD8Qmr9o27I9bCIQH0kZEZ2LHlqJA8pqSUzWuTspcCLOSs5jt7yXhTMhKC6UY479U3WYe+xudjDhplWGQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:21.898Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hjqcan-dsh-goodmemory`
- Submission type: community curation
- Created by `hjqcan` — https://github.com/hjqcan
- Original source repository: https://github.com/hjqcan/dsh-goodmemory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.