### PR TITLE
catalog: add nyantused-cpun-gewu-tools (community curation, created by @nyantused-cpun)

### DIFF
--- a/catalog/plugins/nyantused-cpun-gewu-tools.yaml
+++ b/catalog/plugins/nyantused-cpun-gewu-tools.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: nyantused-cpun-gewu-tools
+name: gewu-tools
+description:
+  en: "The Gewu Inspection Surface : let text-only models in DSH complete visual-inspection tasks through vision subagents."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - gewu
+  - inspection
+  - surface
+  - text
+  - only
+  - models
+  - complete
+  - visual
+  - tasks
+  - through
+  - vision
+  - subagents
+  - dsh
+source:
+  repository: https://github.com/nyantused-cpun/gewu-tools
+  repositoryNodeId: R_kgDOT5_c4Q
+  subpath: null
+  commit: d2ebc982c924fffd7488beafefe3c6e8f59426e2
+creator:
+  github: nyantused-cpun
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:34.417Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nyantused-cpun-gewu-tools`
- Submission type: community curation
- Created by `nyantused-cpun` — https://github.com/nyantused-cpun
- Original source repository: https://github.com/nyantused-cpun/gewu-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.