### PR TITLE
catalog: add zyar-er-dsh-notify-bell (community curation, created by @ZYar-er)

### DIFF
--- a/catalog/plugins/zyar-er-dsh-notify-bell.yaml
+++ b/catalog/plugins/zyar-er-dsh-notify-bell.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: zyar-er-dsh-notify-bell
+name: dsh-notify-bell
+description:
+  en: A community plugin for DeepSeek Harness (DSH) that provides semantic notification sounds for important agent events.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - community
+  - semantic
+  - notification
+  - sounds
+  - important
+  - agent
+  - events
+  - dsh
+source:
+  repository: https://github.com/ZYar-er/dsh-notify-bell
+  repositoryNodeId: R_kgDOT5oY6Q
+  subpath: null
+  commit: 6889435d40af30c8a9d73861d3ebdd0ed5b4f697
+creator:
+  github: ZYar-er
+package:
+  ecosystem: npm
+  name: dsh-notify-bell
+  version: 0.12.0
+  integrity: sha512-VVW40OnwGjdyD2Dy3iIFkBw7z08SCr0ROJxRl/MLMv8w2uk41Qt+8IPUKCRdDOcykWst3gtWmsG34ifkNtLulg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-21T05:24:27.738Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zyar-er-dsh-notify-bell`
- Submission type: community curation
- Created by `ZYar-er` — https://github.com/ZYar-er
- Original source repository: https://github.com/ZYar-er/dsh-notify-bell
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.