### PR TITLE
catalog: add perrylink-dsh-plugin-guide (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/perrylink-dsh-plugin-guide.yaml
+++ b/catalog/plugins/perrylink-dsh-plugin-guide.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: perrylink-dsh-plugin-guide
+name: dsh-plugin-guide
+description:
+  en: "The dsh-plugin-guide knowledge base as an installable DeepSeek Harness plugin: official docs, Cordis primer, community deep-dives, and battle-tested pitfalls registered as an on-demand agent skill."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - agent-skill
+  - plugin-development
+  - knowledge-base
+source:
+  repository: https://github.com/PerryLink/dsh-plugin-guide
+  repositoryNodeId: R_kgDOT3lVQw
+  subpath: null
+  commit: 6f9b50d72cbf101995063654d2c64a39ebc73720
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-plugin-guide
+  version: 0.1.1
+  integrity: sha512-RZ4BByoUzyS7xsvl05NLQyOnrFebQBKsS4uOV7Pwqn+GlMsgQsbIu3cFNae6+Ips4jXSHpjVqRwNdtEY4V7gTw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:23.363Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 28
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `perrylink-dsh-plugin-guide`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-plugin-guide
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.