### PR TITLE
catalog: add fufankeji-dsh-plugin-llm-wiki (community curation, created by @fufankeji)

### DIFF
--- a/catalog/plugins/fufankeji-dsh-plugin-llm-wiki.yaml
+++ b/catalog/plugins/fufankeji-dsh-plugin-llm-wiki.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: fufankeji-dsh-plugin-llm-wiki
+name: "@fufan/dsh-plugin-llm-wiki"
+description:
+  en: Launch the complete FF - LLM Wiki application from DeepSeek Harness
+  evidencePath: packages/examples/ff-llm-wiki-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - knowledge-base
+  - rag
+  - wiki
+  - dsh
+source:
+  repository: https://github.com/fufankeji/deepseek-harness-studio
+  repositoryNodeId: R_kgDOT46iSw
+  subpath: packages/examples/ff-llm-wiki-plugin
+  commit: 3a07208d3f3a6349a476fda0b527e01fc43766a1
+creator:
+  github: fufankeji
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/examples/ff-llm-wiki-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:30:16.575Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fufankeji-dsh-plugin-llm-wiki`
- Submission type: community curation
- Created by `fufankeji` — https://github.com/fufankeji
- Original source repository: https://github.com/fufankeji/deepseek-harness-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.