### PR TITLE
chore(catalog): realign tags of 86 entries with the weighted classifier

### DIFF
--- a/catalog/plugins/2768651338-dsh-effort-slider.yaml
+++ b/catalog/plugins/2768651338-dsh-effort-slider.yaml
@@ -10,11 +10,20 @@ primaryCategory: models-providers-routing
 tags:
   - claude
   - code
-  - webgl
+  - style
+  - reasoning
+  - effort
+  - slider
+  - click
+  - model
+  - menu
+  - panel
+  - scale
+  - stepless
+  - dragging
+  - snaps
+  - release
   - medium
-  - high
-  - ultracode
-  - dsh
 source:
   repository: https://github.com/2768651338/dsh-effort-slider
   repositoryNodeId: R_kgDOT54uWA

--- a/catalog/plugins/a179302-dsh-auto-collapse.yaml
+++ b/catalog/plugins/a179302-dsh-auto-collapse.yaml
@@ -15,7 +15,6 @@ tags:
   - collapse
   - auto-collapse
   - chat
-  - think
 source:
   repository: https://github.com/a179-sanae/dsh-auto-collapse
   repositoryNodeId: R_kgDOT4nMEg

--- a/catalog/plugins/acidgr-dsh-web-lan-access.yaml
+++ b/catalog/plugins/acidgr-dsh-web-lan-access.yaml
@@ -14,15 +14,6 @@ tags:
   - lan
   - remote-access
   - polyfill
-  - remote
-  - access
-  - self
-  - contained
-  - binding
-  - crypto
-  - randomuuid
-  - plain
-  - origins
 source:
   repository: https://github.com/AcidGr/dsh-web-lan-access
   repositoryNodeId: R_kgDOT4ceuA

--- a/catalog/plugins/acidgr-dsh-web-mobile-fix.yaml
+++ b/catalog/plugins/acidgr-dsh-web-mobile-fix.yaml
@@ -14,16 +14,6 @@ tags:
   - mobile
   - web-ui
   - css
-  - layout
-  - fixes
-  - settings
-  - panel
-  - popups
-  - sidebar
-  - session
-  - header
-  - narrow
-  - 700px
 source:
   repository: https://github.com/AcidGr/dsh-web-mobile-fix
   repositoryNodeId: R_kgDOT4cekg

--- a/catalog/plugins/anionex-dsh-computer-use.yaml
+++ b/catalog/plugins/anionex-dsh-computer-use.yaml
@@ -13,16 +13,6 @@ tags:
   - macos
   - accessibility
   - desktop-automation
-  - first
-  - computer
-  - capability
-  - stale
-  - observation
-  - protection
-  - leases
-  - confirmations
-  - screenshots
-  - diagnostics
   - dsh
 source:
   repository: https://github.com/Anionex/dsh-computer-use

--- a/catalog/plugins/anionex-dsh-vision-toolkit.yaml
+++ b/catalog/plugins/anionex-dsh-vision-toolkit.yaml
@@ -20,10 +20,7 @@ tags:
   - ui-restoration
   - screenshot-testing
   - gui-automation
-  - native
-  - integration
-  - agent
-  - vision
+  - dsh
 source:
   repository: https://github.com/Anionex/dsh-vision-toolkit
   repositoryNodeId: R_kgDOT3V-Jw

--- a/catalog/plugins/biociao-dsh-science.yaml
+++ b/catalog/plugins/biociao-dsh-science.yaml
@@ -23,7 +23,6 @@ tags:
   - ssh
   - hpc
   - slurm
-  - claude
 source:
   repository: https://github.com/biociao/dsh-science
   repositoryNodeId: R_kgDOT382Zw

--- a/catalog/plugins/cirelir-dsh-change-review.yaml
+++ b/catalog/plugins/cirelir-dsh-change-review.yaml
@@ -12,8 +12,6 @@ tags:
   - dsh-plugin
   - diff
   - review
-  - write
-  - edit
 source:
   repository: https://github.com/cirelir/dsh-change-review
   repositoryNodeId: R_kgDOT5QGIA

--- a/catalog/plugins/detongz-dsh-client-ui-obsidian-memory.yaml
+++ b/catalog/plugins/detongz-dsh-client-ui-obsidian-memory.yaml
@@ -14,10 +14,6 @@ tags:
   - memory
   - codex
   - dsh-plugin
-  - persistent
-  - local
-  - markdown
-  - vault
 source:
   repository: https://github.com/detongz/dsh-client-ui-obsidian-memory
   repositoryNodeId: R_kgDOT58AYg

--- a/catalog/plugins/dfkai-dsh-board.yaml
+++ b/catalog/plugins/dfkai-dsh-board.yaml
@@ -19,11 +19,6 @@ tags:
   - tokens
   - sidebar
   - ui
-  - client
-  - bundle
-  - token
-  - stats
-  - peak
 source:
   repository: https://github.com/dfkai/dsh-board
   repositoryNodeId: R_kgDOT485gg

--- a/catalog/plugins/docjlm-dsh-arknights.yaml
+++ b/catalog/plugins/docjlm-dsh-arknights.yaml
@@ -8,11 +8,17 @@ unofficial: true
 kind: skin-theme
 primaryCategory: entertainment-customization
 tags:
-- skin
+- unofficial
+- commercial
 - arknights
-- web-ui
-- non-commercial
-- fan-art
+- astral
+- garden
+- skin
+- featuring
+- pramanix
+- eyjafjalla
+- artwork
+- dsh
 source:
   repository: https://github.com/DocJlm/dsh-arknights
   repositoryNodeId: R_kgDOT5vOyA

