### PR TITLE
catalog: add shaoshi20-dshscan (community curation, created by @shaoshi20)

### DIFF
--- a/catalog/plugins/shaoshi20-dshscan.yaml
+++ b/catalog/plugins/shaoshi20-dshscan.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: shaoshi20-dshscan
+name: "@shaoshi/dshscan"
+description:
+  en: "Security scanner for DSH plugins: static and semantic passes over plugin source, DSH-specific attack-surface rules, npm audit, batch scanning, and an HTML report with per-finding severity and evidence."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - security
+  - scanner
+  - skillspectator
+  - supply-chain
+  - ai-security
+source:
+  repository: https://github.com/shaoshi20/dshscan
+  repositoryNodeId: R_kgDOT8KcWw
+  subpath: null
+  commit: e08871356e2cd60f72e1b1880dacbf19f41b8056
+creator:
+  github: shaoshi20
+package:
+  ecosystem: npm
+  name: "@shaoshi/dshscan"
+  version: 0.5.0
+  integrity: sha512-KAfu3M37DCqiUsaUhWh13bHRvPPQ2co5IFkgfM33WEZmWNV1xNcMhcsg86wmEE+m0PZW0d2ghZXPu6UeqvvJGA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:57.957Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shaoshi20-dshscan`
- Submission type: community curation
- Created by `shaoshi20` — https://github.com/shaoshi20
- Original source repository: https://github.com/shaoshi20/dshscan
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.