### PR TITLE
catalog: add pidreamleaves-dsh-auto-reviewer (community curation, created by @Pidreamleaves)

### DIFF
--- a/catalog/plugins/pidreamleaves-dsh-auto-reviewer.yaml
+++ b/catalog/plugins/pidreamleaves-dsh-auto-reviewer.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: pidreamleaves-dsh-auto-reviewer
+name: dsh-auto-reviewer
+description:
+  en: "DSH sandbox-permission auto-review gate: three-layer funnel, lightweight reviewer model, retry with human fallback."
+  evidencePath: packages/auto-review/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - sandbox
+  - permission
+  - auto
+  - review
+  - gate
+  - three
+  - layer
+  - funnel
+  - lightweight
+  - reviewer
+  - model
+  - retry
+  - human
+  - fallback
+  - dsh
+source:
+  repository: https://github.com/Pidreamleaves/dsh-pi-kit
+  repositoryNodeId: R_kgDOT5WMbQ
+  subpath: packages/auto-review
+  commit: 1092e47a9e6e701b93f566286bb72f6873ba89e7
+creator:
+  github: Pidreamleaves
+package:
+  ecosystem: npm
+  name: dsh-auto-reviewer
+  version: 0.1.0
+  integrity: sha512-PSP2D6ze5HYhRqSecUZIAnjoYeZcNyzkYKYHb7HTnLdOCSvfXuzBVPq2jEfWBhW0/4LLfqdrFcqQG+0VmLAhKw==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/auto-review/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:56.664Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pidreamleaves-dsh-auto-reviewer`
- Submission type: community curation
- Created by `Pidreamleaves` — https://github.com/Pidreamleaves
- Original source repository: https://github.com/Pidreamleaves/dsh-pi-kit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.