### PR TITLE
catalog: add tongailinc-dsh-mobile-access (community curation, created by @TongaiLinC)

### DIFF
--- a/catalog/plugins/tongailinc-dsh-mobile-access.yaml
+++ b/catalog/plugins/tongailinc-dsh-mobile-access.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: tongailinc-dsh-mobile-access
+name: dsh-mobile-access
+description:
+  en: Mobile access plugin for DeepSeek Harness
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - mobile
+  - lan
+  - vpn
+  - tailscale
+  - zerotier
+  - gateway
+  - approval-gate
+source:
+  repository: https://github.com/TongaiLinC/dsh-mobile-access
+  repositoryNodeId: R_kgDOT5yGaw
+  subpath: null
+  commit: b2c8b3050443d401d97647f0f5d7bd5bc3bf771d
+creator:
+  github: TongaiLinC
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:41.148Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tongailinc-dsh-mobile-access`
- Submission type: community curation
- Created by `TongaiLinC` — https://github.com/TongaiLinC
- Original source repository: https://github.com/TongaiLinC/dsh-mobile-access
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.