### PR TITLE
catalog: add julescules-dsh-galgame-localization-reverse (community curation, created by @julescules)

### DIFF
--- a/catalog/plugins/julescules-dsh-galgame-localization-reverse.yaml
+++ b/catalog/plugins/julescules-dsh-galgame-localization-reverse.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: julescules-dsh-galgame-localization-reverse
+name: dsh-galgame-localization-reverse
+description:
+  en: Packaged Galgame localization and reverse-engineering skill provider for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - galgame
+  - visual-novel
+  - localization
+  - reverse-engineering
+  - windows
+  - rollback
+  - dsh
+source:
+  repository: https://github.com/julescules/dsh-galgame-localization-reverse
+  repositoryNodeId: R_kgDOT6EYmA
+  subpath: null
+  commit: 081cb721b79a8dabb4d9c4ba36b9a79ac7baaf17
+creator:
+  github: julescules
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:58.238Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `julescules-dsh-galgame-localization-reverse`
- Submission type: community curation
- Created by `julescules` — https://github.com/julescules
- Original source repository: https://github.com/julescules/dsh-galgame-localization-reverse
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.