### PR TITLE
catalog: add laplace-bit-dsh-smooth-stream (community curation, created by @Laplace-bit)

### DIFF
--- a/catalog/plugins/laplace-bit-dsh-smooth-stream.yaml
+++ b/catalog/plugins/laplace-bit-dsh-smooth-stream.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: laplace-bit-dsh-smooth-stream
+name: dsh-smooth-stream
+description:
+  en: Fluid streaming rendering and silky scrolling for DeepSeek Harness replies, including Markdown, code blocks, tables, and tool results.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - cordis
+  - streaming
+  - smooth-streaming
+  - fluid-streaming
+  - streaming-renderer
+  - markdown-streaming
+  - smooth-scrolling
+  - smooth-scroll
+  - smooth-stream
+  - typewriter
+  - typewriter-effect
+  - markdown
+  - chat-ui
+source:
+  repository: https://github.com/Laplace-bit/dsh-smooth-stream
+  repositoryNodeId: R_kgDOT4-heQ
+  subpath: null
+  commit: 97866e7143b844995bc7490f3a5a40f968fe9441
+creator:
+  github: Laplace-bit
+package:
+  ecosystem: npm
+  name: dsh-smooth-stream
+  version: 0.3.4
+  integrity: sha512-YiwYI6Lwu28G5wHvpLFonmuQ+d44EJrp/lzyAp8d5c0B/0Er1p9CfkQvqMadCvMgTA7+pNgT9TBIB93CmaSU0g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:57.472Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 48
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `laplace-bit-dsh-smooth-stream`
- Submission type: community curation
- Created by `Laplace-bit` — https://github.com/Laplace-bit
- Original source repository: https://github.com/Laplace-bit/dsh-smooth-stream
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.