### PR TITLE
catalog: add ice-kele-dsh-llm-guardian (community curation, created by @ice-kele)

### DIFF
--- a/catalog/plugins/ice-kele-dsh-llm-guardian.yaml
+++ b/catalog/plugins/ice-kele-dsh-llm-guardian.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ice-kele-dsh-llm-guardian
+name: dsh-llm-guardian
+description:
+  en: Provider health, quota, account usage, and local model usage statistics for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - llm
+  - provider-health
+  - token-usage
+  - dsh
+source:
+  repository: https://github.com/ice-kele/dsh-llm-guardian
+  repositoryNodeId: R_kgDOT6TAHw
+  subpath: null
+  commit: 32db0da4d418a469f625b84582bcf9d93f64fd4f
+creator:
+  github: ice-kele
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:37.305Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ice-kele-dsh-llm-guardian`
- Submission type: community curation
- Created by `ice-kele` — https://github.com/ice-kele
- Original source repository: https://github.com/ice-kele/dsh-llm-guardian
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.