### PR TITLE
catalog: add vlln-whale-girl (community curation, created by @vlln)

### DIFF
--- a/catalog/plugins/vlln-whale-girl.yaml
+++ b/catalog/plugins/vlln-whale-girl.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: vlln-whale-girl
+name: whale-girl
+description:
+  en: '<p align="center" <strong A desktop pet in the DSH Web GUI (QQ-pet style)</strong <br/ A persistent companion floating bottom-right: draggable, feedable, playable — completed tasks, sessions, and companionship time accrue into seniority levels, titles, and memories. </p'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - align
+  - center
+  - strong
+  - desktop
+  - style
+  - persistent
+  - companion
+  - floating
+  - bottom
+  - right
+  - draggable
+  - feedable
+  - playable
+  - completed
+  - tasks
+  - sessions
+source:
+  repository: https://github.com/vlln/whale-girl
+  repositoryNodeId: R_kgDOT0VkJw
+  subpath: null
+  commit: e22e1fd918746e610f7bfb1713cef1e57a56f37c
+creator:
+  github: vlln
+package:
+  ecosystem: npm
+  name: whale-girl
+  version: 0.1.0
+  integrity: sha512-+VmT+lCLJEzq5hpCEWQgom5sE5wzzCxhuEhE2/YXHeSq+w/M2GSU0dKkWGRjegSWu4ePa66pgnaoRfWPSP9z1A==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:29:55.806Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 267
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vlln-whale-girl`
- Submission type: community curation
- Created by `vlln` — https://github.com/vlln
- Original source repository: https://github.com/vlln/whale-girl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.