### PR TITLE
catalog: add meredith2328-dsh-sticky-note (community curation, created by @Meredith2328)

### DIFF
--- a/catalog/plugins/meredith2328-dsh-sticky-note.yaml
+++ b/catalog/plugins/meredith2328-dsh-sticky-note.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: meredith2328-dsh-sticky-note
+name: dsh-sticky-note
+description:
+  en: sh dsh plugin --profile web add dsh-sticky-note
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - profile
+  - sticky
+  - note
+  - dsh
+source:
+  repository: https://github.com/Meredith2328/dsh-sticky-note
+  repositoryNodeId: R_kgDOT3s9_g
+  subpath: null
+  commit: fcad3d03e049eeb727c90517d567b828c06cbb13
+creator:
+  github: Meredith2328
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:53.090Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `meredith2328-dsh-sticky-note`
- Submission type: community curation
- Created by `Meredith2328` — https://github.com/Meredith2328
- Original source repository: https://github.com/Meredith2328/dsh-sticky-note
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.