### PR TITLE
catalog: add why-daydream-dsh-chaos (community curation, created by @WHY-Daydream)

### DIFF
--- a/catalog/plugins/why-daydream-dsh-chaos.yaml
+++ b/catalog/plugins/why-daydream-dsh-chaos.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: why-daydream-dsh-chaos
+name: "@why-daydream/dsh-chaos"
+description:
+  en: "Fault injection and chaos engineering plugin for DeepSeek Harness: inject latency, timeouts, HTTP errors, malformed/dropped tool results, and LLM provider failures"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - fault
+  - injection
+  - chaos
+  - engineering
+  - inject
+  - latency
+  - timeouts
+  - errors
+  - malformed
+  - dropped
+  - tool
+  - results
+  - provider
+  - failures
+  - dsh
+source:
+  repository: https://github.com/WHY-Daydream/dsh-chaos
+  repositoryNodeId: R_kgDOT59RUQ
+  subpath: null
+  commit: c627991d6000fa70f66cc78917921c4d4af7b9fd
+creator:
+  github: WHY-Daydream
+package:
+  ecosystem: npm
+  name: "@why-daydream/dsh-chaos"
+  version: 0.1.0
+  integrity: sha512-uL5yBD/e2qxRDd3pZJlTwus1nR8ziafl9r6L378VYf9LukrEa4v9ydzAH6LDYAHtfWJfDZpoFOqUDXU0TpGULA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:00.213Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `why-daydream-dsh-chaos`
- Submission type: community curation
- Created by `WHY-Daydream` — https://github.com/WHY-Daydream
- Original source repository: https://github.com/WHY-Daydream/dsh-chaos
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.