### PR TITLE
catalog: add amlyczz-dsh-lark-link (community curation, created by @amlyczz)

### DIFF
--- a/catalog/plugins/amlyczz-dsh-lark-link.yaml
+++ b/catalog/plugins/amlyczz-dsh-lark-link.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: amlyczz-dsh-lark-link
+name: dsh-lark-link
+description:
+  en: High-reliability Feishu/Lark bridge for DeepSeek Harness — QR one-click auth, multi-mode agents, card-based commands, zero-loss outbox, media in/out, session logs, reusable DSH Web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - feishu
+  - lark
+  - bridge
+  - bot
+source:
+  repository: https://github.com/amlyczz/dsh-lark-link
+  repositoryNodeId: R_kgDOT3sk0Q
+  subpath: null
+  commit: 36c3295af81f13a641538e97c0e3e79c07423cdd
+creator:
+  github: amlyczz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:41.640Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 27
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `amlyczz-dsh-lark-link`
- Submission type: community curation
- Created by `amlyczz` — https://github.com/amlyczz
- Original source repository: https://github.com/amlyczz/dsh-lark-link
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.