### PR TITLE
catalog: add alingalingling-dsh-ui-status-label (community curation, created by @alingalingling)

### DIFF
--- a/catalog/plugins/alingalingling-dsh-ui-status-label.yaml
+++ b/catalog/plugins/alingalingling-dsh-ui-status-label.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: alingalingling-dsh-ui-status-label
+name: dsh-ui-status-label
+description:
+  en: "Configurable running-turn status text for dsh Web: General Settings row plus the conversationStatus provider for the chat view"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - configurable
+  - running
+  - turn
+  - status
+  - text
+  - general
+  - settings
+  - plus
+  - conversationstatus
+  - provider
+  - chat
+  - view
+  - dsh
+source:
+  repository: https://github.com/alingalingling/ui-status-label
+  repositoryNodeId: R_kgDOT1oAfQ
+  subpath: null
+  commit: a1621413a4700cb489655ad3ebf7fa8484c3645f
+creator:
+  github: alingalingling
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:04.806Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 40
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alingalingling-dsh-ui-status-label`
- Submission type: community curation
- Created by `alingalingling` — https://github.com/alingalingling
- Original source repository: https://github.com/alingalingling/ui-status-label
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.