### PR TITLE
catalog: add wanghao9610-omdsh-codemode (community curation, created by @wanghao9610)

### DIFF
--- a/catalog/plugins/wanghao9610-omdsh-codemode.yaml
+++ b/catalog/plugins/wanghao9610-omdsh-codemode.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: wanghao9610-omdsh-codemode
+name: "@omdsh-plugins/omdsh-codemode"
+description:
+  en: "Code mode for the DeepSeek Harness web GUI: a third segment beside Chat and Work whose column is the harness's own terminal, running in the conversation's workspace"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - code
+  - mode
+  - third
+  - segment
+  - beside
+  - chat
+  - work
+  - whose
+  - column
+  - terminal
+  - running
+  - conversation
+  - workspace
+  - dsh
+source:
+  repository: https://github.com/omdsh-plugins/omdsh-codemode
+  repositoryNodeId: R_kgDOT5upQQ
+  subpath: null
+  commit: 85f462cd472bae47a6836bd99085016368d44abf
+creator:
+  github: wanghao9610
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:36.377Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanghao9610-omdsh-codemode`
- Submission type: community curation
- Created by `wanghao9610` — https://github.com/wanghao9610
- Original source repository: https://github.com/omdsh-plugins/omdsh-codemode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.