### PR TITLE
catalog: add bobleer-dsh-acp-for-bitfun (community curation, created by @bobleer)

### DIFF
--- a/catalog/plugins/bobleer-dsh-acp-for-bitfun.yaml
+++ b/catalog/plugins/bobleer-dsh-acp-for-bitfun.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: bobleer-dsh-acp-for-bitfun
+name: dsh-acp-for-bitfun
+description:
+  en: "BitFun 与 DSH ACP 交互对接 插件: expose the BitFun agent (https://github.com/GCWing/BitFun) as a subagent provider inside DeepSeek Harness over the Agent Client Protocol"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - bitfun
+  - acp
+  - deepseek-harness
+  - agent-client-protocol
+  - dsh
+source:
+  repository: https://github.com/bobleer/dsh-acp-for-bitfun
+  repositoryNodeId: R_kgDOT3Wc7Q
+  subpath: null
+  commit: 8dedce1ee1a463cfb21e2ac0d8518a8d3c67c5aa
+creator:
+  github: bobleer
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:07.442Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bobleer-dsh-acp-for-bitfun`
- Submission type: community curation
- Created by `bobleer` — https://github.com/bobleer
- Original source repository: https://github.com/bobleer/dsh-acp-for-bitfun
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.