### PR TITLE
catalog: add hellodigua-dsh-emoji (community curation, created by @hellodigua)

### DIFF
--- a/catalog/plugins/hellodigua-dsh-emoji.yaml
+++ b/catalog/plugins/hellodigua-dsh-emoji.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: hellodigua-dsh-emoji
+name: dsh-emoji
+description:
+  en: Tiny semantic inline emoji for DSH Agent responses
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - emoji
+  - inline-emoji
+source:
+  repository: https://github.com/hellodigua/dsh-emoji
+  repositoryNodeId: R_kgDOT2gbBQ
+  subpath: null
+  commit: 96b653a473c978a474dd7d42e86e5b2c79e6dc7c
+creator:
+  github: hellodigua
+package:
+  ecosystem: npm
+  name: dsh-emoji
+  version: 0.3.1
+  integrity: sha512-SbxbvDv2Yf6H9ySHYuRPZw/18oD7v5Ykw6aIez/S8Y61h50IG5GL4JSWKd5jZ761/qSA0TeKaE5PC24TopTYFg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:13.097Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 39
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hellodigua-dsh-emoji`
- Submission type: community curation
- Created by `hellodigua` — https://github.com/hellodigua
- Original source repository: https://github.com/hellodigua/dsh-emoji
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.