### PR TITLE
catalog: add jiay98528-dev-dsh-plugin-weaknet-adaptor (community curation, created by @jiay98528-dev)

### DIFF
--- a/catalog/plugins/jiay98528-dev-dsh-plugin-weaknet-adaptor.yaml
+++ b/catalog/plugins/jiay98528-dev-dsh-plugin-weaknet-adaptor.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: jiay98528-dev-dsh-plugin-weaknet-adaptor
+name: dsh-plugin-weaknet-adaptor
+description:
+  en: Weak-network adaptor for the DeepSeek Harness — 弱网适配插件
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - weak-network
+  - resilience
+  - retry
+  - heartbeat
+  - reconnect
+  - cache
+  - token-economy
+source:
+  repository: https://github.com/jiay98528-dev/dsh-plugin-weaknet-adaptor
+  repositoryNodeId: R_kgDOT6B9_g
+  subpath: null
+  commit: 046b63c3074db4edb7b4e4eae5ee1d105e856e06
+creator:
+  github: jiay98528-dev
+package:
+  ecosystem: npm
+  name: dsh-plugin-weaknet-adaptor
+  version: 1.0.5
+  integrity: sha512-bsGLziFve3EJrKE5/RwzP+MBE3fcCCkl7hDupehizaMV45K/U1L7zWygMmP2odThp2/ZcM5QetnML8qnujQ6Qg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:49.597Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiay98528-dev-dsh-plugin-weaknet-adaptor`
- Submission type: community curation
- Created by `jiay98528-dev` — https://github.com/jiay98528-dev
- Original source repository: https://github.com/jiay98528-dev/dsh-plugin-weaknet-adaptor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.