### PR TITLE
catalog: add p2coder-dsh-task-control (community curation, created by @p2coder)

### DIFF
--- a/catalog/plugins/p2coder-dsh-task-control.yaml
+++ b/catalog/plugins/p2coder-dsh-task-control.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: p2coder-dsh-task-control
+name: dsh-task-control
+description:
+  en: "Task control for DSH Web: pause / resume / cancel the in-flight conversation task from the composer area."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - task
+  - control
+  - pause
+  - resume
+  - cancel
+  - flight
+  - conversation
+  - composer
+  - area
+  - dsh
+source:
+  repository: https://github.com/p2coder/dsh-task-control
+  repositoryNodeId: R_kgDOT5B58Q
+  subpath: null
+  commit: 7369ba718550299cc98834664318c830de81db80
+creator:
+  github: p2coder
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:19.676Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `p2coder-dsh-task-control`
- Submission type: community curation
- Created by `p2coder` — https://github.com/p2coder
- Original source repository: https://github.com/p2coder/dsh-task-control
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.