### PR TITLE
catalog: add whiteicey-dsh-plugin-check (community curation, created by @whiteicey)

### DIFF
--- a/catalog/plugins/whiteicey-dsh-plugin-check.yaml
+++ b/catalog/plugins/whiteicey-dsh-plugin-check.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: whiteicey-dsh-plugin-check
+name: "@deepseek-ai/dsh-plugin-check"
+description:
+  en: "DSH plugin health checker: scan plugin repos for manifest protocol / patch format / build pitfalls / hub registration, zero-dependency read-only diagnostics"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - health
+  - checker
+  - scan
+  - repos
+  - manifest
+  - protocol
+  - patch
+  - format
+  - build
+  - pitfalls
+  - registration
+  - zero
+  - dependency
+  - read
+  - only
+  - diagnostics
+source:
+  repository: https://github.com/omdsh-dev/dsh-plugin-check
+  repositoryNodeId: R_kgDOTyZztw
+  subpath: null
+  commit: 7ba4373c0baf635f03a5f7a92931d6ba4a0ecd3d
+creator:
+  github: whiteicey
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:24.931Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 27
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteicey-dsh-plugin-check`
- Submission type: community curation
- Created by `whiteicey` — https://github.com/whiteicey
- Original source repository: https://github.com/omdsh-dev/dsh-plugin-check
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.