### PR TITLE
catalog: add miku00039-01-dsh-whale-pet (community curation, created by @miku00039-01)

### DIFF
--- a/catalog/plugins/miku00039-01-dsh-whale-pet.yaml
+++ b/catalog/plugins/miku00039-01-dsh-whale-pet.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: miku00039-01-dsh-whale-pet
+name: dsh-whale-pet
+description:
+  en: A Windows desktop pet that bundles DeepSeek Harness service management — start, stop, monitor — and GUI launching into a single zero-dependency .exe .
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - windows
+  - desktop
+  - bundles
+  - service
+  - management
+  - start
+  - stop
+  - monitor
+  - launching
+  - single
+  - zero
+  - dependency
+  - dsh
+source:
+  repository: https://github.com/miku00039-01/dsh-whale-pet
+  repositoryNodeId: R_kgDOT6KOGQ
+  subpath: null
+  commit: 8268907a9fc1448ae7e8d6b5969f29112a1d560d
+creator:
+  github: miku00039-01
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:23.574Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `miku00039-01-dsh-whale-pet`
- Submission type: community curation
- Created by `miku00039-01` — https://github.com/miku00039-01
- Original source repository: https://github.com/miku00039-01/dsh-whale-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.