--- a/catalog/plugins/echouser005-dsh-fate-spectrum.yaml
+++ b/catalog/plugins/echouser005-dsh-fate-spectrum.yaml
@@ -13,7 +13,6 @@ tags:
   - bazi
   - ziwei
   - fate-chart
-  - bundle
   - dsh
 source:
   repository: https://github.com/EchoUser005/dsh-fate-spectrum

--- a/catalog/plugins/featherhunter-dsh-opencode-palette.yaml
+++ b/catalog/plugins/featherhunter-dsh-opencode-palette.yaml
@@ -8,10 +8,22 @@ unofficial: true
 kind: skin-theme
 primaryCategory: entertainment-customization
 tags:
+  - brings
   - opencode
+  - colour
+  - schemes
+  - themes
+  - built
+  - plus
   - system
-  - json
-  - dsh
+  - delivered
+  - through
+  - official
+  - bundle
+  - mechanism
+  - package
+  - ships
+  - cordis
 source:
   repository: https://github.com/FeatherHunter/dsh-opencode-palette
   repositoryNodeId: R_kgDOT5Qmlw

--- a/catalog/plugins/flyvhidbwo-dsh-vision-proxy.yaml
+++ b/catalog/plugins/flyvhidbwo-dsh-vision-proxy.yaml
@@ -19,11 +19,6 @@ tags:
   - vlm
   - qwen
   - dashscope
-  - brain
-  - automatic
-  - transcription
-  - provider
-  - route
 source:
   repository: https://github.com/Flyvhidbwo/dsh-vision-proxy
   repositoryNodeId: R_kgDOT3bpkw

--- a/catalog/plugins/fmlin0429712024-dsh-vision-insights-plugin.yaml
+++ b/catalog/plugins/fmlin0429712024-dsh-vision-insights-plugin.yaml
@@ -17,13 +17,6 @@ tags:
   - edge
   - queue-management
   - linkhealth
-  - side
-  - access
-  - point
-  - openvino
-  - visual
-  - intelligent
-  - queue
 source:
   repository: https://github.com/fmlin0429712024/linkhealth-dsh-platform
   repositoryNodeId: R_kgDOT6mwFA

--- a/catalog/plugins/gin-7-dsh-pet-remielle.yaml
+++ b/catalog/plugins/gin-7-dsh-pet-remielle.yaml
@@ -8,11 +8,22 @@ unofficial: true
 kind: plugin
 primaryCategory: entertainment-customization
 tags:
-- desktop-pet
+- pluggable
+- desktop
+- transparent
+- floating
+- remielle
 - companion
-- web-ui
-- animation
-- fun
+- zenless
+- zone
+- zero
+- switches
+- animated
+- moods
+- while
+- agent
+- works
+- dsh
 source:
   repository: https://github.com/Gin-7/dsh-pet-remielle
   repositoryNodeId: R_kgDOT5B6oA

--- a/catalog/plugins/graysilver-dsh-evolve-modes.yaml
+++ b/catalog/plugins/graysilver-dsh-evolve-modes.yaml
@@ -16,14 +16,6 @@ tags:
   - agent-review
   - plan-mode
   - acceptance-review
-  - composable
-  - working
-  - reasoning
-  - quality
-  - human
-  - reviewed
-  - self
-  - evolution
 source:
   repository: https://github.com/GraySilver/dsh-evolve-modes
   repositoryNodeId: R_kgDOT5_geA

--- a/catalog/plugins/gxinxing-deepseek-harness-tui.yaml
+++ b/catalog/plugins/gxinxing-deepseek-harness-tui.yaml
@@ -8,10 +8,17 @@ unofficial: true
 kind: client-interface
 primaryCategory: user-interface-dashboards
 tags:
-- tui
+- interactive
 - terminal
-- chat-client
-- headless
+- chat
+- full
+- screen
+- curses
+- style
+- client
+- driving
+- sessions
+- dsh
 source:
   repository: https://github.com/gxinxing/deepseek-harness-tui
   repositoryNodeId: R_kgDOT3iQng

--- a/catalog/plugins/huguangyu666-dsh-plugin-notify.yaml
+++ b/catalog/plugins/huguangyu666-dsh-plugin-notify.yaml
@@ -15,8 +15,6 @@ tags:
   - tts
   - voice
   - alert
-  - agent
-  - windows
 source:
   repository: https://github.com/huguangyu666/dsh-plugin-notify
   repositoryNodeId: R_kgDOT4Y5Lg

--- a/catalog/plugins/huguangyu666-dsh-plugin-session-import.yaml
+++ b/catalog/plugins/huguangyu666-dsh-plugin-session-import.yaml
@@ -16,8 +16,6 @@ tags:
   - codex
   - reasonix
   - zcode
-  - claude
-  - code
 source:
   repository: https://github.com/huguangyu666/dsh-plugin-session-import
   repositoryNodeId: R_kgDOT3zPiA

--- a/catalog/plugins/huguangyu666-dsh-store.yaml
+++ b/catalog/plugins/huguangyu666-dsh-store.yaml
@@ -14,8 +14,6 @@ tags:
   - store
   - marketplace
   - plugin-manager
-  - awesome
-  - remove
 source:
   repository: https://github.com/huguangyu666/dsh-store
   repositoryNodeId: R_kgDOT4fvkg

--- a/catalog/plugins/huiliyi37-dsh-tianshu-tui.yaml
+++ b/catalog/plugins/huiliyi37-dsh-tianshu-tui.yaml
@@ -13,17 +13,6 @@ tags:
   - terminal
   - tui
   - cli
-  - tianshu
-  - interactive
-  - official
-  - streaming
-  - markdown
-  - tool
-  - cards
-  - themes
-  - slash
-  - commands
-  - session
 source:
   repository: https://github.com/huiliyi37/dsh-tianshu-tui
   repositoryNodeId: R_kgDOT29GJw

