### PR TITLE
catalog: add wwumit-dsh-compliancehub (community curation, created by @wwumit)

### DIFF
--- a/catalog/plugins/wwumit-dsh-compliancehub.yaml
+++ b/catalog/plugins/wwumit-dsh-compliancehub.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: wwumit-dsh-compliancehub
+name: "@wwumit/dsh-compliancehub"
+description:
+  en: "Compliance skill hub provider for DeepSeek Harness: install cross-border compliance skills (CCPA/GDPR/COPPA/HIPAA x check/guard/compliance, 9 skills) from a line-level JSON catalog via ctx.skills (list/get), with DISCLOSURE v0.2 open-data-layer disclosure."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-skills
+  - skills
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/wwumit/dsh-compliancehub
+  repositoryNodeId: R_kgDOT526Eg
+  subpath: null
+  commit: 8dee3ea589021f3cbd80277a081b73c5255c8505
+creator:
+  github: wwumit
+package:
+  ecosystem: npm
+  name: "@wwumit/dsh-compliancehub"
+  version: 1.1.1
+  integrity: sha512-+TFdaEmPmHyb7KaxPVhAp+AGIyPVpUAMGEY7CtnDpDfyYiu09+jle7LNq/tDxwoKWNbRfOUHzPJykI71BOhoXg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:17.607Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wwumit-dsh-compliancehub`
- Submission type: community curation
- Created by `wwumit` — https://github.com/wwumit
- Original source repository: https://github.com/wwumit/dsh-compliancehub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.