### PR TITLE
catalog: add shinjiyu-dsh-plugin-search (community curation, created by @shinjiyu)

### DIFF
--- a/catalog/plugins/shinjiyu-dsh-plugin-search.yaml
+++ b/catalog/plugins/shinjiyu-dsh-plugin-search.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: shinjiyu-dsh-plugin-search
+name: dsh-plugin-search
+description:
+  en: Zero-config web search for DeepSeek Harness when you are not on the official DeepSeek API.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - web-search
+  - dsh
+source:
+  repository: https://github.com/shinjiyu/dsh-plugin-search
+  repositoryNodeId: R_kgDOT4-SrQ
+  subpath: null
+  commit: 0ceaa1985ad2e7774cd8f06890c4a9b1a7125955
+creator:
+  github: shinjiyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:26.565Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shinjiyu-dsh-plugin-search`
- Submission type: community curation
- Created by `shinjiyu` — https://github.com/shinjiyu
- Original source repository: https://github.com/shinjiyu/dsh-plugin-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.