### PR TITLE
catalog: add wanghao9610-omdsh-editor (community curation, created by @wanghao9610)

### DIFF
--- a/catalog/plugins/wanghao9610-omdsh-editor.yaml
+++ b/catalog/plugins/wanghao9610-omdsh-editor.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: wanghao9610-omdsh-editor
+name: "@omdsh-plugins/omdsh-editor"
+description:
+  en: "Open the current project directory in a native editor from the DeepSeek Harness web GUI: the session header's editor picker, and the host half that finds the installed editors and launches one"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - open
+  - current
+  - directory
+  - native
+  - editor
+  - session
+  - header
+  - picker
+  - host
+  - half
+  - finds
+  - installed
+  - editors
+  - launches
+  - dsh
+source:
+  repository: https://github.com/omdsh-plugins/omdsh-editor
+  repositoryNodeId: R_kgDOT5uomw
+  subpath: null
+  commit: ca9fcb6347b2b1cdb1e2e60da43ca3c7149550ab
+creator:
+  github: wanghao9610
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:37.906Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanghao9610-omdsh-editor`
- Submission type: community curation
- Created by `wanghao9610` — https://github.com/wanghao9610
- Original source repository: https://github.com/omdsh-plugins/omdsh-editor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.