### PR TITLE
catalog: add glfzr-dsh-opencode-go-quota (community curation, created by @GLFzr)

### DIFF
--- a/catalog/plugins/glfzr-dsh-opencode-go-quota.yaml
+++ b/catalog/plugins/glfzr-dsh-opencode-go-quota.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: glfzr-dsh-opencode-go-quota
+name: dsh-opencode-go-quota
+description:
+  en: "OpenCode Go quota ring for DSH Web: shows 5-hour / weekly / monthly usage as a click-to-cycle progress ring left of the model selector, with tiered in-prompt quota warnings (Codex-CLI style)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - opencode
+  - quota
+  - ring
+  - shows
+  - hour
+  - weekly
+  - monthly
+  - usage
+  - click
+  - cycle
+  - progress
+  - left
+  - model
+  - selector
+  - tiered
+  - prompt
+source:
+  repository: https://github.com/GLFzr/dsh-opencode-go-quota
+  repositoryNodeId: R_kgDOT4li1g
+  subpath: null
+  commit: 38ddb2a81166a6a08287896f601a3fa9915b1f6a
+creator:
+  github: GLFzr
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:32.255Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `glfzr-dsh-opencode-go-quota`
- Submission type: community curation
- Created by `GLFzr` — https://github.com/GLFzr
- Original source repository: https://github.com/GLFzr/dsh-opencode-go-quota
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.