### PR TITLE
catalog: add wanghao9610-omdsh-remdev (community curation, created by @wanghao9610)

### DIFF
--- a/catalog/plugins/wanghao9610-omdsh-remdev.yaml
+++ b/catalog/plugins/wanghao9610-omdsh-remdev.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wanghao9610-omdsh-remdev
+name: "@omdsh-plugins/omdsh-remdev"
+description:
+  en: "Remote development for the DeepSeek Harness web GUI: connect a workspace to an SSH server, provision a .dsh-server there, run its files, terminals, conversations and agents on that machine — Work mode included, as the harness running there shown here"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - remote
+  - development
+  - connect
+  - workspace
+  - server
+  - provision
+  - files
+  - terminals
+  - conversations
+  - agents
+  - machine
+  - work
+  - mode
+  - included
+  - running
+  - shown
+source:
+  repository: https://github.com/omdsh-plugins/omdsh-remdev
+  repositoryNodeId: R_kgDOT5uqGQ
+  subpath: null
+  commit: 6f8d0f3777689c008f06f92f30b6b3e2dca32f46
+creator:
+  github: wanghao9610
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:42.658Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanghao9610-omdsh-remdev`
- Submission type: community curation
- Created by `wanghao9610` — https://github.com/wanghao9610
- Original source repository: https://github.com/omdsh-plugins/omdsh-remdev
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.