### PR TITLE
catalog: add kingao294-dsh-skin (community curation, created by @KinGao294)

### DIFF
--- a/catalog/plugins/kingao294-dsh-skin.yaml
+++ b/catalog/plugins/kingao294-dsh-skin.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: kingao294-dsh-skin
+name: dsh-skin
+description:
+  en: "Skin switcher + custom wallpaper for DeepSeek Harness: curated --dsw-alias- palettes, translucent wallpaper with opacity/blur controls, and durable per-user persistence (like Codex themes)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+  - wallpaper
+  - web-ui
+  - pet
+  - desktop-pet
+  - sticker
+  - nailong
+source:
+  repository: https://github.com/KinGao294/dsh-skin
+  repositoryNodeId: R_kgDOT31qHA
+  subpath: null
+  commit: 0a571a27adcc5f780b7b72386c9c294243eec5b3
+creator:
+  github: KinGao294
+package:
+  ecosystem: npm
+  name: dsh-skin
+  version: 0.4.0
+  integrity: sha512-6otf+jt7spFgBFz3rW75YKI+otxWgvQlYNy2dU2SPPv7nJw5G70JW6PC887Wlz5Lg6H1p//WfvMyZKefVYT6Iw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:04.648Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 19
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kingao294-dsh-skin`
- Submission type: community curation
- Created by `KinGao294` — https://github.com/KinGao294
- Original source repository: https://github.com/KinGao294/dsh-skin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.