### PR TITLE
catalog: add 131cda1-dsh-scrape-webpage (community curation, created by @131CDA1)

### DIFF
--- a/catalog/plugins/131cda1-dsh-scrape-webpage.yaml
+++ b/catalog/plugins/131cda1-dsh-scrape-webpage.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: 131cda1-dsh-scrape-webpage
+name: dsh-scrape-webpage
+description:
+  en: powershell dsh plugin --profile web add dsh-scrape-webpage
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - scrape
+  - web
+  - web-scraper
+source:
+  repository: https://github.com/131CDA1/dsh-scrape-webpage
+  repositoryNodeId: R_kgDOT4dW9g
+  subpath: null
+  commit: 7485af10c063579323058583c7f13e69c4c8bd21
+creator:
+  github: 131CDA1
+package:
+  ecosystem: npm
+  name: dsh-scrape-webpage
+  version: 1.0.0
+  integrity: sha512-80IRvkm4WCZH8jpEmtAPLLYCkxrHgcMMUAoc7UGn8mZUY09KA6BpjhuHeLs81gquCym7vrU1tlBjVYNlJhdMOQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:16.863Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `131cda1-dsh-scrape-webpage`
- Submission type: community curation
- Created by `131CDA1` — https://github.com/131CDA1
- Original source repository: https://github.com/131CDA1/dsh-scrape-webpage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.