--- a/catalog/plugins/icetomoyo-workflow.yaml
+++ b/catalog/plugins/icetomoyo-workflow.yaml
@@ -14,9 +14,6 @@ tags:
   - dshtopic
   - multi-agent
   - agent-orchestration
-  - kodax
-  - parity
-  - dynamic
 source:
   repository: https://github.com/omdsh-dev/dsh_workflow
   repositoryNodeId: R_kgDOT2hsPA

--- a/catalog/plugins/jesse-chatnode-wechat.yaml
+++ b/catalog/plugins/jesse-chatnode-wechat.yaml
@@ -16,13 +16,6 @@ tags:
   - ilink
   - conversation-node
   - chat
-  - monitor
-  - approve
-  - agents
-  - gateway
-  - conversation
-  - node
-  - bundle
 source:
   repository: https://github.com/Jesse-njx/dsh-chatnode-wechat
   repositoryNodeId: R_kgDOT3khgw

--- a/catalog/plugins/jiezeng2004-design-dsh-chatgpt-bridge.yaml
+++ b/catalog/plugins/jiezeng2004-design-dsh-chatgpt-bridge.yaml
@@ -12,18 +12,6 @@ tags:
   - dsh
   - mcp
   - chatgpt
-  - bridge
-  - lets
-  - create
-  - view
-  - continue
-  - control
-  - agent
-  - sessions
-  - through
-  - official
-  - protocol
-  - only
 source:
   repository: https://github.com/jiezeng2004-design/dsh-chatgpt-bridge
   repositoryNodeId: R_kgDOT4T3lA

--- a/catalog/plugins/johnxu22786-model-catalog.yaml
+++ b/catalog/plugins/johnxu22786-model-catalog.yaml
@@ -14,7 +14,6 @@ tags:
   - catalog
   - pricing
   - llm
-  - openai
 source:
   repository: https://github.com/JohnXu22786/model-catalog
   repositoryNodeId: R_kgDOT59RnQ

--- a/catalog/plugins/jungod1121-dsh-anchored-standard.yaml
+++ b/catalog/plugins/jungod1121-dsh-anchored-standard.yaml
@@ -14,16 +14,6 @@ tags:
   - preset
   - anchored-standard
   - deepseek-v4-pro
-  - task
-  - aware
-  - phase
-  - spec
-  - react
-  - weak
-  - first
-  - request
-  - anchors
-  - bash
 source:
   repository: https://github.com/Jungod1121/dsh-anchored-standard
   repositoryNodeId: R_kgDOT5AkXw

--- a/catalog/plugins/katsos-dsh-claude-cli.yaml
+++ b/catalog/plugins/katsos-dsh-claude-cli.yaml
@@ -12,16 +12,6 @@ tags:
   - dsh-plugin
   - llm-provider
   - claude-code
-  - locally
-  - installed
-  - claude
-  - code
-  - provider
-  - native
-  - tool
-  - calls
-  - through
-  - bridge
   - dsh
 source:
   repository: https://github.com/katsos/dsh-claude-cli

--- a/catalog/plugins/kinoward-dsh-plugin-subhub.yaml
+++ b/catalog/plugins/kinoward-dsh-plugin-subhub.yaml
@@ -8,9 +8,22 @@ unofficial: true
 kind: plugin
 primaryCategory: models-providers-routing
 tags:
+  - third
+  - party
+  - subscription
+  - models
+  - inside
+  - sign
+  - account
+  - become
+  - available
+  - model
+  - menu
+  - image
+  - understanding
+  - conversation
   - openai
   - chatgpt
-  - dsh
 source:
   repository: https://github.com/kinoward/dsh-plugin-subhub
   repositoryNodeId: R_kgDOT42Y4g

--- a/catalog/plugins/leemancheung-dsh-task-dag.yaml
+++ b/catalog/plugins/leemancheung-dsh-task-dag.yaml
@@ -15,10 +15,6 @@ tags:
   - subagent
   - workflow
   - visualization
-  - persistent
-  - live
-  - subagents
-  - workflows
 source:
   repository: https://github.com/LeemanCheung/dsh-task-dag
   repositoryNodeId: R_kgDOT4VT4g

--- a/catalog/plugins/leon-dsh-task-planner.yaml
+++ b/catalog/plugins/leon-dsh-task-planner.yaml
@@ -14,16 +14,6 @@ tags:
   - planning
   - memory
   - experience
-  - task
-  - muscle
-  - condition
-  - reflex
-  - recall
-  - past
-  - solutions
-  - driven
-  - capability
-  - matching
 source:
   repository: https://github.com/ztl34245881-commits/dsh-task-planner
   repositoryNodeId: R_kgDOT4aFIw

--- a/catalog/plugins/lijian-ui-dsh-im-gateway.yaml
+++ b/catalog/plugins/lijian-ui-dsh-im-gateway.yaml
@@ -17,13 +17,6 @@ tags:
   - wechat
   - weixin
   - cordis
-  - multi
-  - channel
-  - gateway
-  - ilink
-  - scan
-  - binding
-  - streaming
 source:
   repository: https://github.com/lijian-ui/dsh-im-gateway
   repositoryNodeId: R_kgDOT5qajw

--- a/catalog/plugins/lire1131-dsh-undo-savepoint.yaml
+++ b/catalog/plugins/lire1131-dsh-undo-savepoint.yaml
@@ -19,11 +19,6 @@ tags:
   - safe-mode
   - windows
   - powershell
