### PR TITLE
catalog: add whiteicey-dsh-security-audit (community curation, created by @whiteicey)

### DIFF
--- a/catalog/plugins/whiteicey-dsh-security-audit.yaml
+++ b/catalog/plugins/whiteicey-dsh-security-audit.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: whiteicey-dsh-security-audit
+name: "@deepseek-ai/dsh-security-audit"
+description:
+  en: "DSH local security audit tool: read-only scans of config, credential metadata, plugin provenance, session structure and network exposure; redacted, reproducible, locatable risk reports"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - local
+  - security
+  - audit
+  - tool
+  - read
+  - only
+  - scans
+  - config
+  - credential
+  - metadata
+  - provenance
+  - session
+  - structure
+  - network
+  - exposure
+  - redacted
+source:
+  repository: https://github.com/omdsh-dev/dsh-security-audit
+  repositoryNodeId: R_kgDOTz73PA
+  subpath: null
+  commit: bcf475cf753893bd06f3bfae4cf18f3e136a321b
+creator:
+  github: whiteicey
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:28.652Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 13
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteicey-dsh-security-audit`
- Submission type: community curation
- Created by `whiteicey` — https://github.com/whiteicey
- Original source repository: https://github.com/omdsh-dev/dsh-security-audit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.