### PR TITLE
catalog: add r05en1cu-dsh-neoforge (community curation, created by @r05En1cU)

### DIFF
--- a/catalog/plugins/r05en1cu-dsh-neoforge.yaml
+++ b/catalog/plugins/r05en1cu-dsh-neoforge.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: r05en1cu-dsh-neoforge
+name: dsh-neoforge
+description:
+  en: "NeoForge-style standard API layer for DeepSeek Harness plugins: runtime mixins with snapshot/restore + a Cordis-native event bus"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - neoforge
+  - cordis
+  - mixin
+source:
+  repository: https://github.com/r05En1cU/dsh-neoforge
+  repositoryNodeId: R_kgDOT5nVOw
+  subpath: null
+  commit: 7bbee4096ecf563aab5cfff29c4b65f5d36790aa
+creator:
+  github: r05En1cU
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:37.550Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `r05en1cu-dsh-neoforge`
- Submission type: community curation
- Created by `r05En1cU` — https://github.com/r05En1cU
- Original source repository: https://github.com/r05En1cU/dsh-neoforge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.