### PR TITLE
catalog: add grivn-dsh-mnemon (community curation, created by @Grivn)

### DIFF
--- a/catalog/plugins/grivn-dsh-mnemon.yaml
+++ b/catalog/plugins/grivn-dsh-mnemon.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: grivn-dsh-mnemon
+name: dsh-mnemon
+description:
+  en: "Three-tier memory control plane for DeepSeek Harness: persistent runtime context, searchable project documents, pluggable long-term memory, smart routing, supervised agent workflows, WebUI, and headless tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - dsh-plugin
+  - agent-memory
+  - llm-memory
+  - persistent-memory
+  - long-term-memory
+  - runtime-memory
+  - working-memory
+  - cross-session-memory
+  - multi-agent-memory
+  - shared-agent-memory
+  - memory-orchestration
+  - memory-provider
+  - pluggable-memory
+  - context-management
+source:
+  repository: https://github.com/omdsh-dev/dsh-mnemon
+  repositoryNodeId: R_kgDOTz1oiA
+  subpath: null
+  commit: 97019cb91cdbda78b26b92d89ec59dd2b2138ca8
+creator:
+  github: Grivn
+package:
+  ecosystem: npm
+  name: dsh-mnemon
+  version: 0.2.14
+  integrity: sha512-cleCeAHxuQGETanJtg+CUkMC0Xp763+vus3mu1vcgvUJvTwCGIM8Sem7mGbB8KvZhi9c6VGZJyr3L0ThFj83Jw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:30:04.463Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 178
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `grivn-dsh-mnemon`
- Submission type: community curation
- Created by `Grivn` — https://github.com/Grivn
- Original source repository: https://github.com/omdsh-dev/dsh-mnemon
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.