### PR TITLE
catalog: add wanghao9610-omdsh-plughub (community curation, created by @wanghao9610)

### DIFF
--- a/catalog/plugins/wanghao9610-omdsh-plughub.yaml
+++ b/catalog/plugins/wanghao9610-omdsh-plughub.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wanghao9610-omdsh-plughub
+name: "@omdsh-plugins/omdsh-plughub"
+description:
+  en: "The omdsh plugin hub: a Settings tab that installs, disables and configures omdsh plugins from a configurable upstream, from the settings schema each already registers"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - omdsh
+  - settings
+  - installs
+  - disables
+  - configures
+  - configurable
+  - upstream
+  - schema
+  - each
+  - already
+  - registers
+  - dsh
+source:
+  repository: https://github.com/omdsh-plugins/omdsh-plughub
+  repositoryNodeId: R_kgDOT5uoEA
+  subpath: null
+  commit: 0cbed4f9e98ee3c3b62186612d3f717ba5d56e06
+creator:
+  github: wanghao9610
+package:
+  ecosystem: npm
+  name: "@omdsh-plugins/omdsh-plughub"
+  version: 0.2.4
+  integrity: sha512-HHwjG2YptdHIX3ZBfE2Osj8YmMgw3EUMTcQcwE6zVp9aKm3Y1VW6joxD6GMqJxqsxgTYBSiiGCzmycSS7+TTvw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:39.370Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanghao9610-omdsh-plughub`
- Submission type: community curation
- Created by `wanghao9610` — https://github.com/wanghao9610
- Original source repository: https://github.com/omdsh-plugins/omdsh-plughub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.