### PR TITLE
catalog: add sherunlocked-4869-dsh-plugin-msg-nav (community curation, created by @SherUnlocked-4869)

### DIFF
--- a/catalog/plugins/sherunlocked-4869-dsh-plugin-msg-nav.yaml
+++ b/catalog/plugins/sherunlocked-4869-dsh-plugin-msg-nav.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: sherunlocked-4869-dsh-plugin-msg-nav
+name: dsh-plugin-msg-nav
+description:
+  en: "DSH conversation node navigation rail: one dash per user message on the right edge, reading-position tracking, hover preview card, click-to-jump with highlight line, sliding window, auto-hide; host session projection delivers the complete message list instantly (no eager page pulls), with an on-demand loadOlder jump pa"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - navigation
+  - conversation
+source:
+  repository: https://github.com/SherUnlocked-4869/dsh-plugin-msg-nav
+  repositoryNodeId: R_kgDOT4gk_w
+  subpath: null
+  commit: 31521625896bcd3f18e38ea1a092ee7700385385
+creator:
+  github: SherUnlocked-4869
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:07.015Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sherunlocked-4869-dsh-plugin-msg-nav`
- Submission type: community curation
- Created by `SherUnlocked-4869` — https://github.com/SherUnlocked-4869
- Original source repository: https://github.com/SherUnlocked-4869/dsh-plugin-msg-nav
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.