### PR TITLE
catalog: add jiangxingfan1-coder-dsh-id (community curation, created by @jiangxingfan1-coder)

### DIFF
--- a/catalog/plugins/jiangxingfan1-coder-dsh-id.yaml
+++ b/catalog/plugins/jiangxingfan1-coder-dsh-id.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: jiangxingfan1-coder-dsh-id
+name: dsh-id
+description:
+  en: Login, cross-device capability sync, and session handoff for DeepSeek Harness — zero-server, your own private git repo as the account. 零服务端的 dsh 登录/同步/会话接力。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - login
+  - cross
+  - device
+  - capability
+  - sync
+  - session
+  - handoff
+  - zero
+  - server
+  - private
+  - repo
+  - account
+  - dsh
+source:
+  repository: https://github.com/jiangxingfan1-coder/dsh-id
+  repositoryNodeId: R_kgDOT58tQg
+  subpath: null
+  commit: 41941775cee27f7dc3ea7ce0e2f7a8c65e2fee29
+creator:
+  github: jiangxingfan1-coder
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:46.602Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiangxingfan1-coder-dsh-id`
- Submission type: community curation
- Created by `jiangxingfan1-coder` — https://github.com/jiangxingfan1-coder
- Original source repository: https://github.com/jiangxingfan1-coder/dsh-id
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.