### PR TITLE
feat(catalog): enforce public ID conventions and reject degenerate snapshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,10 @@ Never submit credentials, cookies, private email addresses, unpublished source o
 ## YAML and schema rules
 
 Create `catalog/plugins/<plugin-id>.yaml` and validate it against
-[`schemas/plugin.schema.yaml`](schemas/plugin.schema.yaml). The schema is the source of truth for
+[`schemas/plugin.schema.yaml`](schemas/plugin.schema.yaml). The `id` must equal the file's
+basename and must start with your namespace: your `creator.github` handle lowercased (any run
+of characters outside `[a-z0-9]` becomes a single `-`) followed by `-`, for example
+`some-creator-my-plugin` for the handle `Some-Creator`. Catalog validation enforces both. The schema is the source of truth for
 field names and allowed values; [docs/CATEGORIES.md](docs/CATEGORIES.md) defines how to choose the
 single artifact kind, primary category, tags and repository scope.
 

--- a/cli/src/catalog/loadCatalog.ts
+++ b/cli/src/catalog/loadCatalog.ts
@@ -33,8 +33,11 @@ export type CatalogLoadInput = string | CatalogDirectoryInput | PinnedCatalogInp
 
 export type CatalogDiagnosticCode =
   | PublicEntryValidationCode
+  | "degenerate-snapshot"
   | "duplicate-canonical-key"
   | "duplicate-id"
+  | "id-creator-prefix"
+  | "id-filename-mismatch"
   | "invalid-canonical-key"
   | "invalid-catalog-root"
   | "invalid-entry-directory"
@@ -107,6 +110,15 @@ function hasErrorCode(error: unknown, code: string): boolean {
     "code" in error &&
     (error as { code?: unknown }).code === code
   );
