### PR TITLE
catalog: add iccuse-dsh-knowledge (community curation, created by @ICCuse)

### DIFF
--- a/catalog/plugins/iccuse-dsh-knowledge.yaml
+++ b/catalog/plugins/iccuse-dsh-knowledge.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: iccuse-dsh-knowledge
+name: dsh-knowledge
+description:
+  en: "Bridge the agent into the user's global Markdown knowledge base (D:\\knowledge, shared with the Codex kb.cmd CLI): kb add/kb search/kb show/kb timeline tools with byte-compatible frontmatter"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - knowledge-base
+  - memory
+source:
+  repository: https://github.com/ICCuse/dsh-knowledge
+  repositoryNodeId: R_kgDOT4ES3w
+  subpath: null
+  commit: 34bec0c1ec33d32c8546f87d373740333adaddae
+creator:
+  github: ICCuse
+package:
+  ecosystem: npm
+  name: dsh-knowledge
+  version: 0.1.0
+  integrity: sha512-oOfPLv0uyadcmMRPRTaTm3G1zmuUZh1+fzasPWo54J2uYTWYvBzKJadDglhW/pAVKHGa1Y3HZdF540zh+cbGNA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:23.323Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `iccuse-dsh-knowledge`
- Submission type: community curation
- Created by `ICCuse` — https://github.com/ICCuse
- Original source repository: https://github.com/ICCuse/dsh-knowledge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.