### PR TITLE
catalog: add w2112515-dsh-plugin-marketplace (community curation, created by @w2112515)

### DIFF
--- a/catalog/plugins/w2112515-dsh-plugin-marketplace.yaml
+++ b/catalog/plugins/w2112515-dsh-plugin-marketplace.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: w2112515-dsh-plugin-marketplace
+name: "@w2112515/dsh-plugin-marketplace"
+description:
+  en: Out-of-tree installable plugin marketplace bundle for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - tree
+  - installable
+  - marketplace
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/w2112515/dsh-plugin-marketplace
+  repositoryNodeId: R_kgDOT48pbw
+  subpath: null
+  commit: 142311b6cc8a75a1a507efe122f057d11d559fa2
+creator:
+  github: w2112515
+package:
+  ecosystem: npm
+  name: "@w2112515/dsh-plugin-marketplace"
+  version: 0.2.4
+  integrity: sha512-sai2yNOWG5kDTUx3W5eflRV/Cr4X+3isaAthAKHBzSThYp9Gyo4Ko3PUGblZObnfP/X4vmIQTzZE7RMs+3OwIw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:42.638Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `w2112515-dsh-plugin-marketplace`
- Submission type: community curation
- Created by `w2112515` — https://github.com/w2112515
- Original source repository: https://github.com/w2112515/dsh-plugin-marketplace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.