### PR TITLE
catalog: add hexf00-dsh-univer-office (community curation, created by @hexf00)

### DIFF
--- a/catalog/plugins/hexf00-dsh-univer-office.yaml
+++ b/catalog/plugins/hexf00-dsh-univer-office.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: hexf00-dsh-univer-office
+name: dsh-univer-office
+description:
+  en: "DSH × Univer integration with a bundled collaboration Gateway and Viewer: inline previews, live floating Worktree windows, and session-end review actions in DeepSeek Harness."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - univer
+  - spreadsheet
+  - preview
+  - worktree
+source:
+  repository: https://github.com/dream-num/dsh-univer-office
+  repositoryNodeId: R_kgDOT5YrFA
+  subpath: null
+  commit: 85113d6fe76a0a0965ca4afd8b5da764eb34a31d
+creator:
+  github: hexf00
+package:
+  ecosystem: npm
+  name: dsh-univer-office
+  version: 0.2.6
+  integrity: sha512-YU3DkyZYsabr0R0hO6nw4AhC3RCdioaArKJ3JCWxrfjSBM/lMEChFdil0QjGmIOYUJAmwDkhXBXulG6+dz7arQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:44.202Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 77
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hexf00-dsh-univer-office`
- Submission type: community curation
- Created by `hexf00` — https://github.com/hexf00
- Original source repository: https://github.com/dream-num/dsh-univer-office
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.