### PR TITLE
catalog: add glfzr-dsh-file-upload (community curation, created by @GLFzr)

### DIFF
--- a/catalog/plugins/glfzr-dsh-file-upload.yaml
+++ b/catalog/plugins/glfzr-dsh-file-upload.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: glfzr-dsh-file-upload
+name: dsh-file-upload
+description:
+  en: "Codex-style drag-drop for DSH web GUI: drag any file, it lands in ~/.dsh-dropbox, and the path lands in the composer as a whole blue chip (the mandatory .b64 suffix is display-hidden; the real path serializes on submit). Hot-pluggable: install with dsh plugin --profile web add ./plugins/file-upload , no dsh source chan"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - codex
+  - style
+  - drag
+  - drop
+  - file
+  - lands
+  - dropbox
+  - path
+  - composer
+  - whole
+  - blue
+  - chip
+  - mandatory
+  - suffix
+  - display
+  - hidden
+source:
+  repository: https://github.com/GLFzr/dsh-file-upload
+  repositoryNodeId: R_kgDOT4ZkpQ
+  subpath: null
+  commit: baa569938c03404b4eac6c6740c27afb49b60ba8
+creator:
+  github: GLFzr
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:39.576Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `glfzr-dsh-file-upload`
- Submission type: community curation
- Created by `GLFzr` — https://github.com/GLFzr
- Original source repository: https://github.com/GLFzr/dsh-file-upload
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.