### PR TITLE
catalog: add zoahdev-dsh-yap (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-yap.yaml
+++ b/catalog/plugins/zoahdev-dsh-yap.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zoahdev-dsh-yap
+name: dsh-yap
+description:
+  en: sh dsh plugin --profile web add github:zoahdev/dsh-yap
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - meme
+  - yap
+  - fun
+  - dsh
+source:
+  repository: https://github.com/zoahdev/dsh-yap
+  repositoryNodeId: R_kgDOT51XYw
+  subpath: null
+  commit: bdc7476587bf040c89b10b6d0f7e5896d32b0b59
+creator:
+  github: zoahdev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:28:50.685Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-yap`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-yap
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.