### PR TITLE
catalog: add mcxianyujun-dsh-web-search-anysearch (community curation, created by @mcxianyujun)

### DIFF
--- a/catalog/plugins/mcxianyujun-dsh-web-search-anysearch.yaml
+++ b/catalog/plugins/mcxianyujun-dsh-web-search-anysearch.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: mcxianyujun-dsh-web-search-anysearch
+name: dsh-web-search-anysearch
+description:
+  en: "AnySearch Web Search Provider for DeepSeek Harness: native AnySearch /v1/search, dedicated Web settings section, DSH credentials integration, Web and Headless profile support."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - anysearch
+  - deepseek-harness
+  - dsh-plugin
+  - web-search
+  - websearchprovider
+  - search-provider
+  - dsh
+source:
+  repository: https://github.com/mcxianyujun/dsh-web-search-anysearch
+  repositoryNodeId: R_kgDOT6rb4g
+  subpath: null
+  commit: 2431cdd8d3294be594340deec09b6b03dd81f65a
+creator:
+  github: mcxianyujun
+package:
+  ecosystem: npm
+  name: dsh-web-search-anysearch
+  version: 0.1.1
+  integrity: sha512-+xa6ZP48vIqh+eYi7PdbiO2JpXf+9UhoPpMWt0l5TyZRlcWqfpEnBUJMHOASgGyngWXDRgGwP8qo5J84ulTLMg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:15.114Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mcxianyujun-dsh-web-search-anysearch`
- Submission type: community curation
- Created by `mcxianyujun` — https://github.com/mcxianyujun
- Original source repository: https://github.com/mcxianyujun/dsh-web-search-anysearch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.