### PR TITLE
catalog: add zhijiangtang-dsh-plugin-template (community curation, created by @ZhijiangTang)

### DIFF
--- a/catalog/plugins/zhijiangtang-dsh-plugin-template.yaml
+++ b/catalog/plugins/zhijiangtang-dsh-plugin-template.yaml
@@ -1,0 +1,39 @@
+schemaVersion: 1
+id: zhijiangtang-dsh-plugin-template
+name: dsh-plugin-template
+description:
+  en: "DSH bundle-plugin template: scaffold a new tool plugin (the template itself is not published)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin-template
+  - dsh
+source:
+  repository: https://github.com/ZhijiangTang/dsh-plugin-template
+  repositoryNodeId: R_kgDOT5Bjhg
+  subpath: null
+  commit: 775b526963b9e08e3524331d7e7021a56636e582
+creator:
+  github: ZhijiangTang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:37.407Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhijiangtang-dsh-plugin-template`
- Submission type: community curation
- Created by `ZhijiangTang` — https://github.com/ZhijiangTang
- Original source repository: https://github.com/ZhijiangTang/dsh-plugin-template
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.