### PR TITLE
catalog: add wnjxyk-dsh-codex-oauth (community curation, created by @WNJXYK)

### DIFF
--- a/catalog/plugins/wnjxyk-dsh-codex-oauth.yaml
+++ b/catalog/plugins/wnjxyk-dsh-codex-oauth.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: wnjxyk-dsh-codex-oauth
+name: "@wnjxyk/dsh-codex-oauth"
+description:
+  en: "Unified OpenAI Codex subscription plugin for DeepSeek Harness: GPT models, OAuth, quota, image generation, and web search."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - openai
+  - codex
+  - oauth
+  - subscription
+  - dsh
+source:
+  repository: https://github.com/WNJXYK/dsh-codex-oauth
+  repositoryNodeId: R_kgDOT5Lwqg
+  subpath: null
+  commit: 06bc69cea6e92f86c59c50d41d785303d38bf51d
+creator:
+  github: WNJXYK
+package:
+  ecosystem: npm
+  name: "@wnjxyk/dsh-codex-oauth"
+  version: 0.4.2
+  integrity: sha512-du+58OpIu9VZGC8r37lCqEMMIjHzCM5CimyksOWQrpWIGnuhuAsgD15+kSwLGfXU9qDsMstEac9FL4EKiY4yoQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:31.928Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 14
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wnjxyk-dsh-codex-oauth`
- Submission type: community curation
- Created by `WNJXYK` — https://github.com/WNJXYK
- Original source repository: https://github.com/WNJXYK/dsh-codex-oauth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.