### PR TITLE
catalog: add lesliewylie-dsh-md-html-render (community curation, created by @LeslieWylie)

### DIFF
--- a/catalog/plugins/lesliewylie-dsh-md-html-render.yaml
+++ b/catalog/plugins/lesliewylie-dsh-md-html-render.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lesliewylie-dsh-md-html-render
+name: dsh-md-html-render
+description:
+  en: Render Markdown to standalone, self-contained HTML in the DeepSeek Harness — a model-facing md html render tool that works headless, plus a browse/preview/export drawer in the web GUI. One renderer behind both. Zero runtime dependencies.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - markdown
+  - markdown-to-html
+  - html-export
+  - preview
+  - cordis
+  - web-gui
+  - zero-dependency
+source:
+  repository: https://github.com/LeslieWylie/dsh-md-preview
+  repositoryNodeId: R_kgDOT4Uu2Q
+  subpath: null
+  commit: 94d1ba9ec39f46289852af242506ffdd8a80aa9d
+creator:
+  github: LeslieWylie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:17.039Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lesliewylie-dsh-md-html-render`
- Submission type: community curation
- Created by `LeslieWylie` — https://github.com/LeslieWylie
- Original source repository: https://github.com/LeslieWylie/dsh-md-preview
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.