### PR TITLE
catalog: add kunjinkao-os-dsh-mobile-gui-agent (community curation, created by @kunjinkao-os)

### DIFF
--- a/catalog/plugins/kunjinkao-os-dsh-mobile-gui-agent.yaml
+++ b/catalog/plugins/kunjinkao-os-dsh-mobile-gui-agent.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: kunjinkao-os-dsh-mobile-gui-agent
+name: dsh-mobile-gui-agent
+description:
+  en: Android Mobile GUI Agent plugin for DeepSeek Harness with ADB control, verified iterative actions, approval, and a Web mobile view
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - android
+  - adb
+  - gui-agent
+  - mobile-automation
+source:
+  repository: https://github.com/kunjinkao-os/dsh-mobile-gui-agent
+  repositoryNodeId: R_kgDOT4JgFw
+  subpath: null
+  commit: 8083e27f877a4b6290bb34a65586200750151ce1
+creator:
+  github: kunjinkao-os
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:48.541Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kunjinkao-os-dsh-mobile-gui-agent`
- Submission type: community curation
- Created by `kunjinkao-os` — https://github.com/kunjinkao-os
- Original source repository: https://github.com/kunjinkao-os/dsh-mobile-gui-agent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.