### PR TITLE
catalog: add izwarm195-dsh-net-tools (community curation, created by @izwarm195)

### DIFF
--- a/catalog/plugins/izwarm195-dsh-net-tools.yaml
+++ b/catalog/plugins/izwarm195-dsh-net-tools.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: izwarm195-dsh-net-tools
+name: dsh-net-tools
+description:
+  en: "Give DSH your magic : plug sandboxed agents into your local HTTP proxy and fetch blocked sites, docs and APIs in one shot."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - give
+  - magic
+  - plug
+  - sandboxed
+  - agents
+  - local
+  - proxy
+  - fetch
+  - blocked
+  - sites
+  - docs
+  - apis
+  - shot
+  - dsh
+source:
+  repository: https://github.com/izwarm195/dsh-net-tools
+  repositoryNodeId: R_kgDOT6LoYg
+  subpath: null
+  commit: 7392ec55ca6db884821311d739859ddea72211de
+creator:
+  github: izwarm195
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:08.110Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `izwarm195-dsh-net-tools`
- Submission type: community curation
- Created by `izwarm195` — https://github.com/izwarm195
- Original source repository: https://github.com/izwarm195/dsh-net-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.