### PR TITLE
catalog: add shaobeichen-dsh-pocket (community curation, created by @shaobeichen)

### DIFF
--- a/catalog/plugins/shaobeichen-dsh-pocket.yaml
+++ b/catalog/plugins/shaobeichen-dsh-pocket.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: shaobeichen-dsh-pocket
+name: dsh-pocket
+description:
+  en: "Put DeepSeek Harness in your pocket : one package, one settings tab — scan a QR code and your phone shows exactly what's on your computer screen, live, from anywhere."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mobile
+  - remote
+  - qr
+  - tunnel
+source:
+  repository: https://github.com/shaobeichen/dsh-pocket
+  repositoryNodeId: R_kgDOT5HoWg
+  subpath: null
+  commit: 4cdd3ec04ab8943c0264c344ad4779c4727402ef
+creator:
+  github: shaobeichen
+package:
+  ecosystem: npm
+  name: dsh-pocket
+  version: 1.9.2
+  integrity: sha512-MZQjJPJ4xCyJEOj/FP3CiAnvw6kJsLbUZAzhnkBje8MkC+b16adz87PbcUy5c+P7PVemFVnhoIsNhxFue161Hg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: GPL-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:29:54.092Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 458
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shaobeichen-dsh-pocket`
- Submission type: community curation
- Created by `shaobeichen` — https://github.com/shaobeichen
- Original source repository: https://github.com/shaobeichen/dsh-pocket
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.