### PR TITLE
catalog: add minerpi-dsh-trilium (community curation, created by @MineRPi)

### DIFF
--- a/catalog/plugins/minerpi-dsh-trilium.yaml
+++ b/catalog/plugins/minerpi-dsh-trilium.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: minerpi-dsh-trilium
+name: dsh-trilium
+description:
+  en: "A DeepSeek Harness (DSH) Web GUI plugin that connects your Trilium notes to the agent through the ETAPI: durable memory, note management, full-text search, a weekly report workflow, attachments, calendar notes, backups, and a settings card."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - trilium
+  - etapi
+  - memory
+  - notes
+  - knowledge-base
+  - weekly-report
+source:
+  repository: https://github.com/MineRPi/dsh-trilium
+  repositoryNodeId: R_kgDOT569Qg
+  subpath: null
+  commit: 186c8a90ec519e28caf758c2b4689d9a0749109b
+creator:
+  github: MineRPi
+package:
+  ecosystem: npm
+  name: dsh-trilium
+  version: 0.1.2
+  integrity: sha512-g8PjkCi7WeLBWNBu5EhxswPB4ULHtA5wt1NVfzfKJxeLc0pvFa/c54dyA2EuBYrQwbhVi0yDzptE6B6dXwBRFQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:17.072Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `minerpi-dsh-trilium`
- Submission type: community curation
- Created by `MineRPi` — https://github.com/MineRPi
- Original source repository: https://github.com/MineRPi/dsh-trilium
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.