### PR TITLE
catalog: add aks1st-cyber-particle (community curation, created by @AKS1st)

### DIFF
--- a/catalog/plugins/aks1st-cyber-particle.yaml
+++ b/catalog/plugins/aks1st-cyber-particle.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: aks1st-cyber-particle
+name: cyber-particle
+description:
+  en: Particle-network background overlay for the DeepSeek Harness Web shell (browser-rendered, localStorage persistence).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web-ui
+  - background
+  - particles
+source:
+  repository: https://github.com/AKS1st/dsh-cyber-particle
+  repositoryNodeId: R_kgDOT4do6Q
+  subpath: null
+  commit: e08111d59df009454d9de6b8384907f697e038f6
+creator:
+  github: AKS1st
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:47.197Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aks1st-cyber-particle`
- Submission type: community curation
- Created by `AKS1st` — https://github.com/AKS1st
- Original source repository: https://github.com/AKS1st/dsh-cyber-particle
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.