### PR TITLE
catalog: add 1na-ko-dsh-hdc-bridge (community curation, created by @1na-ko)

### DIFF
--- a/catalog/plugins/1na-ko-dsh-hdc-bridge.yaml
+++ b/catalog/plugins/1na-ko-dsh-hdc-bridge.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: 1na-ko-dsh-hdc-bridge
+name: dsh-hdc-bridge
+description:
+  en: "DSH-native HarmonyOS dev-assistant plugin: hdc device bridge with a live device panel, official-first versioned API docs (SDK .d.ts + offline bundled Tier-1 knowledge), and an optional DevEco CLI backend for build/sign/lint."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - harmonyos
+  - openharmony
+  - arkts
+  - hdc
+  - agent
+source:
+  repository: https://github.com/1na-ko/dsh-hdc-bridge
+  repositoryNodeId: R_kgDOT3fowA
+  subpath: null
+  commit: 41b9cf65c2c6571aad27d140d922448082fa965b
+creator:
+  github: 1na-ko
+package:
+  ecosystem: npm
+  name: dsh-hdc-bridge
+  version: 0.7.2
+  integrity: sha512-k0uXupSnCpOxQKAc9/oUSBzF6M9f1K5TXIQd4pQKXiMkT98xt44R0HmJeT2gtFtQx+uEGBwHrIXG+WTNP5M7lw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:45.818Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1na-ko-dsh-hdc-bridge`
- Submission type: community curation
- Created by `1na-ko` — https://github.com/1na-ko
- Original source repository: https://github.com/1na-ko/dsh-hdc-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.