### PR TITLE
ci(catalog): docs gate splits exact-count (main) from no-regression (pull requests)

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -7,6 +7,8 @@ name: validate-catalog
 # advisory one — a catalog pull request could merge red until now.
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -41,5 +43,27 @@ jobs:
       # The docs gate exists in the CLI but ran nowhere: every batch merge desynchronized the
       # README's "**N plugins merged.**" counter (and the schema/category parity it checks) with
       # no red anywhere. The CLI is already built two steps above, so this costs nothing extra.
-      - name: Check catalog documentation
+      # Two modes, one per trigger: on main the count must be EXACT (a red main means a catalog
+      # merge is waiting for its counter re-alignment); on a pull request the merge commit can
+      # never carry the exact next count in a one-plugin-per-PR batch, so the CLI skips the
+      # count assertion and the step after it guards the counter from regressing vs the base.
+      - name: Check catalog documentation (exact count)
+        if: github.event_name != 'pull_request'
         run: node cli/dist/bin.js catalog docs-check .
+
+      - name: Check catalog documentation (pull-request mode)
+        if: github.event_name == 'pull_request'
+        run: node cli/dist/bin.js catalog docs-check . --skip-count
+
+      - name: README counter must not regress against the base
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --depth=1 origin "${{ github.base_ref }}"
+          base=$(git show "origin/${{ github.base_ref }}:README.md" | grep -oE '\*\*[0-9]+ plugins merged\.\*\*' | grep -oE '[0-9]+' | head -1)
+          branch=$(grep -oE '\*\*[0-9]+ plugins merged\.\*\*' README.md | grep -oE '[0-9]+' | head -1)
+          if [ -z "$branch" ]; then echo "README.md: no '**N plugins merged.**' statement found"; exit 1; fi
+          if [ -n "$base" ] && [ "$branch" -lt "$base" ]; then
+            echo "README.md: counter regressed ($branch < $base on the base branch)"
+            exit 1
+          fi
+          echo "README counter $branch does not regress the base (${base:-none})"

--- a/cli/src/app.ts
+++ b/cli/src/app.ts
@@ -123,8 +123,9 @@ export async function runCli(
   catalog.command("docs-check")
     .description("check required public catalog documentation")
     .argument("[root]", "public repository root", ".")
-    .action(async (root: string) => {
-      result = await docsCheckCommand(dependencies, root);
+    .option("--skip-count", "skip the exact README entry-count assertion (pull-request mode)")
+    .action(async (root: string, options: { skipCount?: boolean }) => {
+      result = await docsCheckCommand(dependencies, root, options);
     });
   catalog.command("github-forms-check")
     .description("check structured public GitHub issue forms")

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -155,6 +155,7 @@ function sameValues(left: readonly string[], right: readonly string[]): boolean 
 export async function docsCheckCommand(
   context: CatalogCommandContext,
   rootInput: string,
+  options: { skipCount?: boolean } = {},
 ): Promise<number> {
   let root: string;
   try {
@@ -237,8 +238,15 @@ export async function docsCheckCommand(
   }
   const snapshot = await context.loadCatalog({ root: rootInput });
   diagnostics.push(...snapshot.diagnostics);
+  // Exact-count enforcement is a main-branch concern: a one-plugin-per-PR batch can never
+  // carry the next count in its merge commit, so the pull-request gate passes --skip-count
+  // and replaces this with a no-regression comparison against the base branch instead.
   const readme = contents.get("README.md");
-  if (readme !== undefined && !readme.includes(`**${snapshot.entries.length} plugins merged.**`)) {
+  if (
+    options.skipCount !== true &&
+    readme !== undefined &&
+    !readme.includes(`**${snapshot.entries.length} plugins merged.**`)
+  ) {
     diagnostics.push({
       file: "README.md",
       code: "docs",

--- a/cli/tests/catalog-command.test.ts
+++ b/cli/tests/catalog-command.test.ts
@@ -361,7 +361,7 @@ describe("public repository checks", () => {
       license: { spdx: "MIT" },
       verification: { status: "eligible", checkedAt: "2026-08-23T00:00:00.000Z", repositoryIdentity: "resolved", smokeTest: null },
     } as never;
-    const snapshot = { source: { kind: "directory" }, entries: [entry], diagnostics: [] };
+    const snapshot = { source: { kind: "directory" as const }, entries: [entry], diagnostics: [] };
 
     const strict = harness(snapshot);
     expect(await runCli(["catalog", "docs-check", root], strict.dependencies)).toBe(1);

--- a/cli/tests/catalog-command.test.ts
+++ b/cli/tests/catalog-command.test.ts
@@ -337,6 +337,41 @@ describe("public repository checks", () => {
     expect(test.output().stderr).toContain(file);
   });
 
+  it("tolerates a stale README counter with --skip-count, but still enforces it by default", async () => {
+    // The PR gate runs on the merge commit: a one-entry batch PR reads 484 entries against a
+    // README that says 483, and no single-PR branch can ever carry the exact next count when
+    // siblings merge first. PR mode therefore skips the exact-count assertion (the workflow
+    // replaces it with a no-regression check against the base), while main keeps enforcing it.
+    const root = publicRoot();
+    const entry = {
+      schemaVersion: 1,
+      id: "fixture-plugin",
+      name: "Fixture Plugin",
+      description: { en: "A sufficiently detailed fixture plugin description.", evidencePath: "README.md" },
+      unofficial: true,
+      kind: "plugin",
+      primaryCategory: "coding-developer-tools",
+      tags: ["coding"],
+      source: { repository: "https://github.com/creator/fixture-plugin", repositoryNodeId: "R_fixture", subpath: null, commit: "a".repeat(40) },
+      creator: { github: "creator" },
+      package: null,
+      dsh: { profiles: ["default"], evidencePath: "package.json" },
+      repositoryScope: "dedicated",
+      popularity: { starsPolicy: "exact-repository", stars: 1 },
+      license: { spdx: "MIT" },
+      verification: { status: "eligible", checkedAt: "2026-08-23T00:00:00.000Z", repositoryIdentity: "resolved", smokeTest: null },
+    } as never;
+    const snapshot = { source: { kind: "directory" }, entries: [entry], diagnostics: [] };
+
+    const strict = harness(snapshot);
+    expect(await runCli(["catalog", "docs-check", root], strict.dependencies)).toBe(1);
+    expect(strict.output().stderr).toContain("catalog count must report 1 plugins merged");
+
+    const lenient = harness(snapshot);
+    expect(await runCli(["catalog", "docs-check", root, "--skip-count"], lenient.dependencies)).toBe(0);
+    expect(lenient.output().stdout).toBe("Catalog documentation checks passed for 1 entries.\n");
+  });
+
   it("detects unbalanced Markdown fences and schema/category drift", async () => {
     const fenceRoot = publicRoot();
     writeFileSync(join(fenceRoot, "docs/CREDIT.md"), "```text\nunclosed\n");


### PR DESCRIPTION
Every one-plugin-per-PR batch was born red: the docs-check ran on the merge commit and demanded the README counter be exact, which no single-PR branch can ever satisfy once a sibling merges first. The CLI gains a --skip-count flag (tested red-then-green in catalog-command.test.ts); the workflow runs the exact count only on pushes to main, and pull requests run --skip-count plus a no-regression comparison of the README counter against the base branch.