### PR TITLE
catalog: add tiantianflow-dsh-tailscale-gateway (community curation, created by @TiantianFlow)

### DIFF
--- a/catalog/plugins/tiantianflow-dsh-tailscale-gateway.yaml
+++ b/catalog/plugins/tiantianflow-dsh-tailscale-gateway.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: tiantianflow-dsh-tailscale-gateway
+name: dsh-tailscale-gateway
+description:
+  en: "Private Tailscale access for DeepSeek Harness Web: exact user allowlists, loopback-only gateway, and guarded Serve setup"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - tailscale
+  - serve
+  - reverse-proxy
+  - gateway
+  - websocket
+  - remote-access
+  - security
+source:
+  repository: https://github.com/TiantianFlow/dsh-one-gateway
+  repositoryNodeId: R_kgDOT6PdtQ
+  subpath: null
+  commit: 1a578019dfa2374223e469519e4a1e269d2e8e38
+creator:
+  github: TiantianFlow
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:57.926Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tiantianflow-dsh-tailscale-gateway`
- Submission type: community curation
- Created by `TiantianFlow` — https://github.com/TiantianFlow
- Original source repository: https://github.com/TiantianFlow/dsh-one-gateway
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.