### PR TITLE
catalog: add lesliewylie-dsh-fleet-audit (community curation, created by @LeslieWylie)

### DIFF
--- a/catalog/plugins/lesliewylie-dsh-fleet-audit.yaml
+++ b/catalog/plugins/lesliewylie-dsh-fleet-audit.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: lesliewylie-dsh-fleet-audit
+name: dsh-fleet-audit
+description:
+  en: "DSH agent-fleet hygiene audit: credential-file permissions, embedded credentials in git remotes (masked), provider token-prefix literals. Read-only, zero-dependency, deterministic."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - agent
+  - fleet
+  - hygiene
+  - audit
+  - credential
+  - file
+  - permissions
+  - embedded
+  - credentials
+  - remotes
+  - masked
+  - provider
+  - token
+  - prefix
+  - literals
+  - read
+source:
+  repository: https://github.com/LeslieWylie/dsh-fleet-audit
+  repositoryNodeId: R_kgDOT4TfUQ
+  subpath: null
+  commit: ea36c49c33798a460478f07d11654149e59a7b1c
+creator:
+  github: LeslieWylie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:44.745Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lesliewylie-dsh-fleet-audit`
- Submission type: community curation
- Created by `LeslieWylie` — https://github.com/LeslieWylie
- Original source repository: https://github.com/LeslieWylie/dsh-fleet-audit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.