### PR TITLE
catalog: add xiezongchen-dsh-md-notes (community curation, created by @XieZongChen)

### DIFF
--- a/catalog/plugins/xiezongchen-dsh-md-notes.yaml
+++ b/catalog/plugins/xiezongchen-dsh-md-notes.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: xiezongchen-dsh-md-notes
+name: dsh-md-notes
+description:
+  en: '<p align="center" DSH third-party plugin (bundle): <b MD Notes Manager</b <br / <a href="docs/usage.md" User Guide</a · <a href="docs/features.md" Features</a · <a href="docs/architecture.md" Architecture</a · <a href="docs/context.md" Context</a · <a href="docs/TODO.md" Roadmap</a · <a href="CHANGELOG.md" Changelog</a'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - align
+  - center
+  - third
+  - party
+  - bundle
+  - notes
+  - manager
+  - href
+  - docs
+  - usage
+  - user
+  - guide
+  - features
+  - architecture
+  - context
+  - todo
+source:
+  repository: https://github.com/XieZongChen/dsh-md-notes
+  repositoryNodeId: R_kgDOT5caOg
+  subpath: null
+  commit: f5d744c3bf84d7d33bbb074aae030b49c9abc18d
+creator:
+  github: XieZongChen
+package:
+  ecosystem: npm
+  name: dsh-md-notes
+  version: 0.6.0
+  integrity: sha512-QvHDntQfF1GDpjk44Gj9Sjp6f1ICXWL6MSo9aIIF54jkzWNaFvWojIN4lE31+u624vQrT3jQEyeA3sFizBt/tA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:33.430Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 13
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiezongchen-dsh-md-notes`
- Submission type: community curation
- Created by `XieZongChen` — https://github.com/XieZongChen
- Original source repository: https://github.com/XieZongChen/dsh-md-notes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.