### PR TITLE
catalog: add hyp6666-dsh-open-eyes (community curation, created by @Hyp6666)

### DIFF
--- a/catalog/plugins/hyp6666-dsh-open-eyes.yaml
+++ b/catalog/plugins/hyp6666-dsh-open-eyes.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: hyp6666-dsh-open-eyes
+name: dsh-open-eyes
+description:
+  en: A lightweight DeepSeek Harness vision delegation tool for text-only routes, with native OpenAI Responses, Chat Completions, and Anthropic Messages adapters.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - multimodal
+  - tool-plugin
+  - openai-responses
+  - openai
+  - anthropic
+  - typescript
+  - dsh
+source:
+  repository: https://github.com/hyper-dsh-plugins/dsh-open-eyes
+  repositoryNodeId: R_kgDOT5COcA
+  subpath: null
+  commit: 390e2305798dd6fcec9897fdc8414ed3753f01a3
+creator:
+  github: Hyp6666
+package:
+  ecosystem: npm
+  name: dsh-open-eyes
+  version: 0.1.0
+  integrity: sha512-9istiQVu6fAsu8XcjZ3dqzTHt6PKqafDwwjrb3Lj1Qm6Ul9YzfLBlETjSFPBgzt0ao6tNLyGmyAxadVM1igWAg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:01.838Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hyp6666-dsh-open-eyes`
- Submission type: community curation
- Created by `Hyp6666` — https://github.com/Hyp6666
- Original source repository: https://github.com/hyper-dsh-plugins/dsh-open-eyes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.