### PR TITLE
catalog: add howe829-dsh-plugin (community curation, created by @Howe829)

### DIFF
--- a/catalog/plugins/howe829-dsh-plugin.yaml
+++ b/catalog/plugins/howe829-dsh-plugin.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: howe829-dsh-plugin
+name: "@awiki/dsh-plugin"
+description:
+  en: AWiki identity and messaging plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - awiki
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-messaging
+source:
+  repository: https://github.com/AgentConnect/dsh-awiki
+  repositoryNodeId: R_kgDOT4nC7Q
+  subpath: null
+  commit: c8313493399676d5ae33184a20b381833a820b24
+creator:
+  github: Howe829
+package:
+  ecosystem: npm
+  name: "@awiki/dsh-plugin"
+  version: 0.3.0
+  integrity: sha512-ZLgI3LivVKXn/i+7aT3yFLhHKB/bL+7Qaaa5Rrdp8Lnv/guVaML4p6gu3Opl7jG+ut1Ij6o78B8wwFZVieXgfQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:19.943Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `howe829-dsh-plugin`
- Submission type: community curation
- Created by `Howe829` — https://github.com/Howe829
- Original source repository: https://github.com/AgentConnect/dsh-awiki
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.