### PR TITLE
catalog: add jamesyasr-dsh-email-push-master (community curation, created by @JamesYasR)

### DIFF
--- a/catalog/plugins/jamesyasr-dsh-email-push-master.yaml
+++ b/catalog/plugins/jamesyasr-dsh-email-push-master.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: jamesyasr-dsh-email-push-master
+name: dsh-email-push-master
+description:
+  en: "Email reminders from your DSH agent when you're away — a hardened fork of dsh-notify-skill: stable SMTP (no 535 retry loop), connect/idle timeouts, --check self-test, and full message headers."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skill
+  - notify
+  - email
+  - smtp
+source:
+  repository: https://github.com/JamesYasR/dsh-email-push-master
+  repositoryNodeId: R_kgDOT56doQ
+  subpath: null
+  commit: a49c277fdca9fd4912e8bd5b2398f5ac20c9db59
+creator:
+  github: JamesYasR
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:43.162Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jamesyasr-dsh-email-push-master`
- Submission type: community curation
- Created by `JamesYasR` — https://github.com/JamesYasR
- Original source repository: https://github.com/JamesYasR/dsh-email-push-master
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.