### PR TITLE
catalog: add xu964262001-sudo-dsh-tool-diagnose (community curation, created by @xu964262001-sudo)

### DIFF
--- a/catalog/plugins/xu964262001-sudo-dsh-tool-diagnose.yaml
+++ b/catalog/plugins/xu964262001-sudo-dsh-tool-diagnose.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: xu964262001-sudo-dsh-tool-diagnose
+name: dsh-tool-diagnose
+description:
+  en: A DeepSeek Harness bundle plugin exposing a diagnose tool over an extensible ctx.diagnostics check registry.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - bundle
+  - exposing
+  - diagnose
+  - tool
+  - over
+  - extensible
+  - diagnostics
+  - check
+  - registry
+  - dsh
+source:
+  repository: https://github.com/xu-kai-quan/dsh-tool-diagnose
+  repositoryNodeId: R_kgDOT5uu3g
+  subpath: null
+  commit: 112df5167cb9c857e5f17d8f7f1ed232b279814f
+creator:
+  github: xu964262001-sudo
+package:
+  ecosystem: npm
+  name: dsh-tool-diagnose
+  version: 0.1.0
+  integrity: sha512-wT1x+FL/n9+OlwHPE1VUe45I76VB3LNT+RtGGZm4mlYZzFkWg11lkURo1dFx4rBCZnoSsf4bvihrb5elTzM50g==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:18.862Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xu964262001-sudo-dsh-tool-diagnose`
- Submission type: community curation
- Created by `xu964262001-sudo` — https://github.com/xu964262001-sudo
- Original source repository: https://github.com/xu-kai-quan/dsh-tool-diagnose
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.