### PR TITLE
catalog: add qing3a-verify-auditor (community curation, created by @qing3a)

### DIFF
--- a/catalog/plugins/qing3a-verify-auditor.yaml
+++ b/catalog/plugins/qing3a-verify-auditor.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: qing3a-verify-auditor
+name: "@qing3a/verify-auditor"
+description:
+  en: system-prompt/assemble → agent/pre-step → agent/request → llm/stream → tools/pre-execute → tools/execute → tools/post-execute → tools/result
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - system
+  - prompt
+  - assemble
+  - agent
+  - step
+  - request
+  - stream
+  - tools
+  - execute
+  - post
+  - result
+  - dsh
+source:
+  repository: https://github.com/qing3a/dsh-plugin-verify
+  repositoryNodeId: R_kgDOT3vipw
+  subpath: auditor
+  commit: 7a027fcca26652fc4a2f3491f847d47a390457fa
+creator:
+  github: qing3a
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: auditor/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:17.580Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qing3a-verify-auditor`
- Submission type: community curation
- Created by `qing3a` — https://github.com/qing3a
- Original source repository: https://github.com/qing3a/dsh-plugin-verify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.