### PR TITLE
catalog: add pgzxb-dsh-feishu (community curation, created by @PGZXB)

### DIFF
--- a/catalog/plugins/pgzxb-dsh-feishu.yaml
+++ b/catalog/plugins/pgzxb-dsh-feishu.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: pgzxb-dsh-feishu
+name: "@dsh-feishu/dsh-feishu"
+description:
+  en: "The Feishu UI for DeepSeek Harness (dsh) — a dsh-native plugin: live streaming cards, in-card questions & approvals, one-QR setup."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - agent
+  - feishu
+  - lark
+  - surface
+  - bundle
+  - cards
+source:
+  repository: https://github.com/PGZXB/dsh-feishu
+  repositoryNodeId: R_kgDOT4E-GQ
+  subpath: null
+  commit: c58683b6acb39f332a0f9708f2ca2aba4a971572
+creator:
+  github: PGZXB
+package:
+  ecosystem: npm
+  name: "@dsh-feishu/dsh-feishu"
+  version: 0.2.0
+  integrity: sha512-/pdg1ZSpDJxr0ARDJ5JX5KtDSf/AdzBZu3mEM9+tlPX550TZdjokvPPVij9tlODm0NSjzWGIBqjb7mYGLOxKhw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:44.717Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 24
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pgzxb-dsh-feishu`
- Submission type: community curation
- Created by `PGZXB` — https://github.com/PGZXB
- Original source repository: https://github.com/PGZXB/dsh-feishu
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.