### PR TITLE
catalog: add imkingjh999-dsh-tool-accurate-vision (community curation, created by @imkingjh999)

### DIFF
--- a/catalog/plugins/imkingjh999-dsh-tool-accurate-vision.yaml
+++ b/catalog/plugins/imkingjh999-dsh-tool-accurate-vision.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: imkingjh999-dsh-tool-accurate-vision
+name: dsh-tool-accurate-vision
+description:
+  en: "Model-facing accurate vision tool: precise image spatial reasoning via a vision model"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - image-analysis
+  - bounding-box
+source:
+  repository: https://github.com/imkingjh999/dsh-tool-accurate-vision
+  repositoryNodeId: R_kgDOT7Ag0Q
+  subpath: null
+  commit: 042e5c092a78f183bf2ddfcc76b16ecd42cdca11
+creator:
+  github: imkingjh999
+package:
+  ecosystem: npm
+  name: dsh-tool-accurate-vision
+  version: 0.1.0
+  integrity: sha512-+MEkTwIs42Cb2lbTjKalXbF7MLFUZUeiLxqe7T2VjBw45ezSAlaV3sRhfhAuCrpZ5IuLaFKEilKfe/U8GjmpUA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:40.290Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `imkingjh999-dsh-tool-accurate-vision`
- Submission type: community curation
- Created by `imkingjh999` — https://github.com/imkingjh999
- Original source repository: https://github.com/imkingjh999/dsh-tool-accurate-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.