### PR TITLE
catalog: add loudmore-dsh-drop-to-path (community curation, created by @loudMore)

### DIFF
--- a/catalog/plugins/loudmore-dsh-drop-to-path.yaml
+++ b/catalog/plugins/loudmore-dsh-drop-to-path.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: loudmore-dsh-drop-to-path
+name: "@dsh-external/dsh-drop-to-path"
+description:
+  en: Drop or paste images, PDFs, office docs, zips, videos and audio into the DSH composer as workspace file paths instead of model attachments — lets a text-only model agent read them via vision tools.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - drop
+  - paste
+  - images
+  - pdfs
+  - office
+  - docs
+  - zips
+  - videos
+  - audio
+  - composer
+  - workspace
+  - file
+  - paths
+  - instead
+  - model
+  - attachments
+source:
+  repository: https://github.com/loudMore/dsh-drop-to-path
+  repositoryNodeId: R_kgDOT3sspg
+  subpath: null
+  commit: a00a5a2e18fd89e829b1c96f2f2e85af67366e10
+creator:
+  github: loudMore
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:51.993Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `loudmore-dsh-drop-to-path`
- Submission type: community curation
- Created by `loudMore` — https://github.com/loudMore
- Original source repository: https://github.com/loudMore/dsh-drop-to-path
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.