### PR TITLE
catalog: add polinni-dsh-personal-center (community curation, created by @PolinNi)

### DIFF
--- a/catalog/plugins/polinni-dsh-personal-center.yaml
+++ b/catalog/plugins/polinni-dsh-personal-center.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: polinni-dsh-personal-center
+name: dsh-personal-center
+description:
+  en: sh dsh plugin --profile web add github:PolinniZhong/dsh-personal-center
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - profile
+  - polinnizhong
+  - personal
+  - center
+  - dsh
+source:
+  repository: https://github.com/PolinniZhong/dsh-personal-center
+  repositoryNodeId: R_kgDOT9xnkg
+  subpath: null
+  commit: 8362fcce9d4fe5a85948b98641b58f0ca45eff2b
+creator:
+  github: PolinNi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:51.146Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 22
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `polinni-dsh-personal-center`
- Submission type: community curation
- Created by `PolinNi` — https://github.com/PolinNi
- Original source repository: https://github.com/PolinniZhong/dsh-personal-center
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.