### PR TITLE
catalog: add bowenliang123-dsh-context (community curation, created by @bowenliang123)

### DIFF
--- a/catalog/plugins/bowenliang123-dsh-context.yaml
+++ b/catalog/plugins/bowenliang123-dsh-context.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: bowenliang123-dsh-context
+name: dsh-context
+description:
+  en: A DeepSeek Harness plugin for context insight and management, with context dashboard and context command, for understanding how the context is made of, and how it evolves.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - context
+  - token
+  - ui
+source:
+  repository: https://github.com/bowenliang123/dsh-context
+  repositoryNodeId: R_kgDOT4KirQ
+  subpath: null
+  commit: 52fbb1bfa77511e2fa1583dca10e916fbaae3e41
+creator:
+  github: bowenliang123
+package:
+  ecosystem: npm
+  name: dsh-context
+  version: 0.20.0
+  integrity: sha512-7I+LBvN4ZOMaC71dQs/dkF3qVqiTFm3GcWXKSz81P0uNGrQ37WK5HAUA57wq7pHDJOJTyf1WR7pkcu/5Xf0OMw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:29:48.402Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 825
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bowenliang123-dsh-context`
- Submission type: community curation
- Created by `bowenliang123` — https://github.com/bowenliang123
- Original source repository: https://github.com/bowenliang123/dsh-context
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.