### PR TITLE
catalog: add wanbinyu-dsh-billing-community-bundle (community curation, created by @Wanbinyu)

### DIFF
--- a/catalog/plugins/wanbinyu-dsh-billing-community-bundle.yaml
+++ b/catalog/plugins/wanbinyu-dsh-billing-community-bundle.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wanbinyu-dsh-billing-community-bundle
+name: dsh-billing-community-bundle
+description:
+  en: Installable DeepSeek Harness bundle for the dsh-billing host projection and client UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - installable
+  - bundle
+  - billing
+  - host
+  - projection
+  - client
+  - dsh
+source:
+  repository: https://github.com/Wanbinyu/dsh-billing
+  repositoryNodeId: R_kgDOT37M3g
+  subpath: null
+  commit: 07419e3141fae1def451f3ac7f2a13b27b617459
+creator:
+  github: Wanbinyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:48.115Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanbinyu-dsh-billing-community-bundle`
- Submission type: community curation
- Created by `Wanbinyu` — https://github.com/Wanbinyu
- Original source repository: https://github.com/Wanbinyu/dsh-billing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.