### PR TITLE
catalog: add linhut-gongwen-skill (community curation, created by @linhut)

### DIFF
--- a/catalog/plugins/linhut-gongwen-skill.yaml
+++ b/catalog/plugins/linhut-gongwen-skill.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: linhut-gongwen-skill
+name: gongwen-skill
+description:
+  en: bash git clone https://github.com/linhut/gongwen-skill.git cd gongwen-skill pip install -r requirements.txt
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - chinese
+  - document
+  - government
+  - format
+  - gb-t-9704
+  - docx
+  - official-document
+  - dsh
+  - deepseek-harness
+  - skill
+  - cordis
+  - config-panel
+source:
+  repository: https://github.com/linhut/gongwen-skill
+  repositoryNodeId: R_kgDOTeG1GQ
+  subpath: null
+  commit: a4d744768493aa242ccc1c16ececbdc4e722c37e
+creator:
+  github: linhut
+package:
+  ecosystem: npm
+  name: gongwen-skill
+  version: 2.1.0
+  integrity: sha512-dQRkeWuAmbDaTaqSbT9BML488qGqTaef1a4jH8uCiRh0ryoa9sHFQeib+yFoHUWhi+WnUWdmVmdk4xkeG5NB0g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:24.437Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `linhut-gongwen-skill`
- Submission type: community curation
- Created by `linhut` — https://github.com/linhut
- Original source repository: https://github.com/linhut/gongwen-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.