### PR TITLE
catalog: add zljr-dsh-share (community curation, created by @zljr)

### DIFF
--- a/catalog/plugins/zljr-dsh-share.yaml
+++ b/catalog/plugins/zljr-dsh-share.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zljr-dsh-share
+name: "@zljr/dsh-share"
+description:
+  en: "Session share plugin for DeepSeek Harness: generate a read-only LAN share link (frozen transcript snapshot) for the current session."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - share
+  - lan
+source:
+  repository: https://github.com/zljr/dsh-share
+  repositoryNodeId: R_kgDOT5B2bw
+  subpath: null
+  commit: c3f21ece2f6c511c20d469a0252717f8e9cc2cfb
+creator:
+  github: zljr
+package:
+  ecosystem: npm
+  name: "@zljr/dsh-share"
+  version: 0.1.1
+  integrity: sha512-sL02Lr82bicuCaNgPJGWOk5DBB+FQ8EeKwKvMAM/yTBQCOXt3NzmSXJOWZHEXMxkzQ9OKqO8ZShyeHjnAH3cfA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:52.478Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zljr-dsh-share`
- Submission type: community curation
- Created by `zljr` — https://github.com/zljr
- Original source repository: https://github.com/zljr/dsh-share
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.