### PR TITLE
catalog: add wangxing-git-dsh-autogate (community curation, created by @wangxing-git)

### DIFF
--- a/catalog/plugins/wangxing-git-dsh-autogate.yaml
+++ b/catalog/plugins/wangxing-git-dsh-autogate.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: wangxing-git-dsh-autogate
+name: dsh-autogate
+description:
+  en: "Languages: 简体中文 · English (this page)"
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - auto
+  - approval
+  - permission
+  - security
+source:
+  repository: https://github.com/wangxing-git/dsh-autogate
+  repositoryNodeId: R_kgDOT5aMgQ
+  subpath: null
+  commit: 22c2914d7b787e2a257072d9573855f09ef30250
+creator:
+  github: wangxing-git
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:11.986Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wangxing-git-dsh-autogate`
- Submission type: community curation
- Created by `wangxing-git` — https://github.com/wangxing-git
- Original source repository: https://github.com/wangxing-git/dsh-autogate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.