### PR TITLE
catalog: add halosb-dsh-bg-beautify (community curation, created by @halosb)

### DIFF
--- a/catalog/plugins/halosb-dsh-bg-beautify.yaml
+++ b/catalog/plugins/halosb-dsh-bg-beautify.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: halosb-dsh-bg-beautify
+name: dsh-bg-beautify
+description:
+  en: powershell dsh plugin --profile web add github:halosb/dsh-bg-beautify
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - theme
+  - background
+  - ui
+  - cordis
+source:
+  repository: https://github.com/halosb/dsh-bg-beautify
+  repositoryNodeId: R_kgDOT4qhqQ
+  subpath: null
+  commit: 9c1510dc23e35897efa08f519f5ef66262b06df5
+creator:
+  github: halosb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:33.844Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `halosb-dsh-bg-beautify`
- Submission type: community curation
- Created by `halosb` — https://github.com/halosb
- Original source repository: https://github.com/halosb/dsh-bg-beautify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.