### PR TITLE
catalog: add xiaohj233-dsh-sandbox-schema-shim (community curation, created by @xiaohj233)

### DIFF
--- a/catalog/plugins/xiaohj233-dsh-sandbox-schema-shim.yaml
+++ b/catalog/plugins/xiaohj233-dsh-sandbox-schema-shim.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: xiaohj233-dsh-sandbox-schema-shim
+name: dsh-sandbox-schema-shim
+description:
+  en: Compatibility shim that removes redundant sandbox escalation fields from model-facing shell and file tool schemas only in danger-full-access sessions.
+  evidencePath: packages/sandbox-schema-shim/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - compatibility
+  - shim
+  - removes
+  - redundant
+  - sandbox
+  - escalation
+  - fields
+  - model
+  - facing
+  - shell
+  - file
+  - tool
+  - schemas
+  - only
+  - danger
+  - full
+source:
+  repository: https://github.com/xiaohj233/dsh-compat-shims
+  repositoryNodeId: R_kgDOT4ZsWw
+  subpath: packages/sandbox-schema-shim
+  commit: ba4088c1a7b77b1c73fd5d5438f46800720d6bcd
+creator:
+  github: xiaohj233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/sandbox-schema-shim/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:20.803Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaohj233-dsh-sandbox-schema-shim`
- Submission type: community curation
- Created by `xiaohj233` — https://github.com/xiaohj233
- Original source repository: https://github.com/xiaohj233/dsh-compat-shims
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.