### PR TITLE
catalog: add joeylee12629-star-dsh-runtime (community curation, created by @joeylee12629-star)

### DIFF
--- a/catalog/plugins/joeylee12629-star-dsh-runtime.yaml
+++ b/catalog/plugins/joeylee12629-star-dsh-runtime.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: joeylee12629-star-dsh-runtime
+name: "@open-design/dsh-runtime"
+description:
+  en: DeepSeek Harness profile runtime for OpenDesign
+  evidencePath: packages/dsh-runtime/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - profile
+  - runtime
+  - opendesign
+  - dsh
+source:
+  repository: https://github.com/nexu-io/open-design
+  repositoryNodeId: R_kgDOSOgY8g
+  subpath: packages/dsh-runtime
+  commit: 713caf01106f2d3595823d5f1b81db8a8b3fb930
+creator:
+  github: joeylee12629-star
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh-runtime/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:29.109Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `joeylee12629-star-dsh-runtime`
- Submission type: community curation
- Created by `joeylee12629-star` — https://github.com/joeylee12629-star
- Original source repository: https://github.com/nexu-io/open-design
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.