### PR TITLE
catalog: add ok-wx-dsh-ocgo-lite (community curation, created by @OK-wx)

### DIFF
--- a/catalog/plugins/ok-wx-dsh-ocgo-lite.yaml
+++ b/catalog/plugins/ok-wx-dsh-ocgo-lite.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: ok-wx-dsh-ocgo-lite
+name: dsh-ocgo-lite
+description:
+  en: sh dsh plugin --profile web add github:OK-wx/dsh-ocgo-lite
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - profile
+  - ocgo
+  - lite
+  - dsh
+source:
+  repository: https://github.com/OK-wx/dsh-ocgo-lite
+  repositoryNodeId: R_kgDOT5gIuw
+  subpath: null
+  commit: 96314bcd7966c88b6907fe5797719793a9b014e9
+creator:
+  github: OK-wx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:12.220Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ok-wx-dsh-ocgo-lite`
- Submission type: community curation
- Created by `OK-wx` — https://github.com/OK-wx
- Original source repository: https://github.com/OK-wx/dsh-ocgo-lite
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.