-  - system
-  - config
-  - files
-  - change
-  - last
 source:
   repository: https://github.com/lire1131/dsh-undo-savepoint
   repositoryNodeId: R_kgDOT4Bt6g

--- a/catalog/plugins/loadingvx-dsh-workbench-plugin.yaml
+++ b/catalog/plugins/loadingvx-dsh-workbench-plugin.yaml
@@ -8,7 +8,22 @@ unofficial: true
 kind: plugin
 primaryCategory: user-interface-dashboards
 tags:
-  - dsh
+  - three
+  - column
+  - workbench
+  - chat
+  - left
+  - codemirror
+  - editor
+  - local
+  - terminal
+  - center
+  - right
+  - dock
+  - file
+  - tree
+  - including
+  - streamed
 source:
   repository: https://github.com/loadingvx/deepseek-harness-workbench-plugin
   repositoryNodeId: R_kgDOT5Ea5w

--- a/catalog/plugins/luke-yong-dsh-plugin-knowledge-graph.yaml
+++ b/catalog/plugins/luke-yong-dsh-plugin-knowledge-graph.yaml
@@ -13,16 +13,6 @@ tags:
   - knowledge-graph
   - code-graph
   - read-graph
-  - read
-  - graph
-  - tool
-  - backed
-  - codebase
-  - knowledge
-  - contains
-  - exports
-  - imports
-  - symbol
   - dsh
 source:
   repository: https://github.com/Luke-Yong/dsh-plugin-knowledge-graph

--- a/catalog/plugins/mangmax-dsh-themes.yaml
+++ b/catalog/plugins/mangmax-dsh-themes.yaml
@@ -8,11 +8,18 @@ unofficial: true
 kind: skin-theme
 primaryCategory: entertainment-customization
 tags:
-- themes
 - appearance
-- dark-mode
-- vscode-themes
-- web-ui
+- themes
+- built
+- palettes
+- light
+- dark
+- system
+- mode
+- code
+- theme
+- import
+- dsh
 source:
   repository: https://github.com/MangMax/dsh-themes
   repositoryNodeId: R_kgDOT35ZdQ

--- a/catalog/plugins/mars-sea-dsh-commandcode-provider.yaml
+++ b/catalog/plugins/mars-sea-dsh-commandcode-provider.yaml
@@ -16,14 +16,6 @@ tags:
   - adapter
   - provider
   - bundle
-  - unofficial
-  - command
-  - code
-  - ported
-  - registers
-  - route
-  - models
-  - page
 source:
   repository: https://github.com/Mars-Sea/dsh-commandcode-provider
   repositoryNodeId: R_kgDOT4UInw

--- a/catalog/plugins/max-samson-dsh-usage-chart.yaml
+++ b/catalog/plugins/max-samson-dsh-usage-chart.yaml
@@ -18,11 +18,6 @@ tags:
   - dashboard
   - charts
   - visualization
-  - token
-  - adapter
-  - pricing
-  - json
-  - user
 source:
   repository: https://github.com/Max-Samson/dsh-usage-chart
   repositoryNodeId: R_kgDOT3rZaQ

--- a/catalog/plugins/maxwell-feng-dsh-windows-ocr.yaml
+++ b/catalog/plugins/maxwell-feng-dsh-windows-ocr.yaml
@@ -14,16 +14,6 @@ tags:
   - ocr
   - windows
   - privacy
-  - recognize
-  - attached
-  - images
-  - built
-  - engine
-  - media
-  - send
-  - only
-  - recognized
-  - text
 source:
   repository: https://github.com/maxwell-feng/dsh-windows-ocr
   repositoryNodeId: R_kgDOT5FbXQ

--- a/catalog/plugins/moguiyu-dsh-tavily-workspace.yaml
+++ b/catalog/plugins/moguiyu-dsh-tavily-workspace.yaml
@@ -9,10 +9,17 @@ kind: plugin
 primaryCategory: search-research
 tags:
 - tavily
-- web-search
-- search-tool
-- api-keys
+- search
+- integration
+- advanced
+- tool
+- multi
+- management
+- usage
+- gauge
 - settings
+- card
+- dsh
 source:
   repository: https://github.com/moguiyu/dsh-tavily
   repositoryNodeId: R_kgDOT5QALQ

--- a/catalog/plugins/mooling0602-dsh-web-file-uploader.yaml
+++ b/catalog/plugins/mooling0602-dsh-web-file-uploader.yaml
@@ -14,16 +14,6 @@ tags:
   - web
   - upload
   - attachment
-  - style
-  - paperclip
-  - attach
-  - button
-  - composer
-  - uploads
-  - files
-  - host
-  - model
-  - aware
 source:
   repository: https://github.com/Mooling0602/dsh-web-file-uploader
   repositoryNodeId: R_kgDOT6UzDg

--- a/catalog/plugins/nagi-ovo-dsh-visualize.yaml
+++ b/catalog/plugins/nagi-ovo-dsh-visualize.yaml
@@ -8,11 +8,22 @@ unofficial: true
 kind: plugin
 primaryCategory: user-interface-dashboards
 tags:
+- inline
 - visualization
-- inline-cards
-- sandboxed-html
-- web-ui
+- visualize
+- tool
+- plus
+- bundled
 - skill
+- model
+- render
+- interactive
+- html
+- fragments
+- sandboxed
+- cards
+- directly
+- conversation
 source:
   repository: https://github.com/Nagi-ovo/dsh-visualize
   repositoryNodeId: R_kgDOT3X7_w

--- a/catalog/plugins/nonamelego-dsh-catppuccin.yaml
+++ b/catalog/plugins/nonamelego-dsh-catppuccin.yaml
@@ -13,17 +13,6 @@ tags:
   - catppuccin
   - theme
   - dsh-plugin
