### PR TITLE
catalog: add itr-del-dsh-feishu (community curation, created by @itr-del)

### DIFF
--- a/catalog/plugins/itr-del-dsh-feishu.yaml
+++ b/catalog/plugins/itr-del-dsh-feishu.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: itr-del-dsh-feishu
+name: dsh-feishu
+description:
+  en: Feishu (Lark) IM bridge for DeepSeek Harness (dsh)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - feishu
+  - lark
+  - bridge
+  - dsh
+source:
+  repository: https://github.com/itr-del/dsh-feishu
+  repositoryNodeId: R_kgDOT4RdAA
+  subpath: null
+  commit: 33478f52215074f0f08eb9034a164574a1ad0ff9
+creator:
+  github: itr-del
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:06.559Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `itr-del-dsh-feishu`
- Submission type: community curation
- Created by `itr-del` — https://github.com/itr-del
- Original source repository: https://github.com/itr-del/dsh-feishu
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.