### PR TITLE
catalog: add reshuibuduo-tmcra-deepseek-harness-local-memory (community curation, created by @reshuibuduo)

### DIFF
--- a/catalog/plugins/reshuibuduo-tmcra-deepseek-harness-local-memory.yaml
+++ b/catalog/plugins/reshuibuduo-tmcra-deepseek-harness-local-memory.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: reshuibuduo-tmcra-deepseek-harness-local-memory
+name: tmcra-deepseek-harness-local-memory
+description:
+  en: Owner-local TMCRA recall and role-separated writeback for DeepSeek Harness
+  evidencePath: integrations/deepseek-harness-local/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-memory
+  - local-first
+  - tmcra
+  - dsh
+source:
+  repository: https://github.com/reshuibuduo/tmcra-memory
+  repositoryNodeId: R_kgDOSnb4Vw
+  subpath: integrations/deepseek-harness-local
+  commit: 49c5a3648d18af3a6af3b13540ca5469c2842b7e
+creator:
+  github: reshuibuduo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: integrations/deepseek-harness-local/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:21.958Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `reshuibuduo-tmcra-deepseek-harness-local-memory`
- Submission type: community curation
- Created by `reshuibuduo` — https://github.com/reshuibuduo
- Original source repository: https://github.com/reshuibuduo/tmcra-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.