### PR TITLE
catalog: add beizi6-dsh-opencodego-usage (community curation, created by @BeiZi6)

### DIFF
--- a/catalog/plugins/beizi6-dsh-opencodego-usage.yaml
+++ b/catalog/plugins/beizi6-dsh-opencodego-usage.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: beizi6-dsh-opencodego-usage
+name: dsh-opencodego-usage
+description:
+  en: "OpenCodeGo quota monitor for the DeepSeek Harness (DSH) Web GUI: a breathing indicator at the bottom-right of the input box shows your remaining quota at a glance; click it to open a liquid-glass panel with per-window progress bars and reset times."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - opencodego
+  - usage
+  - quota
+  - web-gui
+source:
+  repository: https://github.com/BeiZi6/dsh-opencodego-usage
+  repositoryNodeId: R_kgDOT4iZkQ
+  subpath: null
+  commit: 0990d71ccb0965c758b86a048a8a2614d082a14f
+creator:
+  github: BeiZi6
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:23.480Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `beizi6-dsh-opencodego-usage`
- Submission type: community curation
- Created by `BeiZi6` — https://github.com/BeiZi6
- Original source repository: https://github.com/BeiZi6/dsh-opencodego-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.