### PR TITLE
catalog: add sutera-diffusus-dsh-sandbox (community curation, created by @Sutera-Diffusus)

### DIFF
--- a/catalog/plugins/sutera-diffusus-dsh-sandbox.yaml
+++ b/catalog/plugins/sutera-diffusus-dsh-sandbox.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: sutera-diffusus-dsh-sandbox
+name: dsh-sandbox
+description:
+  en: powershell git clone https://github.com/Sutera-Diffusus/dsh-sandbox-tester.git cd dsh-sandbox-tester
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - powershell
+  - clone
+  - sutera
+  - diffusus
+  - sandbox
+  - tester
+  - dsh
+source:
+  repository: https://github.com/Sutera-Diffusus/dsh-sandbox-tester
+  repositoryNodeId: R_kgDOT6O37Q
+  subpath: null
+  commit: 8fd746dc1fd0946c5491b0e2967ab0d22e4fba4e
+creator:
+  github: Sutera-Diffusus
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:45.314Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sutera-diffusus-dsh-sandbox`
- Submission type: community curation
- Created by `Sutera-Diffusus` — https://github.com/Sutera-Diffusus
- Original source repository: https://github.com/Sutera-Diffusus/dsh-sandbox-tester
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.