### PR TITLE
catalog: add xiaoshihou514-dsh-desktop-pet (community curation, created by @xiaoshihou514)

### DIFF
--- a/catalog/plugins/xiaoshihou514-dsh-desktop-pet.yaml
+++ b/catalog/plugins/xiaoshihou514-dsh-desktop-pet.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: xiaoshihou514-dsh-desktop-pet
+name: dsh-desktop-pet
+description:
+  en: Linux and Windows desktop companion for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - linux
+  - windows
+  - desktop
+  - companion
+  - dsh
+source:
+  repository: https://github.com/xiaoshihou514/dsh-desktop-pet
+  repositoryNodeId: R_kgDOT39HpA
+  subpath: null
+  commit: 5f0060620d3b25c37c1d725af877f78708672ef5
+creator:
+  github: xiaoshihou514
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:08.360Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 24
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaoshihou514-dsh-desktop-pet`
- Submission type: community curation
- Created by `xiaoshihou514` — https://github.com/xiaoshihou514
- Original source repository: https://github.com/xiaoshihou514/dsh-desktop-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.