### PR TITLE
catalog: add bramblexu-dsh-annotate (community curation, created by @BrambleXu)

### DIFF
--- a/catalog/plugins/bramblexu-dsh-annotate.yaml
+++ b/catalog/plugins/bramblexu-dsh-annotate.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: bramblexu-dsh-annotate
+name: dsh-annotate
+description:
+  en: Browser element annotation bridge for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - annotation
+  - browser
+  - visual-debugging
+  - dsh
+source:
+  repository: https://github.com/BrambleXu/dsh-annotate
+  repositoryNodeId: R_kgDOT33P0A
+  subpath: null
+  commit: 43f39543f720d6f8851924f1387c797f04debd21
+creator:
+  github: BrambleXu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:24.915Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bramblexu-dsh-annotate`
- Submission type: community curation
- Created by `BrambleXu` — https://github.com/BrambleXu
- Original source repository: https://github.com/BrambleXu/dsh-annotate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.