+}
+
+/**
+ * The creator's GitHub login normalized as the public-ID prefix slug: lowercase, with every
+ * run of characters outside [a-z0-9] collapsed into a single "-". Measured against all 483
+ * published entries — every one of them starts with `${creatorSlug(creator.github)}-`.
+ */
+function creatorSlug(creatorGithub: string): string {
+  return creatorGithub.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-");
 }
 
 function safeEntryLabel(fileName: string): string {
@@ -239,6 +251,11 @@ export async function loadCatalog(input: CatalogLoadInput): Promise<CatalogSnaps
     entryDirectory = await containedRealPath(root, requestedEntryDirectory) ?? "";
   } catch (error) {
     if (hasErrorCode(error, "ENOENT")) {
+      // A local development tree may not have grown its entry directory yet; a materialized
+      // snapshot without one is a broken or truncated publication, never an empty catalog.
+      if (normalized.source.kind === "snapshot") {
+        diagnostics.push(degenerateSnapshotDiagnostic());
+      }
       return snapshotResult(normalized.source, [], diagnostics);
     }
     diagnostics.push({
@@ -333,6 +350,29 @@ export async function loadCatalog(input: CatalogLoadInput): Promise<CatalogSnaps
     }
 
     const entry = parsed as PublicCatalogEntry;
+    const baseName = directoryEntry.name.slice(0, -".yaml".length);
+    let violatesIdConvention = false;
+    if (entry.id !== baseName) {
+      violatesIdConvention = true;
+      diagnostics.push({
+        file,
+        code: "id-filename-mismatch",
+        message: "public ID must equal the catalog file's basename",
+      });
+    }
+    const expectedPrefix = `${creatorSlug(entry.creator.github)}-`;
+    if (!entry.id.startsWith(expectedPrefix)) {
+      violatesIdConvention = true;
+      diagnostics.push({
+        file,
+        code: "id-creator-prefix",
+        message: `public ID must start with the creator slug prefix "${expectedPrefix}"`,
+      });
+    }
+    if (violatesIdConvention) {
+      continue;
+    }
+
     try {
       candidates.push({
         canonicalKey: canonicalPluginKey(entry.source.repositoryNodeId, entry.source.subpath),
@@ -371,5 +411,25 @@ export async function loadCatalog(input: CatalogLoadInput): Promise<CatalogSnaps
     .map((candidate) => candidate.entry)
     .sort((left, right) => compareText(left.id, right.id));
 
+  // A snapshot that validates cleanly and still yields zero entries is degenerate: the
+  // published catalog always carries entries, so "empty and silent" here previously let
+  // `search` exit 0 with "No plugins found" against hundreds of published plugins.
+  if (
+    normalized.source.kind === "snapshot" &&
+    entries.length === 0 &&
+    diagnostics.length === 0
+  ) {
+    diagnostics.push(degenerateSnapshotDiagnostic());
+  }
+
   return snapshotResult(normalized.source, entries, diagnostics);
+}
+
+function degenerateSnapshotDiagnostic(): CatalogDiagnostic {
+  return {
+    file: ENTRY_DIRECTORY,
+    code: "degenerate-snapshot",
+    message:
+      "materialized snapshot contains no plugin entries; the published catalog is never empty, so this snapshot is broken or truncated",
+  };
 }

--- a/cli/tests/catalog-command.test.ts
+++ b/cli/tests/catalog-command.test.ts
@@ -87,7 +87,9 @@ describe("catalog validate", () => {
     expect(snapshot).toMatchObject({
       source: { kind: "snapshot", declaredRevision: revision, pinStatus: "declared-local" },
       entries: [],
-      diagnostics: [],
+      // An entry-less snapshot is now itself a validation failure: the published catalog is
+      // never empty, so a materialized snapshot with zero entries is broken or truncated.
+      diagnostics: [expect.objectContaining({ code: "degenerate-snapshot" })],
     });
   });
 
@@ -127,7 +129,9 @@ describe("catalog validate", () => {
         pinStatus: "declared-local",
       },
       entries: [],
-      diagnostics: [],
+      // An entry-less snapshot is now itself a validation failure: the published catalog is
+      // never empty, so a materialized snapshot with zero entries is broken or truncated.
+      diagnostics: [expect.objectContaining({ code: "degenerate-snapshot" })],
     });
   });
 

--- a/cli/tests/catalog-id-conventions.test.ts
+++ b/cli/tests/catalog-id-conventions.test.ts
@@ -1,0 +1,109 @@
+// The public catalog has one naming convention that every merged entry already follows but
+// nothing enforced: the public ID is the file's basename, and it starts with the creator's
+// GitHub login normalized as a slug (lowercase, every run of non-[a-z0-9] collapsed to "-")
+// followed by "-". These tests pin that convention as loadCatalog diagnostics so a new entry
+// cannot drift from it.
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadCatalog } from "../src/catalog/index.js";
+
+const publicRoot = fileURLToPath(new URL("../../", import.meta.url));
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function realEntry(): Promise<Record<string, unknown>> {
+  const entryDirectory = join(publicRoot, "catalog/plugins");
+  const files = (await readdir(entryDirectory)).filter((file) => file.endsWith(".yaml")).sort();
+  const first = files[0]!;
+  return parseYaml(await readFile(join(entryDirectory, first), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+async function fixtureRoot(
+  entries: Record<string, Record<string, unknown>>,
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "dsh-id-conventions-"));
+  temporaryRoots.push(root);
+  await mkdir(join(root, "schemas"), { recursive: true });
+  await writeFile(
+    join(root, "schemas/plugin.schema.yaml"),
+    await readFile(join(publicRoot, "schemas/plugin.schema.yaml"), "utf8"),
+  );
+  await mkdir(join(root, "catalog/plugins"), { recursive: true });
+  for (const [fileName, entry] of Object.entries(entries)) {
+    await writeFile(join(root, "catalog/plugins", fileName), stringifyYaml(entry));
+  }
+  return root;
+}
+
+describe("public ID conventions", () => {
+  it("rejects an entry whose ID does not match its file basename", async () => {
+    const entry = await realEntry();
+    const id = entry.id as string;
+    const root = await fixtureRoot({ [`${id}-renamed.yaml`]: entry });
+
+    const snapshot = await loadCatalog(root);
+
+    expect(snapshot.diagnostics).toContainEqual(
+      expect.objectContaining({
+        file: `catalog/plugins/${id}-renamed.yaml`,
+        code: "id-filename-mismatch",
+      }),
+    );
+    expect(snapshot.entries).toHaveLength(0);
+  });
+
+  it("rejects an ID that does not start with the creator's slug followed by a dash", async () => {
+    const entry = await realEntry();
+    const forged = { ...entry, id: "someone-else-plugin" };
+    const root = await fixtureRoot({ "someone-else-plugin.yaml": forged });
+
+    const snapshot = await loadCatalog(root);
+
+    expect(snapshot.diagnostics).toContainEqual(
+      expect.objectContaining({
+        file: "catalog/plugins/someone-else-plugin.yaml",
+        code: "id-creator-prefix",
+      }),
+    );
+    expect(snapshot.entries).toHaveLength(0);
+  });
+
+  it("normalizes the creator login as a slug: lowercase, non-alphanumeric runs become one dash", async () => {
+    // The schema already restricts creator.github to the GitHub login charset
+    // ([A-Za-z0-9-]), so the transforms the slug performs on real data are lowercasing and
+    // collapsing dash runs; "2nd--1st-X" exercises both within the schema-legal charset.
+    const entry = await realEntry();
+    const accepted = {
+      ...entry,
+      id: "2nd-1st-x-example-plugin",
+      creator: { github: "2nd--1st-X" },
+    };
+    const root = await fixtureRoot({ "2nd-1st-x-example-plugin.yaml": accepted });
+
+    const snapshot = await loadCatalog(root);
+
+    expect(snapshot.diagnostics).toEqual([]);
+    expect(snapshot.entries).toHaveLength(1);
+  });
+
+  it("accepts every published entry — the convention was measured against the live catalog", async () => {
+    const snapshot = await loadCatalog(publicRoot);
+
+    expect(snapshot.diagnostics).toEqual([]);
+    expect(snapshot.entries.length).toBeGreaterThanOrEqual(483);
+  });
+});

--- a/cli/tests/degenerate-snapshot.test.ts
+++ b/cli/tests/degenerate-snapshot.test.ts
@@ -1,0 +1,79 @@
+// A materialized snapshot is the published catalog: it always carries plugin entries. A
+// snapshot that validates its schema and then yields ZERO entries with ZERO diagnostics is not
+// "an empty catalog" — it is a broken or truncated snapshot, and treating it as valid let
+// `search` exit 0 with "No plugins found" against 483 published plugins. A local development
+// tree, on the other hand, may legitimately be empty while an author bootstraps it.
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadCatalog } from "../src/catalog/index.js";
+
+const REVISION = "a".repeat(40);
+const publicRoot = fileURLToPath(new URL("../../", import.meta.url));
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function schemaOnlyRoot(options: { withEmptyEntryDirectory: boolean }): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "dsh-degenerate-snapshot-"));
+  temporaryRoots.push(root);
+  await mkdir(join(root, "schemas"), { recursive: true });
+  await writeFile(
+    join(root, "schemas/plugin.schema.yaml"),
+    await readFile(join(publicRoot, "schemas/plugin.schema.yaml"), "utf8"),
+  );
+  if (options.withEmptyEntryDirectory) {
+    await mkdir(join(root, "catalog/plugins"), { recursive: true });
+  }
+  return root;
+}
+
+describe("degenerate snapshots", () => {
+  it("rejects a snapshot whose entry directory is missing", async () => {
+    const root = await schemaOnlyRoot({ withEmptyEntryDirectory: false });
+
+    const snapshot = await loadCatalog({ kind: "snapshot", root, revision: REVISION });
+
+    expect(snapshot.entries).toHaveLength(0);
+    expect(snapshot.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "degenerate-snapshot" }),
+    );
+  });
+
+  it("rejects a snapshot that yields zero entries without any other diagnostic", async () => {
+    const root = await schemaOnlyRoot({ withEmptyEntryDirectory: true });
+
+    const snapshot = await loadCatalog({ kind: "snapshot", root, revision: REVISION });
+
+    expect(snapshot.entries).toHaveLength(0);
+    expect(snapshot.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "degenerate-snapshot" }),
+    );
+  });
+
+  it("still allows an empty local development tree", async () => {
+    const root = await schemaOnlyRoot({ withEmptyEntryDirectory: true });
+
+    const snapshot = await loadCatalog({ kind: "directory", root });
+
+    expect(snapshot.entries).toHaveLength(0);
+    expect(snapshot.diagnostics).toEqual([]);
+  });
+
+  it("still allows a local development tree without the entry directory", async () => {
+    const root = await schemaOnlyRoot({ withEmptyEntryDirectory: false });
+
+    const snapshot = await loadCatalog({ kind: "directory", root });
+
+    expect(snapshot.entries).toHaveLength(0);
+    expect(snapshot.diagnostics).toEqual([]);
+  });
+});

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -49,7 +49,10 @@ Constant `1`. Identifies public schema version 1; any other value is invalid.
 
 String matching `^[a-z0-9]+(?:-[a-z0-9]+)*$` — lowercase kebab-case, no leading/trailing or
 double hyphens. Per [CONTRIBUTING.md](../CONTRIBUTING.md), the entry file must be named
