### PR TITLE
catalog: add why-daydream-dsh-tool-transaction (community curation, created by @WHY-Daydream)

### DIFF
--- a/catalog/plugins/why-daydream-dsh-tool-transaction.yaml
+++ b/catalog/plugins/why-daydream-dsh-tool-transaction.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: why-daydream-dsh-tool-transaction
+name: "@why-daydream/dsh-tool-transaction"
+description:
+  en: "Saga-style compensating transactions for DeepSeek Harness: transactional tool/step execution with reverse-order compensation"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - saga
+  - style
+  - compensating
+  - transactions
+  - transactional
+  - tool
+  - step
+  - execution
+  - reverse
+  - order
+  - compensation
+  - dsh
+source:
+  repository: https://github.com/WHY-Daydream/dsh-tool-transaction
+  repositoryNodeId: R_kgDOT6ANcw
+  subpath: null
+  commit: 3cb93915ad077bb144d176ca210e13033dda77b2
+creator:
+  github: WHY-Daydream
+package:
+  ecosystem: npm
+  name: "@why-daydream/dsh-tool-transaction"
+  version: 0.1.0
+  integrity: sha512-nQpn6giWzs3zIypPhYHcWxGk3uZ0PSjswPBJcjZMsnhP+dvU7CXUlH+P7VRGrwFyhgGoAggU3ASKxKh4F4R8bA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:01.874Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `why-daydream-dsh-tool-transaction`
- Submission type: community curation
- Created by `WHY-Daydream` — https://github.com/WHY-Daydream
- Original source repository: https://github.com/WHY-Daydream/dsh-tool-transaction
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.