### PR TITLE
catalog: add tingyang266-dsh-logistics-tracker (community curation, created by @tingyang266)

### DIFF
--- a/catalog/plugins/tingyang266-dsh-logistics-tracker.yaml
+++ b/catalog/plugins/tingyang266-dsh-logistics-tracker.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: tingyang266-dsh-logistics-tracker
+name: dsh-logistics-tracker
+description:
+  en: 把密钥写进 $DSH HOME/.credentials.yaml （Windows 默认 C:\Users\<你 \.dsh\.credentials.yaml ）：
+  evidencePath: dsh-logistics-tracker/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - logistics
+  - express
+  - tracking
+  - kuaidi
+  - kuaidi100
+  - kdniao
+source:
+  repository: https://github.com/tingyang266/dsh-logistics-tracker
+  repositoryNodeId: R_kgDOT5IxNA
+  subpath: dsh-logistics-tracker
+  commit: 1d9157831ed63ebf5a10fac28c682484b128dd26
+creator:
+  github: tingyang266
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-logistics-tracker/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:39.260Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tingyang266-dsh-logistics-tracker`
- Submission type: community curation
- Created by `tingyang266` — https://github.com/tingyang266
- Original source repository: https://github.com/tingyang266/dsh-logistics-tracker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.