### PR TITLE
catalog: add shinjiyu-dsh-plugin-multimodal (community curation, created by @shinjiyu)

### DIFF
--- a/catalog/plugins/shinjiyu-dsh-plugin-multimodal.yaml
+++ b/catalog/plugins/shinjiyu-dsh-plugin-multimodal.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: shinjiyu-dsh-plugin-multimodal
+name: dsh-plugin-multimodal
+description:
+  en: "Vision sidecar for DeepSeek Harness: accept image attachments on text-only models, describe them, then send text to the main model."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - multimodal
+  - dsh
+source:
+  repository: https://github.com/shinjiyu/dsh-plugin-multimodal
+  repositoryNodeId: R_kgDOT49x2A
+  subpath: null
+  commit: b9b82a61859de52d1a1573b0119e91e5aced37e1
+creator:
+  github: shinjiyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:22.371Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shinjiyu-dsh-plugin-multimodal`
- Submission type: community curation
- Created by `shinjiyu` — https://github.com/shinjiyu
- Original source repository: https://github.com/shinjiyu/dsh-plugin-multimodal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.