### PR TITLE
catalog: add zhaoolee-dsh-notes (community curation, created by @zhaoolee)

### DIFF
--- a/catalog/plugins/zhaoolee-dsh-notes.yaml
+++ b/catalog/plugins/zhaoolee-dsh-notes.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zhaoolee-dsh-notes
+name: "@zhaoolee/dsh-notes"
+description:
+  en: sh dsh plugin --profile web add @zhaoolee/dsh-notes
+  evidencePath: dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - smartisan
+  - notes
+  - markdown
+  - ai-agent
+source:
+  repository: https://github.com/zhaoolee/notes
+  repositoryNodeId: R_kgDORnX0QA
+  subpath: dsh-plugin
+  commit: 58dc452f12052a70b794d2c88b9e236620a7604a
+creator:
+  github: zhaoolee
+package:
+  ecosystem: npm
+  name: "@zhaoolee/dsh-notes"
+  version: 0.1.2
+  integrity: sha512-Ynl7mlVee8NzOUFcUSzttDoJlNQyH6h2RKo3q77X+/AXMsdGZuZv76vcJiQe5idO1biw6QabBlNGqQKjjUPG6w==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:33.751Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhaoolee-dsh-notes`
- Submission type: community curation
- Created by `zhaoolee` — https://github.com/zhaoolee
- Original source repository: https://github.com/zhaoolee/notes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.