### PR TITLE
catalog: add orxz-ui (community curation, created by @orxz)

### DIFF
--- a/catalog/plugins/orxz-ui.yaml
+++ b/catalog/plugins/orxz-ui.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: orxz-ui
+name: "@dshthemes/ui"
+description:
+  en: "Theme picker plugin for deepseek-harness themes: registers all themes, adds a settings row, and persists third-party selection"
+  evidencePath: packages/ui/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - theme
+  - ui-theme
+source:
+  repository: https://github.com/orxz/deepseek-harness-themes
+  repositoryNodeId: R_kgDOT3ZFmQ
+  subpath: packages/ui
+  commit: f83ad9980be8b8e47d02e1c3cf8443ab6a02bee3
+creator:
+  github: orxz
+package:
+  ecosystem: npm
+  name: "@dshthemes/ui"
+  version: 0.2.0
+  integrity: sha512-KGWA69xUP8DID9/hVHqsQe/joOA290CkK/hoqMCRRJ+/RDYC3d/Cns0XvgKFquB0W0nvNhFVxGlX3AAqOwRjdg==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/ui/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:50.454Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `orxz-ui`
- Submission type: community curation
- Created by `orxz` — https://github.com/orxz
- Original source repository: https://github.com/orxz/deepseek-harness-themes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.