### PR TITLE
catalog: add 1624318455-dsh-plugin-tts (community curation, created by @1624318455)

### DIFF
--- a/catalog/plugins/1624318455-dsh-plugin-tts.yaml
+++ b/catalog/plugins/1624318455-dsh-plugin-tts.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: 1624318455-dsh-plugin-tts
+name: "@dsh-external/dsh-plugin-tts"
+description:
+  en: "- 中文 README （简体中文） - RVC Custom Voice Guide — custom voices · chunked progressive playback · compact index · voice packs · portable runtime - User Guide (执行手册) — step-by-step, for first-time users - Adaptive chunked playback design — how gapless long reads work"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - custom
+  - voice
+  - guide
+  - voices
+  - chunked
+  - progressive
+  - playback
+  - compact
+  - index
+  - packs
+  - portable
+  - runtime
+  - user
+  - step
+  - first
+  - time
+source:
+  repository: https://github.com/1624318455/dsh-plugin-tts
+  repositoryNodeId: R_kgDOT48FpA
+  subpath: null
+  commit: 136ed935bcaa741e623164dd7f9328f1bfce5481
+creator:
+  github: "1624318455"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:33.555Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1624318455-dsh-plugin-tts`
- Submission type: community curation
- Created by `1624318455` — https://github.com/1624318455
- Original source repository: https://github.com/1624318455/dsh-plugin-tts
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.