### PR TITLE
catalog: add xinyuehtx-dsh-plugin-hooks-ordering (community curation, created by @xinyuehtx)

### DIFF
--- a/catalog/plugins/xinyuehtx-dsh-plugin-hooks-ordering.yaml
+++ b/catalog/plugins/xinyuehtx-dsh-plugin-hooks-ordering.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: xinyuehtx-dsh-plugin-hooks-ordering
+name: "@tengxiaohtx/dsh-plugin-hooks-ordering"
+description:
+  en: Deterministic before/after ordering for Cordis waterfall hooks, contributed across independent plugins
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - cordis
+  - hooks
+  - ordering
+  - waterfall
+  - deepseek-harness
+  - dsh
+  - topological-sort
+source:
+  repository: https://github.com/xinyuehtx/dsh-plugin-hooks-ordering
+  repositoryNodeId: R_kgDOT6xUFQ
+  subpath: null
+  commit: a56532dbf7662d8d93b7f1c5f0bf6e407fab4b8b
+creator:
+  github: xinyuehtx
+package:
+  ecosystem: npm
+  name: "@tengxiaohtx/dsh-plugin-hooks-ordering"
+  version: 0.2.0
+  integrity: sha512-PvKPL7NsA7m995PcLPQTWkO4pKj1FQUjDD5WyG40BavIW299RUBGG4rSYyDarKxjmNeY4imCCYLbuoAoP9ioGg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:17.142Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xinyuehtx-dsh-plugin-hooks-ordering`
- Submission type: community curation
- Created by `xinyuehtx` — https://github.com/xinyuehtx
- Original source repository: https://github.com/xinyuehtx/dsh-plugin-hooks-ordering
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.