### PR TITLE
catalog: add wly10-knowlp-dsh (community curation, created by @wly10)

### DIFF
--- a/catalog/plugins/wly10-knowlp-dsh.yaml
+++ b/catalog/plugins/wly10-knowlp-dsh.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wly10-knowlp-dsh
+name: "@eqman00003/knowlp-dsh"
+description:
+  en: bash pip install -e ".[mcp]" → python -m knowlp search / auto feedback 可用
+  evidencePath: packages/dsh-native/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - bash
+  - install
+  - python
+  - knowlp
+  - search
+  - auto
+  - feedback
+  - dsh
+source:
+  repository: https://github.com/wly8691-jpg/knowlp-rag
+  repositoryNodeId: R_kgDOTP1rJw
+  subpath: packages/dsh-native
+  commit: a7a4cf712b49ae4a41353c9226b4854d4c8393c2
+creator:
+  github: wly10
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-native/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:32.404Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wly10-knowlp-dsh`
- Submission type: community curation
- Created by `wly10` — https://github.com/wly10
- Original source repository: https://github.com/wly8691-jpg/knowlp-rag
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.