-  - themes
-  - toggleable
-  - glassmorphism
-  - skin
-  - latte
-  - frapp
-  - macchiato
-  - mocha
-  - registered
-  - official
-  - system
 source:
   repository: https://github.com/NoNameLeGo/dsh-catppuccin-theme
   repositoryNodeId: R_kgDOT4fijQ

--- a/catalog/plugins/oil-oil-dsh-vision.yaml
+++ b/catalog/plugins/oil-oil-dsh-vision.yaml
@@ -13,13 +13,6 @@ tags:
   - vision
   - multimodal
   - image-understanding
-  - near
-  - native
-  - image
-  - understanding
-  - text
-  - only
-  - models
   - dsh
 source:
   repository: https://github.com/oil-oil/dsh-vision

--- a/catalog/plugins/pengpengyi92-dsh-quant.yaml
+++ b/catalog/plugins/pengpengyi92-dsh-quant.yaml
@@ -16,14 +16,6 @@ tags:
   - technical-analysis
   - indicators
   - backtest
-  - everything
-  - native
-  - tools
-  - pluggable
-  - domains
-  - data
-  - alpha
-  - risk
 source:
   repository: https://github.com/pengpengyi92/dsh-quant
   repositoryNodeId: R_kgDOT51x8w

--- a/catalog/plugins/pengyue-polaron-dsh-plugin-genui.yaml
+++ b/catalog/plugins/pengyue-polaron-dsh-plugin-genui.yaml
@@ -14,14 +14,6 @@ tags:
   - genui
   - mcp
   - react
-  - task
-  - specific
-  - apps
-  - state
-  - carried
-  - next
-  - agent
-  - turn
   - dsh
 source:
   repository: https://github.com/pengyue-polaron/deepseek-harness-genui

--- a/catalog/plugins/perrylink-dsh-background-agents.yaml
+++ b/catalog/plugins/perrylink-dsh-background-agents.yaml
@@ -21,9 +21,6 @@ tags:
   - message-bus
   - task-board
   - collaboration
-  - interactive
-  - long
-  - session
 source:
   repository: https://github.com/PerryLink/dsh-background-agents
   repositoryNodeId: R_kgDOT38lTw

--- a/catalog/plugins/perrylink-dsh-checkpoint-rewind.yaml
+++ b/catalog/plugins/perrylink-dsh-checkpoint-rewind.yaml
@@ -20,10 +20,6 @@ tags:
   - workspace-safety
   - undo
   - cordis-plugin
-  - unified
-  - checkpoints
-  - session
-  - workspace
 source:
   repository: https://github.com/PerryLink/dsh-checkpoint-rewind
   repositoryNodeId: R_kgDOT3vfIw

--- a/catalog/plugins/perrylink-dsh-composer-history.yaml
+++ b/catalog/plugins/perrylink-dsh-composer-history.yaml
@@ -21,9 +21,6 @@ tags:
   - context-window
   - typescript
   - ui
-  - style
-  - input
-  - history
 source:
   repository: https://github.com/PerryLink/dsh-composer-history
   repositoryNodeId: R_kgDOT3r_7g

--- a/catalog/plugins/perrylink-dsh-doublecheck.yaml
+++ b/catalog/plugins/perrylink-dsh-doublecheck.yaml
@@ -17,13 +17,6 @@ tags:
   - skill
   - quality-gate
   - delivery-gate
-  - delivery
-  - quality
-  - gate
-  - grill
-  - test
-  - implementation
-  - prove
 source:
   repository: https://github.com/PerryLink/dsh-doublecheck
   repositoryNodeId: R_kgDOT397Fg

--- a/catalog/plugins/perrylink-dsh-mcp-panel.yaml
+++ b/catalog/plugins/perrylink-dsh-mcp-panel.yaml
@@ -18,12 +18,6 @@ tags:
   - management
   - observability
   - panel
-  - console
-  - official
-  - client
-  - command
-  - health
-  - diagnostics
 source:
   repository: https://github.com/PerryLink/dsh-mcp-panel
   repositoryNodeId: R_kgDOT3-v7A

--- a/catalog/plugins/perrylink-dsh-permission-rules.yaml
+++ b/catalog/plugins/perrylink-dsh-permission-rules.yaml
@@ -19,11 +19,6 @@ tags:
   - network
   - network-policy
   - proxy
-  - declarative
-  - claude
-  - code
-  - style
-  - rules
 source:
   repository: https://github.com/PerryLink/dsh-permission-rules
   repositoryNodeId: R_kgDOT3vUCw

--- a/catalog/plugins/phant0meow-meow-memory.yaml
+++ b/catalog/plugins/phant0meow-meow-memory.yaml
@@ -14,16 +14,6 @@ tags:
   - memory
   - agent-memory
   - project-memory
-  - cross
-  - session
-  - seven
-  - layer
-  - sqlite
-  - first
-  - turn
-  - snapshot
-  - injection
-  - message
 source:
   repository: https://github.com/Phant0Meow/dsh-meow-memory
   repositoryNodeId: R_kgDOT4MGmA

--- a/catalog/plugins/pyf2818-dsh-bili-widget.yaml
+++ b/catalog/plugins/pyf2818-dsh-bili-widget.yaml
@@ -8,11 +8,12 @@ unofficial: true
 kind: plugin
 primaryCategory: entertainment-customization
 tags:
+- dsh
+- dsh-plugin
 - bilibili
 - video
-- floating-window
-- web-ui
-- entertainment
+- floating-widget
+- deepseek-harness
 source:
   repository: https://github.com/pyf2818/dsh-bili-widget
   repositoryNodeId: R_kgDOT5Nvmg

