### PR TITLE
catalog: add dickpy-dsh-cloud-sync (community curation, created by @dickpy)

### DIFF
--- a/catalog/plugins/dickpy-dsh-cloud-sync.yaml
+++ b/catalog/plugins/dickpy-dsh-cloud-sync.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: dickpy-dsh-cloud-sync
+name: "@dickpy/dsh-cloud-sync"
+description:
+  en: Portable DeepSeek Harness profile and local-plugin source synchronization.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - portable
+  - profile
+  - local
+  - source
+  - synchronization
+  - dsh
+source:
+  repository: https://github.com/dickpy/dsh-cloud-sync
+  repositoryNodeId: R_kgDOT5UfzQ
+  subpath: null
+  commit: 85e2f20d6da5dfc9ee466ba54e3e28b14eb0e85f
+creator:
+  github: dickpy
+package:
+  ecosystem: npm
+  name: "@dickpy/dsh-cloud-sync"
+  version: 0.20.6
+  integrity: sha512-NOKm2KA+uXwsmTDas1ESxHCn8TFsjIx8Loup/G01uY6teWO45jxHnk9DpjbAmt9WJxvPBJZReaOi4nWXK/Y9BQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:48.524Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 14
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dickpy-dsh-cloud-sync`
- Submission type: community curation
- Created by `dickpy` — https://github.com/dickpy
- Original source repository: https://github.com/dickpy/dsh-cloud-sync
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.