### PR TITLE
catalog: add shinjiyu-plugin-evolve (community curation, created by @shinjiyu)

### DIFF
--- a/catalog/plugins/shinjiyu-plugin-evolve.yaml
+++ b/catalog/plugins/shinjiyu-plugin-evolve.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: shinjiyu-plugin-evolve
+name: plugin-evolve
+description:
+  en: Host-agnostic controller for staging, validating, scoring, and solidifying evolved tool plugins.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - agent
+  - evolution
+  - controller
+  - dsh
+source:
+  repository: https://github.com/shinjiyu/deepseek-harness-evolver
+  repositoryNodeId: R_kgDOT4Efmg
+  subpath: null
+  commit: 64e293a68f96d23378936028d50fe18320e4bcd5
+creator:
+  github: shinjiyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:04.005Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shinjiyu-plugin-evolve`
- Submission type: community curation
- Created by `shinjiyu` — https://github.com/shinjiyu
- Original source repository: https://github.com/shinjiyu/deepseek-harness-evolver
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.