### PR TITLE
catalog: add invalid-email-address-dsh-notifier (community curation, created by @invalid-email-address)

### DIFF
--- a/catalog/plugins/invalid-email-address-dsh-notifier.yaml
+++ b/catalog/plugins/invalid-email-address-dsh-notifier.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: invalid-email-address-dsh-notifier
+name: dsh-notifier
+description:
+  en: Unified notification push plugin for DeepSeek Harness (DSH) — one minimal notify() API in front, 27 channels behind.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - notify
+  - notification
+  - dingtalk
+  - feishu
+  - wxpusher
+  - pushplus
+  - serverchan
+  - bark
+  - telegram
+  - webhook
+  - qq-bot
+  - weixin
+  - ilink
+  - qr-login
+source:
+  repository: https://github.com/THEWOLFWALKER/dsh-notifier
+  repositoryNodeId: R_kgDOT41BcA
+  subpath: null
+  commit: cc4781e9939210b2d91b63f5448ccef40708a7c2
+creator:
+  github: invalid-email-address
+package:
+  ecosystem: npm
+  name: dsh-notifier
+  version: 0.8.4
+  integrity: sha512-UTE4bpUelvGDrDOixVCCk7JbInYaKn656WI09PaUI8XYnTlNfS7W11vBOpS2FKb3HiBeJ0B3w4zsihv9uOl1/Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:50.123Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 58
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `invalid-email-address-dsh-notifier`
- Submission type: community curation
- Created by `invalid-email-address` — https://github.com/invalid-email-address
- Original source repository: https://github.com/THEWOLFWALKER/dsh-notifier
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.