### PR TITLE
catalog: add renzic-stone-dsh-easyrewrite (community curation, created by @Renzic-Stone)

### DIFF
--- a/catalog/plugins/renzic-stone-dsh-easyrewrite.yaml
+++ b/catalog/plugins/renzic-stone-dsh-easyrewrite.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: renzic-stone-dsh-easyrewrite
+name: dsh-easyrewrite
+description:
+  en: dsh deepseek-harness recall rewrite bubble-edit version-pager i18n multilingual
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - client-plugin
+  - ui
+  - edit
+  - rewrite
+  - bubble-edit
+  - recall
+  - undo
+  - rollback
+  - version-pager
+  - i18n
+  - internationalization
+  - multilingual
+  - localization
+  - zh
+source:
+  repository: https://github.com/Renzic-Stone/DSH-EasyRewrite
+  repositoryNodeId: R_kgDOT8dWBg
+  subpath: null
+  commit: c1b1e990c4f7195548df38d819684f5329cf948e
+creator:
+  github: Renzic-Stone
+package:
+  ecosystem: npm
+  name: dsh-easyrewrite
+  version: 1.3.6
+  integrity: sha512-S3D7nHSlvbYsSyrIPUqrNQG/7vzxsu4yOaoi9rqYnpauoK0qEcjygS2+H22zrIKTX9fKDW/s6qndVdzVtWF6Nw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:46.768Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 43
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `renzic-stone-dsh-easyrewrite`
- Submission type: community curation
- Created by `Renzic-Stone` — https://github.com/Renzic-Stone
- Original source repository: https://github.com/Renzic-Stone/DSH-EasyRewrite
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.