### PR TITLE
catalog: add ximengxiaolan-dsh-vision-bridge (community curation, created by @ximengxiaolan)

### DIFF
--- a/catalog/plugins/ximengxiaolan-dsh-vision-bridge.yaml
+++ b/catalog/plugins/ximengxiaolan-dsh-vision-bridge.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: ximengxiaolan-dsh-vision-bridge
+name: dsh-vision-bridge
+description:
+  en: Composer-attached images are auto-described by an OpenAI-compatible vision model and handed to text-only models (DeepSeek) as text.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - composer
+  - attached
+  - images
+  - auto
+  - described
+  - openai
+  - compatible
+  - vision
+  - model
+  - handed
+  - text
+  - only
+  - models
+  - dsh
+source:
+  repository: https://github.com/ximengxiaolan/dsh-vision-bridge
+  repositoryNodeId: R_kgDOT4K4aA
+  subpath: null
+  commit: 55bbd9bfc5889b8dc8a01bdbb18dc814cf983357
+creator:
+  github: ximengxiaolan
+package:
+  ecosystem: npm
+  name: dsh-vision-bridge
+  version: 0.1.0
+  integrity: sha512-J1mcV5UN0fJiGUQwt/KG/MiuDh3+wwfIBmlfKsTTZDIypvEt9RpPn+g9qN3S+Ei9rjKSsdl+CEJB69Xmw/n1Fw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:34.363Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ximengxiaolan-dsh-vision-bridge`
- Submission type: community curation
- Created by `ximengxiaolan` — https://github.com/ximengxiaolan
- Original source repository: https://github.com/ximengxiaolan/dsh-vision-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.