### PR TITLE
catalog: add michengai-dsh-agency-agents (community curation, created by @MichengAI)

### DIFF
--- a/catalog/plugins/michengai-dsh-agency-agents.yaml
+++ b/catalog/plugins/michengai-dsh-agency-agents.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: michengai-dsh-agency-agents
+name: "@michengai/dsh-agency-agents"
+description:
+  en: Agency Experts — a summonable domain-expert roster for DSH (expert mode)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - agency
+  - experts
+  - summonable
+  - domain
+  - expert
+  - roster
+  - mode
+  - dsh
+source:
+  repository: https://github.com/MichengAI/dsh-agency-agents
+  repositoryNodeId: R_kgDOT5GPeg
+  subpath: null
+  commit: d419213ebdce301c39ce170752d26078b075c7ca
+creator:
+  github: MichengAI
+package:
+  ecosystem: npm
+  name: "@michengai/dsh-agency-agents"
+  version: 0.1.20
+  integrity: sha512-AS7r2iIRLOaKjipUqrP0cUkXcSRcaNw6oKIt6K0DY/BGjFxazc9wEk4o7nQkmjquMTeWXx481URBS5I7MDiP9g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:36.478Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 16
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `michengai-dsh-agency-agents`
- Submission type: community curation
- Created by `MichengAI` — https://github.com/MichengAI
- Original source repository: https://github.com/MichengAI/dsh-agency-agents
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.