### PR TITLE
catalog: add zimai233-dsh-image-search (community curation, created by @zimai233)

### DIFF
--- a/catalog/plugins/zimai233-dsh-image-search.yaml
+++ b/catalog/plugins/zimai233-dsh-image-search.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zimai233-dsh-image-search
+name: dsh-image-search
+description:
+  en: Multi-engine reverse image search aggregator for DeepSeek Harness. Turn one public image URL into Google Lens / Baidu / Yandex / TinEye / SauceNAO / IQDB / Ascii2d search links.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - image-search
+  - reverse-image
+  - vision
+  - search
+  - aggregator
+source:
+  repository: https://github.com/zimai233/dsh-image-search
+  repositoryNodeId: R_kgDOT3-9zw
+  subpath: null
+  commit: 95ac2b739f7464386cb28c2b758cbc9382befe5a
+creator:
+  github: zimai233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:38.567Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zimai233-dsh-image-search`
- Submission type: community curation
- Created by `zimai233` — https://github.com/zimai233
- Original source repository: https://github.com/zimai233/dsh-image-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.