### PR TITLE
catalog: add luciobaiocchi-dsh-towel (community curation, created by @luciobaiocchi)

### DIFF
--- a/catalog/plugins/luciobaiocchi-dsh-towel.yaml
+++ b/catalog/plugins/luciobaiocchi-dsh-towel.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: luciobaiocchi-dsh-towel
+name: dsh-towel
+description:
+  en: DeepSeek Harness adapter for Towel agent capabilities
+  evidencePath: integrations/deepseek-harness/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - adapter
+  - towel
+  - agent
+  - capabilities
+  - dsh
+source:
+  repository: https://github.com/luciobaiocchi/twl
+  repositoryNodeId: R_kgDOTibDyw
+  subpath: integrations/deepseek-harness
+  commit: e057070bdf0ee28c7238ee91271aabb74abbe778
+creator:
+  github: luciobaiocchi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: integrations/deepseek-harness/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:14.049Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luciobaiocchi-dsh-towel`
- Submission type: community curation
- Created by `luciobaiocchi` — https://github.com/luciobaiocchi
- Original source repository: https://github.com/luciobaiocchi/twl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.