### PR TITLE
catalog: add sanqipanax-dsh-sticker-board (community curation, created by @sanqiPanax)

### DIFF
--- a/catalog/plugins/sanqipanax-dsh-sticker-board.yaml
+++ b/catalog/plugins/sanqipanax-dsh-sticker-board.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: sanqipanax-dsh-sticker-board
+name: dsh-sticker-board
+description:
+  en: Fridge-magnet sticker board for DeepSeek Harness (DSH) Web.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - sticker
+  - quick-task
+  - composer
+  - web-ui
+source:
+  repository: https://github.com/sanqiPanax/dsh-sticker-board
+  repositoryNodeId: R_kgDOT6MEjg
+  subpath: null
+  commit: 080e3e075c636b518d451dd01a41cc5a624b530c
+creator:
+  github: sanqiPanax
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:02.579Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sanqipanax-dsh-sticker-board`
- Submission type: community curation
- Created by `sanqiPanax` — https://github.com/sanqiPanax
- Original source repository: https://github.com/sanqiPanax/dsh-sticker-board
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.