--- a/catalog/plugins/qjcnmd-reasoning-slider.yaml
+++ b/catalog/plugins/qjcnmd-reasoning-slider.yaml
@@ -13,12 +13,6 @@ tags:
   - deepseek-harness
   - reasoning
   - slider
-  - codex
-  - style
-  - effort
-  - embedded
-  - model
-  - selector
 source:
   repository: https://github.com/qjcnmd/dsh-reasoning-slider
   repositoryNodeId: R_kgDOT4WR2A

--- a/catalog/plugins/ralf0131-dsh-plugin.yaml
+++ b/catalog/plugins/ralf0131-dsh-plugin.yaml
@@ -17,7 +17,6 @@ tags:
   - genai
   - observability
   - loongsuite
-  - standalone
 source:
   repository: https://github.com/loongsuite/dsh-plugin
   repositoryNodeId: R_kgDOT49nog

--- a/catalog/plugins/samizuhm-dsh-client-ui-theme-xp.yaml
+++ b/catalog/plugins/samizuhm-dsh-client-ui-theme-xp.yaml
@@ -14,16 +14,6 @@ tags:
   - windows-xp
   - luna
   - ui
-  - windows
-  - desktop
-  - floating
-  - window
-  - manager
-  - taskbar
-  - icons
-  - explorer
-  - style
-  - workspace
 source:
   repository: https://github.com/SamizuHM/dsh-client-ui-theme-xp
   repositoryNodeId: R_kgDOT4UM1A

--- a/catalog/plugins/scorp1o117-dsh-tdai-memory.yaml
+++ b/catalog/plugins/scorp1o117-dsh-tdai-memory.yaml
@@ -17,8 +17,6 @@ tags:
   - rag
   - vector-search
   - persona
-  - agent
-  - tdai
 source:
   repository: https://github.com/Scorp1o117/dsh-tdai-memory
   repositoryNodeId: R_kgDOT3e4Sg

--- a/catalog/plugins/siegfly-dsh-deepseek-vision.yaml
+++ b/catalog/plugins/siegfly-dsh-deepseek-vision.yaml
@@ -17,13 +17,6 @@ tags:
   - provider
   - llm-gateway
   - coding-agent
-  - tree
-  - gateway
-  - route
-  - claims
-  - image
-  - input
-  - transparently
 source:
   repository: https://github.com/siegfly/dsh-deepseek-vision
   repositoryNodeId: R_kgDOT491Vw

--- a/catalog/plugins/sjh9714-dsh-movein.yaml
+++ b/catalog/plugins/sjh9714-dsh-movein.yaml
@@ -15,15 +15,6 @@ tags:
   - migration
   - mcp
   - skills
-  - migrate
-  - whole
-  - claude
-  - code
-  - codex
-  - setup
-  - command
-  - import
-  - slash
 source:
   repository: https://github.com/sjh9714/dsh-movein
   repositoryNodeId: R_kgDOT469Vg

--- a/catalog/plugins/sjh9714-dsh-win32.yaml
+++ b/catalog/plugins/sjh9714-dsh-win32.yaml
@@ -17,13 +17,6 @@ tags:
   - git-bash
   - persistent-shell
   - minimal-mode
-  - shell
-  - working
-  - persistent
-  - minimal
-  - mode
-  - sandbox
-  - included
 source:
   repository: https://github.com/sjh9714/dsh-win32
   repositoryNodeId: R_kgDOT5Ca-w

--- a/catalog/plugins/sliverp-deepseek-harness-qqbot.yaml
+++ b/catalog/plugins/sliverp-deepseek-harness-qqbot.yaml
@@ -11,8 +11,6 @@ tags:
   - deepseek-harness
   - qqbot
   - cordis
-  - channel
-  - bridge
   - dsh
 source:
   repository: https://github.com/sliverp/DeepSeek-harness-qqbot

--- a/catalog/plugins/sliverp-deepseek-harness-wecom.yaml
+++ b/catalog/plugins/sliverp-deepseek-harness-wecom.yaml
@@ -12,11 +12,6 @@ tags:
   - wecom
   - wework
   - cordis
-  - text
-  - image
-  - file
-  - channel
-  - bridge
   - dsh
 source:
   repository: https://github.com/sliverp/DeepSeek-harness-wecom

--- a/catalog/plugins/sluckyli2023-dsh-mcp-lens.yaml
+++ b/catalog/plugins/sluckyli2023-dsh-mcp-lens.yaml
@@ -19,11 +19,6 @@ tags:
   - cost-optimization
   - tool-discovery
   - tool-routing
-  - context
-  - cost
-  - model
-  - facing
-  - tools
 source:
   repository: https://github.com/labmimors/dsh-mcp-lens
   repositoryNodeId: R_kgDOT4aglQ

--- a/catalog/plugins/smackgg-dsh-archived-sessions.yaml
+++ b/catalog/plugins/smackgg-dsh-archived-sessions.yaml
@@ -11,10 +11,6 @@ tags:
   - deepseek-harness
   - dsh
   - archived-sessions
-  - view
-  - restore
-  - archived
-  - sessions
 source:
   repository: https://github.com/smackgg/dsh-archived-sessions
   repositoryNodeId: R_kgDOT4O1rA

--- a/catalog/plugins/smalldy-godot-bridge.yaml
+++ b/catalog/plugins/smalldy-godot-bridge.yaml
@@ -17,13 +17,6 @@ tags:
   - mcp
   - game-development
   - ai-agent
-  - launch
-  - drive
-  - running
-  - game
-  - through
-  - interaction
-  - server
 source:
   repository: https://github.com/Smalldy/godot-bridge
   repositoryNodeId: R_kgDOT4fcwA

