### PR TITLE
catalog: add jason12196-weshop-dsh-plugin (community curation, created by @Jason12196)

### DIFF
--- a/catalog/plugins/jason12196-weshop-dsh-plugin.yaml
+++ b/catalog/plugins/jason12196-weshop-dsh-plugin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: jason12196-weshop-dsh-plugin
+name: weshop-dsh-plugin
+description:
+  en: Native Cordis WeShop canvas, tools, skills, and Web UI for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - native
+  - cordis
+  - weshop
+  - canvas
+  - tools
+  - skills
+  - dsh
+source:
+  repository: https://github.com/weshopai/weshop-dsh-plugin
+  repositoryNodeId: R_kgDOT4B7aA
+  subpath: null
+  commit: c90f80ec7c23a291425de08a11adf802826b422a
+creator:
+  github: Jason12196
+package:
+  ecosystem: npm
+  name: weshop-dsh-plugin
+  version: 1.0.2
+  integrity: sha512-xq4jAxjhXl/54FSiZg5cVdcDgvzWHOfJ/B32aSJnpyO+ZRX4uvsISeQnMsElYDt/MYxzGJfclGv5HH8MflrBpg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:44.234Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jason12196-weshop-dsh-plugin`
- Submission type: community curation
- Created by `Jason12196` — https://github.com/Jason12196
- Original source repository: https://github.com/weshopai/weshop-dsh-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.