### PR TITLE
catalog: add trungtaottn-dsh-file-pane (community curation, created by @trungtaottn)

### DIFF
--- a/catalog/plugins/trungtaottn-dsh-file-pane.yaml
+++ b/catalog/plugins/trungtaottn-dsh-file-pane.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: trungtaottn-dsh-file-pane
+name: dsh-file-pane
+description:
+  en: "Remote file viewer for DeepSeek Harness web: read agent-produced/edited files in a Codex/Warp-style pane, without downloading. Works when DSH is hosted on a homelab/server and you connect from another device."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - file-viewer
+  - remote
+  - web-ui
+  - pane
+source:
+  repository: https://github.com/trungtaottn/dsh-file-pane
+  repositoryNodeId: R_kgDOT5-Dgg
+  subpath: null
+  commit: f6e211f71e8ddad8cfe8ddf3a738b8831d6310cb
+creator:
+  github: trungtaottn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:08.770Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `trungtaottn-dsh-file-pane`
- Submission type: community curation
- Created by `trungtaottn` — https://github.com/trungtaottn
- Original source repository: https://github.com/trungtaottn/dsh-file-pane
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.