### PR TITLE
catalog: add waynejin0918-dsh-wm (community curation, created by @WayneJin0918)

### DIFF
--- a/catalog/plugins/waynejin0918-dsh-wm.yaml
+++ b/catalog/plugins/waynejin0918-dsh-wm.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: waynejin0918-dsh-wm
+name: dsh-wm
+description:
+  en: "Playable world-model toolkit for DeepSeek Harness: look at frames, compare pred vs GT, watch the action track, name the 3D / pixel / latent route, and RSI the research loop."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - world-model
+  - knowledge
+  - rsi
+  - research
+  - ssim
+  - rollout
+  - pixel
+  - latent
+  - 3d
+  - video-generation
+source:
+  repository: https://github.com/WayneJin0918/dsh-wm
+  repositoryNodeId: R_kgDOT6n8nA
+  subpath: null
+  commit: cd06866a638b1dcc80defa6d674ff3470ff0ad31
+creator:
+  github: WayneJin0918
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:30.898Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `waynejin0918-dsh-wm`
- Submission type: community curation
- Created by `WayneJin0918` — https://github.com/WayneJin0918
- Original source repository: https://github.com/WayneJin0918/dsh-wm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.