### PR TITLE
catalog: add shengsheng90-dsh-taskboard (community curation, created by @shengsheng90)

### DIFF
--- a/catalog/plugins/shengsheng90-dsh-taskboard.yaml
+++ b/catalog/plugins/shengsheng90-dsh-taskboard.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: shengsheng90-dsh-taskboard
+name: "@shengsheng/dsh-taskboard"
+description:
+  en: Native local project taskboard bundle for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - native
+  - local
+  - taskboard
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/shengsheng90/DSH-taskboard
+  repositoryNodeId: R_kgDOT38l5g
+  subpath: null
+  commit: b3b0928172fa3f82a3802089cecb82e403b15ebc
+creator:
+  github: shengsheng90
+package:
+  ecosystem: npm
+  name: "@shengsheng/dsh-taskboard"
+  version: 0.1.2
+  integrity: sha512-OtkHYxSH6x+sX7daLkWiMHjX4kRygKnfrJsIg58s+ZT4sPltclC2RmAncQqO3cemtpgBJL2kLL1cMTNzYEF/Uw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:34.054Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 100
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shengsheng90-dsh-taskboard`
- Submission type: community curation
- Created by `shengsheng90` — https://github.com/shengsheng90
- Original source repository: https://github.com/shengsheng90/DSH-taskboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.