### PR TITLE
catalog: add zoahdev-dsh-firecrawl (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-firecrawl.yaml
+++ b/catalog/plugins/zoahdev-dsh-firecrawl.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zoahdev-dsh-firecrawl
+name: dsh-firecrawl
+description:
+  en: "Firecrawl bridge for DeepSeek Harness: scrape URLs to LLM-ready Markdown and search the web via the Firecrawl Cloud API."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - firecrawl
+  - scrape
+  - web-search
+  - agent
+  - dsh
+source:
+  repository: https://github.com/zoahdev/dsh-firecrawl
+  repositoryNodeId: R_kgDOT69DZg
+  subpath: null
+  commit: e3b2cee2f54da826982a423b627345c96131cf43
+creator:
+  github: zoahdev
+package:
+  ecosystem: npm
+  name: dsh-firecrawl
+  version: 0.1.0
+  integrity: sha512-3ZwNjXKXxTySromCVx/56bAANt8j9Oer77PbfHQEhlGiDWGLnRaLLxEC2l5NF97tgGXN8CH54+0dpRqY68ZvjQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:47.737Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-firecrawl`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-firecrawl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.