### PR TITLE
catalog: add q1hangl-dsh-ask-guard (community curation, created by @Q1hangL)

### DIFF
--- a/catalog/plugins/q1hangl-dsh-ask-guard.yaml
+++ b/catalog/plugins/q1hangl-dsh-ask-guard.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: q1hangl-dsh-ask-guard
+name: dsh-ask-guard
+description:
+  en: "Timeout guard for ask user question: a lost or unanswered question resolves as a structured ASK TIMEOUT instead of hanging the turn forever"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ask-user-question
+  - timeout
+source:
+  repository: https://github.com/Q1hangL/dsh-ask-guard
+  repositoryNodeId: R_kgDOT4oZ9Q
+  subpath: null
+  commit: a45f230320edd3b2ca20fd4f4d0ccdf9ff186114
+creator:
+  github: Q1hangL
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:36.017Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `q1hangl-dsh-ask-guard`
- Submission type: community curation
- Created by `Q1hangL` — https://github.com/Q1hangL
- Original source repository: https://github.com/Q1hangL/dsh-ask-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.