### PR TITLE
catalog: add polinnizhong-dsh-omi-voice (community curation, created by @PolinniZhong)

### DIFF
--- a/catalog/plugins/polinnizhong-dsh-omi-voice.yaml
+++ b/catalog/plugins/polinnizhong-dsh-omi-voice.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: polinnizhong-dsh-omi-voice
+name: dsh-omi-voice
+description:
+  en: bash dsh plugin --profile web add "github:PolinniZhong/dsh-omi-voice v0.1.2&path:/"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - bash
+  - profile
+  - polinnizhong
+  - voice
+  - path
+  - dsh
+source:
+  repository: https://github.com/PolinniZhong/dsh-omi-voice
+  repositoryNodeId: R_kgDOT7_WKg
+  subpath: null
+  commit: 92bf49d9bc17fa33eb48485c424d798b6eb5c97d
+creator:
+  github: PolinniZhong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:14.530Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 37
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `polinnizhong-dsh-omi-voice`
- Submission type: community curation
- Created by `PolinniZhong` — https://github.com/PolinniZhong
- Original source repository: https://github.com/PolinniZhong/dsh-omi-voice
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.