### PR TITLE
catalog: add l541402398-dsh-file-uploads (community curation, created by @l541402398)

### DIFF
--- a/catalog/plugins/l541402398-dsh-file-uploads.yaml
+++ b/catalog/plugins/l541402398-dsh-file-uploads.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: l541402398-dsh-file-uploads
+name: dsh-file-uploads
+description:
+  en: Upload arbitrary local files from the DeepSeek Harness Web composer, attach them to prompts, and manage stored uploads in Settings.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - file-upload
+  - web-ui
+source:
+  repository: https://github.com/l541402398/dsh-file-uploads
+  repositoryNodeId: R_kgDOT4CYnA
+  subpath: null
+  commit: 3ea46e1583eac426cc34e191ea811e71b0c8347e
+creator:
+  github: l541402398
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:43.297Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `l541402398-dsh-file-uploads`
- Submission type: community curation
- Created by `l541402398` — https://github.com/l541402398
- Original source repository: https://github.com/l541402398/dsh-file-uploads
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.