### PR TITLE
catalog: add wenhongpan-dsh-projects (community curation, created by @WenhongPan)

### DIFF
--- a/catalog/plugins/wenhongpan-dsh-projects.yaml
+++ b/catalog/plugins/wenhongpan-dsh-projects.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wenhongpan-dsh-projects
+name: dsh-projects
+description:
+  en: Project and session management, searchable sessions, native folder picking, and sidebar organization for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - projects
+  - sessions
+  - sidebar
+  - native-picker
+  - workspace
+source:
+  repository: https://github.com/WenhongPan/dsh-projects
+  repositoryNodeId: R_kgDOT6XZ-w
+  subpath: null
+  commit: 01033952e2ba30ff141371a133c368a8a80fe16d
+creator:
+  github: WenhongPan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:15.437Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wenhongpan-dsh-projects`
- Submission type: community curation
- Created by `WenhongPan` — https://github.com/WenhongPan
- Original source repository: https://github.com/WenhongPan/dsh-projects
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.