### PR TITLE
catalog: add qing3a-dsh-event-auditor (community curation, created by @qing3a)

### DIFF
--- a/catalog/plugins/qing3a-dsh-event-auditor.yaml
+++ b/catalog/plugins/qing3a-dsh-event-auditor.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: qing3a-dsh-event-auditor
+name: "@qing3a/dsh-event-auditor"
+description:
+  en: bash dsh plugin --profile <profile add @qing3a/dsh-event-auditor dsh --profile <profile
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - audit
+  - events
+source:
+  repository: https://github.com/qing3a/dsh-event-auditor
+  repositoryNodeId: R_kgDOT3l83Q
+  subpath: null
+  commit: 4c533668186a6dadb804b839a0e1b90b69fdabb2
+creator:
+  github: qing3a
+package:
+  ecosystem: npm
+  name: "@qing3a/dsh-event-auditor"
+  version: 0.1.0
+  integrity: sha512-ZfKc2Ej0PWqMmXYFvZsk+fnkvd/w9v5ZcgQFFavxPO6u/nS0MyJzGUFHB4xQUbaz+FwAcnCCihHoi+e8noKIUQ==
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:23:59.710Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qing3a-dsh-event-auditor`
- Submission type: community curation
- Created by `qing3a` — https://github.com/qing3a
- Original source repository: https://github.com/qing3a/dsh-event-auditor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.