### PR TITLE
catalog: add y2zyyr-debug-dsh-token-usage-sidebar (community curation, created by @y2zyyr-debug)

### DIFF
--- a/catalog/plugins/y2zyyr-debug-dsh-token-usage-sidebar.yaml
+++ b/catalog/plugins/y2zyyr-debug-dsh-token-usage-sidebar.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: y2zyyr-debug-dsh-token-usage-sidebar
+name: "@y2zyyr/dsh-token-usage-sidebar"
+description:
+  en: Persistent Token Usage insights for DeepSeek Harness, backed by a scalable durable SQLite ledger.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - token-usage
+source:
+  repository: https://github.com/y2zyyr/dsh-token-usage-sidebar
+  repositoryNodeId: R_kgDOT53ZAA
+  subpath: null
+  commit: bcebd95cc494a0fa6aa59a71ed6bc6f621557c82
+creator:
+  github: y2zyyr-debug
+package:
+  ecosystem: npm
+  name: "@y2zyyr/dsh-token-usage-sidebar"
+  version: 1.1.2
+  integrity: sha512-w5C2pslbmmdqyKP9x7EVYY72aqtzyp+NHj+w4AkOysFuQWSqFrrf2UvGogMHVQTDpXJIXw6BIQUzB4BBHkN4BA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:20.251Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `y2zyyr-debug-dsh-token-usage-sidebar`
- Submission type: community curation
- Created by `y2zyyr-debug` — https://github.com/y2zyyr-debug
- Original source repository: https://github.com/y2zyyr/dsh-token-usage-sidebar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.