### PR TITLE
catalog: add houyanchao-dsh-timeline (community curation, created by @houyanchao)

### DIFF
--- a/catalog/plugins/houyanchao-dsh-timeline.yaml
+++ b/catalog/plugins/houyanchao-dsh-timeline.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: houyanchao-dsh-timeline
+name: dsh-timeline
+description:
+  en: "DeepSeek Harness (DSH) plugin: timeline navigation, starred folders, conversation export, prompt library, and quick notes in one."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - timeline
+  - conversation
+  - export
+  - bookmark
+source:
+  repository: https://github.com/houyanchao/dsh-timeline
+  repositoryNodeId: R_kgDOT643yw
+  subpath: null
+  commit: 599dfb47934a2afb00c29e00d303acfb966ad2cd
+creator:
+  github: houyanchao
+package:
+  ecosystem: npm
+  name: dsh-timeline
+  version: 0.1.3
+  integrity: sha512-EmCwC06XnGWkr5Xz5xQJMnurUZGvSQ2fbBh7uVGWiLBoFoaG03wQIJoTbigWqj72mpRHarqrcxpSoTLBsSVMRg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: GPL-3.0-or-later
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:44.197Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 13
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `houyanchao-dsh-timeline`
- Submission type: community curation
- Created by `houyanchao` — https://github.com/houyanchao
- Original source repository: https://github.com/houyanchao/dsh-timeline
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.