### PR TITLE
catalog: add btspoony-dsh-advisor (community curation, created by @btspoony)

### DIFF
--- a/catalog/plugins/btspoony-dsh-advisor.yaml
+++ b/catalog/plugins/btspoony-dsh-advisor.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: btspoony-dsh-advisor
+name: dsh-advisor
+description:
+  en: "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+source:
+  repository: https://github.com/omdsh-dev/dsh-advisor
+  repositoryNodeId: R_kgDOTxd6Kg
+  subpath: null
+  commit: afe8bdbf17a83826cd6fdfc3b21e9850ecc43395
+creator:
+  github: btspoony
+package:
+  ecosystem: npm
+  name: dsh-advisor
+  version: 0.2.4
+  integrity: sha512-42xAc7vBDKaEdHnl7PiT6Xfs4SkKTXS3/iC1sNbb1N9oYr+YFJAI5HHhgBbUtYCxiXW+zdEXeqV42tXUdRgjpA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:21.151Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 15
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `btspoony-dsh-advisor`
- Submission type: community curation
- Created by `btspoony` — https://github.com/btspoony
- Original source repository: https://github.com/omdsh-dev/dsh-advisor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.