### PR TITLE
catalog: add relistencode-dsh-extension-hub (community curation, created by @Relistencode)

### DIFF
--- a/catalog/plugins/relistencode-dsh-extension-hub.yaml
+++ b/catalog/plugins/relistencode-dsh-extension-hub.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: relistencode-dsh-extension-hub
+name: dsh-extension-hub
+description:
+  en: "Extension Hub for DeepSeek Harness (DSH): manage skills, MCP servers and plugins from the DSH Web settings page — list / create / edit / delete / enable-disable, import from Claude and Codex, manage official & third-party plugins, a Plugin Market with a curated store (npm one-click install) and GitHub discovery, and ke"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - skill
+  - mcp
+  - extension
+  - cordis
+source:
+  repository: https://github.com/Relistencode/dsh-extension-hub
+  repositoryNodeId: R_kgDOT4tCvw
+  subpath: null
+  commit: 514a63215a98ec247f3b2c4b72e1cf05eb3f329d
+creator:
+  github: Relistencode
+package:
+  ecosystem: npm
+  name: dsh-extension-hub
+  version: 0.2.18
+  integrity: sha512-fBmLEuL82JrxmSAoCBt0yf0NtAFeu1g5mfpOnPxR1C8d/gGVf6LbElorMEp2wuXq2lF2dWjJ1A8a1D8lboX2iw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:54.448Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `relistencode-dsh-extension-hub`
- Submission type: community curation
- Created by `Relistencode` — https://github.com/Relistencode
- Original source repository: https://github.com/Relistencode/dsh-extension-hub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.