### PR TITLE
catalog: add samge0-dsh-plugin-qcc (community curation, created by @Samge0)

### DIFF
--- a/catalog/plugins/samge0-dsh-plugin-qcc.yaml
+++ b/catalog/plugins/samge0-dsh-plugin-qcc.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: samge0-dsh-plugin-qcc
+name: dsh-plugin-qcc
+description:
+  en: Qichacha (企查查) company-data plugin for DeepSeek Harness — 5 agent tools + settings-page account management. Unofficial, for personal study and research.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - qichacha
+  - company-data
+  - dsh
+source:
+  repository: https://github.com/Samge0/dsh-plugin-qcc
+  repositoryNodeId: R_kgDOT5bjoQ
+  subpath: null
+  commit: cac41802ae32a09d7cca76897959436cc9b432c4
+creator:
+  github: Samge0
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:01.180Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `samge0-dsh-plugin-qcc`
- Submission type: community curation
- Created by `Samge0` — https://github.com/Samge0
- Original source repository: https://github.com/Samge0/dsh-plugin-qcc
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.