### PR TITLE
catalog: add ruby1304-dsh-vision-subagent (community curation, created by @ruby1304)

### DIFF
--- a/catalog/plugins/ruby1304-dsh-vision-subagent.yaml
+++ b/catalog/plugins/ruby1304-dsh-vision-subagent.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: ruby1304-dsh-vision-subagent
+name: dsh-vision-subagent
+description:
+  en: "Vision for text-only DeepSeek Harness agents: delegate image reading to a one-shot subagent on a configurable vision route (MiniMax / Kimi / any OpenAI-compatible provider), keeping image bytes and the vision model's context out of the main session."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - vision
+  - multimodal
+  - subagent
+  - minimax
+  - kimi
+  - moonshot
+  - cordis
+source:
+  repository: https://github.com/ruby1304/dsh-vision-subagent
+  repositoryNodeId: R_kgDOT5SHWw
+  subpath: null
+  commit: 0e55e84bde9d3cb9b64c2e8bc7b5bfaa3123c437
+creator:
+  github: ruby1304
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:25.104Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ruby1304-dsh-vision-subagent`
- Submission type: community curation
- Created by `ruby1304` — https://github.com/ruby1304
- Original source repository: https://github.com/ruby1304/dsh-vision-subagent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.