### PR TITLE
catalog: add stardustlc666-dsh-codex-port (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-codex-port.yaml
+++ b/catalog/plugins/stardustlc666-dsh-codex-port.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: stardustlc666-dsh-codex-port
+name: dsh-codex-port
+description:
+  en: "Move the whole official Codex plugin family into DSH: scan ~/.codex unpacked plugins and plugin caches, then batch-port their skills into DSH skills (automatic frontmatter conversion, codex-only files stripped, name sanitization, idempotent skips)."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - codex
+  - skills
+  - migration
+  - dsh-plugin
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-codex-port
+  repositoryNodeId: R_kgDOT4tVPg
+  subpath: null
+  commit: ee733c77fa9b14a8d97cb2d343144bd34966bea6
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-codex-port
+  version: 0.1.1
+  integrity: sha512-bExur1r2TWX4HyqRonpQmN677MXVfg1SNdu2DI9TIpgiSJpCBu4gUa0N+EsXvhQmIVWG+Lg2owZX4JndSk1MWw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:09.858Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-codex-port`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-codex-port
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.