### PR TITLE
catalog: add jiao-xxx-dsh-auto-approve (community curation, created by @Jiao-XXX)

### DIFF
--- a/catalog/plugins/jiao-xxx-dsh-auto-approve.yaml
+++ b/catalog/plugins/jiao-xxx-dsh-auto-approve.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: jiao-xxx-dsh-auto-approve
+name: dsh-auto-approve
+description:
+  en: <p align="center" <strong 比 Workspace Write 更省心，比 Full access 更安全 / More convenient than Workspace Write, safer than Full access</strong </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - permissions
+  - permission-preset
+  - approval
+  - auto-approve
+  - sandbox
+  - escalation
+  - security
+source:
+  repository: https://github.com/Jiao-XXX/dsh-auto-approve
+  repositoryNodeId: R_kgDOT4QeuQ
+  subpath: null
+  commit: a8c2d7e6ccacaa15c18c4d1d56b0ba4d75cb6a39
+creator:
+  github: Jiao-XXX
+package:
+  ecosystem: npm
+  name: dsh-auto-approve
+  version: 0.5.1
+  integrity: sha512-cQcL96C0Ix9/3cr6isA0WiVvaduIlEEfdQQ7G2yVB4+w1ekY86vZbTsoB7X2gEch5kzI3W+LireSXIfDh/w8kQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:22.832Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiao-xxx-dsh-auto-approve`
- Submission type: community curation
- Created by `Jiao-XXX` — https://github.com/Jiao-XXX
- Original source repository: https://github.com/Jiao-XXX/dsh-auto-approve
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.