### PR TITLE
catalog: add wanghao9610-omdsh-remctrl (community curation, created by @wanghao9610)

### DIFF
--- a/catalog/plugins/wanghao9610-omdsh-remctrl.yaml
+++ b/catalog/plugins/wanghao9610-omdsh-remctrl.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wanghao9610-omdsh-remctrl
+name: "@omdsh-plugins/omdsh-remctrl"
+description:
+  en: "Remote control for the DeepSeek Harness: puts its own interface on a public address behind a passcode, over a cloudflared tunnel by default, so the window you reach from a phone is the window you left open"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - remote
+  - control
+  - puts
+  - interface
+  - public
+  - address
+  - behind
+  - passcode
+  - over
+  - cloudflared
+  - tunnel
+  - default
+  - window
+  - reach
+  - phone
+  - left
+source:
+  repository: https://github.com/omdsh-plugins/omdsh-remctrl
+  repositoryNodeId: R_kgDOT5uqYA
+  subpath: null
+  commit: 2db97e0cb228b0ee84c7601074e48ebbc168096b
+creator:
+  github: wanghao9610
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:40.939Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanghao9610-omdsh-remctrl`
- Submission type: community curation
- Created by `wanghao9610` — https://github.com/wanghao9610
- Original source repository: https://github.com/omdsh-plugins/omdsh-remctrl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.