### PR TITLE
catalog: add 0xsline-dsh-spotlight (community curation, created by @0xsline)

### DIFF
--- a/catalog/plugins/0xsline-dsh-spotlight.yaml
+++ b/catalog/plugins/0xsline-dsh-spotlight.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: 0xsline-dsh-spotlight
+name: "@0xsline/dsh-spotlight"
+description:
+  en: Keyboard-first command palette for DeepSeek Harness Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - keyboard
+  - first
+  - command
+  - palette
+  - dsh
+source:
+  repository: https://github.com/0xsline/dsh-spotlight
+  repositoryNodeId: R_kgDOT3YMUg
+  subpath: null
+  commit: dd7ef5ed160aa1a624559de16eafd4ea9406d7ed
+creator:
+  github: 0xsline
+package:
+  ecosystem: npm
+  name: "@0xsline/dsh-spotlight"
+  version: 0.0.2
+  integrity: sha512-xqJyEjLjFShNgliG1TCHJf0umTZzW12byg4YKAJ8r+SeZsJ+D733+lPmzHkX7mKu6rjF35d5e1iypesiEkaqTQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:18.218Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `0xsline-dsh-spotlight`
- Submission type: community curation
- Created by `0xsline` — https://github.com/0xsline
- Original source repository: https://github.com/0xsline/dsh-spotlight
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.