### PR TITLE
catalog: add dream12347-dsh-session-manager (community curation, created by @dream12347)

### DIFF
--- a/catalog/plugins/dream12347-dsh-session-manager.yaml
+++ b/catalog/plugins/dream12347-dsh-session-manager.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dream12347-dsh-session-manager
+name: dsh-session-manager
+description:
+  en: "Full session management for the DSH web UI: delete (with trash/restore/purge), restore archived sessions, activity stats, continue/pause, fork to a new chat, unread markers, and open log folders. Plus a global context compaction threshold. No harness changes."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - full
+  - session
+  - management
+  - delete
+  - trash
+  - restore
+  - purge
+  - archived
+  - sessions
+  - activity
+  - stats
+  - continue
+  - pause
+  - fork
+  - chat
+  - unread
+source:
+  repository: https://github.com/dream12347/dsh-session-manager
+  repositoryNodeId: R_kgDOT4dLug
+  subpath: null
+  commit: 751059bb0425ab03f43b8f46f6bfecec5e699a6b
+creator:
+  github: dream12347
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:01.530Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 47
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dream12347-dsh-session-manager`
- Submission type: community curation
- Created by `dream12347` — https://github.com/dream12347
- Original source repository: https://github.com/dream12347/dsh-session-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.