### PR TITLE
catalog: add nixz0824-dsh-sound-cue (community curation, created by @Nixz0824)

### DIFF
--- a/catalog/plugins/nixz0824-dsh-sound-cue.yaml
+++ b/catalog/plugins/nixz0824-dsh-sound-cue.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: nixz0824-dsh-sound-cue
+name: "@dsh-external/dsh-sound-cue"
+description:
+  en: Click to hear the two default (style A) cues — the same notes the plugin synthesizes. If the browser blocks autoplay, click once more on the preview page.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - sound
+  - notification
+  - web-audio
+source:
+  repository: https://github.com/Nixz0824/dsh-sound-cue
+  repositoryNodeId: R_kgDOT6-72g
+  subpath: null
+  commit: 02c80d2c4836585e893c044530255fdb7de8f3ba
+creator:
+  github: Nixz0824
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:31.218Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nixz0824-dsh-sound-cue`
- Submission type: community curation
- Created by `Nixz0824` — https://github.com/Nixz0824
- Original source repository: https://github.com/Nixz0824/dsh-sound-cue
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.