### PR TITLE
catalog: add hellosky983-dsh-mc-agent (community curation, created by @hellosky983)

### DIFF
--- a/catalog/plugins/hellosky983-dsh-mc-agent.yaml
+++ b/catalog/plugins/hellosky983-dsh-mc-agent.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: hellosky983-dsh-mc-agent
+name: dsh-mc-agent
+description:
+  en: "AI-assisted Minecraft for DeepSeek Harness: drive an autonomous Mineflayer agent (survival, mining, chat, live map) with vision/control tools, plus a built-in launcher (Microsoft sign-in, version download, game launch)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - minecraft
+  - launcher
+  - game
+source:
+  repository: https://github.com/hellosky983/dsh-mc-agent
+  repositoryNodeId: R_kgDOT4SQsA
+  subpath: null
+  commit: 67e02fedc9c5c62be0bcc632857ffe3d7c3d8f20
+creator:
+  github: hellosky983
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:41.074Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hellosky983-dsh-mc-agent`
- Submission type: community curation
- Created by `hellosky983` — https://github.com/hellosky983
- Original source repository: https://github.com/hellosky983/dsh-mc-agent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.