### PR TITLE
catalog: add niiang-dsh-kimino-theme (community curation, created by @niiang)

### DIFF
--- a/catalog/plugins/niiang-dsh-kimino-theme.yaml
+++ b/catalog/plugins/niiang-dsh-kimino-theme.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: niiang-dsh-kimino-theme
+name: dsh-kimino-theme
+description:
+  en: Kimi no Na wa (Your Name) theme for DeepSeek Harness Web GUI — dynamic Cordis plugin source (host + client halves) plus an installable dsh bundle, with wallpaper/logo assets
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - theme
+  - your-name
+  - kimi-no-na-wa
+source:
+  repository: https://github.com/niiang/dsh-kimino-theme
+  repositoryNodeId: R_kgDOT5-lCQ
+  subpath: null
+  commit: 4c01c9701690c5e4ccfe0253225f4cba9254414f
+creator:
+  github: niiang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:12.336Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 19
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `niiang-dsh-kimino-theme`
- Submission type: community curation
- Created by `niiang` — https://github.com/niiang
- Original source repository: https://github.com/niiang/dsh-kimino-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.