### PR TITLE
catalog: add youkongling-dsh-plugin-gate (community curation, created by @youkongling)

### DIFF
--- a/catalog/plugins/youkongling-dsh-plugin-gate.yaml
+++ b/catalog/plugins/youkongling-dsh-plugin-gate.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: youkongling-dsh-plugin-gate
+name: dsh-plugin-gate
+description:
+  en: DSH plugin installation gate ported from Codex safe materialization and Claude Code marketplace validation/policy scanning
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - security
+  - supply-chain
+  - gate
+source:
+  repository: https://github.com/youkongling/dsh-plugin-gate
+  repositoryNodeId: R_kgDOT6Ehog
+  subpath: null
+  commit: ce061bb6466d8ed84fc8ac525475411c21ac9647
+creator:
+  github: youkongling
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:29.511Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `youkongling-dsh-plugin-gate`
- Submission type: community curation
- Created by `youkongling` — https://github.com/youkongling
- Original source repository: https://github.com/youkongling/dsh-plugin-gate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.