### PR TITLE
catalog: add huanlinoto-dsh-plugin-d399 (community curation, created by @HuanLinOTO)

### DIFF
--- a/catalog/plugins/huanlinoto-dsh-plugin-d399.yaml
+++ b/catalog/plugins/huanlinoto-dsh-plugin-d399.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: huanlinoto-dsh-plugin-d399
+name: "@huanlin/dsh-plugin-d399"
+description:
+  en: "src/ ├── index.ts host half: 空 apply ├── invariant.ts 包不变量伴生（空 installer） └── client/ ├── index.tsx apply: provide d399Games 服务 + 注册内置游戏 + 挂载 overlay ├── registry.ts D399GamesService 实现 + Game 类型 ├── useSessionRunning.ts useSyncExternalStore 订阅 current session 的 running ├── D399Overlay.tsx 主组件: teaser / menu / game mod"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - dsh
+source:
+  repository: https://github.com/HuanLinOTO/dsh-plugin-d399
+  repositoryNodeId: R_kgDOT0AjRA
+  subpath: null
+  commit: fe5e1179daef7ee68df993654aa687a196bc6a0d
+creator:
+  github: HuanLinOTO
+package:
+  ecosystem: npm
+  name: "@huanlin/dsh-plugin-d399"
+  version: 0.1.1
+  integrity: sha512-VeyxXJ1futke3V5g1ILuI/0tg2525O48rmSA7GfKza/vRzeMbFCYAGQdwxTuYV1q2g0Rq8tkRWtNmqhig79fKA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: AGPL-3.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:47.025Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huanlinoto-dsh-plugin-d399`
- Submission type: community curation
- Created by `HuanLinOTO` — https://github.com/HuanLinOTO
- Original source repository: https://github.com/HuanLinOTO/dsh-plugin-d399
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.