### PR TITLE
catalog: add xinyuehtx-dsh-profile-hooks-ordering-example (community curation, created by @xinyuehtx)

### DIFF
--- a/catalog/plugins/xinyuehtx-dsh-profile-hooks-ordering-example.yaml
+++ b/catalog/plugins/xinyuehtx-dsh-profile-hooks-ordering-example.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: xinyuehtx-dsh-profile-hooks-ordering-example
+name: dsh-profile-hooks-ordering-example
+description:
+  en: Example dsh profile that pulls in @tengxiaohtx/dsh-plugin-hooks-ordering
+  evidencePath: examples/dsh-profile/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - example
+  - profile
+  - pulls
+  - tengxiaohtx
+  - hooks
+  - ordering
+  - dsh
+source:
+  repository: https://github.com/xinyuehtx/dsh-plugin-hooks-ordering
+  repositoryNodeId: R_kgDOT6xUFQ
+  subpath: examples/dsh-profile
+  commit: a56532dbf7662d8d93b7f1c5f0bf6e407fab4b8b
+creator:
+  github: xinyuehtx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: examples/dsh-profile/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T02:30:21.533Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xinyuehtx-dsh-profile-hooks-ordering-example`
- Submission type: community curation
- Created by `xinyuehtx` — https://github.com/xinyuehtx
- Original source repository: https://github.com/xinyuehtx/dsh-plugin-hooks-ordering
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.