### PR TITLE
catalog: add shanliuling-dsh-image-gen (community curation, created by @shanliuling)

### DIFF
--- a/catalog/plugins/shanliuling-dsh-image-gen.yaml
+++ b/catalog/plugins/shanliuling-dsh-image-gen.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: shanliuling-dsh-image-gen
+name: dsh-image-gen
+description:
+  en: Bring ChatGPT-like image generation to DeepSeek Harness — Gemini, OpenAI, Seedream & more.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ai-agent
+  - image-generation
+  - ai-image-generation
+  - multimodal
+  - gemini
+  - openai
+  - openai-compatible
+  - seedream
+  - volcengine
+  - byok
+  - cordis
+source:
+  repository: https://github.com/shanliuling/dsh-image-gen
+  repositoryNodeId: R_kgDOT7D7kQ
+  subpath: null
+  commit: 57b0fdc4bf05ecaef9edc8e6d40bf286d074ca57
+creator:
+  github: shanliuling
+package:
+  ecosystem: npm
+  name: dsh-image-gen
+  version: 0.1.4
+  integrity: sha512-vk2RCbDTO91bVpmaL3XIRoQAIONkAo9WP3Idm5FY2i1/vdB1BZhpM5ZStlRoDhom29d5XrvS+nzvEEYVY4ZgxA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:30:12.851Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 135
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shanliuling-dsh-image-gen`
- Submission type: community curation
- Created by `shanliuling` — https://github.com/shanliuling
- Original source repository: https://github.com/shanliuling/dsh-image-gen
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.