### PR TITLE
catalog: add isanti2016-dsh-quicksight (community curation, created by @Isanti2016)

### DIFF
--- a/catalog/plugins/isanti2016-dsh-quicksight.yaml
+++ b/catalog/plugins/isanti2016-dsh-quicksight.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: isanti2016-dsh-quicksight
+name: dsh-quicksight
+description:
+  en: "Two-tier image reading for text-only models in DeepSeek Harness: fast local OCR (RapidOCR, offline) first, then a vision model via modlens as fallback."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - ocr
+  - rapidocr
+  - vision
+  - image
+  - quicksight
+source:
+  repository: https://github.com/Isanti2016/dsh-quicksight
+  repositoryNodeId: R_kgDOT500FQ
+  subpath: null
+  commit: 648123d4a605e53bf74c0e6189462004ba4bc9b7
+creator:
+  github: Isanti2016
+package:
+  ecosystem: npm
+  name: dsh-quicksight
+  version: 0.1.1
+  integrity: sha512-Yv8ehofUvDCz0fbCQaXhVJeDWOZeTgH8Hp25DFX/XXFxwGluWWwxktmIvCIkJdw+n4vRA2dgnZm08uhkynVxvA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:41.678Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `isanti2016-dsh-quicksight`
- Submission type: community curation
- Created by `Isanti2016` — https://github.com/Isanti2016
- Original source repository: https://github.com/Isanti2016/dsh-quicksight
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.