### PR TITLE
catalog: add hellodigua-dsh-share (community curation, created by @hellodigua)

### DIFF
--- a/catalog/plugins/hellodigua-dsh-share.yaml
+++ b/catalog/plugins/hellodigua-dsh-share.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: hellodigua-dsh-share
+name: dsh-share
+description:
+  en: Share DSH Q&As or selected conversation groups as PNG or Markdown.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - share-image
+  - screenshot
+source:
+  repository: https://github.com/hellodigua/dsh-share
+  repositoryNodeId: R_kgDOT2V8jQ
+  subpath: null
+  commit: c109330b755c793cbc701a4e6a972d620a6667da
+creator:
+  github: hellodigua
+package:
+  ecosystem: npm
+  name: dsh-share
+  version: 0.3.1
+  integrity: sha512-QSkMqSbdT9yfyKO3tMfKHTJw61sZbiq1Okp24wLi6qv9lbfz8epDzrSGst4Zrha4wUre4rsoUSZa5SjDSvCZlQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:21.949Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 32
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hellodigua-dsh-share`
- Submission type: community curation
- Created by `hellodigua` — https://github.com/hellodigua
- Original source repository: https://github.com/hellodigua/dsh-share
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.