### PR TITLE
catalog: add physicolor-harness-widgets (community curation, created by @Physicolor)

### DIFF
--- a/catalog/plugins/physicolor-harness-widgets.yaml
+++ b/catalog/plugins/physicolor-harness-widgets.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: physicolor-harness-widgets
+name: harness-widgets
+description:
+  en: "Right-hand widget rail for DeepSeek Harness Web UI: live session stats (turns, LLM/tool time, TTFT, speed, cache hit, tokens) plus OpenCode Go quota (rolling/weekly/monthly) proxied by a same-origin host route; an extensible widget registry as the base for more platform usage widgets, visuals, utility actions and exter"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - right
+  - hand
+  - widget
+  - rail
+  - live
+  - session
+  - stats
+  - turns
+  - tool
+  - time
+  - ttft
+  - speed
+  - cache
+  - tokens
+  - plus
+  - opencode
+source:
+  repository: https://github.com/Physicolor/harness-widgets
+  repositoryNodeId: R_kgDOT5Kptg
+  subpath: null
+  commit: 4a2a591b7be1ed804c002996d090d233ded934c0
+creator:
+  github: Physicolor
+package:
+  ecosystem: npm
+  name: harness-widgets
+  version: 0.2.3
+  integrity: sha512-qT2mtb3RxAt5p6HliK9M4VTWZyFTyT+rixPLAzmXVLHKiKQYaiApKqkNkaKmzdgJTJKcJOjvK05gZ8uFCB9Dsw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:32.985Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `physicolor-harness-widgets`
- Submission type: community curation
- Created by `Physicolor` — https://github.com/Physicolor
- Original source repository: https://github.com/Physicolor/harness-widgets
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.