### PR TITLE
catalog: add liceses-dsh-status-rotator (community curation, created by @liceses)

### DIFF
--- a/catalog/plugins/liceses-dsh-status-rotator.yaml
+++ b/catalog/plugins/liceses-dsh-status-rotator.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: liceses-dsh-status-rotator
+name: dsh-status-rotator
+description:
+  en: Rotates the DSH chat turn-status label ("Deep diving...") through user-defined phrases every few seconds, editable from DSH's settings panel.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - ui
+  - status
+  - rotator
+source:
+  repository: https://github.com/01Virex/dsh-status-rotator
+  repositoryNodeId: R_kgDOT3j7xw
+  subpath: null
+  commit: cab8715d471b0d83814f247c3adbe64e520fa6ea
+creator:
+  github: liceses
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:59.777Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 47
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liceses-dsh-status-rotator`
- Submission type: community curation
- Created by `liceses` — https://github.com/liceses
- Original source repository: https://github.com/01Virex/dsh-status-rotator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.