### PR TITLE
catalog: add bill9109-dsh-web-ui-notify (community curation, created by @bill9109)

### DIFF
--- a/catalog/plugins/bill9109-dsh-web-ui-notify.yaml
+++ b/catalog/plugins/bill9109-dsh-web-ui-notify.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: bill9109-dsh-web-ui-notify
+name: "@bill9109/dsh-web-ui-notify"
+description:
+  en: Desktop notifications for DeepSeek Harness approvals, questions, and turn completion — so neither DSH nor you end up waiting while you browse another tab.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - web-ui
+  - desktop-notification
+  - approval
+  - notify
+  - dsh
+source:
+  repository: https://github.com/bill9109/dsh-web-ui-notify
+  repositoryNodeId: R_kgDOTuSGFA
+  subpath: null
+  commit: 865d2f6fc93f2e0d051d53df772646cb831a43ed
+creator:
+  github: bill9109
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:49.677Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 22
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bill9109-dsh-web-ui-notify`
- Submission type: community curation
- Created by `bill9109` — https://github.com/bill9109
- Original source repository: https://github.com/bill9109/dsh-web-ui-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.