### PR TITLE
catalog: add magian1127-deepseek-harness-zh-pro (community curation, created by @magian1127)

### DIFF
--- a/catalog/plugins/magian1127-deepseek-harness-zh-pro.yaml
+++ b/catalog/plugins/magian1127-deepseek-harness-zh-pro.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: magian1127-deepseek-harness-zh-pro
+name: deepseek-harness-zh_pro
+description:
+  en: A comprehensive enhancement plugin for DeepSeek Harness
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - chinese
+  - zh
+  - enhancement
+source:
+  repository: https://github.com/magian1127/deepseek-harness-zh_pro
+  repositoryNodeId: R_kgDOT5B4eQ
+  subpath: null
+  commit: 820977146097983c5a7f130454d4d9e452d49535
+creator:
+  github: magian1127
+package:
+  ecosystem: npm
+  name: deepseek-harness-zh_pro
+  version: 0.7.0
+  integrity: sha512-m8A0VT1teV/8VpGd6TExdpFXsrYC8H9bfwhgi51heHkgADopZawFZM/kbprquTZPtr0WCe0lJRMHBn8TOb8Drg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:22.728Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 17
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `magian1127-deepseek-harness-zh-pro`
- Submission type: community curation
- Created by `magian1127` — https://github.com/magian1127
- Original source repository: https://github.com/magian1127/deepseek-harness-zh_pro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.