### PR TITLE
catalog: add 6mikao9-dsh-wsl-workspace (community curation, created by @6Mikao9)

### DIFF
--- a/catalog/plugins/6mikao9-dsh-wsl-workspace.yaml
+++ b/catalog/plugins/6mikao9-dsh-wsl-workspace.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: 6mikao9-dsh-wsl-workspace
+name: dsh-wsl-workspace
+description:
+  en: "WSL workspace support for DeepSeek Harness: add a WSL workspace from the web GUI and run the whole agent session (bash + file tools) inside the WSL distribution, VS Code Remote-WSL style. No toolchain install inside WSL required."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - wsl
+  - workspace
+  - windows
+source:
+  repository: https://github.com/6Mikao9/dsh-wsl-workspace
+  repositoryNodeId: R_kgDOT4ZaUw
+  subpath: null
+  commit: 3861bd984c3877cfca71fb51f81e688e0ef7f238
+creator:
+  github: 6Mikao9
+package:
+  ecosystem: npm
+  name: dsh-wsl-workspace
+  version: 0.2.3
+  integrity: sha512-3L8zcNFLi8WU3OM0nVrm2wLG/6gtKKRzKMPznRIxJ1iAmzALLzkaO/HmVDKJWC0uzdRjZ+f3aKuGk/dVJfwY8g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:19.144Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 35
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `6mikao9-dsh-wsl-workspace`
- Submission type: community curation
- Created by `6Mikao9` — https://github.com/6Mikao9
- Original source repository: https://github.com/6Mikao9/dsh-wsl-workspace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.