### PR TITLE
catalog: add ox0400-dsh-vault (community curation, created by @Ox0400)

### DIFF
--- a/catalog/plugins/ox0400-dsh-vault.yaml
+++ b/catalog/plugins/ox0400-dsh-vault.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: ox0400-dsh-vault
+name: dsh-vault
+description:
+  en: "Encrypted credential vault for DeepSeek Harness: store and retrieve usernames, emails, phone numbers, passwords, TOTP secrets, SSH/API-key/OAuth developer credentials through model tools and a Settings UI page."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - encrypted
+  - credential
+  - vault
+  - store
+  - retrieve
+  - usernames
+  - emails
+  - phone
+  - numbers
+  - passwords
+  - totp
+  - secrets
+  - oauth
+  - developer
+  - credentials
+  - through
+source:
+  repository: https://github.com/Ox0400/dsh-vault
+  repositoryNodeId: R_kgDOT39tAw
+  subpath: null
+  commit: 555fdddda0b4517e0540d66a66f772bb84dc0b82
+creator:
+  github: Ox0400
+package:
+  ecosystem: npm
+  name: dsh-vault
+  version: 1.9.2
+  integrity: sha512-FfAnCWgToFZP9GQV0sRLicdrmRyv49NkgYe3O0mFQm09S6PTDfC09ucDg404DVeMj3vdxWs/2fxmJT5UiyOiRg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:17.965Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ox0400-dsh-vault`
- Submission type: community curation
- Created by `Ox0400` — https://github.com/Ox0400
- Original source repository: https://github.com/Ox0400/dsh-vault
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.