### PR TITLE
catalog: add whiteicey-dsh-toolkit (community curation, created by @whiteicey)

### DIFF
--- a/catalog/plugins/whiteicey-dsh-toolkit.yaml
+++ b/catalog/plugins/whiteicey-dsh-toolkit.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: whiteicey-dsh-toolkit
+name: "@deepseek-ai/dsh-toolkit"
+description:
+  en: "DSH zero-dependency toolkit collection: time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema in one entry point"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - zero
+  - dependency
+  - toolkit
+  - collection
+  - time
+  - encoding
+  - json
+  - calculator
+  - regex
+  - markdown
+  - diff
+  - stat
+  - schema
+  - entry
+  - point
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-toolkit
+  repositoryNodeId: R_kgDOTySMpA
+  subpath: null
+  commit: 1fda0fb9f6762c01affac50ca15c8eabfd6cd8f7
+creator:
+  github: whiteicey
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:35.791Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 25
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteicey-dsh-toolkit`
- Submission type: community curation
- Created by `whiteicey` — https://github.com/whiteicey
- Original source repository: https://github.com/omdsh-dev/dsh-toolkit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.