### PR TITLE
catalog: add tang-mm95-dsh-single-instance-guard (community curation, created by @Tang-mm95)

### DIFF
--- a/catalog/plugins/tang-mm95-dsh-single-instance-guard.yaml
+++ b/catalog/plugins/tang-mm95-dsh-single-instance-guard.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: tang-mm95-dsh-single-instance-guard
+name: dsh-single-instance-guard
+description:
+  en: "DSH HOME single-instance lock plugin: aborts startup loudly when another dsh server already uses the same data directory, preventing concurrent session-log writes (the 'seq gap in committed region' corruption class)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - single-instance
+  - lock
+source:
+  repository: https://github.com/Tang-mm95/dsh-single-instance-guard
+  repositoryNodeId: R_kgDOT6hdRQ
+  subpath: null
+  commit: 666bad9ddedeb21d496ba96368bdbeb9d1752704
+creator:
+  github: Tang-mm95
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:31.205Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tang-mm95-dsh-single-instance-guard`
- Submission type: community curation
- Created by `Tang-mm95` — https://github.com/Tang-mm95
- Original source repository: https://github.com/Tang-mm95/dsh-single-instance-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.