### PR TITLE
catalog: add mrmoradzekri-hub-dsh-web-search-ollama (community curation, created by @mrmoradzekri-hub)

### DIFF
--- a/catalog/plugins/mrmoradzekri-hub-dsh-web-search-ollama.yaml
+++ b/catalog/plugins/mrmoradzekri-hub-dsh-web-search-ollama.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: mrmoradzekri-hub-dsh-web-search-ollama
+name: dsh-web-search-ollama
+description:
+  en: Ollama-backed web search + web fetch for DeepSeek Harness (local signed-in Ollama, no DeepSeek key)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - ollama
+  - backed
+  - search
+  - fetch
+  - local
+  - signed
+  - dsh
+source:
+  repository: https://github.com/mrmoradzekri-hub/dsh-web-search-ollama
+  repositoryNodeId: R_kgDOT6FgqA
+  subpath: null
+  commit: 68630315ec1cfaf20c7d86f9386d4e34d4db74f4
+creator:
+  github: mrmoradzekri-hub
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:25.824Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mrmoradzekri-hub-dsh-web-search-ollama`
- Submission type: community curation
- Created by `mrmoradzekri-hub` — https://github.com/mrmoradzekri-hub
- Original source repository: https://github.com/mrmoradzekri-hub/dsh-web-search-ollama
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.