### PR TITLE
catalog: add sutera-diffusus-dsh-windows-notify (community curation, created by @Sutera-Diffusus)

### DIFF
--- a/catalog/plugins/sutera-diffusus-dsh-windows-notify.yaml
+++ b/catalog/plugins/sutera-diffusus-dsh-windows-notify.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: sutera-diffusus-dsh-windows-notify
+name: dsh-windows-notify
+description:
+  en: "Windows-grade notifications for DeepSeek Harness: system toasts, custom sounds, and a taskbar tray badge for task completion and decision prompts — a native DSH profile plugin (bundle + client + settings namespace), zero patching of built-in packages."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - notifications
+  - windows
+  - toast
+  - tray
+source:
+  repository: https://github.com/Sutera-Diffusus/dsh-windows-notify
+  repositoryNodeId: R_kgDOT5Tv8w
+  subpath: null
+  commit: 42c3ae80e1beac7516e8678b3dd449c2f0f55e25
+creator:
+  github: Sutera-Diffusus
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:06.980Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sutera-diffusus-dsh-windows-notify`
- Submission type: community curation
- Created by `Sutera-Diffusus` — https://github.com/Sutera-Diffusus
- Original source repository: https://github.com/Sutera-Diffusus/dsh-windows-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.