### PR TITLE
catalog: add qinluza-dsh-file-undo (community curation, created by @QinLuza)

### DIFF
--- a/catalog/plugins/qinluza-dsh-file-undo.yaml
+++ b/catalog/plugins/qinluza-dsh-file-undo.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: qinluza-dsh-file-undo
+name: dsh-file-undo
+description:
+  en: "Undo file write/edit operations in DSH: snapshot the before-state of every write/edit mutation and restore it with /undo"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - undo
+  - file
+  - write
+  - edit
+  - operations
+  - snapshot
+  - before
+  - state
+  - every
+  - mutation
+  - restore
+  - dsh
+source:
+  repository: https://github.com/QinLuza/dsh-file-undo
+  repositoryNodeId: R_kgDOT5xDuA
+  subpath: null
+  commit: d9cd7cd83dde82b43ff86ce088ed143095b8051d
+creator:
+  github: QinLuza
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:18.977Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qinluza-dsh-file-undo`
- Submission type: community curation
- Created by `QinLuza` — https://github.com/QinLuza
- Original source repository: https://github.com/QinLuza/dsh-file-undo
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.