### PR TITLE
catalog: add saya-ch-dsh-mobile (community curation, created by @saya-ch)

### DIFF
--- a/catalog/plugins/saya-ch-dsh-mobile.yaml
+++ b/catalog/plugins/saya-ch-dsh-mobile.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: saya-ch-dsh-mobile
+name: dsh-mobile
+description:
+  en: <p align="center" Secure, live LAN access to DeepSeek Harness from a phone.</p
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - android
+  - lan
+  - mobile
+source:
+  repository: https://github.com/saya-ch/dsh-mobile
+  repositoryNodeId: R_kgDOT4-yyw
+  subpath: null
+  commit: 218cd8b470cdbd43fc44db2219fd950ab3d743b9
+creator:
+  github: saya-ch
+package:
+  ecosystem: npm
+  name: dsh-mobile
+  version: 0.1.0-alpha.36
+  integrity: sha512-lLz9Ok0s/hl8+rvceuomfKAr5mrggsSeZESJjCxltuLCKhNutLEalqOleN58JQaPWAo/xCGP8UwFKGOCc5bVbg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:36.008Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 121
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `saya-ch-dsh-mobile`
- Submission type: community curation
- Created by `saya-ch` — https://github.com/saya-ch
- Original source repository: https://github.com/saya-ch/dsh-mobile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.