### PR TITLE
catalog: add isilsolme-dsh-splash-launcher (community curation, created by @Isilsolme)

### DIFF
--- a/catalog/plugins/isilsolme-dsh-splash-launcher.yaml
+++ b/catalog/plugins/isilsolme-dsh-splash-launcher.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: isilsolme-dsh-splash-launcher
+name: dsh-splash-launcher
+description:
+  en: "DSH Windows one-click launcher with a stroke-by-stroke startup animation: ships a self-contained DSH-GUI.exe and registers the desktop launch agent tool."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - windows
+  - click
+  - launcher
+  - stroke
+  - startup
+  - animation
+  - ships
+  - self
+  - contained
+  - registers
+  - desktop
+  - launch
+  - agent
+  - tool
+  - dsh
+source:
+  repository: https://github.com/Isilsolme/dsh-splash-launcher
+  repositoryNodeId: R_kgDOT5UB8g
+  subpath: null
+  commit: 1f71f423a5b8449f47492de67fa17b3905c3fc2f
+creator:
+  github: Isilsolme
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:05.035Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `isilsolme-dsh-splash-launcher`
- Submission type: community curation
- Created by `Isilsolme` — https://github.com/Isilsolme
- Original source repository: https://github.com/Isilsolme/dsh-splash-launcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.