### PR TITLE
catalog: add jinkailiu-dsh-autonomy (community curation, created by @JinkaiLiu)

### DIFF
--- a/catalog/plugins/jinkailiu-dsh-autonomy.yaml
+++ b/catalog/plugins/jinkailiu-dsh-autonomy.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jinkailiu-dsh-autonomy
+name: dsh-autonomy
+description:
+  en: Switch between Chat and Agent without leaving your DeepSeek Harness session.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent
+  - chat-mode
+  - autonomy
+source:
+  repository: https://github.com/JinkaiLiu/dsh-autonomy
+  repositoryNodeId: R_kgDOT5uINA
+  subpath: null
+  commit: 14003cf289e1b5e8b9926ba7f7db0061b465b0d5
+creator:
+  github: JinkaiLiu
+package:
+  ecosystem: npm
+  name: dsh-autonomy
+  version: 0.1.0
+  integrity: sha512-rIqUheleGBnhV7Gg4UIY7fi7EemDioZy4tGkEs4BGRGCO1X8xoUnvWKhubNhrKE+EDvnOxCEBquhjQ0Hrvl4wA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:34.168Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jinkailiu-dsh-autonomy`
- Submission type: community curation
- Created by `JinkaiLiu` — https://github.com/JinkaiLiu
- Original source repository: https://github.com/JinkaiLiu/dsh-autonomy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.