### PR TITLE
catalog: add orxz-core (community curation, created by @orxz)

### DIFF
--- a/catalog/plugins/orxz-core.yaml
+++ b/catalog/plugins/orxz-core.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: orxz-core
+name: "@dshthemes/core"
+description:
+  en: Theme definitions and registration helpers for deepseek-harness themes
+  evidencePath: packages/core/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - theme
+  - ui-theme
+source:
+  repository: https://github.com/orxz/deepseek-harness-themes
+  repositoryNodeId: R_kgDOT3ZFmQ
+  subpath: packages/core
+  commit: f83ad9980be8b8e47d02e1c3cf8443ab6a02bee3
+creator:
+  github: orxz
+package:
+  ecosystem: npm
+  name: "@dshthemes/core"
+  version: 0.2.0
+  integrity: sha512-EEKWXkSJbsMqseyyucODQCwVe/roCFTc2rlV1VnuhGe7umfUvgrrIu9p++Hp6cAiUBzAF0yDG3SzXbDb7eCq6A==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/core/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:50.454Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `orxz-core`
- Submission type: community curation
- Created by `orxz` — https://github.com/orxz
- Original source repository: https://github.com/orxz/deepseek-harness-themes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.