### PR TITLE
catalog: add nirvana-jie-dsh-session-tree (community curation, created by @Nirvana-Jie)

### DIFF
--- a/catalog/plugins/nirvana-jie-dsh-session-tree.yaml
+++ b/catalog/plugins/nirvana-jie-dsh-session-tree.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: nirvana-jie-dsh-session-tree
+name: "@nirvana-jie/dsh-session-tree"
+description:
+  en: Live session lineage and branching inside DeepSeek Harness Web.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - live
+  - session
+  - lineage
+  - branching
+  - inside
+  - dsh
+source:
+  repository: https://github.com/Nirvana-Jie/dsh-session-tree
+  repositoryNodeId: R_kgDOT3_4UQ
+  subpath: null
+  commit: f7e202f89d5e236337724f4edd8eb8e9a956c153
+creator:
+  github: Nirvana-Jie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:50.743Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nirvana-jie-dsh-session-tree`
- Submission type: community curation
- Created by `Nirvana-Jie` — https://github.com/Nirvana-Jie
- Original source repository: https://github.com/Nirvana-Jie/dsh-session-tree
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.