### PR TITLE
catalog: add bugmaker2-dsh-github (community curation, created by @bugmaker2)

### DIFF
--- a/catalog/plugins/bugmaker2-dsh-github.yaml
+++ b/catalog/plugins/bugmaker2-dsh-github.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: bugmaker2-dsh-github
+name: dsh-github
+description:
+  en: Source Control and GitHub panel for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - git
+  - source-control
+  - dsh
+source:
+  repository: https://github.com/PivotStackIntelligence/dsh-github
+  repositoryNodeId: R_kgDOT3mybQ
+  subpath: null
+  commit: 781722d799c5570ca9dfbb47d8044d29784ff0fc
+creator:
+  github: bugmaker2
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:39.358Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 18
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bugmaker2-dsh-github`
- Submission type: community curation
- Created by `bugmaker2` — https://github.com/bugmaker2
- Original source repository: https://github.com/PivotStackIntelligence/dsh-github
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.