--- a/catalog/plugins/sorwcyra-ds-vision-plugin.yaml
+++ b/catalog/plugins/sorwcyra-ds-vision-plugin.yaml
@@ -18,12 +18,7 @@ tags:
   - image-to-text
   - web-composer
   - typescript
-  - automatic
-  - image
-  - text
-  - bridge
-  - plus
-  - tools
+  - dsh
 source:
   repository: https://github.com/Sorwcyra/ds-vision-plugin
   repositoryNodeId: R_kgDOT37aUQ

--- a/catalog/plugins/sr043-dsh-codex-subscription.yaml
+++ b/catalog/plugins/sr043-dsh-codex-subscription.yaml
@@ -21,9 +21,6 @@ tags:
   - oauth
   - web-search
   - image-generation
-  - codex
-  - subscriptions
-  - login
 source:
   repository: https://github.com/WSL043/dsh-codex-subscription
   repositoryNodeId: R_kgDOT3wJGQ

--- a/catalog/plugins/starslittle-dsh-blue-whale.yaml
+++ b/catalog/plugins/starslittle-dsh-blue-whale.yaml
@@ -14,16 +14,6 @@ tags:
   - theme
   - skin
   - blue-whale
-  - chat
-  - style
-  - blue
-  - whale
-  - color
-  - light
-  - dark
-  - follow
-  - built
-  - appearance
 source:
   repository: https://github.com/starslittle/dsh-blue-whale
   repositoryNodeId: R_kgDOT4mb6g

--- a/catalog/plugins/starslittle-dsh-queue-plus.yaml
+++ b/catalog/plugins/starslittle-dsh-queue-plus.yaml
@@ -13,17 +13,6 @@ tags:
   - dsh-plugin
   - queue
   - prompt-queue
-  - calm
-  - unified
-  - prompt
-  - smart
-  - expansion
-  - persistent
-  - confirmations
-  - editing
-  - steering
-  - accessible
-  - reordering
 source:
   repository: https://github.com/starslittle/dsh-queue-plus
   repositoryNodeId: R_kgDOT4rBjw

--- a/catalog/plugins/sutera-diffusus-dsh-whale-musume.yaml
+++ b/catalog/plugins/sutera-diffusus-dsh-whale-musume.yaml
@@ -8,11 +8,13 @@ unofficial: true
 kind: plugin
 primaryCategory: entertainment-customization
 tags:
+- dsh
+- dsh-plugin
+- deepseek-harness
 - mascot
-- companion
-- web-ui
-- animation
-- fun
+- desktop-pet
+- whale-girl
+- cute
 source:
   repository: https://github.com/Sutera-Diffusus/dsh-whale-musume
   repositoryNodeId: R_kgDOT5YdoQ

--- a/catalog/plugins/taekchef-dsh-genui.yaml
+++ b/catalog/plugins/taekchef-dsh-genui.yaml
@@ -12,18 +12,6 @@ tags:
   - deepseek-harness
   - generative-ui
   - ui
-  - genui
-  - interactive
-  - components
-  - rendered
-  - inline
-  - assistant
-  - replies
-  - fence
-  - layout
-  - charts
-  - plots
-  - forms
 source:
   repository: https://github.com/omdsh-dev/dsh-genui
   repositoryNodeId: R_kgDOT3XuFg

--- a/catalog/plugins/tkingxiao-dsh-any-background.yaml
+++ b/catalog/plugins/tkingxiao-dsh-any-background.yaml
@@ -14,16 +14,6 @@ tags:
   - theme
   - wallpaper
   - web-ui
-  - appearance
-  - custom
-  - color
-  - style
-  - wheel
-  - background
-  - opacity
-  - blur
-  - controls
-  - separate
 source:
   repository: https://github.com/Tkingxiao/dsh-any-background
   repositoryNodeId: R_kgDOT4tdOg

--- a/catalog/plugins/turtle1999-dsh-tui.yaml
+++ b/catalog/plugins/turtle1999-dsh-tui.yaml
@@ -8,10 +8,20 @@ unofficial: true
 kind: client-interface
 primaryCategory: user-interface-dashboards
 tags:
-- tui
+- interactive
 - terminal
-- chat-client
-- pi-tui
+- front
+- door
+- agents
+- session
+- picker
+- streaming
+- chat
+- view
+- keyboard
+- first
+- controls
+- dsh
 source:
   repository: https://github.com/turtle1999/turtle-ui
   repositoryNodeId: R_kgDOT1JF8Q

--- a/catalog/plugins/vickyxai-dsh-clawrouter.yaml
+++ b/catalog/plugins/vickyxai-dsh-clawrouter.yaml
@@ -15,15 +15,7 @@ tags:
   - x402
   - llm-router
   - code-review
-  - second
-  - brain
-  - agent
-  - strong
-  - model
-  - review
-  - before
-  - risky
-  - tool
+  - dsh
 source:
   repository: https://github.com/BlockRunAI/dsh-clawrouter
   repositoryNodeId: R_kgDOT34UjA

--- a/catalog/plugins/vlln-dsh-navbar.yaml
+++ b/catalog/plugins/vlln-dsh-navbar.yaml
@@ -8,9 +8,22 @@ unofficial: true
 kind: plugin
 primaryCategory: user-interface-dashboards
 tags:
+  - conversation
+  - navigation
+  - rail
+  - node
   - user
-  - client
-  - dsh
+  - message
+  - along
+  - right
+  - edge
+  - chat
+  - hover
+  - preview
+  - cards
+  - click
+  - scroll
+  - wheel
 source:
   repository: https://github.com/vlln/dsh-navbar
   repositoryNodeId: R_kgDOT0bTDw

