### PR TITLE
catalog: add cedric-m-dsh-balance-meter (community curation, created by @Cedric-M)

### DIFF
--- a/catalog/plugins/cedric-m-dsh-balance-meter.yaml
+++ b/catalog/plugins/cedric-m-dsh-balance-meter.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: cedric-m-dsh-balance-meter
+name: dsh-balance-meter
+description:
+  en: Official, proxy-compatible, or locally accounted balance and session-cost readout for the DSH web GUI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - official
+  - proxy
+  - compatible
+  - locally
+  - accounted
+  - balance
+  - session
+  - cost
+  - readout
+  - dsh
+source:
+  repository: https://github.com/Ghost011118/dsh-balance-meter
+  repositoryNodeId: R_kgDOT3q9Aw
+  subpath: null
+  commit: 1a277e8eb9ee5ebbf8589e6bbb96bfe9ac282c11
+creator:
+  github: Cedric-M
+package:
+  ecosystem: npm
+  name: dsh-balance-meter
+  version: 0.1.0
+  integrity: sha512-skTw/Njkqbm0pDLsBYPXhobf9VZayEa/wiahy0WYPLJBaj4LBGxNSY8wkENmMoHVu7qZC8hZcZlr75WpHrtgOQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:03.257Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 19
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cedric-m-dsh-balance-meter`
- Submission type: community curation
- Created by `Cedric-M` — https://github.com/Cedric-M
- Original source repository: https://github.com/Ghost011118/dsh-balance-meter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.