### PR TITLE
catalog: add cxauo-wanjiqi-meme (community curation, created by @CXAUO)

### DIFF
--- a/catalog/plugins/cxauo-wanjiqi-meme.yaml
+++ b/catalog/plugins/cxauo-wanjiqi-meme.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: cxauo-wanjiqi-meme
+name: wanjiqi-meme
+description:
+  en: bash dsh plugin --profile web add "github:Chu-Xin-r/wanjiqi-meme"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - skill
+  - agentskills
+  - csgo
+  - cs2
+  - meme
+  - wanjiqi
+  - claude-code
+  - dsh
+source:
+  repository: https://github.com/Chu-Xin-r/wanjiqi-meme
+  repositoryNodeId: R_kgDOT4m_Pg
+  subpath: null
+  commit: de4eac5ba5275ba08012fa71619298b19e9dcae6
+creator:
+  github: CXAUO
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:36.546Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cxauo-wanjiqi-meme`
- Submission type: community curation
- Created by `CXAUO` — https://github.com/CXAUO
- Original source repository: https://github.com/Chu-Xin-r/wanjiqi-meme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.