### PR TITLE
catalog: add weike-zhang-dsh-svg-motion (community curation, created by @weike-zhang)

### DIFF
--- a/catalog/plugins/weike-zhang-dsh-svg-motion.yaml
+++ b/catalog/plugins/weike-zhang-dsh-svg-motion.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: weike-zhang-dsh-svg-motion
+name: dsh-svg-motion
+description:
+  en: "Animate any SVG into a professional assembly video (transparent PNG sequence + MP4). dsh plugin: registers an animate svg tool the model can call."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - animate
+  - professional
+  - assembly
+  - video
+  - transparent
+  - sequence
+  - registers
+  - tool
+  - model
+  - call
+  - dsh
+source:
+  repository: https://github.com/weike-zhang/dsh-svg-motion
+  repositoryNodeId: R_kgDOT51-fw
+  subpath: null
+  commit: 6c5d2a662ae0971dc50b81022b13a1ea4dc44097
+creator:
+  github: weike-zhang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:27:58.687Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `weike-zhang-dsh-svg-motion`
- Submission type: community curation
- Created by `weike-zhang` — https://github.com/weike-zhang
- Original source repository: https://github.com/weike-zhang/dsh-svg-motion
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.