-`catalog/plugins/<id>.yaml` with the identical value.
+`catalog/plugins/<id>.yaml` with the identical value; the validator rejects a mismatch
+(`id-filename-mismatch`). The ID must also start with the creator's namespace: the
+`creator.github` handle lowercased, with every run of characters outside `[a-z0-9]` collapsed
+into a single `-`, followed by `-` (`id-creator-prefix`).
 
 ### `name`
 


### PR DESCRIPTION
## What

Two validator hardenings in `cli/src/catalog/loadCatalog.ts`, TDD throughout (every diagnostic was written as a failing test first):

### 1. Public ID convention diagnostics (new gate)

All 483 published entries already follow the same naming convention, but nothing enforced it. Two new diagnostics pin it:

- **`id-filename-mismatch`** — `id` must equal the entry file's basename (`catalog/plugins/<id>.yaml`).
- **`id-creator-prefix`** — `id` must start with the creator's namespace slug: `creator.github` lowercased, every run of characters outside `[a-z0-9]` collapsed into a single `-`, followed by `-`.

**Normalization was measured before the rule was written.** A script ran the candidate slug (`lowercase` + collapse non-`[a-z0-9]` runs to `-`) against all 483 real entries: **483/483 comply, zero near-misses**. The only transforms real data exercises are lowercasing (e.g. `Yan-Zero` → `yan-zero-…`) and hyphens passing through (e.g. `a903067276-rgb` → `a903067276-rgb-…`); the schema already restricts `creator.github` to the GitHub login charset `[A-Za-z0-9-]`, so dots/underscores can never reach the validator, and the run-collapse rule is a safe superset.

