### PR TITLE
catalog: add kamitobiharu-dsh-multi-search (community curation, created by @KamitobiHaru)

### DIFF
--- a/catalog/plugins/kamitobiharu-dsh-multi-search.yaml
+++ b/catalog/plugins/kamitobiharu-dsh-multi-search.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: kamitobiharu-dsh-multi-search
+name: "@kamitobi/dsh-multi-search"
+description:
+  en: Community plugin — NOT affiliated with DeepSeek AI. Extensible multi-provider web search for DSH — built-in DashScope and MiMo, easy to add more.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - web-search
+  - dashscope
+  - mimo
+  - xiaomi
+  - aliyun
+  - openai
+  - qwen
+source:
+  repository: https://github.com/KamitobiHaru/dsh-multi-search
+  repositoryNodeId: R_kgDOT5yIMA
+  subpath: null
+  commit: 7c89d1c6a0405c6329a15dd8675c2d240977c4b4
+creator:
+  github: KamitobiHaru
+package:
+  ecosystem: npm
+  name: "@kamitobi/dsh-multi-search"
+  version: 0.2.3
+  integrity: sha512-OpUkIzFTJdmmM+gylfu0vFlmX5rC4pOsTZzglCFGbW3xJLFbWAkzYPjKIBoQa/VJiqtyZrNC028q5j1By7fbkg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:38.775Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kamitobiharu-dsh-multi-search`
- Submission type: community curation
- Created by `KamitobiHaru` — https://github.com/KamitobiHaru
- Original source repository: https://github.com/KamitobiHaru/dsh-multi-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.