### PR TITLE
catalog: add zer0zio-stack-dsh-opencode-go-quota (community curation, created by @zer0zio-stack)

### DIFF
--- a/catalog/plugins/zer0zio-stack-dsh-opencode-go-quota.yaml
+++ b/catalog/plugins/zer0zio-stack-dsh-opencode-go-quota.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: zer0zio-stack-dsh-opencode-go-quota
+name: dsh-opencode-go-quota
+description:
+  en: "DeepSeek Harness web plugin: static 余额 badge that fetches the active provider's plan limit or prepaid balance on expand, with token usage and spend estimated from the DeepSeek pricing table."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - quota
+  - balance
+  - opencode
+source:
+  repository: https://github.com/zer0zio-stack/dsh-opencode-go-quota
+  repositoryNodeId: R_kgDOT5MQ3g
+  subpath: null
+  commit: 99b164636d0e3405d98673f11cbeff74bee938af
+creator:
+  github: zer0zio-stack
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:32.333Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zer0zio-stack-dsh-opencode-go-quota`
- Submission type: community curation
- Created by `zer0zio-stack` — https://github.com/zer0zio-stack
- Original source repository: https://github.com/zer0zio-stack/dsh-opencode-go-quota
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.