### PR TITLE
catalog: add dawnliming-dsh-chinese-mode (community curation, created by @dawnliming)

### DIFF
--- a/catalog/plugins/dawnliming-dsh-chinese-mode.yaml
+++ b/catalog/plugins/dawnliming-dsh-chinese-mode.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: dawnliming-dsh-chinese-mode
+name: dsh-chinese-mode
+description:
+  en: "A global Simplified-Chinese mode plugin for DeepSeek Harness Web: a compact Chinese Mode pill beside the permission selector in the input box, which injects language requirements into the system prompt of any preset when enabled."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - chinese
+  - zh
+source:
+  repository: https://github.com/dawnliming/dsh-chinese-mode
+  repositoryNodeId: R_kgDOT5vY1w
+  subpath: null
+  commit: 830f1fce7f199c0683311c3c5afe251a5d869af0
+creator:
+  github: dawnliming
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:27.818Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dawnliming-dsh-chinese-mode`
- Submission type: community curation
- Created by `dawnliming` — https://github.com/dawnliming
- Original source repository: https://github.com/dawnliming/dsh-chinese-mode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.