### PR TITLE
catalog: add sliverp-deepseek-harness-weixin (community curation, created by @sliverp)

### DIFF
--- a/catalog/plugins/sliverp-deepseek-harness-weixin.yaml
+++ b/catalog/plugins/sliverp-deepseek-harness-weixin.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: sliverp-deepseek-harness-weixin
+name: deepseek-harness-weixin
+description:
+  en: Official Weixin iLink text, image, and file bridge for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - weixin
+  - wechat
+  - ilink
+  - chatbot
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/sliverp/DeepSeek-harness-weixin
+  repositoryNodeId: R_kgDOT3mlLA
+  subpath: null
+  commit: 361927d701f664074b1ea72096f8e61c121a602d
+creator:
+  github: sliverp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:42.151Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sliverp-deepseek-harness-weixin`
- Submission type: community curation
- Created by `sliverp` — https://github.com/sliverp
- Original source repository: https://github.com/sliverp/DeepSeek-harness-weixin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.