### PR TITLE
catalog: add fsmargoo-dsh-custom-tool (community curation, created by @FSMargoo)

### DIFF
--- a/catalog/plugins/fsmargoo-dsh-custom-tool.yaml
+++ b/catalog/plugins/fsmargoo-dsh-custom-tool.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: fsmargoo-dsh-custom-tool
+name: dsh-custom-tool
+description:
+  en: "DSH custom tools: manage user-defined JavaScript tools in the settings UI with a Monaco editor; the model creates its own tools through custom tool create"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - custom
+  - tools
+  - manage
+  - user
+  - defined
+  - javascript
+  - settings
+  - monaco
+  - editor
+  - model
+  - creates
+  - through
+  - tool
+  - create
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-custom-tool
+  repositoryNodeId: R_kgDOT3UCWw
+  subpath: null
+  commit: 7cb95649dca9b380c9a30af96bdbef87a76a2259
+creator:
+  github: FSMargoo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:34.342Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 24
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fsmargoo-dsh-custom-tool`
- Submission type: community curation
- Created by `FSMargoo` — https://github.com/FSMargoo
- Original source repository: https://github.com/omdsh-dev/dsh-custom-tool
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.