### PR TITLE
catalog: add yinren112-dsh-plugin-connection-banner (community curation, created by @yinren112)

### DIFF
--- a/catalog/plugins/yinren112-dsh-plugin-connection-banner.yaml
+++ b/catalog/plugins/yinren112-dsh-plugin-connection-banner.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: yinren112-dsh-plugin-connection-banner
+name: dsh-plugin-connection-banner
+description:
+  en: Visible reconnecting banner for the DeepSeek Harness Web UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - connection
+  - web-ui
+  - dsh
+source:
+  repository: https://github.com/yinren112/dsh-plugin-connection-banner
+  repositoryNodeId: R_kgDOT4DTuQ
+  subpath: null
+  commit: 9be1394fa21ede8abe6e4f629bbf546bc6987a2d
+creator:
+  github: yinren112
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:26.954Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yinren112-dsh-plugin-connection-banner`
- Submission type: community curation
- Created by `yinren112` — https://github.com/yinren112
- Original source repository: https://github.com/yinren112/dsh-plugin-connection-banner
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.