### PR TITLE
catalog: add perrylink-dsh-talk (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/perrylink-dsh-talk.yaml
+++ b/catalog/plugins/perrylink-dsh-talk.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: perrylink-dsh-talk
+name: dsh-talk
+description:
+  en: "Voice-first session loop for DeepSeek Harness: a composer microphone button with browser/local speech-to-text (Web Speech, FunASR, whisper.cpp), a speak tool for text-to-speech replies (browser, edge-tts, piper), event announcements with mute, and speak-to-interrupt."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - voice
+  - speech
+  - tts
+  - stt
+  - speech-to-text
+  - text-to-speech
+  - microphone
+source:
+  repository: https://github.com/PerryLink/dsh-talk
+  repositoryNodeId: R_kgDOT6VAKA
+  subpath: null
+  commit: c475fda51294bf0f1f33b045b434b78261d93479
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-talk
+  version: 0.1.0
+  integrity: sha512-kV5qT3HkL08dPKB2cWh6sOMaf/22uYP0w5P0epcByxPKf5IoK0UALEZk5tzwlvLhxtJ8z7uSkdDxlJ/OR7771Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:05.713Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `perrylink-dsh-talk`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-talk
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.