### PR TITLE
catalog: add fly233338-dsh-overleaf (community curation, created by @fly233338)

### DIFF
--- a/catalog/plugins/fly233338-dsh-overleaf.yaml
+++ b/catalog/plugins/fly233338-dsh-overleaf.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: fly233338-dsh-overleaf
+name: dsh-overleaf
+description:
+  en: DSH bundle that exposes multiple Overleaf projects through OverleafMCP
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - overleaf
+  - mcp
+  - latex
+source:
+  repository: https://github.com/fly233338/dsh-overleaf
+  repositoryNodeId: R_kgDOT4Mxzw
+  subpath: null
+  commit: abebb782b69a02c913fdc686985026387ceeb829
+creator:
+  github: fly233338
+package:
+  ecosystem: npm
+  name: dsh-overleaf
+  version: 0.1.1
+  integrity: sha512-QPpEOBci7+gpCX25Kpa2dS/EN4C8sJBeEtq/+yGfsQ9ndxvh6FJDs8hzhjf340Vd3LcfLazLSNj6y+mIpywl0w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:29.320Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fly233338-dsh-overleaf`
- Submission type: community curation
- Created by `fly233338` — https://github.com/fly233338
- Original source repository: https://github.com/fly233338/dsh-overleaf
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.