### PR TITLE
catalog: add yytbit-oh-my-deepseek-harness (community curation, created by @YYTbit)

### DIFF
--- a/catalog/plugins/yytbit-oh-my-deepseek-harness.yaml
+++ b/catalog/plugins/yytbit-oh-my-deepseek-harness.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: yytbit-oh-my-deepseek-harness
+name: oh-my-deepseek-harness
+description:
+  en: Multi-agent orchestration for DeepSeek Harness -- specialized agents, task orchestration, workflow skills
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - multi-agent
+  - orchestration
+  - autopilot
+  - oh-my
+  - dsh
+source:
+  repository: https://github.com/YYTbit/oh-my-deepseek-harness
+  repositoryNodeId: R_kgDOT4fwWA
+  subpath: null
+  commit: 1b2da9a3c3dd02475721e8fcdd5b44712e730201
+creator:
+  github: YYTbit
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:21:35.804Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yytbit-oh-my-deepseek-harness`
- Submission type: community curation
- Created by `YYTbit` — https://github.com/YYTbit
- Original source repository: https://github.com/YYTbit/oh-my-deepseek-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.