### PR TITLE
catalog: add nixz0824-dsh-usage-stats-plus (community curation, created by @Nixz0824)

### DIFF
--- a/catalog/plugins/nixz0824-dsh-usage-stats-plus.yaml
+++ b/catalog/plugins/nixz0824-dsh-usage-stats-plus.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: nixz0824-dsh-usage-stats-plus
+name: dsh-usage-stats-plus
+description:
+  en: Fork of Ychris12138/dsh-usage-stats (MIT), based on v0.2.0.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - token-usage
+  - balance
+  - usage-stats
+  - cost
+source:
+  repository: https://github.com/Nixz0824/dsh-usage-stats-plus
+  repositoryNodeId: R_kgDOT69gIQ
+  subpath: null
+  commit: 5c6c8129365e4a3bb4feaac98adddc6cce073f51
+creator:
+  github: Nixz0824
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:32.800Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nixz0824-dsh-usage-stats-plus`
- Submission type: community curation
- Created by `Nixz0824` — https://github.com/Nixz0824
- Original source repository: https://github.com/Nixz0824/dsh-usage-stats-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.