### PR TITLE
catalog: add mishibeikejie-zat-dsh-engine (community curation, created by @mishibeikejie)

### DIFF
--- a/catalog/plugins/mishibeikejie-zat-dsh-engine.yaml
+++ b/catalog/plugins/mishibeikejie-zat-dsh-engine.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: mishibeikejie-zat-dsh-engine
+name: zat-dsh-engine
+description:
+  en: Zat-DSH Engine 鈥?the visual plugin marketplace for DeepSeek Harness. Browse, search, install, update and uninstall community plugins from GitHub's dsh-plugin topic, with bilingual intros and a China mirror fallback.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - marketplace
+  - market
+  - dsh-plugin
+source:
+  repository: https://github.com/mishibeikejie/zat-dsh-engine
+  repositoryNodeId: R_kgDOT4WvbQ
+  subpath: null
+  commit: b3b7ce6969fc806df1edb4170073ddd50c6927c0
+creator:
+  github: mishibeikejie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:37.444Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 77
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mishibeikejie-zat-dsh-engine`
- Submission type: community curation
- Created by `mishibeikejie` — https://github.com/mishibeikejie
- Original source repository: https://github.com/mishibeikejie/zat-dsh-engine
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.