### PR TITLE
catalog: add qimidandapigu-dsh-xiaotangyuan-game (community curation, created by @qimidandapigu)

### DIFF
--- a/catalog/plugins/qimidandapigu-dsh-xiaotangyuan-game.yaml
+++ b/catalog/plugins/qimidandapigu-dsh-xiaotangyuan-game.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: qimidandapigu-dsh-xiaotangyuan-game
+name: "@qimidandapigu/dsh-xiaotangyuan-game"
+description:
+  en: XiaoTangYuan game AI runtime for DeepSeek Harness.
+  evidencePath: apps/harness-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - xiaotangyuan
+  - game-ai
+  - game-agent
+  - dsh
+source:
+  repository: https://github.com/qimidandapigu/dsh-xiaotangyuan-game
+  repositoryNodeId: R_kgDOT4qPIA
+  subpath: apps/harness-plugin
+  commit: 6ab710b16d48522b48593513fc350817a5e9367a
+creator:
+  github: qimidandapigu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: apps/harness-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:15.643Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qimidandapigu-dsh-xiaotangyuan-game`
- Submission type: community curation
- Created by `qimidandapigu` — https://github.com/qimidandapigu
- Original source repository: https://github.com/qimidandapigu/dsh-xiaotangyuan-game
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.