### PR TITLE
catalog: add hi-wenw-dsh-telegram-channel (community curation, created by @hi-wenw)

### DIFF
--- a/catalog/plugins/hi-wenw-dsh-telegram-channel.yaml
+++ b/catalog/plugins/hi-wenw-dsh-telegram-channel.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: hi-wenw-dsh-telegram-channel
+name: dsh-telegram-channel
+description:
+  en: "DeepSeek Harness Telegram mobile remote: workspace→session, /last context, /model — dsh-plugin"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - telegram
+  - bot
+  - mobile
+  - remote
+  - channel
+  - sessions
+  - workspace
+  - model
+  - bind
+  - unbind
+  - remove
+  - clear
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+source:
+  repository: https://github.com/hi-wenw/dsh-telegram-channel
+  repositoryNodeId: R_kgDOT4L0JQ
+  subpath: null
+  commit: 93f3bec975044ab2b44cc319f2b61d6bd3959c9b
+creator:
+  github: hi-wenw
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:42.707Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hi-wenw-dsh-telegram-channel`
- Submission type: community curation
- Created by `hi-wenw` — https://github.com/hi-wenw
- Original source repository: https://github.com/hi-wenw/dsh-telegram-channel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.