### PR TITLE
catalog: add jannchie-dsh-bill (community curation, created by @Jannchie)

### DIFF
--- a/catalog/plugins/jannchie-dsh-bill.yaml
+++ b/catalog/plugins/jannchie-dsh-bill.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: jannchie-dsh-bill
+name: dsh-bill
+description:
+  en: Cost tracking for DSH (DeepSeek Harness). A line under each turn tells you what that turn cost; the Cost tab tells you what the money went on.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - cost
+  - usage
+  - token
+  - pricing
+  - dashboard
+source:
+  repository: https://github.com/Jannchie/dsh-bill
+  repositoryNodeId: R_kgDOT559Lw
+  subpath: null
+  commit: a95b79dbe068060dc2723d4fd43d70bdceaf4728
+creator:
+  github: Jannchie
+package:
+  ecosystem: npm
+  name: dsh-bill
+  version: 0.13.1
+  integrity: sha512-3hVNV5e1aWDDcFx0xRp79VpgQZ5zKLEfchztkomnkvSKgWcM3gEiRNgeV0pXsk1curg76yH4g4ldGe21gK3uEw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:09.576Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jannchie-dsh-bill`
- Submission type: community curation
- Created by `Jannchie` — https://github.com/Jannchie
- Original source repository: https://github.com/Jannchie/dsh-bill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.