### PR TITLE
catalog: add julescules-dsh-windows-workspace-guard (community curation, created by @julescules)

### DIFF
--- a/catalog/plugins/julescules-dsh-windows-workspace-guard.yaml
+++ b/catalog/plugins/julescules-dsh-windows-workspace-guard.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: julescules-dsh-windows-workspace-guard
+name: dsh-windows-workspace-guard
+description:
+  en: Windows workspace, system-mutation, Git-risk, approval, settings, and audit guard for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - powershell
+  - windows
+  - workspace-safety
+  - audit-log
+  - git-safety
+  - approval-policy
+  - settings-card
+  - windows-security
+  - dsh
+source:
+  repository: https://github.com/julescules/dsh-windows-workspace-guard
+  repositoryNodeId: R_kgDOT6DOHw
+  subpath: null
+  commit: 217173c7fe48e6c8e96a4602a7a3a059c89711c9
+creator:
+  github: julescules
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:25:59.685Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `julescules-dsh-windows-workspace-guard`
- Submission type: community curation
- Created by `julescules` — https://github.com/julescules
- Original source repository: https://github.com/julescules/dsh-windows-workspace-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.