### PR TITLE
catalog: add cloader-dsh-taskboard (community curation, created by @cloader)

### DIFF
--- a/catalog/plugins/cloader-dsh-taskboard.yaml
+++ b/catalog/plugins/cloader-dsh-taskboard.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: cloader-dsh-taskboard
+name: dsh-taskboard
+description:
+  en: "Agent-first task board for the DSH web GUI: host-authoritative task ledger with taskboard agent tools, project (= workspace) claim boundaries, per-task model execution in fresh sessions, optional per-task git-worktree isolation (dedicated task branches, commit evidence, one-click merge), host-side cron scheduling, and "
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - taskboard
+  - kanban
+  - agent
+source:
+  repository: https://github.com/cloader/dsh-taskboard
+  repositoryNodeId: R_kgDOT5BykQ
+  subpath: null
+  commit: cfea989d51a7df565305b4f24a1e7b50b5dcde72
+creator:
+  github: cloader
+package:
+  ecosystem: npm
+  name: dsh-taskboard
+  version: 0.4.2
+  integrity: sha512-1s+JhzviITXWPKVVx1AKDgPx85cGEphJGVyoCY1ARVV95xNRdhlWMuAet0gQpvCxY676mExpN8cpXseL2i/jCg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:27.192Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 15
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cloader-dsh-taskboard`
- Submission type: community curation
- Created by `cloader` — https://github.com/cloader
- Original source repository: https://github.com/cloader/dsh-taskboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.