### 2. `degenerate-snapshot` (kill the silent empty catalog)

The ENOENT branch for `catalog/plugins` returned `entries: []` with zero diagnostics. For a materialized snapshot (`source.kind === "snapshot"`) that meant a well-formed, schema-only snapshot with ZERO plugins validated clean, and `search` exited 0 with "No plugins found" against 483 published plugins. Now: a snapshot whose entry directory is missing, or that yields zero entries with no other diagnostic, gets a **`degenerate-snapshot` error** (exit ≠ 0). A local development tree (`kind: "directory"`) may still be legitimately empty.

## TDD reds (before each fix)

- `rejects an entry whose ID does not match its file basename` — red, then green.
- `rejects an ID that does not start with the creator's slug followed by a dash` — red, then green.
- `normalizes the creator login as a slug` — red, then green (also surfaced that the schema forbids non-login charsets, see above).
- `rejects a snapshot whose entry directory is missing` — red, then green.
- `rejects a snapshot that yields zero entries without any other diagnostic` — red, then green.
- Guard tests that were green from the start and stayed green: empty local dev tree (with and without `catalog/plugins`) stays allowed; all 483 published entries pass.

Two pre-existing tests in `cli/tests/catalog-command.test.ts` asserted the old contract (empty snapshot ⇒ zero diagnostics); they now expect the `degenerate-snapshot` diagnostic — a strengthening, not a masking.

## Verification

- `npm test` — 189/189 passing (35 files).
- `npm run typecheck` — clean.
- Real gate on the published catalog: `node cli/dist/bin.js catalog validate --catalog .` → `483 entries valid`, exit 0.
- Negative proof through the built binary: a real entry copied to a wrong filename → `catalog/plugins/wrong-name.yaml [id-filename-mismatch]: …`, exit 1.
- `catalog docs-check .` → passing (doc edits keep policy markers and fences intact).

## Docs

- `docs/SCHEMA.md` → `id` section documents both rules and their diagnostic codes.
- `CONTRIBUTING.md` → YAML rules section states the basename + creator-prefix requirement with an example.

The `validate-catalog` workflow builds the CLI from this commit, so the gate is live for every PR from this one onward.
