### PR TITLE
catalog: add mohammmadfg-dsh-proxy (community curation, created by @mohammmadfg)

### DIFF
--- a/catalog/plugins/mohammmadfg-dsh-proxy.yaml
+++ b/catalog/plugins/mohammmadfg-dsh-proxy.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: mohammmadfg-dsh-proxy
+name: "@smanx/dsh-proxy"
+description:
+  en: "LAN reverse proxy for the DeepSeek Harness web app: forwards the local DSH port to a second, authenticated port (HTTP + WebSocket) with a web-based login page and a Basic Auth fallback."
+  evidencePath: dsh-proxy/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - reverse
+  - proxy
+  - forwards
+  - local
+  - port
+  - second
+  - authenticated
+  - websocket
+  - login
+  - page
+  - basic
+  - auth
+  - fallback
+  - dsh
+source:
+  repository: https://github.com/smanx/dsh-proxy
+  repositoryNodeId: R_kgDOT5CxOQ
+  subpath: dsh-proxy
+  commit: 49bf77a6f72201afd729ad7bc1630f26bbc0be4e
+creator:
+  github: mohammmadfg
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-proxy/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:29.689Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mohammmadfg-dsh-proxy`
- Submission type: community curation
- Created by `mohammmadfg` — https://github.com/mohammmadfg
- Original source repository: https://github.com/smanx/dsh-proxy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.