### PR TITLE
catalog: add jjxjjjjiik-bot-dsh-chat-timeline (community curation, created by @jjxjjjjiik-bot)

### DIFF
--- a/catalog/plugins/jjxjjjjiik-bot-dsh-chat-timeline.yaml
+++ b/catalog/plugins/jjxjjjjiik-bot-dsh-chat-timeline.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: jjxjjjjiik-bot-dsh-chat-timeline
+name: dsh-chat-timeline
+description:
+  en: ⭐️ If you find this plugin helpful, please consider giving it a free Star! Your support is the greatest motivation for continuous maintenance~
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - conversation
+  - navigation
+  - timeline
+source:
+  repository: https://github.com/jjxjjjjiik-bot/dsh-chat-timeline
+  repositoryNodeId: R_kgDOT4kI3Q
+  subpath: null
+  commit: 881628765ce558255637433bbcc742f2aef2f026
+creator:
+  github: jjxjjjjiik-bot
+package:
+  ecosystem: npm
+  name: dsh-chat-timeline
+  version: 0.1.3
+  integrity: sha512-SEBzHXQI6tlAunje4F8TNH9RuNV4Bx/1OiGrn+4zJhqiFCwcsbOfFwSPnitJcJR4lw7Yn+mwS0nUdcUX8u7m/A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:55.218Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 23
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jjxjjjjiik-bot-dsh-chat-timeline`
- Submission type: community curation
- Created by `jjxjjjjiik-bot` — https://github.com/jjxjjjjiik-bot
- Original source repository: https://github.com/jjxjjjjiik-bot/dsh-chat-timeline
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.