### PR TITLE
catalog: add wanshichenguang-dsh-tool-vision (community curation, created by @wanshichenguang)

### DIFF
--- a/catalog/plugins/wanshichenguang-dsh-tool-vision.yaml
+++ b/catalog/plugins/wanshichenguang-dsh-tool-vision.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wanshichenguang-dsh-tool-vision
+name: dsh-tool-vision
+description:
+  en: "DeepSeek Harness plugin: model-facing image describe (识图) tool over the DashScope OpenAI-compatible API (qwen3.7-flash), plus a paste bridge that turns pasted images into file paths on text-only sessions and renders them back in the transcript. Bring your own DASHSCOPE API KEY."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - vision
+  - qwen
+  - dashscope
+  - image
+  - paste
+source:
+  repository: https://github.com/wanshichenguang/dsh-tool-vision
+  repositoryNodeId: R_kgDOT6B01Q
+  subpath: null
+  commit: bb8f60f67285a6293615d3c75c413ed797620e5e
+creator:
+  github: wanshichenguang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:13.717Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanshichenguang-dsh-tool-vision`
- Submission type: community curation
- Created by `wanshichenguang` — https://github.com/wanshichenguang
- Original source repository: https://github.com/wanshichenguang/dsh-tool-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.