### PR TITLE
catalog: add limbo947-dsh-recall-plugin (community curation, created by @limbo947)

### DIFF
--- a/catalog/plugins/limbo947-dsh-recall-plugin.yaml
+++ b/catalog/plugins/limbo947-dsh-recall-plugin.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: limbo947-dsh-recall-plugin
+name: dsh-recall-plugin
+description:
+  en: Recall a message, and your project files go back with it.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - recall
+  - message
+  - files
+  - back
+  - dsh
+source:
+  repository: https://github.com/limbo947/dsh-recall-plugin
+  repositoryNodeId: R_kgDOT4ncMg
+  subpath: null
+  commit: 198f57982ce4d6ebc402b7ccd1180592b27e778b
+creator:
+  github: limbo947
+package:
+  ecosystem: npm
+  name: dsh-recall-plugin
+  version: 1.5.1
+  integrity: sha512-9e1xHAoIZjWQxdOAWscEFkxkNjsj7M8lqia94Vol+FIKU0I9Y4FmbK7ilvUe8zGWGgsb2X4gUhbEgPcsm2Zl5Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:32.921Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 25
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `limbo947-dsh-recall-plugin`
- Submission type: community curation
- Created by `limbo947` — https://github.com/limbo947
- Original source repository: https://github.com/limbo947/dsh-recall-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.