### PR TITLE
catalog: add 777-zen-dsh-tool-demo-cap (community curation, created by @777-Zen)

### DIFF
--- a/catalog/plugins/777-zen-dsh-tool-demo-cap.yaml
+++ b/catalog/plugins/777-zen-dsh-tool-demo-cap.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: 777-zen-dsh-tool-demo-cap
+name: dsh-tool-demo-cap
+description:
+  en: "Demo dsh profile bundle with a capabilities declaration: same echo tool as dsh-tool-demo, plus ctx.provide('capabilityIndex.declarations', ...) for the dsh-capability-index plugin"
+  evidencePath: examples/dsh-tool-demo-cap/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - demo
+  - profile
+  - bundle
+  - capabilities
+  - declaration
+  - same
+  - echo
+  - tool
+  - plus
+  - provide
+  - capabilityindex
+  - declarations
+  - capability
+  - index
+  - dsh
+source:
+  repository: https://github.com/777-Zen/dsh-capability-index
+  repositoryNodeId: R_kgDOT5uPHQ
+  subpath: examples/dsh-tool-demo-cap
+  commit: e023dd110748741f06767c1d6cefd2261305b48c
+creator:
+  github: 777-Zen
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: examples/dsh-tool-demo-cap/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:30:14.293Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `777-zen-dsh-tool-demo-cap`
- Submission type: community curation
- Created by `777-Zen` — https://github.com/777-Zen
- Original source repository: https://github.com/777-Zen/dsh-capability-index
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.