### PR TITLE
catalog: add tyan66666-billion-context-dsh (community curation, created by @Tyan66666)

### DIFF
--- a/catalog/plugins/tyan66666-billion-context-dsh.yaml
+++ b/catalog/plugins/tyan66666-billion-context-dsh.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: tyan66666-billion-context-dsh
+name: billion-context-dsh
+description:
+  en: Active Context Pruning (ACP) for the DeepSeek Harness — model-driven context management as a CompactionEngine backend.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - acp
+  - context-management
+  - context-compression
+  - llm
+  - agent
+  - compaction
+source:
+  repository: https://github.com/Tyan66666/billion-context-dsh
+  repositoryNodeId: R_kgDOT3jkfQ
+  subpath: null
+  commit: f2a284737067b3ee6ea1bfc6c2c12edb0fb984f2
+creator:
+  github: Tyan66666
+package:
+  ecosystem: npm
+  name: billion-context-dsh
+  version: 0.2.8
+  integrity: sha512-rIkK8hHMNrlWWkN4nKinqZ5kHjNCSBS1tyh9yR5/2x8blpDDHAOnN/o2FUJxqANok6rdMung27v0AiVS3rLrpA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:16.114Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 35
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tyan66666-billion-context-dsh`
- Submission type: community curation
- Created by `Tyan66666` — https://github.com/Tyan66666
- Original source repository: https://github.com/Tyan66666/billion-context-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.