### PR TITLE
catalog: add iiwish-dsh-testkit (community curation, created by @iiwish)

### DIFF
--- a/catalog/plugins/iiwish-dsh-testkit.yaml
+++ b/catalog/plugins/iiwish-dsh-testkit.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: iiwish-dsh-testkit
+name: dsh-testkit
+description:
+  en: Real-host lifecycle testing for DeepSeek Harness plugins.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-testing
+  - lifecycle-testing
+source:
+  repository: https://github.com/iiwish/dsh-testkit
+  repositoryNodeId: R_kgDOT5F4rw
+  subpath: null
+  commit: 27607d18f9d05ce262be197aa9f74cffbbf59cbd
+creator:
+  github: iiwish
+package:
+  ecosystem: npm
+  name: dsh-testkit
+  version: 0.3.2
+  integrity: sha512-TSR1TSpktUXOZBWwrik6sY9eDJbhaoquo4oWcOW/QXAxdr/iEXuanck2Y0zCvkBAnQbaJ6xiSVVYfJQFhmGR2Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:24.900Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `iiwish-dsh-testkit`
- Submission type: community curation
- Created by `iiwish` — https://github.com/iiwish
- Original source repository: https://github.com/iiwish/dsh-testkit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.