### PR TITLE
catalog: add modusensus-dsh-mneme (community curation, created by @modusensus)

### DIFF
--- a/catalog/plugins/modusensus-dsh-mneme.yaml
+++ b/catalog/plugins/modusensus-dsh-mneme.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: modusensus-dsh-mneme
+name: "@modusensus/dsh-mneme"
+description:
+  en: "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel"
+  evidencePath: dsh-mneme/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - cross
+  - session
+  - memory
+  - autodream
+  - consolidation
+  - sqlite
+  - store
+  - markdown
+  - mirrors
+  - model
+  - tools
+  - automatic
+  - injection
+  - summarization
+  - user
+  - profile
+source:
+  repository: https://github.com/modusensus/dsh-mneme
+  repositoryNodeId: R_kgDOT3faAQ
+  subpath: dsh-mneme
+  commit: 719b8f79ef97418bb3a1d9b07147fa739f6a39f2
+creator:
+  github: modusensus
+package:
+  ecosystem: npm
+  name: "@modusensus/dsh-mneme"
+  version: 0.4.7
+  integrity: sha512-GdZgvWNjgSq/+sHPKMXg6CvIDWIAjb/fg2mpbGP0ulPqnhKQOBrTlsEPSpUXsdKFT8YOaoqhq/LcYh68BypvPQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-mneme/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:18.820Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `modusensus-dsh-mneme`
- Submission type: community curation
- Created by `modusensus` — https://github.com/modusensus
- Original source repository: https://github.com/modusensus/dsh-mneme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.