--- a/catalog/plugins/weijiafu14-pi2dsh.yaml
+++ b/catalog/plugins/weijiafu14-pi2dsh.yaml
@@ -13,17 +13,7 @@ tags:
   - pi-package
   - migration
   - compatibility
-  - bridge
-  - ecosystems
-  - general
-  - host
-  - runs
-  - unmodified
-  - extensions
-  - native
-  - plus
-  - package
-  - conversion
+  - dsh
 source:
   repository: https://github.com/weijiafu14/pi2dsh
   repositoryNodeId: R_kgDOT3reRg

--- a/catalog/plugins/welsione-dsh-mmx-bridge.yaml
+++ b/catalog/plugins/welsione-dsh-mmx-bridge.yaml
@@ -14,16 +14,6 @@ tags:
   - mmx-cli
   - multimodal
   - ai-agent
-  - bridge
-  - tool
-  - covers
-  - describe
-  - image
-  - video
-  - speech
-  - music
-  - cover
-  - search
 source:
   repository: https://github.com/welsione/dsh-mmx-bridge
   repositoryNodeId: R_kgDOT4L_7w

--- a/catalog/plugins/wz-heng-dsh-feishu-bridge.yaml
+++ b/catalog/plugins/wz-heng-dsh-feishu-bridge.yaml
@@ -15,15 +15,6 @@ tags:
   - lark
   - bridge
   - agent
-  - shell
-  - spawns
-  - supervises
-  - channel
-  - python
-  - process
-  - managed
-  - child
-  - host
 source:
   repository: https://github.com/wz-heng/dsh-feishu-bridge
   repositoryNodeId: R_kgDOT4Q3_A

--- a/catalog/plugins/xgone-dsh-remote.yaml
+++ b/catalog/plugins/xgone-dsh-remote.yaml
@@ -19,11 +19,6 @@ tags:
   - remote-access
   - gateway
   - login
-  - remote
-  - access
-  - gate
-  - signed
-  - session
 source:
   repository: https://github.com/xgone/dsh-remote
   repositoryNodeId: R_kgDOT53uWg

--- a/catalog/plugins/xiaozhe7772222-dsh-opencode-zen.yaml
+++ b/catalog/plugins/xiaozhe7772222-dsh-opencode-zen.yaml
@@ -15,14 +15,6 @@ tags:
   - free
   - llm
   - provider
-  - tier
-  - models
-  - zero
-  - config
-  - public
-  - quota
-  - aware
-  - pacing
 source:
   repository: https://github.com/xiaozhe7772222/dsh-opencode-zen
   repositoryNodeId: R_kgDOT6cL2A

--- a/catalog/plugins/yan-zero-dsh-codex-connect.yaml
+++ b/catalog/plugins/yan-zero-dsh-codex-connect.yaml
@@ -14,8 +14,6 @@ tags:
   - chatgpt-oauth
   - oauth
   - codex
-  - chatgpt
-  - models
   - dsh
 source:
   repository: https://github.com/franksong2702/dsh-codex-connect

--- a/catalog/plugins/ysr666-dsh-vision-router.yaml
+++ b/catalog/plugins/ysr666-dsh-vision-router.yaml
@@ -17,13 +17,6 @@ tags:
   - image
   - ocr
   - screenshot
-  - eyes
-  - text
-  - only
-  - agents
-  - built
-  - free
-  - chain
 source:
   repository: https://github.com/ysr666/dsh-vision-router
   repositoryNodeId: R_kgDOT3rG5g

--- a/catalog/plugins/yytbit-dsh-plugin-claude-bridge.yaml
+++ b/catalog/plugins/yytbit-dsh-plugin-claude-bridge.yaml
@@ -15,12 +15,6 @@ tags:
   - skills
   - migration
   - bridge
-  - claude
-  - code
-  - configuration
-  - zero
-  - full
-  - compatibility
   - dsh
 source:
   repository: https://github.com/YYTbit/dsh-plugin-claude-bridge

--- a/catalog/plugins/zoahdev-dsh-github-intelligence.yaml
+++ b/catalog/plugins/zoahdev-dsh-github-intelligence.yaml
@@ -15,15 +15,7 @@ tags:
   - issues
   - pull-requests
   - agent
-  - most
-  - comprehensive
-  - developer
-  - intelligence
-  - read
-  - only
-  - tools
-  - across
-  - gitlab
+  - dsh
 source:
   repository: https://github.com/zoahdev/dsh-github-intelligence
   repositoryNodeId: R_kgDOT46Gwg

--- a/catalog/plugins/zoahdev-dsh-plugin-doctor.yaml
+++ b/catalog/plugins/zoahdev-dsh-plugin-doctor.yaml
@@ -15,15 +15,6 @@ tags:
   - cli
   - security
   - supply-chain
-  - health
-  - checks
-  - manifest
-  - patch
-  - entry
-  - build
-  - pack
-  - install
-  - verification
 source:
   repository: https://github.com/zoahdev/dsh-plugin-doctor
   repositoryNodeId: R_kgDOT48tCw


### PR DESCRIPTION
The catalog's `tags:` field used to be filled by naively splitting the entry description into words, which let generic prose ("first", "contained", "700px") leak into the public tag lists. Tag inference now prefers the keywords the plugin package itself declares, falls back to the description split only when nothing is declared, and filters ecosystem/prose stopwords with word-boundary matching.

This PR realigns the `tags:` field of 86 published entries with that rule, recomputed from each entry's pinned source. Only the `tags:` block changes — no descriptions, categories, or other fields. Entries whose pinned source is not locally comparable were left untouched.

Validated locally: `catalog validate` and `catalog docs-check` pass for all 483 entries.