### PR TITLE
catalog: add keyiadiannao-dsh-power-button (community curation, created by @keyiadiannao)

### DIFF
--- a/catalog/plugins/keyiadiannao-dsh-power-button.yaml
+++ b/catalog/plugins/keyiadiannao-dsh-power-button.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: keyiadiannao-dsh-power-button
+name: dsh-power-button
+description:
+  en: "Self-contained power control for DSH: sidebar power button with an upward 重启/关机 menu plus a Windows-shutdown-style overlay. Own restart & shutdown engine (no dependency on other plugins), MIT licensed."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - restart
+  - shutdown
+  - power
+  - client-plugin
+  - dsh-plugin
+source:
+  repository: https://github.com/keyiadiannao/dsh-power-button
+  repositoryNodeId: R_kgDOT5CoBw
+  subpath: null
+  commit: e878b9cee784486ad6a1e0d666aa207a985a8c9c
+creator:
+  github: keyiadiannao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:41.670Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `keyiadiannao-dsh-power-button`
- Submission type: community curation
- Created by `keyiadiannao` — https://github.com/keyiadiannao
- Original source repository: https://github.com/keyiadiannao/dsh-power-button
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.