### PR TITLE
catalog: add pakiknowledge-dsh-notify-skill (community curation, created by @PAKIKNOWLEDGE)

### DIFF
--- a/catalog/plugins/pakiknowledge-dsh-notify-skill.yaml
+++ b/catalog/plugins/pakiknowledge-dsh-notify-skill.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: pakiknowledge-dsh-notify-skill
+name: dsh-notify-skill
+description:
+  en: Email reminders from your DSH agent when you're away — fires at goal completion, blockage, before asking the user a decision, and at long-task milestones.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skill
+  - notify
+  - email
+  - smtp
+  - reminder
+source:
+  repository: https://github.com/PAKIKNOWLEDGE/dsh-notify-skill
+  repositoryNodeId: R_kgDOT4HkxQ
+  subpath: null
+  commit: 8b2f157e75f44e1012d863594d8a67cbb0e26d77
+creator:
+  github: PAKIKNOWLEDGE
+package:
+  ecosystem: npm
+  name: dsh-notify-skill
+  version: 0.1.0
+  integrity: sha512-YLjY0VuVOxYvUHgoJM1njCVcXvkMYh0ax/KCQyX8G6zu/JCd8QQV8fWFWvjQqRBplBIpxx75q7StiVL0fIf3jw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:54.512Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pakiknowledge-dsh-notify-skill`
- Submission type: community curation
- Created by `PAKIKNOWLEDGE` — https://github.com/PAKIKNOWLEDGE
- Original source repository: https://github.com/PAKIKNOWLEDGE/dsh-notify-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.