### PR TITLE
catalog: add zimai233-dsh-figma-to-lottie (community curation, created by @zimai233)

### DIFF
--- a/catalog/plugins/zimai233-dsh-figma-to-lottie.yaml
+++ b/catalog/plugins/zimai233-dsh-figma-to-lottie.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zimai233-dsh-figma-to-lottie
+name: dsh-figma-to-lottie
+description:
+  en: Figma/SVG to Lottie animation compiler for DeepSeek Harness. Turn SVG paths and keyframe data into self-contained .lottie.json files.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - lottie
+  - animation
+  - figma
+  - svg
+  - design
+source:
+  repository: https://github.com/zimai233/dsh-figma-to-lottie
+  repositoryNodeId: R_kgDOT3-83g
+  subpath: null
+  commit: 8e21469374ebe4241b515f95552b1d8db8b79bb8
+creator:
+  github: zimai233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:23.196Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zimai233-dsh-figma-to-lottie`
- Submission type: community curation
- Created by `zimai233` — https://github.com/zimai233
- Original source repository: https://github.com/zimai233/dsh-figma-to-lottie
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.