### PR TITLE
catalog: add pypcfx-glitch-dsh-plugin-risk-rule-design (community curation, created by @pypcfx-glitch)

### DIFF
--- a/catalog/plugins/pypcfx-glitch-dsh-plugin-risk-rule-design.yaml
+++ b/catalog/plugins/pypcfx-glitch-dsh-plugin-risk-rule-design.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: pypcfx-glitch-dsh-plugin-risk-rule-design
+name: dsh-plugin-risk-rule-design
+description:
+  en: bash dsh plugin --profile web install dsh-plugin-risk-rule-design
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - risk-control
+  - rule-mining
+source:
+  repository: https://github.com/pypcfx-glitch/risk-rule-design
+  repositoryNodeId: R_kgDOT9Fw8w
+  subpath: null
+  commit: 89dff5161873917548ae28c1b1cb5f36f2f817fd
+creator:
+  github: pypcfx-glitch
+package:
+  ecosystem: npm
+  name: dsh-plugin-risk-rule-design
+  version: 1.0.2
+  integrity: sha512-/taQTF6DoZczfzts2s0fq0/U5K56qu/T5c2BAJHKIsW2DgVfjKdsXFkpCM975WbbEv6rXNE4g/tHUbNXySwRvw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:56.232Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pypcfx-glitch-dsh-plugin-risk-rule-design`
- Submission type: community curation
- Created by `pypcfx-glitch` — https://github.com/pypcfx-glitch
- Original source repository: https://github.com/pypcfx-glitch/risk-rule-design
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.