### PR TITLE
catalog: add inschrift-spruch-raum-dsh-plugin-template (community curation, created by @inschrift-spruch-raum)

### DIFF
--- a/catalog/plugins/inschrift-spruch-raum-dsh-plugin-template.yaml
+++ b/catalog/plugins/inschrift-spruch-raum-dsh-plugin-template.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: inschrift-spruch-raum-dsh-plugin-template
+name: "@your-scope/dsh-plugin-template"
+description:
+  en: Standalone Cordis plugin template for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - standalone
+  - cordis
+  - template
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/plugin-template
+  repositoryNodeId: R_kgDOT1GF5w
+  subpath: null
+  commit: 2803a03858e914101be93a2f51558717af37303d
+creator:
+  github: inschrift-spruch-raum
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:38.040Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `inschrift-spruch-raum-dsh-plugin-template`
- Submission type: community curation
- Created by `inschrift-spruch-raum` — https://github.com/inschrift-spruch-raum
- Original source repository: https://github.com/omdsh-dev/plugin-template
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.