### PR TITLE
catalog: add caoyiwei850-dsh-client-ui-skins (community curation, created by @caoyiwei850)

### DIFF
--- a/catalog/plugins/caoyiwei850-dsh-client-ui-skins.yaml
+++ b/catalog/plugins/caoyiwei850-dsh-client-ui-skins.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: caoyiwei850-dsh-client-ui-skins
+name: dsh-client-ui-skins
+description:
+  en: "DSH skin plugin: built-in skins + custom image skins, pure client plugin (no source patch)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - skin
+  - built
+  - skins
+  - custom
+  - image
+  - pure
+  - client
+  - source
+  - patch
+  - dsh
+source:
+  repository: https://github.com/caoyiwei850/dsh-client-ui-skins
+  repositoryNodeId: R_kgDOT45Hlg
+  subpath: null
+  commit: cc5b092f1ecc8f9810d83aa2aabb6f70007570bb
+creator:
+  github: caoyiwei850
+package:
+  ecosystem: npm
+  name: dsh-client-ui-skins
+  version: 0.1.11
+  integrity: sha512-iO/PIn8LY1680EqKt8IVExE/4EgcOh5J1BdrZ62RcUqKtY6rdCMbFDzIALHzdQhprnBrlBxy0CfYjNmpHvaODg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:26.343Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `caoyiwei850-dsh-client-ui-skins`
- Submission type: community curation
- Created by `caoyiwei850` — https://github.com/caoyiwei850
- Original source repository: https://github.com/caoyiwei850/dsh-client-ui-skins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.