### PR TITLE
catalog: add senmuuuuw-dsh-whale-report (community curation, created by @SenmuuuuW)

### DIFF
--- a/catalog/plugins/senmuuuuw-dsh-whale-report.yaml
+++ b/catalog/plugins/senmuuuuw-dsh-whale-report.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: senmuuuuw-dsh-whale-report
+name: dsh-whale-report
+description:
+  en: <p align="center" <b Your Agent, in numbers.</b </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - report
+  - analytics
+  - agent
+  - cost
+  - token
+  - whale
+source:
+  repository: https://github.com/SenmuuuuW/dsh-whale-report
+  repositoryNodeId: R_kgDOT4RZrQ
+  subpath: null
+  commit: 5fccde44b1e06f927c651ed6418ffd28ea638132
+creator:
+  github: SenmuuuuW
+package:
+  ecosystem: npm
+  name: dsh-whale-report
+  version: 0.4.0
+  integrity: sha512-auYDK1gsio3AuQB31GWmkJuDbIaps9KuctOG6ZwkT6dvw5onFnm2T10UqGnJDDdl4UpVGBj9JJcexd1hRVpJvg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:39.955Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 28
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `senmuuuuw-dsh-whale-report`
- Submission type: community curation
- Created by `SenmuuuuW` — https://github.com/SenmuuuuW
- Original source repository: https://github.com/SenmuuuuW/dsh-whale-report
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.