### PR TITLE
catalog: add wyuc-dsh-openmaic (community curation, created by @wyuc)

### DIFF
--- a/catalog/plugins/wyuc-dsh-openmaic.yaml
+++ b/catalog/plugins/wyuc-dsh-openmaic.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: wyuc-dsh-openmaic
+name: "@openmaic/dsh-openmaic"
+description:
+  en: "OpenMAIC for DeepSeek Harness: generate classrooms and render slides, interactive widgets, teaching cards, plus a Socratic teaching skill"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - openmaic
+  - generate
+  - classrooms
+  - render
+  - slides
+  - interactive
+  - widgets
+  - teaching
+  - cards
+  - plus
+  - socratic
+  - skill
+  - dsh
+source:
+  repository: https://github.com/THU-MAIC/dsh-openmaic
+  repositoryNodeId: R_kgDOT3Y2Ug
+  subpath: null
+  commit: 09c1693cfe83224db89fdd4abd245ac9174d3a05
+creator:
+  github: wyuc
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:58.657Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 21
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wyuc-dsh-openmaic`
- Submission type: community curation
- Created by `wyuc` — https://github.com/wyuc
- Original source repository: https://github.com/THU-MAIC/dsh-openmaic
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.