### PR TITLE
catalog: add fredalxin-dsh-plugin-solo-thinking (community curation, created by @fredalxin)

### DIFF
--- a/catalog/plugins/fredalxin-dsh-plugin-solo-thinking.yaml
+++ b/catalog/plugins/fredalxin-dsh-plugin-solo-thinking.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: fredalxin-dsh-plugin-solo-thinking
+name: dsh-plugin-solo-thinking
+description:
+  en: Solo-style isolated brainstorm branches and Handoffs for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - brainstorm
+  - solo-thinking
+  - handoff
+  - multi-agent
+source:
+  repository: https://github.com/fredalxin/dsh-solo-thinking
+  repositoryNodeId: R_kgDOT4fWlg
+  subpath: null
+  commit: a77f3bb45ae8557df8a849e03ca0ed0b2d1a9e5d
+creator:
+  github: fredalxin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:01.573Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 20
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fredalxin-dsh-plugin-solo-thinking`
- Submission type: community curation
- Created by `fredalxin` — https://github.com/fredalxin
- Original source repository: https://github.com/fredalxin/dsh-solo-thinking
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.