### PR TITLE
catalog: add qiuner-dsh-plugin-desktop (community curation, created by @Qiuner)

### DIFF
--- a/catalog/plugins/qiuner-dsh-plugin-desktop.yaml
+++ b/catalog/plugins/qiuner-dsh-plugin-desktop.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: qiuner-dsh-plugin-desktop
+name: dsh-plugin-desktop
+description:
+  en: "DSH Desktop: an Electron shell composed as a DeepSeek Harness Cordis plugin"
+  evidencePath: dsh-plugin-desktop/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - desktop
+  - electron
+  - shell
+  - composed
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/anywhere-labs/deepseek-harness-desktop
+  repositoryNodeId: R_kgDOT3jedQ
+  subpath: dsh-plugin-desktop
+  commit: 744615278c518a6699a17ff3fb98ab0ee1cbd756
+creator:
+  github: Qiuner
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: dsh-plugin-desktop/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:51.727Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qiuner-dsh-plugin-desktop`
- Submission type: community curation
- Created by `Qiuner` — https://github.com/Qiuner
- Original source repository: https://github.com/anywhere-labs/deepseek-harness-desktop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.