### PR TITLE
catalog: add perrylink-dsh-library (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/perrylink-dsh-library.yaml
+++ b/catalog/plugins/perrylink-dsh-library.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: perrylink-dsh-library
+name: dsh-library
+description:
+  en: "Local document knowledge base for DeepSeek Harness: library add/remove/list, hybrid semantic+keyword library search with diversity re-ranking, relevance filtering and lost-in-the-middle avoidance, citation-aware injection, library cite check and library diagnose 鈥?SQLite-backed index via the storage domain, local embed"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - rag
+  - knowledge-base
+  - retrieval
+  - embedding
+  - vector-search
+  - citation-validation
+  - document-library
+source:
+  repository: https://github.com/PerryLink/dsh-library
+  repositoryNodeId: R_kgDOT6UKYg
+  subpath: null
+  commit: 2507285852160903d2c452e5a06f100cb0a68cd6
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-library
+  version: 0.1.1
+  integrity: sha512-hO/Uok/Km/FbHriPGzRSW9/taXo5yhS2NIO3rzBCaBYWV93meeeDgScZ6Gmq3sS3KUJbKCWH7AqhfOgDkL/aPQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:27.965Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `perrylink-dsh-library`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-library
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.