### PR TITLE
catalog: add lzszq-research-plugin (community curation, created by @lzszq)

### DIFF
--- a/catalog/plugins/lzszq-research-plugin.yaml
+++ b/catalog/plugins/lzszq-research-plugin.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: lzszq-research-plugin
+name: "@dsh-scholar/research-plugin"
+description:
+  en: "DSH Research OS — a fully automated scientific research plugin for DSH (DeepSeek Harness): survey, idea, experiment contract, durable runner jobs, claim-evidence ledger, manuscript and release bundle."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - research
+  - fully
+  - automated
+  - scientific
+  - survey
+  - idea
+  - experiment
+  - contract
+  - durable
+  - runner
+  - jobs
+  - claim
+  - evidence
+  - ledger
+  - manuscript
+  - release
+source:
+  repository: https://github.com/lzszq/dsh-scholar
+  repositoryNodeId: R_kgDOTwDjAA
+  subpath: null
+  commit: 76bfe960e9107a992dae506c3ebc298a99f57760
+creator:
+  github: lzszq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:27.269Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 26
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lzszq-research-plugin`
- Submission type: community curation
- Created by `lzszq` — https://github.com/lzszq
- Original source repository: https://github.com/lzszq/dsh-scholar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.