### PR TITLE
catalog: add lynx-gt-dsh-subagent-cwd (community curation, created by @lynx-gt)

### DIFF
--- a/catalog/plugins/lynx-gt-dsh-subagent-cwd.yaml
+++ b/catalog/plugins/lynx-gt-dsh-subagent-cwd.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: lynx-gt-dsh-subagent-cwd
+name: dsh-subagent-cwd
+description:
+  en: "Enhanced subagent delegation tools for DeepSeek Harness with per-call cwd control: everything in dsh-subagent-tools plus a cwd parameter, shipped with the two in-process provider patches it requires."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - subagent
+  - delegation
+  - cwd
+source:
+  repository: https://github.com/lynx-gt/dsh-subagent-cwd
+  repositoryNodeId: R_kgDOT36g9g
+  subpath: null
+  commit: 2b2552e0b762aef8a2e5490a18d118018dc1e469
+creator:
+  github: lynx-gt
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:13.504Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lynx-gt-dsh-subagent-cwd`
- Submission type: community curation
- Created by `lynx-gt` — https://github.com/lynx-gt
- Original source repository: https://github.com/lynx-gt/dsh-subagent-cwd
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.