### PR TITLE
catalog: add mexiaosqwq-dsh-mobile-nav (community curation, created by @mexiaosqwq)

### DIFF
--- a/catalog/plugins/mexiaosqwq-dsh-mobile-nav.yaml
+++ b/catalog/plugins/mexiaosqwq-dsh-mobile-nav.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: mexiaosqwq-dsh-mobile-nav
+name: "@dsh-external/dsh-mobile-nav"
+description:
+  en: sh dsh plugin --profile web add github:mexiaosqwq/dsh-web-mobile
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - profile
+  - mexiaosqwq
+  - mobile
+  - dsh
+source:
+  repository: https://github.com/mexiaosqwq/dsh-web-mobile
+  repositoryNodeId: R_kgDOT42FlA
+  subpath: null
+  commit: aa2c396e3d30949445161ace79f05b42f8cccc33
+creator:
+  github: mexiaosqwq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:07.924Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 45
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mexiaosqwq-dsh-mobile-nav`
- Submission type: community curation
- Created by `mexiaosqwq` — https://github.com/mexiaosqwq
- Original source repository: https://github.com/mexiaosqwq/dsh-web-mobile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.