### PR TITLE
ci: run the docs gate the CLI already ships in every pull request

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -37,3 +37,9 @@ jobs:
 
       - name: Validate catalog
         run: node cli/dist/bin.js catalog validate --catalog .
+
+      # The docs gate exists in the CLI but ran nowhere: every batch merge desynchronized the
+      # README's "**N plugins merged.**" counter (and the schema/category parity it checks) with
+      # no red anywhere. The CLI is already built two steps above, so this costs nothing extra.
+      - name: Check catalog documentation
+        run: node cli/dist/bin.js catalog docs-check .


### PR DESCRIPTION
`catalog docs-check` (README merged-count literal, schema/category parity, policy markers) existed only as a CLI command — no workflow ran it, so every batch merge could desynchronize the README counter with no red anywhere. The CLI is already built from the commit under test in this workflow; this adds the one missing step. Verified locally against the 483-entry tree.