### PR TITLE
catalog: add make0209-dsh-usage-stats (community curation, created by @Make0209)

### DIFF
--- a/catalog/plugins/make0209-dsh-usage-stats.yaml
+++ b/catalog/plugins/make0209-dsh-usage-stats.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: make0209-dsh-usage-stats
+name: dsh-usage-stats
+description:
+  en: bash dsh plugin --profile web add dsh-usage-stats
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - usage
+  - stats
+  - heatmap
+  - tokens
+  - balance
+source:
+  repository: https://github.com/Make0209/dsh-usage-stats
+  repositoryNodeId: R_kgDOT4cFoQ
+  subpath: null
+  commit: 8992d306cdca8857b4362868d591fde3689765b0
+creator:
+  github: Make0209
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:43.242Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 26
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `make0209-dsh-usage-stats`
- Submission type: community curation
- Created by `Make0209` — https://github.com/Make0209
- Original source repository: https://github.com/Make0209/dsh-usage-stats
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.