### PR TITLE
catalog: add whiteguo233-dsh-plugin (community curation, created by @whiteguo233)

### DIFF
--- a/catalog/plugins/whiteguo233-dsh-plugin.yaml
+++ b/catalog/plugins/whiteguo233-dsh-plugin.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: whiteguo233-dsh-plugin
+name: "@openbiliclaw/dsh-plugin"
+description:
+  en: "OpenBiliClaw DeepSeek Harness plugin: the user-consumption side (recommendations, delight, saved, Socratic chat, profile, probes, activity) as a web-GUI sidebar, plus agent-bridge tools and the openbiliclaw-adapter skill for closed-loop use inside DSH."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - openbiliclaw
+  - user
+  - consumption
+  - side
+  - recommendations
+  - delight
+  - saved
+  - socratic
+  - chat
+  - profile
+  - probes
+  - activity
+  - sidebar
+  - plus
+  - agent
+  - bridge
+source:
+  repository: https://github.com/whiteguo233/dsh-openbiliclaw
+  repositoryNodeId: R_kgDOT2rCBQ
+  subpath: null
+  commit: ac13101186e4e35780a1f1e4a68029ae903bf39b
+creator:
+  github: whiteguo233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:54.733Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 50
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteguo233-dsh-plugin`
- Submission type: community curation
- Created by `whiteguo233` — https://github.com/whiteguo233
- Original source repository: https://github.com/whiteguo233/dsh-openbiliclaw
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.