### PR TITLE
catalog: add titanwings-dsh-automation (community curation, created by @titanwings)

### DIFF
--- a/catalog/plugins/titanwings-dsh-automation.yaml
+++ b/catalog/plugins/titanwings-dsh-automation.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: titanwings-dsh-automation
+name: "@dsh-external/dsh-automation"
+description:
+  en: Run coding tasks on schedule in fresh Agent sessions, and manage automations from DeepSeek Harness Web or an Agent
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - automation
+  - scheduled-task
+  - coding-agent
+  - cordis
+source:
+  repository: https://github.com/titanwings/dsh-automation
+  repositoryNodeId: R_kgDOT3ZClQ
+  subpath: null
+  commit: f8f43b2873a3f9dd57d86d61eb401770b2bc9ca5
+creator:
+  github: titanwings
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:41.080Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 72
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `titanwings-dsh-automation`
- Submission type: community curation
- Created by `titanwings` — https://github.com/titanwings
- Original source repository: https://github.com/titanwings/dsh-automation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.