### PR TITLE
catalog: add iccuse-dsh-file-memory (community curation, created by @ICCuse)

### DIFF
--- a/catalog/plugins/iccuse-dsh-file-memory.yaml
+++ b/catalog/plugins/iccuse-dsh-file-memory.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: iccuse-dsh-file-memory
+name: dsh-file-memory
+description:
+  en: "File-backed working memory tools for DeepSeek Harness: memorize/recall key premises verbatim in a session notes file so they survive context compaction losslessly"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+source:
+  repository: https://github.com/ICCuse/dsh-file-memory
+  repositoryNodeId: R_kgDOT4DMcA
+  subpath: null
+  commit: 979b17a7409bdb8a0bc4bb93c005d51adf284ce8
+creator:
+  github: ICCuse
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:34.438Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `iccuse-dsh-file-memory`
- Submission type: community curation
- Created by `ICCuse` — https://github.com/ICCuse
- Original source repository: https://github.com/ICCuse/dsh-file-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.