### PR TITLE
catalog: add michengai-dsh-skills-manager (community curation, created by @MichengAI)

### DIFF
--- a/catalog/plugins/michengai-dsh-skills-manager.yaml
+++ b/catalog/plugins/michengai-dsh-skills-manager.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: michengai-dsh-skills-manager
+name: "@michengai/dsh-skills-manager"
+description:
+  en: NPM-installable DSH Web plugin for managing local skills and viewing shared Agent skills safely.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skill
+  - skills
+  - cordis
+source:
+  repository: https://github.com/MichengAI/dsh-skills-manager
+  repositoryNodeId: R_kgDOT4_luQ
+  subpath: null
+  commit: a9eccf93adf92a31b35477a0eeb2226f1fdd7992
+creator:
+  github: MichengAI
+package:
+  ecosystem: npm
+  name: "@michengai/dsh-skills-manager"
+  version: 0.1.23
+  integrity: sha512-XLKS9y/p/cFgtAXhrdetgT+Yrv8dBhvN+tMJAtY0jo6vxPYtY43bk7bJVBugIZH55hxQfcdEsZKcmCnImHvlmg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:19.492Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 18
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `michengai-dsh-skills-manager`
- Submission type: community curation
- Created by `MichengAI` — https://github.com/MichengAI
- Original source repository: https://github.com/MichengAI/dsh-skills-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.