### PR TITLE
catalog: add mutalucem-dsh-plugin-integration (community curation, created by @MutaLucem)

### DIFF
--- a/catalog/plugins/mutalucem-dsh-plugin-integration.yaml
+++ b/catalog/plugins/mutalucem-dsh-plugin-integration.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: mutalucem-dsh-plugin-integration
+name: dsh-plugin-integration
+description:
+  en: bash dsh plugin --profile web add github:MutaLucem/dsh-plugin-integration
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-manager
+  - plugin-integration
+  - compatibility
+  - toggle
+source:
+  repository: https://github.com/MutaLucem/dsh-plugin-integration
+  repositoryNodeId: R_kgDOT56RTg
+  subpath: null
+  commit: 0f720b7e53c0633b77e48c04c8bb8e06d16b7a37
+creator:
+  github: MutaLucem
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:10.669Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mutalucem-dsh-plugin-integration`
- Submission type: community curation
- Created by `MutaLucem` — https://github.com/MutaLucem
- Original source repository: https://github.com/MutaLucem/dsh-plugin-integration
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.