### PR TITLE
catalog: add isheng-eqi-dsh-hermes-memory (community curation, created by @isheng-eqi)

### DIFF
--- a/catalog/plugins/isheng-eqi-dsh-hermes-memory.yaml
+++ b/catalog/plugins/isheng-eqi-dsh-hermes-memory.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: isheng-eqi-dsh-hermes-memory
+name: dsh-hermes-memory
+description:
+  en: "Hermes-style persistent memory for DeepSeek Harness (DSH) — a faithful port of the hermes-agent MEMORY.md / USER.md mechanism: bounded dual-bank memory, one memory tool (add/replace/remove/batch), frozen-snapshot injection, nudge reminders. Zero external dependencies, zero LLM cost."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - agent-memory
+  - long-term-memory
+  - hermes-agent
+  - cordis
+source:
+  repository: https://github.com/isheng-eqi/dsh-hermes-memory
+  repositoryNodeId: R_kgDOT6vYWA
+  subpath: null
+  commit: fd1a1f4852daa6edb4bfbe4b6953645b5deebef3
+creator:
+  github: isheng-eqi
+package:
+  ecosystem: npm
+  name: dsh-hermes-memory
+  version: 1.0.0
+  integrity: sha512-3GxXK67vHaWXOKnskSL4Um147mt1i1ukUy11p5S2bQHn5OmhRs7upcMgk6E/QYaj/prGgbp95DwGdBCvThad/A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:03.398Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `isheng-eqi-dsh-hermes-memory`
- Submission type: community curation
- Created by `isheng-eqi` — https://github.com/isheng-eqi
- Original source repository: https://github.com/isheng-eqi/dsh-hermes-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.