### PR TITLE
catalog: add 7omb2006-desktop (community curation, created by @7oMB2006)

### DIFF
--- a/catalog/plugins/7omb2006-desktop.yaml
+++ b/catalog/plugins/7omb2006-desktop.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: 7omb2006-desktop
+name: "@oh-dsh/desktop"
+description:
+  en: "Oh-DSH: installable Desktop, Web, and TUI surfaces over DeepSeek Harness"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - installable
+  - desktop
+  - surfaces
+  - over
+  - dsh
+source:
+  repository: https://github.com/hust-open-atom-club/oh-dsh
+  repositoryNodeId: R_kgDOT05OeQ
+  subpath: null
+  commit: 007506581042c978db5d3283e28df5bf10f84619
+creator:
+  github: 7oMB2006
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:29:57.742Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 257
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `7omb2006-desktop`
- Submission type: community curation
- Created by `7oMB2006` — https://github.com/7oMB2006
- Original source repository: https://github.com/hust-open-atom-club/oh-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.