### PR TITLE
catalog: add aks1st-dsh-mermaid (community curation, created by @AKS1st)

### DIFF
--- a/catalog/plugins/aks1st-dsh-mermaid.yaml
+++ b/catalog/plugins/aks1st-dsh-mermaid.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: aks1st-dsh-mermaid
+name: dsh-mermaid
+description:
+  en: Render mermaid fences in DSH Web conversation messages as interactive-free SVG diagrams (lazy-loaded, strict security).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web-ui
+  - mermaid
+  - diagram
+  - svg
+source:
+  repository: https://github.com/AKS1st/dsh-mermaid
+  repositoryNodeId: R_kgDOT4vqGg
+  subpath: null
+  commit: 2708cdf2e2eb1c0cd15448c3d3d680b8fba58d48
+creator:
+  github: AKS1st
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:19.630Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aks1st-dsh-mermaid`
- Submission type: community curation
- Created by `AKS1st` — https://github.com/AKS1st
- Original source repository: https://github.com/AKS1st/dsh-mermaid
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.