### PR TITLE
catalog: add limuyang2-dsh-agent-team (community curation, created by @limuyang2)

### DIFF
--- a/catalog/plugins/limuyang2-dsh-agent-team.yaml
+++ b/catalog/plugins/limuyang2-dsh-agent-team.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: limuyang2-dsh-agent-team
+name: "@limuyang2/dsh-agent-team"
+description:
+  en: Multi-agent team management plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - multi
+  - agent
+  - team
+  - management
+  - dsh
+source:
+  repository: https://github.com/limuyang2/agent-team
+  repositoryNodeId: R_kgDOT6nArw
+  subpath: null
+  commit: a538d18c6430603708625186db40c57044324f30
+creator:
+  github: limuyang2
+package:
+  ecosystem: npm
+  name: "@limuyang2/dsh-agent-team"
+  version: 0.1.3
+  integrity: sha512-UF/wO9MQmUp7eO+foLpuLXqBw0Gf7CH7LK/w6HY4VS+oSDah/GgXxsaS9oc5uaB4J6QZGmuetkArRbp5pZQWww==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:10.933Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 18
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `limuyang2-dsh-agent-team`
- Submission type: community curation
- Created by `limuyang2` — https://github.com/limuyang2
- Original source repository: https://github.com/limuyang2/agent-team
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.