### PR TITLE
catalog: add jihongboo-dsh-apple-mode (community curation, created by @jihongboo)

### DIFF
--- a/catalog/plugins/jihongboo-dsh-apple-mode.yaml
+++ b/catalog/plugins/jihongboo-dsh-apple-mode.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: jihongboo-dsh-apple-mode
+name: dsh-apple-mode
+description:
+  en: "Xcode AI integration for DeepSeek Harness: 26 Xcode MCP tools (mcpbridge), Apple platform skills, Xcode Intelligence-style persona. Agent preset + global MCP bundle."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - xcode
+  - integration
+  - tools
+  - mcpbridge
+  - apple
+  - platform
+  - skills
+  - intelligence
+  - style
+  - persona
+  - agent
+  - preset
+  - global
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/jihongboo/dsh-apple-mode
+  repositoryNodeId: R_kgDOT3lv_Q
+  subpath: null
+  commit: 2000ae233bfc2d193b4d276062e9f7737807c021
+creator:
+  github: jihongboo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:32.733Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jihongboo-dsh-apple-mode`
- Submission type: community curation
- Created by `jihongboo` — https://github.com/jihongboo
- Original source repository: https://github.com/jihongboo/dsh-apple-mode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.