### PR TITLE
catalog: add william-jin-cmu-dsh-stickers (community curation, created by @william-jin-cmu)

### DIFF
--- a/catalog/plugins/william-jin-cmu-dsh-stickers.yaml
+++ b/catalog/plugins/william-jin-cmu-dsh-stickers.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: william-jin-cmu-dsh-stickers
+name: "@dsh-external/dsh-stickers"
+description:
+  en: bash pnpm install pnpm run typecheck pnpm test pnpm run build
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - bash
+  - pnpm
+  - install
+  - typecheck
+  - test
+  - build
+  - dsh
+source:
+  repository: https://github.com/william-jin-cmu/dsh-stickers
+  repositoryNodeId: R_kgDOTyPJHQ
+  subpath: null
+  commit: 1703f09915db1058b6031b31e52fd404560e0a78
+creator:
+  github: william-jin-cmu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:52.837Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 22
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `william-jin-cmu-dsh-stickers`
- Submission type: community curation
- Created by `william-jin-cmu` — https://github.com/william-jin-cmu
- Original source repository: https://github.com/william-jin-cmu/dsh-stickers
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.