### PR TITLE
catalog: add aik358-dsh-auto-memory (community curation, created by @Aik358)

### DIFF
--- a/catalog/plugins/aik358-dsh-auto-memory.yaml
+++ b/catalog/plugins/aik358-dsh-auto-memory.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: aik358-dsh-auto-memory
+name: "@a9i5k4/dsh-auto-memory"
+description:
+  en: "A cache-friendly three-layer memory engine for the DeepSeek Harness Web GUI — lean auto injection, per-turn AI consolidation, on-demand reads and cross-tool memory inheritance — wrapped in human touches: proactive calendar reminders, warm AI greetings, and a daily journal that writes itself."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - memory
+  - auto-memory
+source:
+  repository: https://github.com/Aik358/dsh-auto-memory
+  repositoryNodeId: R_kgDOT4IjKA
+  subpath: null
+  commit: 2e5ce9cb760e81e7e662db75783c64bc598dfe8d
+creator:
+  github: Aik358
+package:
+  ecosystem: npm
+  name: "@a9i5k4/dsh-auto-memory"
+  version: 0.1.29
+  integrity: sha512-GZ/LCqeYqHiShEHFs9MK/VA43FHaw9YqrUIm405bszcK1VniSCk4LZeibqRTVS/ky50ooh+MZs5oBVwejnjpSw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:29.880Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 27
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aik358-dsh-auto-memory`
- Submission type: community curation
- Created by `Aik358` — https://github.com/Aik358
- Original source repository: https://github.com/Aik358/dsh-auto-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.