### PR TITLE
catalog: add michengai-dsh-codex-ui (community curation, created by @MichengAI)

### DIFF
--- a/catalog/plugins/michengai-dsh-codex-ui.yaml
+++ b/catalog/plugins/michengai-dsh-codex-ui.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: michengai-dsh-codex-ui
+name: "@michengai/dsh-codex-ui"
+description:
+  en: Rebuild the DeepSeek Harness Web sidebar, workspace tree, search, and turn navigation in a Codex-style layout
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - rebuild
+  - sidebar
+  - workspace
+  - tree
+  - search
+  - turn
+  - navigation
+  - codex
+  - style
+  - layout
+  - dsh
+source:
+  repository: https://github.com/MichengAI/dsh-codex-ui
+  repositoryNodeId: R_kgDOT4iDRA
+  subpath: null
+  commit: 5321915cdc8d1579ab808e409c765eae173cfd46
+creator:
+  github: MichengAI
+package:
+  ecosystem: npm
+  name: "@michengai/dsh-codex-ui"
+  version: 0.2.64
+  integrity: sha512-OOegQFm2X52lsDebE1dYbZ4lKPKnmljchr3CgOFsezXOdc4RSYJBigAB1+AoGq/XFzcuxQc03ziSHwLT5T+S9Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:06.071Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 25
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `michengai-dsh-codex-ui`
- Submission type: community curation
- Created by `MichengAI` — https://github.com/MichengAI
- Original source repository: https://github.com/MichengAI/dsh-codex-ui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.