### PR TITLE
catalog: add kingofsoysauce-dsh-skin-market (community curation, created by @kingOfSoySauce)

### DIFF
--- a/catalog/plugins/kingofsoysauce-dsh-skin-market.yaml
+++ b/catalog/plugins/kingofsoysauce-dsh-skin-market.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: kingofsoysauce-dsh-skin-market
+name: dsh-skin-market
+description:
+  en: Native skin marketplace and lifecycle manager for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - native
+  - skin
+  - marketplace
+  - lifecycle
+  - manager
+  - dsh
+source:
+  repository: https://github.com/kingOfSoySauce/dsh-skin-market
+  repositoryNodeId: R_kgDOT6BqBg
+  subpath: null
+  commit: d0b477836f808d576e8c380107dd99337681ac77
+creator:
+  github: kingOfSoySauce
+package:
+  ecosystem: npm
+  name: dsh-skin-market
+  version: 0.1.32
+  integrity: sha512-jn6BAOn3P+Wrpp1Nx+Dzor3ciA88z2Jxazlxr3Tc7CcAzFHlUIfjrxKwWkP5VBlZyZ1dl26YVb8pq3lLtjJgUg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:42.598Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 76
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kingofsoysauce-dsh-skin-market`
- Submission type: community curation
- Created by `kingOfSoySauce` — https://github.com/kingOfSoySauce
- Original source repository: https://github.com/kingOfSoySauce/dsh-skin-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.