### PR TITLE
catalog: add zimai233-dsh-exam-countdown (community curation, created by @zimai233)

### DIFF
--- a/catalog/plugins/zimai233-dsh-exam-countdown.yaml
+++ b/catalog/plugins/zimai233-dsh-exam-countdown.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zimai233-dsh-exam-countdown
+name: dsh-exam-countdown
+description:
+  en: Chinese exam countdown for DeepSeek Harness. Query 64 built-in exams (gaokao, kaoyan, civil service, CET-4/6, CPA, bar exam...) and get days-until dates computed by pure date math with rolling yearly recurrence.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - exam
+  - countdown
+  - education
+source:
+  repository: https://github.com/zimai233/dsh-exam-countdown
+  repositoryNodeId: R_kgDOT3-9EQ
+  subpath: null
+  commit: 54492515553fcf38a48f372e381bbf3252abcc38
+creator:
+  github: zimai233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:51.069Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zimai233-dsh-exam-countdown`
- Submission type: community curation
- Created by `zimai233` — https://github.com/zimai233
- Original source repository: https://github.com/zimai233/dsh-exam-countdown
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.