### PR TITLE
catalog: add lhh010-dsh-minigames (community curation, created by @lhh010)

### DIFF
--- a/catalog/plugins/lhh010-dsh-minigames.yaml
+++ b/catalog/plugins/lhh010-dsh-minigames.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: lhh010-dsh-minigames
+name: "@dsh-external/dsh-minigames"
+description:
+  en: "Floating mini-games window in the DSH Web UI: a slacking-off companion for killing time while waiting for model replies or fixing bugs."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - floating
+  - mini
+  - games
+  - window
+  - slacking
+  - companion
+  - killing
+  - time
+  - while
+  - waiting
+  - model
+  - replies
+  - fixing
+  - bugs
+  - dsh
+source:
+  repository: https://github.com/lhh010/dsh-minigames
+  repositoryNodeId: R_kgDOT3X1ew
+  subpath: null
+  commit: 4d79c012c60f1be508c388c8319dbff9d1389a65
+creator:
+  github: lhh010
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:26.068Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 26
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lhh010-dsh-minigames`
- Submission type: community curation
- Created by `lhh010` — https://github.com/lhh010
- Original source repository: https://github.com/lhh010/dsh-minigames
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.