### PR TITLE
catalog: add hyrious-dsh-oomol (community curation, created by @hyrious)

### DIFF
--- a/catalog/plugins/hyrious-dsh-oomol.yaml
+++ b/catalog/plugins/hyrious-dsh-oomol.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: hyrious-dsh-oomol
+name: dsh-oomol
+description:
+  en: "OOMOL Connector integration for DeepSeek Harness: connect apps and call Actions through progressive MCP discovery."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - oomol
+  - connector
+  - agent-tools
+source:
+  repository: https://github.com/oomol-lab/dsh-oomol
+  repositoryNodeId: R_kgDOT5339w
+  subpath: null
+  commit: d84c461cb22068c90fedfc578fa3e38ce58d6ead
+creator:
+  github: hyrious
+package:
+  ecosystem: npm
+  name: dsh-oomol
+  version: 0.1.4
+  integrity: sha512-ZfrqQDpsW+UrdWEuFBchxayHwkG8ltWVLhg3+z/F61pZc8F/YNVCcFmD7qP4YF5xjmPjHzQ3waLfK5HPotunLg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:54.644Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hyrious-dsh-oomol`
- Submission type: community curation
- Created by `hyrious` — https://github.com/hyrious
- Original source repository: https://github.com/oomol-lab/dsh-oomol
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.