### PR TITLE
catalog: add jitengfei-dsh-whale-arcade (community curation, created by @jitengfei)

### DIFF
--- a/catalog/plugins/jitengfei-dsh-whale-arcade.yaml
+++ b/catalog/plugins/jitengfei-dsh-whale-arcade.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: jitengfei-dsh-whale-arcade
+name: dsh-whale-arcade
+description:
+  en: Community-maintained floating whale arcade for DeepSeek Harness with four browser-local games
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - whale
+  - arcade
+  - browser-game
+  - gomoku
+  - dsh
+source:
+  repository: https://github.com/jitengfei/dsh-whale-arcade
+  repositoryNodeId: R_kgDOT4h9KQ
+  subpath: null
+  commit: 16bd3b05869d5c609724df29c345a117e91776a0
+creator:
+  github: jitengfei
+package:
+  ecosystem: npm
+  name: dsh-whale-arcade
+  version: 0.1.0
+  integrity: sha512-wjZ7cASPjM6vVQsYVQO0ecpwsXngNgrIk8Ta7+G3arffhm98qa+O4Y9gEAQTgvwn04PSZZyUB+5nIa7NC6BTjw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:12.690Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jitengfei-dsh-whale-arcade`
- Submission type: community curation
- Created by `jitengfei` — https://github.com/jitengfei
- Original source repository: https://github.com/jitengfei/dsh-whale-arcade
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.