### PR TITLE
catalog: add icekale-dsh-provider-auto (community curation, created by @icekale)

### DIFF
--- a/catalog/plugins/icekale-dsh-provider-auto.yaml
+++ b/catalog/plugins/icekale-dsh-provider-auto.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: icekale-dsh-provider-auto
+name: dsh-provider-auto
+description:
+  en: Automatically add reasoning-level controls to compatible DSH provider models.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - llm
+  - reasoning-effort
+  - openai-compatible
+  - dsh
+source:
+  repository: https://github.com/icekale/dsh-provider-auto
+  repositoryNodeId: R_kgDOT530bg
+  subpath: null
+  commit: ddc840c19932697ad398bfdd20c367b8d58bb6da
+creator:
+  github: icekale
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:38.865Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `icekale-dsh-provider-auto`
- Submission type: community curation
- Created by `icekale` — https://github.com/icekale
- Original source repository: https://github.com/icekale/dsh-provider-auto
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.