### PR TITLE
catalog: add jtdaugh-bundle (community curation, created by @jtdaugh)

### DIFF
--- a/catalog/plugins/jtdaugh-bundle.yaml
+++ b/catalog/plugins/jtdaugh-bundle.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: jtdaugh-bundle
+name: "@dsh-voice/bundle"
+description:
+  en: "dsh-voice — voice notes in, spoken answers out: dictate audio that becomes user messages (transcribe), have the agent read replies aloud (speak), and leave walk-away narration on long headless runs. Local-first, plain audio files under ~/.dsh/voice/"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - voice
+  - stt
+  - tts
+  - speech-to-text
+  - text-to-speech
+  - whisper
+  - macos
+  - hands-free
+  - audio
+source:
+  repository: https://github.com/Jesse-njx/dsh-voice
+  repositoryNodeId: R_kgDOT3oUHA
+  subpath: null
+  commit: 37164b11690ae9f3f33d6de91ce52a755b3eef64
+creator:
+  github: jtdaugh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:31.248Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jtdaugh-bundle`
- Submission type: community curation
- Created by `jtdaugh` — https://github.com/jtdaugh
- Original source repository: https://github.com/Jesse-njx/dsh-voice
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.