### PR TITLE
catalog: add kexuejin-dsh-zhihu-dashboard (community curation, created by @kexuejin)

### DIFF
--- a/catalog/plugins/kexuejin-dsh-zhihu-dashboard.yaml
+++ b/catalog/plugins/kexuejin-dsh-zhihu-dashboard.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: kexuejin-dsh-zhihu-dashboard
+name: dsh-zhihu-dashboard
+description:
+  en: "Zhihu (知乎) dashboard for DeepSeek Harness: hot list with trends, follow feed, post tracking, and app-idea distillation — from the UI and as native agent tools (zhihu search/hot/answer/global search/followees)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - zhihu
+  - dashboard
+  - hot-list
+  - post-tracking
+  - agent-tools
+  - dsh
+source:
+  repository: https://github.com/kexuejin/dsh-zhihu-dashboard
+  repositoryNodeId: R_kgDOT5pRaw
+  subpath: null
+  commit: b0fbe1ef4ebb33115ae9fdce571c5abaeb7b9c35
+creator:
+  github: kexuejin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:40.189Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kexuejin-dsh-zhihu-dashboard`
- Submission type: community curation
- Created by `kexuejin` — https://github.com/kexuejin
- Original source repository: https://github.com/kexuejin/dsh-zhihu-dashboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.