### PR TITLE
catalog: add fsmargoo-dsh-notification (community curation, created by @FSMargoo)

### DIFF
--- a/catalog/plugins/fsmargoo-dsh-notification.yaml
+++ b/catalog/plugins/fsmargoo-dsh-notification.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: fsmargoo-dsh-notification
+name: dsh-notification
+description:
+  en: "Browser desktop notifications when the DeepSeek Harness finishes a turn: configurable per-outcome toggles and include/exclude keyword rules, shown through the browser Notification API."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - browser
+  - desktop
+  - notifications
+  - finishes
+  - turn
+  - configurable
+  - outcome
+  - toggles
+  - include
+  - exclude
+  - keyword
+  - rules
+  - shown
+  - through
+  - notification
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-notification
+  repositoryNodeId: R_kgDOT3UB3g
+  subpath: null
+  commit: ddec603395a223deb46c75b74274c41849c6a131
+creator:
+  github: FSMargoo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:39.413Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 71
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fsmargoo-dsh-notification`
- Submission type: community curation
- Created by `FSMargoo` — https://github.com/FSMargoo
- Original source repository: https://github.com/omdsh-dev/dsh-notification
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.