### PR TITLE
catalog: add zoahdev-dsh-plugin-template (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-plugin-template.yaml
+++ b/catalog/plugins/zoahdev-dsh-plugin-template.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zoahdev-dsh-plugin-template
+name: dsh-plugin-template
+description:
+  en: "Minimal, verified template for DeepSeek Harness plugins: bundle manifest, one tool, tests, and CI smoke load."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - template
+  - cordis
+  - agent
+  - dsh
+source:
+  repository: https://github.com/zoahdev/dsh-plugin-template
+  repositoryNodeId: R_kgDOT44Ilg
+  subpath: null
+  commit: 7df29cfa4eb729b99b5e968829d82d512f6889d0
+creator:
+  github: zoahdev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:22:53.867Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-plugin-template`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-plugin-template
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.