### PR TITLE
catalog: add orxz-deepseek-harness-pets (community curation, created by @orxz)

### DIFF
--- a/catalog/plugins/orxz-deepseek-harness-pets.yaml
+++ b/catalog/plugins/orxz-deepseek-harness-pets.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: orxz-deepseek-harness-pets
+name: deepseek-harness-pets
+description:
+  en: A desktop pet for DeepSeek Harness (dsh) — a whale that swims in the corner of your Web UI and reacts to your agent's turns.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - pet
+  - pixel-art
+  - petdex
+  - dsh
+source:
+  repository: https://github.com/orxz/deepseek-harness-pets
+  repositoryNodeId: R_kgDOT4iEHA
+  subpath: null
+  commit: 62b3e498cdb0bb7acbe3043a9e84eaba905f1e09
+creator:
+  github: orxz
+package:
+  ecosystem: npm
+  name: deepseek-harness-pets
+  version: 0.2.3
+  integrity: sha512-ZrnqUP1011SJ57cNRX2k3qJaWvpsNwG6TJDKFVGc/4EJ7oTGeriBg+6Hzc6RiiAERr+/FHDSrBBm1qaGxPVpTA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:26.524Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `orxz-deepseek-harness-pets`
- Submission type: community curation
- Created by `orxz` — https://github.com/orxz
- Original source repository: https://github.com/orxz/deepseek-harness-pets
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.