### PR TITLE
catalog: add rxiain-dsh-openviking (community curation, created by @Rxiain)

### DIFF
--- a/catalog/plugins/rxiain-dsh-openviking.yaml
+++ b/catalog/plugins/rxiain-dsh-openviking.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: rxiain-dsh-openviking
+name: dsh-openviking
+description:
+  en: OpenViking retrieval, resource management, auto-recall and session memory for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - openviking
+  - agent-memory
+  - context-database
+  - ai-agents
+  - cordis
+  - typescript
+source:
+  repository: https://github.com/Rxiain/dsh-openviking
+  repositoryNodeId: R_kgDOT4WYJA
+  subpath: null
+  commit: e7d47c53487b15ee4091ca6a8e0e094a2f8d250f
+creator:
+  github: Rxiain
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:56.447Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rxiain-dsh-openviking`
- Submission type: community curation
- Created by `Rxiain` — https://github.com/Rxiain
- Original source repository: https://github.com/Rxiain/dsh-openviking
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.