### PR TITLE
catalog: add wanghao9610-omdsh-shortcuts (community curation, created by @wanghao9610)

### DIFF
--- a/catalog/plugins/wanghao9610-omdsh-shortcuts.yaml
+++ b/catalog/plugins/wanghao9610-omdsh-shortcuts.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wanghao9610-omdsh-shortcuts
+name: "@omdsh-plugins/omdsh-shortcuts"
+description:
+  en: "Bind a chord to anything the harness can do: a menu the desktop shell renders natively, a switchboard the runtime dispatches through, and an in-page listener for the web — one document, two surfaces"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - bind
+  - chord
+  - anything
+  - menu
+  - desktop
+  - shell
+  - renders
+  - natively
+  - switchboard
+  - runtime
+  - dispatches
+  - through
+  - page
+  - listener
+  - document
+  - surfaces
+source:
+  repository: https://github.com/omdsh-plugins/omdsh-shortcuts
+  repositoryNodeId: R_kgDOT5uoNg
+  subpath: null
+  commit: e59753c0d960f0ca7032399dd49ee644e00476ae
+creator:
+  github: wanghao9610
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:26:44.225Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanghao9610-omdsh-shortcuts`
- Submission type: community curation
- Created by `wanghao9610` — https://github.com/wanghao9610
- Original source repository: https://github.com/omdsh-plugins/omdsh-shortcuts
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.