### PR TITLE
catalog: add uigdwunm-dsh-process-fold (community curation, created by @uigdwunm)

### DIFF
--- a/catalog/plugins/uigdwunm-dsh-process-fold.yaml
+++ b/catalog/plugins/uigdwunm-dsh-process-fold.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: uigdwunm-dsh-process-fold
+name: dsh-process-fold
+description:
+  en: Fold DSH Web execution steps into compact expandable process boxes while keeping dialogue and final answers outside.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - conversation-ui
+  - process-fold
+source:
+  repository: https://github.com/uigdwunm/dsh-process-fold
+  repositoryNodeId: R_kgDOT64m6g
+  subpath: null
+  commit: 786e786f110bf93d772f6252d88177c4e3624ab2
+creator:
+  github: uigdwunm
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:49.455Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uigdwunm-dsh-process-fold`
- Submission type: community curation
- Created by `uigdwunm` — https://github.com/uigdwunm
- Original source repository: https://github.com/uigdwunm/dsh-process-fold
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.