### PR TITLE
catalog: add williamshi666-dsh-wsl-workspace-picker (community curation, created by @WilliamShi666)

### DIFF
--- a/catalog/plugins/williamshi666-dsh-wsl-workspace-picker.yaml
+++ b/catalog/plugins/williamshi666-dsh-wsl-workspace-picker.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: williamshi666-dsh-wsl-workspace-picker
+name: dsh-wsl-workspace-picker
+description:
+  en: "Enhanced workspace directory browser for the dsh web UI: quick access to /mnt Windows drives, full breadcrumb ancestry from the filesystem root, and an always-visible path input."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - wsl
+  - workspace
+  - directory-picker
+  - web-ui
+source:
+  repository: https://github.com/WilliamShi666/dsh-wsl-workspace-picker
+  repositoryNodeId: R_kgDOT60ImA
+  subpath: null
+  commit: ff742be2e1dfc25f3ae7fa5f3758b43a1431cdf2
+creator:
+  github: WilliamShi666
+package:
+  ecosystem: npm
+  name: dsh-wsl-workspace-picker
+  version: 0.1.1
+  integrity: sha512-tbQleF9v3z6c1sQb9ybUFKtNsR+o/yWc6abiMhHTQSneUn69U0vLbgkR6GWB4tkcqhwg/WxrM68Q7pp7dYITTA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:03.278Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `williamshi666-dsh-wsl-workspace-picker`
- Submission type: community curation
- Created by `WilliamShi666` — https://github.com/WilliamShi666
- Original source repository: https://github.com/WilliamShi666/dsh-wsl-workspace-picker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.