### PR TITLE
catalog: add rindbeans-dsh-miraculous-standard (community curation, created by @rinDBeans)

### DIFF
--- a/catalog/plugins/rindbeans-dsh-miraculous-standard.yaml
+++ b/catalog/plugins/rindbeans-dsh-miraculous-standard.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: rindbeans-dsh-miraculous-standard
+name: dsh-miraculous-standard
+description:
+  en: Miraculous Standard — unified anchored agent preset for DeepSeek V4 Pro/Flash (official API & opencode-go). Minimal-exact two-tool first-request bootstrap, model-aware Pro/Flash paths, unified context gate, epoch-aware catalog management, rc7-ready shell handling.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - agent-preset
+  - preset
+  - miraculous-standard
+  - deepseek-v4-pro
+  - deepseek-v4-flash
+  - opencode-go
+source:
+  repository: https://github.com/rinDBeans/dsh-miraculous-standard
+  repositoryNodeId: R_kgDOT5zagg
+  subpath: null
+  commit: 9b54d1768143709f0718db944e2b01d010874581
+creator:
+  github: rinDBeans
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:13.722Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rindbeans-dsh-miraculous-standard`
- Submission type: community curation
- Created by `rinDBeans` — https://github.com/rinDBeans
- Original source repository: https://github.com/rinDBeans/dsh-miraculous-standard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.