### PR TITLE
catalog: add wsxwj123-dsh-pet-bridge (community curation, created by @wsxwj123)

### DIFF
--- a/catalog/plugins/wsxwj123-dsh-pet-bridge.yaml
+++ b/catalog/plugins/wsxwj123-dsh-pet-bridge.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: wsxwj123-dsh-pet-bridge
+name: dsh-pet-bridge
+description:
+  en: "DSH server plugin: push dsh session status to the cc-pet desktop pet bubble in real time."
+  evidencePath: packages/dsh-pet-bridge/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - server
+  - push
+  - session
+  - status
+  - desktop
+  - bubble
+  - real
+  - time
+  - dsh
+source:
+  repository: https://github.com/wsxwj123/dsh-plugins
+  repositoryNodeId: R_kgDOT3-OnA
+  subpath: packages/dsh-pet-bridge
+  commit: 269acbc87df039a2aba9cc405dea488fbfceb414
+creator:
+  github: wsxwj123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: packages/dsh-pet-bridge/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:06.339Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wsxwj123-dsh-pet-bridge`
- Submission type: community curation
- Created by `wsxwj123` — https://github.com/wsxwj123
- Original source repository: https://github.com/wsxwj123/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.