### PR TITLE
catalog: add wsxwj123-dsh-composer-tools (community curation, created by @wsxwj123)

### DIFF
--- a/catalog/plugins/wsxwj123-dsh-composer-tools.yaml
+++ b/catalog/plugins/wsxwj123-dsh-composer-tools.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wsxwj123-dsh-composer-tools
+name: dsh-composer-tools
+description:
+  en: "DSH web plugin: arrow-key input history (session-scoped, draft-preserving) + instructions viewer/editor (global & project AGENTS.md/CLAUDE.md) + prompt library (Cherry Studio agents-zh, AGPL-3.0, append-to-input)."
+  evidencePath: packages/dsh-composer-tools/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - arrow
+  - input
+  - history
+  - session
+  - scoped
+  - draft
+  - preserving
+  - instructions
+  - viewer
+  - editor
+  - global
+  - agents
+  - claude
+  - prompt
+  - library
+  - cherry
+source:
+  repository: https://github.com/wsxwj123/dsh-plugins
+  repositoryNodeId: R_kgDOT3-OnA
+  subpath: packages/dsh-composer-tools
+  commit: 269acbc87df039a2aba9cc405dea488fbfceb414
+creator:
+  github: wsxwj123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-composer-tools/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:06.339Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wsxwj123-dsh-composer-tools`
- Submission type: community curation
- Created by `wsxwj123` — https://github.com/wsxwj123
- Original source repository: https://github.com/wsxwj123/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.