### PR TITLE
catalog: add chinesezjc-dsh-interconnect (community curation, created by @Chinesezjc)

### DIFF
--- a/catalog/plugins/chinesezjc-dsh-interconnect.yaml
+++ b/catalog/plugins/chinesezjc-dsh-interconnect.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: chinesezjc-dsh-interconnect
+name: dsh-interconnect
+description:
+  en: "Cross-instance message/event handoff plugins for DeepSeek Harness (DSH): interconnect service + model-facing tools"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - cross
+  - instance
+  - message
+  - event
+  - handoff
+  - interconnect
+  - service
+  - model
+  - facing
+  - tools
+  - dsh
+source:
+  repository: https://github.com/Chinesezjc/dsh-interconnect
+  repositoryNodeId: R_kgDOT3VC4w
+  subpath: null
+  commit: 32ca0ec0441983f7eded7c6d2bfbecfda02087b0
+creator:
+  github: Chinesezjc
+package:
+  ecosystem: npm
+  name: dsh-interconnect
+  version: 0.9.0
+  integrity: sha512-CASqTZoWCV8vbjm4L+m1d+NeWIK4e5g+tFfz/ySkQYPJSq7if4F6nf2/+Yt7E8Lr593P8Pm2Rc8Xxb6JSXiDxg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:11.617Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 34
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chinesezjc-dsh-interconnect`
- Submission type: community curation
- Created by `Chinesezjc` — https://github.com/Chinesezjc
- Original source repository: https://github.com/Chinesezjc/dsh-interconnect
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.