### PR TITLE
catalog: add johnxu22786-keel (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-keel.yaml
+++ b/catalog/plugins/johnxu22786-keel.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: johnxu22786-keel
+name: keel
+description:
+  en: Write the spec first, then the code. Turn "don't ship it broken" from a slogan into skills, tooling, and gates.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - spec-driven
+  - spec-first
+  - skill-pack
+  - keel
+  - dsh
+source:
+  repository: https://github.com/JohnXu22786/spec-driven
+  repositoryNodeId: R_kgDOT59QUg
+  subpath: null
+  commit: 378e0cdba34dfca5ce421dcf74a17d681364a36f
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:37.149Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-keel`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/spec-driven
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.