### PR TITLE
catalog: add heshuaichen-charlie-dsh-lark-channel (community curation, created by @heshuaichen-charlie)

### DIFF
--- a/catalog/plugins/heshuaichen-charlie-dsh-lark-channel.yaml
+++ b/catalog/plugins/heshuaichen-charlie-dsh-lark-channel.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: heshuaichen-charlie-dsh-lark-channel
+name: dsh-lark-channel
+description:
+  en: "Lark/Feishu IM bot channel for DeepSeek Harness: chats drive agents, replies and approvals return as messages and cards"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - lark
+  - feishu
+  - larksuite
+  - channel
+  - chatbot
+  - im-bot
+  - cordis
+  - ai-agent
+source:
+  repository: https://github.com/omdsh-dev/dsh-lark
+  repositoryNodeId: R_kgDOT36l8w
+  subpath: null
+  commit: 632807d9abafbb866a5e208a0298eff21c7856d1
+creator:
+  github: heshuaichen-charlie
+package:
+  ecosystem: npm
+  name: dsh-lark-channel
+  version: 0.0.7
+  integrity: sha512-jLuzsoVxlyNMjk3wCrYrDMWNvLOpGlmcffGLWcebFS86Z9bPnMGuWhczII1cUxztHlK3MFAVtzd7lJARBuU16w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:03.186Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 40
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `heshuaichen-charlie-dsh-lark-channel`
- Submission type: community curation
- Created by `heshuaichen-charlie` — https://github.com/heshuaichen-charlie
- Original source repository: https://github.com/omdsh-dev/dsh-lark
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.