### PR TITLE
catalog: add kam74515-boop-dsh-everything-oauth (community curation, created by @kam74515-boop)

### DIFF
--- a/catalog/plugins/kam74515-boop-dsh-everything-oauth.yaml
+++ b/catalog/plugins/kam74515-boop-dsh-everything-oauth.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: kam74515-boop-dsh-everything-oauth
+name: dsh-everything-oauth
+description:
+  en: Import local Codex / Grok / Claude / Copilot / Gemini login state into DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - oauth
+  - codex
+  - claude
+  - grok
+  - opencode
+  - dsh
+source:
+  repository: https://github.com/kam74515-boop/dsh-everything-oauth
+  repositoryNodeId: R_kgDOT4BMLg
+  subpath: null
+  commit: fe7b691f52bc1acd433095f4abc47fa0e577dd89
+creator:
+  github: kam74515-boop
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:14.175Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kam74515-boop-dsh-everything-oauth`
- Submission type: community curation
- Created by `kam74515-boop` — https://github.com/kam74515-boop
- Original source repository: https://github.com/kam74515-boop/dsh-everything-oauth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.