### PR TITLE
catalog: add zlyraz-dsh-ballute (community curation, created by @Zlyraz)

### DIFF
--- a/catalog/plugins/zlyraz-dsh-ballute.yaml
+++ b/catalog/plugins/zlyraz-dsh-ballute.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: zlyraz-dsh-ballute
+name: dsh-ballute
+description:
+  en: "dsh-ballute is a crash-protection plugin for DeepSeek Harness (DSH). DSH silently removes crashing slot entries — you get a blank panel and the tab quietly disappears, errors only land in the console. Ballute turns that into something you can see, attribute and recover from:"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+source:
+  repository: https://github.com/Zlyraz/dsh-ballute
+  repositoryNodeId: R_kgDOT51uQA
+  subpath: null
+  commit: 68e4b07bb108bdad7cdb782d0b2ce15755356526
+creator:
+  github: Zlyraz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:43.078Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zlyraz-dsh-ballute`
- Submission type: community curation
- Created by `Zlyraz` — https://github.com/Zlyraz
- Original source repository: https://github.com/Zlyraz/dsh-ballute
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.