### PR TITLE
catalog: add vladimir-human-humanizer-ru-dsh (community curation, created by @Vladimir-Human)

### DIFF
--- a/catalog/plugins/vladimir-human-humanizer-ru-dsh.yaml
+++ b/catalog/plugins/vladimir-human-humanizer-ru-dsh.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: vladimir-human-humanizer-ru-dsh
+name: humanizer-ru-dsh
+description:
+  en: "An agent skill that finds and removes traces of machine generation from Russian-language text. It rewrites AI-sounding prose into human prose without distorting the meaning, and it leaves live human writing alone: a false positive costs more than a miss."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - agent
+  - skill
+  - finds
+  - removes
+  - traces
+  - machine
+  - generation
+  - russian
+  - language
+  - text
+  - rewrites
+  - sounding
+  - prose
+  - human
+  - without
+  - distorting
+source:
+  repository: https://github.com/Vladimir-Human/humanizer-ru
+  repositoryNodeId: R_kgDOQ-W4Ug
+  subpath: dsh
+  commit: e5f4eba5d0c5e5e1bdc59c5aec23fa69d1b401ea
+creator:
+  github: Vladimir-Human
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:57.231Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vladimir-human-humanizer-ru-dsh`
- Submission type: community curation
- Created by `Vladimir-Human` — https://github.com/Vladimir-Human
- Original source repository: https://github.com/Vladimir-Human/humanizer-ru
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.