### PR TITLE
catalog: add anionex-dsh-turn-rewind (community curation, created by @Anionex)

### DIFF
--- a/catalog/plugins/anionex-dsh-turn-rewind.yaml
+++ b/catalog/plugins/anionex-dsh-turn-rewind.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: anionex-dsh-turn-rewind
+name: "@anionex/dsh-turn-rewind"
+description:
+  en: Turn-level conversation and workspace rewind for DeepSeek Harness, powered by a persistent Change Ledger
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - restore-point
+  - workspace
+  - change-ledger
+  - turn-rewind
+source:
+  repository: https://github.com/Anionex/dsh-turn-rewind
+  repositoryNodeId: R_kgDOT3V_Zg
+  subpath: null
+  commit: b1b85f18aaaaf71d76c84613429ce04d71f69620
+creator:
+  github: Anionex
+package:
+  ecosystem: npm
+  name: "@anionex/dsh-turn-rewind"
+  version: 0.1.1
+  integrity: sha512-pgFXZmvQDynLDDbpSltCTxWEgPOFuvZojuPgWDZ3Em/OlFicoRoHQQbhHRuitvXgVF/t4tvCApaDtAhs0+ZvOg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:30.941Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 96
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `anionex-dsh-turn-rewind`
- Submission type: community curation
- Created by `Anionex` — https://github.com/Anionex
- Original source repository: https://github.com/Anionex/dsh-turn-rewind
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.