### PR TITLE
catalog: add timwhitez-candidate-baseline (community curation, created by @timwhitez)

### DIFF
--- a/catalog/plugins/timwhitez-candidate-baseline.yaml
+++ b/catalog/plugins/timwhitez-candidate-baseline.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: timwhitez-candidate-baseline
+name: "@dsh-self-evolving/candidate-baseline"
+description:
+  en: Stable baseline parent candidate. Namespace-form DSH bundle; loaded through the real Cordis Loader in Gate 0. Not a profile, not a generated candidate.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - stable
+  - baseline
+  - parent
+  - candidate
+  - namespace
+  - form
+  - bundle
+  - loaded
+  - through
+  - real
+  - cordis
+  - loader
+  - gate
+  - profile
+  - generated
+  - dsh
+source:
+  repository: https://github.com/timwhitez/dsh-self-evolving
+  repositoryNodeId: R_kgDOT5BH8A
+  subpath: packages/candidate-baseline
+  commit: 4eb3bb4058dce4330ecbfc2b96e9c2bdabb71677
+creator:
+  github: timwhitez
+package:
+  ecosystem: npm
+  name: "@dsh-self-evolving/candidate-baseline"
+  version: 0.2.0
+  integrity: sha512-o51swT/PuIJXRVU86nbxvDHUxCJIDREIGsZ59CTc5hmkSG1JJA+vn44eJe0jTMlRiv3PRzb7u/HTB4jmkIDJEw==
+dsh:
+  profiles:
+    - headless
+  evidencePath: packages/candidate-baseline/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:34.311Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `timwhitez-candidate-baseline`
- Submission type: community curation
- Created by `timwhitez` — https://github.com/timwhitez
- Original source repository: https://github.com/timwhitez/dsh-self-evolving
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.