### PR TITLE
catalog: add aks1st-model-usage-plugin (community curation, created by @AKS1st)

### DIFF
--- a/catalog/plugins/aks1st-model-usage-plugin.yaml
+++ b/catalog/plugins/aks1st-model-usage-plugin.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: aks1st-model-usage-plugin
+name: model-usage-plugin
+description:
+  en: Per-model token usage, cost estimation and DeepSeek account balance for the DeepSeek Harness Web UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - tokens
+  - usage
+  - cost
+  - balance
+source:
+  repository: https://github.com/AKS1st/model-usage-plugin
+  repositoryNodeId: R_kgDOT4vqLg
+  subpath: null
+  commit: 62b5c88f574f68623c8096ccdb0e2159452c1565
+creator:
+  github: AKS1st
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:22.166Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aks1st-model-usage-plugin`
- Submission type: community curation
- Created by `AKS1st` — https://github.com/AKS1st
- Original source repository: https://github.com/AKS1st/model-usage-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.