### PR TITLE
catalog: add viger1-dsh-pilot (community curation, created by @Viger1)

### DIFF
--- a/catalog/plugins/viger1-dsh-pilot.yaml
+++ b/catalog/plugins/viger1-dsh-pilot.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: viger1-dsh-pilot
+name: dsh-pilot
+description:
+  en: Hands for your DeepSeek Harness agent — autonomous browser operation with a native permission model. Accessibility-ref page snapshots let a text-only model navigate, act, and test without vision or CSS-selector guessing.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - browser
+  - automation
+  - playwright
+  - accessibility
+  - agent
+source:
+  repository: https://github.com/Viger1/dsh-pilot
+  repositoryNodeId: R_kgDOT6Feyg
+  subpath: null
+  commit: 65340d67a4de840205b9e8d00debed3180e87ad8
+creator:
+  github: Viger1
+package:
+  ecosystem: npm
+  name: dsh-pilot
+  version: 0.1.1
+  integrity: sha512-hmNIxdV9Ct/VcUJgr3Z6/mlNmUDVQji9lhU/CTJdxSNJ4M27pw29BoxS6tfVHhiB2cTZNLgdgGfSPOoIpD2UcA==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:54.225Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `viger1-dsh-pilot`
- Submission type: community curation
- Created by `Viger1` — https://github.com/Viger1
- Original source repository: https://github.com/Viger1/dsh-pilot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.