### PR TITLE
docs: the catalog counts 483 merged plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ repository carries the public catalog data, schema and policies they both consum
 
 ## Catalog status
 
-**210 plugins merged.** Every plugin enters through an individually reviewed pull request, one at
+**483 plugins merged.** Every plugin enters through an individually reviewed pull request, one at
 a time, from the original creator repository, with a pinned source commit and explicit
 attribution.
 


### PR DESCRIPTION
The 273 curation pull requests landed, so the README's merged-plugin count moves 210 → 483. The Top 10 table was re-checked against the grown catalog and is already current (no ranking change). `catalog docs-check` and `catalog validate` pass for all 483 entries.