### PR TITLE
catalog: add urzeye-dsh-outline (community curation, created by @urzeye)

### DIFF
--- a/catalog/plugins/urzeye-dsh-outline.yaml
+++ b/catalog/plugins/urzeye-dsh-outline.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: urzeye-dsh-outline
+name: dsh-outline
+description:
+  en: "DSH web plugin: a realtime conversation outline panel (user questions + markdown headings) for the DeepSeek Harness Web GUI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - realtime
+  - conversation
+  - outline
+  - panel
+  - user
+  - questions
+  - markdown
+  - headings
+  - dsh
+source:
+  repository: https://github.com/urzeye/dsh-outline
+  repositoryNodeId: R_kgDOT4P1Ow
+  subpath: null
+  commit: 2978994bca5fa8b86fcaac245da1f9e6135ac66f
+creator:
+  github: urzeye
+package:
+  ecosystem: npm
+  name: dsh-outline
+  version: 0.1.5
+  integrity: sha512-0UF3mbJg45Rca0Lx4g7PRj1TmLH0H1maePJCw8v54/WKhkHsqlxJyM/eMMWXO49O4Ir431QGLQ8gAA/s+/kemQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:25.674Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 14
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `urzeye-dsh-outline`
- Submission type: community curation
- Created by `urzeye` — https://github.com/urzeye
- Original source repository: https://github.com/urzeye/dsh-outline
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.