### PR TITLE
catalog: add klrsl-dsh-biomemory (community curation, created by @KLRSL)

### DIFF
--- a/catalog/plugins/klrsl-dsh-biomemory.yaml
+++ b/catalog/plugins/klrsl-dsh-biomemory.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: klrsl-dsh-biomemory
+name: dsh-biomemory
+description:
+  en: "A cross-session memory plugin for DeepSeek Harness (DSH), designed like a human brain: layered memory, graded approval, memory metabolism, fully transparent and editable."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - memory
+  - biomimetic
+  - markdown
+  - recall
+source:
+  repository: https://github.com/KLRSL/dsh-biomemory
+  repositoryNodeId: R_kgDOT5gnrw
+  subpath: null
+  commit: b6350d0c69ef6cd2bf8a64fc9206c084f8eb5162
+creator:
+  github: KLRSL
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:15.602Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `klrsl-dsh-biomemory`
- Submission type: community curation
- Created by `KLRSL` — https://github.com/KLRSL
- Original source repository: https://github.com/KLRSL/dsh-biomemory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.