### PR TITLE
catalog: add kayshen-x-dsh-noema (community curation, created by @Kayshen-X)

### DIFF
--- a/catalog/plugins/kayshen-x-dsh-noema.yaml
+++ b/catalog/plugins/kayshen-x-dsh-noema.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: kayshen-x-dsh-noema
+name: "@zseven-w/dsh-noema"
+description:
+  en: "Noema long-term memory plugin for DSH: durable, inspectable agent memory with recall tools and a settings page."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - noema
+  - memory
+  - agent
+source:
+  repository: https://github.com/ZSeven-W/dsh-noema
+  repositoryNodeId: R_kgDOT4XHhg
+  subpath: null
+  commit: 77f3a0c426440499d96b2cf9b7fa0c9ca3b5f4a6
+creator:
+  github: Kayshen-X
+package:
+  ecosystem: npm
+  name: "@zseven-w/dsh-noema"
+  version: 0.1.0-rc.2
+  integrity: sha512-c6leET/aLddICgknf+//nZ8b1Kl9X378ZHNgSFOGL/rerkRfQ7njcAwqmRhShVG+S+R6UB4DSnsTvw798Ywgdw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:30:11.201Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 121
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kayshen-x-dsh-noema`
- Submission type: community curation
- Created by `Kayshen-X` — https://github.com/Kayshen-X
- Original source repository: https://github.com/ZSeven-W/dsh-noema
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.