### PR TITLE
catalog: add iccuse-dsh-premise-guard (community curation, created by @ICCuse)

### DIFF
--- a/catalog/plugins/iccuse-dsh-premise-guard.yaml
+++ b/catalog/plugins/iccuse-dsh-premise-guard.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: iccuse-dsh-premise-guard
+name: dsh-premise-guard
+description:
+  en: "Post-compaction premise-drift guard plugin for DeepSeek Harness: after a compaction summary drops a critical literal anchor (path, value, error code) it injects a one-shot notice telling the model what it may have lost and how to recover it from the log"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+source:
+  repository: https://github.com/ICCuse/dsh-premise-guard
+  repositoryNodeId: R_kgDOT4DKSw
+  subpath: null
+  commit: 2161842c336d4d580ffcf928fad44cf307082084
+creator:
+  github: ICCuse
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:35.944Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `iccuse-dsh-premise-guard`
- Submission type: community curation
- Created by `ICCuse` — https://github.com/ICCuse
- Original source repository: https://github.com/ICCuse/dsh-premise-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.