### PR TITLE
catalog: add adoresever-graph-memory (community curation, created by @adoresever)

### DIFF
--- a/catalog/plugins/adoresever-graph-memory.yaml
+++ b/catalog/plugins/adoresever-graph-memory.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: adoresever-graph-memory
+name: graph-memory
+description:
+  en: Knowledge graph memory for DeepSeek Harness and OpenClaw — cross-session recall, PageRank, communities, and vector search
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - cordis
+  - openclaw
+  - agent-memory
+  - knowledge-graph
+  - sqlite
+  - dsh
+source:
+  repository: https://github.com/adoresever/graph-memory
+  repositoryNodeId: R_kgDORjueyw
+  subpath: null
+  commit: 83ffb2771022a8d323feefc280ae4f198d8b85e5
+creator:
+  github: adoresever
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:29:50.349Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 565
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `adoresever-graph-memory`
- Submission type: community curation
- Created by `adoresever` — https://github.com/adoresever
- Original source repository: https://github.com/adoresever/graph-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.