### PR TITLE
catalog: add hg1048596-pixel-dsh-recall-unread (community curation, created by @hg1048596-pixel)

### DIFF
--- a/catalog/plugins/hg1048596-pixel-dsh-recall-unread.yaml
+++ b/catalog/plugins/hg1048596-pixel-dsh-recall-unread.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: hg1048596-pixel-dsh-recall-unread
+name: dsh-recall-unread
+description:
+  en: "DeepSeek Harness plugin: recall sent-but-unread text messages before the model reads them."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - recall
+source:
+  repository: https://github.com/hg1048596-pixel/dsh-recall-unread
+  repositoryNodeId: R_kgDOT66B8Q
+  subpath: null
+  commit: e9a22bad1f246584ac153a250436732c754b7e72
+creator:
+  github: hg1048596-pixel
+package:
+  ecosystem: npm
+  name: dsh-recall-unread
+  version: 1.1.0
+  integrity: sha512-fVqFuXHjXitInuYlLlMcFMsoKDvEP7d2hItu7ZDj6jwt2SVISecKUjbjxuWMNhxXFVo+CsyreZ+cDgT/7wVPxQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:31.341Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 33
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hg1048596-pixel-dsh-recall-unread`
- Submission type: community curation
- Created by `hg1048596-pixel` — https://github.com/hg1048596-pixel
- Original source repository: https://github.com/hg1048596-pixel/dsh-recall-unread
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.