### PR TITLE
catalog: add pensivefei-deep-read-summarize (community curation, created by @PensiveFei)

### DIFF
--- a/catalog/plugins/pensivefei-deep-read-summarize.yaml
+++ b/catalog/plugins/pensivefei-deep-read-summarize.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: pensivefei-deep-read-summarize
+name: deep-read-summarize
+description:
+  en: "Deep reading & summarization for DSH: books/papers/videos/web → structured Obsidian notes. Plugin parsers, MapReduce deep-read, JSON Schema output, idempotent cache."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - workflow
+  - summarization
+  - deep-read
+  - obsidian
+  - llm
+  - subagent
+  - mapreduce
+  - parsers
+source:
+  repository: https://github.com/PensiveFei/deep-read-summarize
+  repositoryNodeId: R_kgDOT8o-ig
+  subpath: null
+  commit: 491a7cb0f5ec9e43d4134b7824081b6e172d882c
+creator:
+  github: PensiveFei
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:56.605Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 21
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pensivefei-deep-read-summarize`
- Submission type: community curation
- Created by `PensiveFei` — https://github.com/PensiveFei
- Original source repository: https://github.com/PensiveFei/deep-read-summarize
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.