### PR TITLE
catalog: add timwhitez-core (community curation, created by @timwhitez)

### DIFF
--- a/catalog/plugins/timwhitez-core.yaml
+++ b/catalog/plugins/timwhitez-core.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: timwhitez-core
+name: "@dsh-self-evolving/core"
+description:
+  en: "Trusted durable RSI controller: content-addressed object store, hash-chain journal, pure state reducer + snapshot, action saga, budget double-entry ledger. Crash-safe by construction; the filesystem is the source of truth (spec 06)."
+  evidencePath: packages/dsh-self-evolving/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - bundle
+  - self-evolving
+  - rsi
+  - controller
+  - journal
+source:
+  repository: https://github.com/timwhitez/dsh-self-evolving
+  repositoryNodeId: R_kgDOT5BH8A
+  subpath: packages/dsh-self-evolving
+  commit: 4eb3bb4058dce4330ecbfc2b96e9c2bdabb71677
+creator:
+  github: timwhitez
+package:
+  ecosystem: npm
+  name: "@dsh-self-evolving/core"
+  version: 0.2.3
+  integrity: sha512-FoOt/YVhpEZXCsQU/wfBk60IiBnwfn/TfKuHz9neKhFlmIbxQW2iJ7cPRa3hHkyZhkrJ+iQkp5VEYPRGIR/HOg==
+dsh:
+  profiles:
+    - headless
+  evidencePath: packages/dsh-self-evolving/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:34.311Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `timwhitez-core`
- Submission type: community curation
- Created by `timwhitez` — https://github.com/timwhitez
- Original source repository: https://github.com/timwhitez/dsh-self-evolving
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.