### PR TITLE
catalog: add ccq1-dsh-side-panel (community curation, created by @ccq1)

### DIFF
--- a/catalog/plugins/ccq1-dsh-side-panel.yaml
+++ b/catalog/plugins/ccq1-dsh-side-panel.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ccq1-dsh-side-panel
+name: "@dsh-external/dsh-side-panel"
+description:
+  en: Git review, terminal, and file workspace panel for DSH Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - review
+  - terminal
+  - file
+  - workspace
+  - panel
+  - dsh
+source:
+  repository: https://github.com/ccq1/dsh-side-panel
+  repositoryNodeId: R_kgDOTxs3Sg
+  subpath: null
+  commit: baca7806714ac577ac529647f105d58a2a10b228
+creator:
+  github: ccq1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:18.134Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 16
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ccq1-dsh-side-panel`
- Submission type: community curation
- Created by `ccq1` — https://github.com/ccq1
- Original source repository: https://github.com/ccq1/dsh-side-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.