### PR TITLE
catalog: add jing-hy-dsh-task-runner (community curation, created by @jing-hy)

### DIFF
--- a/catalog/plugins/jing-hy-dsh-task-runner.yaml
+++ b/catalog/plugins/jing-hy-dsh-task-runner.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jing-hy-dsh-task-runner
+name: dsh-task-runner
+description:
+  en: "DSH plugin: project/task dual-mode workspaces. Tasks skip the workspace picker — every task conversation gets a fresh scratch directory under D:\\dsh working\\<name -<timestamp (Codex-style), while projects keep the existing workspace flow. Ships an idempotent host patch (script) for the official 'dsh-client-ui-workspace"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - workspace
+  - task
+  - scratch
+source:
+  repository: https://github.com/jing-hy/dsh-task-runner
+  repositoryNodeId: R_kgDOT6K0Xw
+  subpath: null
+  commit: 61bcfea2b82cc9726215b4855ab7a355b41b341b
+creator:
+  github: jing-hy
+package:
+  ecosystem: npm
+  name: dsh-task-runner
+  version: 1.1.0
+  integrity: sha512-fJe2rQ+NiSLfFLKhPXne/saTKQP9pM2c40xWSE1Bq6t82NceMiiwcK5VLsVUle8rq65UZ3wKzBH5BoV6cCN8kA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:52.526Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jing-hy-dsh-task-runner`
- Submission type: community curation
- Created by `jing-hy` — https://github.com/jing-hy
- Original source repository: https://github.com/jing-hy/dsh-task-runner
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.