### PR TITLE
catalog: add wanbinyu-dsh-plugin-git-inspect (community curation, created by @Wanbinyu)

### DIFF
--- a/catalog/plugins/wanbinyu-dsh-plugin-git-inspect.yaml
+++ b/catalog/plugins/wanbinyu-dsh-plugin-git-inspect.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: wanbinyu-dsh-plugin-git-inspect
+name: dsh-plugin-git-inspect
+description:
+  en: Read-only Git inspection tools for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - git
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/Wanbinyu/dsh-plugin-git-inspect
+  repositoryNodeId: R_kgDOT37G4Q
+  subpath: null
+  commit: 1c14f3cae436e0ec94c68bf34fe16416daeba968
+creator:
+  github: Wanbinyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:10.520Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanbinyu-dsh-plugin-git-inspect`
- Submission type: community curation
- Created by `Wanbinyu` — https://github.com/Wanbinyu
- Original source repository: https://github.com/Wanbinyu/dsh-plugin-git-inspect
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.