### PR TITLE
catalog: add unclecode-toolshrink (community curation, created by @unclecode)

### DIFF
--- a/catalog/plugins/unclecode-toolshrink.yaml
+++ b/catalog/plugins/unclecode-toolshrink.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: unclecode-toolshrink
+name: toolshrink
+description:
+  en: Reduce large agent tool output by what it means, not by where it was cut.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - agent
+  - llm
+  - context
+  - tool-output
+  - truncation
+  - deepseek-harness
+  - claude-code
+  - codex
+  - context-engineering
+  - dsh
+source:
+  repository: https://github.com/unclecode/toolshrink
+  repositoryNodeId: R_kgDOT7K6Eg
+  subpath: null
+  commit: 3d654ab491146dd685f0b47fef94e78a14590860
+creator:
+  github: unclecode
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:15.219Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `unclecode-toolshrink`
- Submission type: community curation
- Created by `unclecode` — https://github.com/unclecode
- Original source repository: https://github.com/unclecode/toolshrink
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.