### PR TITLE
catalog: add zlyraz-crash-test-dummy (community curation, created by @Zlyraz)

### DIFF
--- a/catalog/plugins/zlyraz-crash-test-dummy.yaml
+++ b/catalog/plugins/zlyraz-crash-test-dummy.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: zlyraz-crash-test-dummy
+name: crash-test-dummy
+description:
+  en: dsh plugin add github:Zlyraz/crash-test-dummy
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - zlyraz
+  - crash
+  - test
+  - dummy
+  - dsh
+source:
+  repository: https://github.com/Zlyraz/crash-test-dummy
+  repositoryNodeId: R_kgDOT538oQ
+  subpath: null
+  commit: 8a9db95693c6e828cac28edce1ae91be8f4237c3
+creator:
+  github: Zlyraz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:41.633Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zlyraz-crash-test-dummy`
- Submission type: community curation
- Created by `Zlyraz` — https://github.com/Zlyraz
- Original source repository: https://github.com/Zlyraz/crash-test-dummy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.