### PR TITLE
catalog: add liceses-dsh-gitbash-preset (community curation, created by @liceses)

### DIFF
--- a/catalog/plugins/liceses-dsh-gitbash-preset.yaml
+++ b/catalog/plugins/liceses-dsh-gitbash-preset.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: liceses-dsh-gitbash-preset
+name: "@icelily/dsh-gitbash-preset"
+description:
+  en: "DeepSeek Harness plugin: installs the 'minimal-gitbash' agent preset — the Windows variant of the shipped minimal preset that routes the bash tool through Git for Windows bash (MSYS), with automatic shell discovery and sandbox-aware gating."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - agent-preset
+  - minimal
+  - git-bash
+  - msys
+  - windows
+source:
+  repository: https://github.com/liceses/dsh-gitbash-preset
+  repositoryNodeId: R_kgDOT43K9A
+  subpath: null
+  commit: db21575b52e249f6a2eeeef0eb9ff92dc72943c8
+creator:
+  github: liceses
+package:
+  ecosystem: npm
+  name: "@icelily/dsh-gitbash-preset"
+  version: 0.1.2
+  integrity: sha512-GOlfDPOM4Vz8PJZqpl+ayD1Wd3h3fpxY4ycwjLLD7ICVYhJRX2H38LwzXkfdz6J6FKEBUCbiooBDL5g4yNN+1Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:30:06.385Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 134
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liceses-dsh-gitbash-preset`
- Submission type: community curation
- Created by `liceses` — https://github.com/liceses
- Original source repository: https://github.com/liceses/dsh-gitbash-preset
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.