### PR TITLE
catalog: add leemancheung-dsh-qq2007-skin (community curation, created by @LeemanCheung)

### DIFF
--- a/catalog/plugins/leemancheung-dsh-qq2007-skin.yaml
+++ b/catalog/plugins/leemancheung-dsh-qq2007-skin.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: leemancheung-dsh-qq2007-skin
+name: dsh-qq2007-skin
+description:
+  en: QQ 2007-inspired retro messenger skin for the DeepSeek Harness Web GUI, with Codex-generated original artwork, compact desktop chrome, an account card, optional original send chime, and reversible settings.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+  - retro-ui
+  - qq2007
+  - web-ui
+source:
+  repository: https://github.com/LeemanCheung/dsh-qq2007-skin
+  repositoryNodeId: R_kgDOT5DeZQ
+  subpath: null
+  commit: e7c61af021dab1d387566a07d3528dc563e4f070
+creator:
+  github: LeemanCheung
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:11.876Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leemancheung-dsh-qq2007-skin`
- Submission type: community curation
- Created by `LeemanCheung` — https://github.com/LeemanCheung
- Original source repository: https://github.com/LeemanCheung/dsh-qq2007-skin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.