### PR TITLE
catalog: add dddmuc-dsh-free-search (community curation, created by @DDDMUC)

### DIFF
--- a/catalog/plugins/dddmuc-dsh-free-search.yaml
+++ b/catalog/plugins/dddmuc-dsh-free-search.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dddmuc-dsh-free-search
+name: dsh-free-search
+description:
+  en: "Free web search for DeepSeek Harness: 10 engines (Bing/DuckDuckGo/AnySearch/SearXNG/Exa/Tavily/Keenable keyless) + time filtering + platform search + web fetch, with web settings UI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - web-search
+  - duckduckgo
+  - bing
+  - tavily
+  - exa
+  - keenable
+  - perplexity
+  - search
+  - free
+source:
+  repository: https://github.com/DDDMUC/dsh-free-search
+  repositoryNodeId: R_kgDOT4kVug
+  subpath: null
+  commit: dc88da137813fb55b22918f77c94561b6f1acefa
+creator:
+  github: DDDMUC
+package:
+  ecosystem: npm
+  name: dsh-free-search
+  version: 0.4.11
+  integrity: sha512-4hHSPbSu9MdTtiUGsUjliLUEIiOgvovT2rbB7bLTVVcg8zKrnkyx7GoIj6r7M34XMlgOMRwP5WLkHHWCcqi53A==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:09.768Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 48
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dddmuc-dsh-free-search`
- Submission type: community curation
- Created by `DDDMUC` — https://github.com/DDDMUC
- Original source repository: https://github.com/DDDMUC/dsh-free-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.