### PR TITLE
catalog: add wuxiangru915-dsh-session-manager (community curation, created by @wuxiangru915)

### DIFF
--- a/catalog/plugins/wuxiangru915-dsh-session-manager.yaml
+++ b/catalog/plugins/wuxiangru915-dsh-session-manager.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: wuxiangru915-dsh-session-manager
+name: "@dshwp/dsh-session-manager"
+description:
+  en: Session manager for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - session-management
+  - archived-sessions
+source:
+  repository: https://github.com/wuxiangru915/dsh-session-manager
+  repositoryNodeId: R_kgDOT5ctXQ
+  subpath: null
+  commit: 2050471867d6e6e8c6cb81b2e99e00318d31056c
+creator:
+  github: wuxiangru915
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:16.188Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wuxiangru915-dsh-session-manager`
- Submission type: community curation
- Created by `wuxiangru915` — https://github.com/wuxiangru915
- Original source repository: https://github.com/wuxiangru915/dsh-session-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.