### PR TITLE
catalog: add jiaoqsh-dsh-document (community curation, created by @jiaoqsh)

### DIFF
--- a/catalog/plugins/jiaoqsh-dsh-document.yaml
+++ b/catalog/plugins/jiaoqsh-dsh-document.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: jiaoqsh-dsh-document
+name: "@jiaoqsh/dsh-document"
+description:
+  en: "DeepSeek Harness bundle: the read document tool reads Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV, and PDF files as Markdown for the model"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - document
+  - pdf
+  - docx
+  - markdown
+  - anydoc
+source:
+  repository: https://github.com/jiaoqsh/dsh-document
+  repositoryNodeId: R_kgDOT5KkyA
+  subpath: null
+  commit: 393aad9bbc454f4ac182ac8326e2749cdd761514
+creator:
+  github: jiaoqsh
+package:
+  ecosystem: npm
+  name: "@jiaoqsh/dsh-document"
+  version: 0.1.1
+  integrity: sha512-NN1nNyWA+wZdlQFlXHD2iZqTPgGKjG7jzQgo7HQ67V0IClA6bVofKu6O3/yU8jBi0ErikATML++HptSQd9Tq5w==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:48.211Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiaoqsh-dsh-document`
- Submission type: community curation
- Created by `jiaoqsh` — https://github.com/jiaoqsh
- Original source repository: https://github.com/jiaoqsh/dsh-document
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.