### PR TITLE
catalog: add zimai233-dsh-wash-calendar (community curation, created by @zimai233)

### DIFF
--- a/catalog/plugins/zimai233-dsh-wash-calendar.yaml
+++ b/catalog/plugins/zimai233-dsh-wash-calendar.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zimai233-dsh-wash-calendar
+name: dsh-wash-calendar
+description:
+  en: Recurring habit scheduling calendar for DeepSeek Harness. Turn last-wash dates and intervals into next-occurrence, schedule, check and advice tools for any recurring health/habit routine.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - habit
+  - health
+  - calendar
+  - schedule
+  - wellness
+source:
+  repository: https://github.com/zimai233/dsh-wash-calendar
+  repositoryNodeId: R_kgDOT3-9Rw
+  subpath: null
+  commit: 3622edd766f0c2c8319f64ab6891221c96865ac2
+creator:
+  github: zimai233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:40.130Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zimai233-dsh-wash-calendar`
- Submission type: community curation
- Created by `zimai233` — https://github.com/zimai233
- Original source repository: https://github.com/zimai233/dsh-wash-calendar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.