### PR TITLE
catalog: add nailing10086-zx-dsh-custom-ui (community curation, created by @nailing10086-zx)

### DIFF
--- a/catalog/plugins/nailing10086-zx-dsh-custom-ui.yaml
+++ b/catalog/plugins/nailing10086-zx-dsh-custom-ui.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: nailing10086-zx-dsh-custom-ui
+name: dsh-custom-ui
+description:
+  en: "Custom UI for DeepSeek Harness Web: balance meter in the composer stats line, right-side file tree sidebar, and workspace file open."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - custom
+  - balance
+  - meter
+  - composer
+  - stats
+  - line
+  - right
+  - side
+  - file
+  - tree
+  - sidebar
+  - workspace
+  - open
+  - dsh
+source:
+  repository: https://github.com/nailing10086-zx/dsh-custom-ui
+  repositoryNodeId: R_kgDOT58OQg
+  subpath: null
+  commit: f9376e50dffbd23494d5044bcf0ced21dc9aaf13
+creator:
+  github: nailing10086-zx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:27.334Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nailing10086-zx-dsh-custom-ui`
- Submission type: community curation
- Created by `nailing10086-zx` — https://github.com/nailing10086-zx
- Original source repository: https://github.com/nailing10086-zx/dsh-custom-ui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.