### PR TITLE
catalog: add spirtxiaoqi7-mindspace-dsh-local-rag (community curation, created by @Spirtxiaoqi7)

### DIFF
--- a/catalog/plugins/spirtxiaoqi7-mindspace-dsh-local-rag.yaml
+++ b/catalog/plugins/spirtxiaoqi7-mindspace-dsh-local-rag.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: spirtxiaoqi7-mindspace-dsh-local-rag
+name: mindspace-dsh-local-rag
+description:
+  en: Local, model-invoked hybrid RAG for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - rag
+  - local-rag
+  - hybrid-search
+  - arpm
+  - bm25
+  - vector-search
+  - dsh
+source:
+  repository: https://github.com/Spirtxiaoqi7/mindspace-dsh-local-rag
+  repositoryNodeId: R_kgDOT4IhvQ
+  subpath: null
+  commit: 744bec2d8b6a5039ebe7d20720e3a4d8d13f39fb
+creator:
+  github: Spirtxiaoqi7
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:23.905Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `spirtxiaoqi7-mindspace-dsh-local-rag`
- Submission type: community curation
- Created by `Spirtxiaoqi7` — https://github.com/Spirtxiaoqi7
- Original source repository: https://github.com/Spirtxiaoqi7/mindspace-dsh-local-rag
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.