### PR TITLE
catalog: add anacondakc-dsh-stock-market (community curation, created by @AnacondaKC)

### DIFF
--- a/catalog/plugins/anacondakc-dsh-stock-market.yaml
+++ b/catalog/plugins/anacondakc-dsh-stock-market.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: anacondakc-dsh-stock-market
+name: dsh-stock-market
+description:
+  en: DSH Shanghai and Shenzhen A-share market plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - shanghai
+  - shenzhen
+  - share
+  - market
+  - dsh
+source:
+  repository: https://github.com/AnacondaKC/dsh-stock-market
+  repositoryNodeId: R_kgDOT2Jb2A
+  subpath: null
+  commit: 02278af12330102c534c843a668d1c8407dbde1b
+creator:
+  github: AnacondaKC
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:16.607Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 16
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `anacondakc-dsh-stock-market`
- Submission type: community curation
- Created by `AnacondaKC` — https://github.com/AnacondaKC
- Original source repository: https://github.com/AnacondaKC/dsh-stock-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.