### PR TITLE
catalog: add xingyingyuzhui-dsh-liquid-glass (community curation, created by @xingyingyuzhui)

### DIFF
--- a/catalog/plugins/xingyingyuzhui-dsh-liquid-glass.yaml
+++ b/catalog/plugins/xingyingyuzhui-dsh-liquid-glass.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: xingyingyuzhui-dsh-liquid-glass
+name: dsh-liquid-glass
+description:
+  en: sh dsh plugin --profile web add github:xingyingyuzhui/dsh-liquid-glass
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - theme
+  - skin
+  - liquid-glass
+  - glassmorphism
+source:
+  repository: https://github.com/xingyingyuzhui/dsh-liquid-glass
+  repositoryNodeId: R_kgDOT5AMbA
+  subpath: null
+  commit: 573a81d66ddff86216a61ebee4c755ed49ae31de
+creator:
+  github: xingyingyuzhui
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:02.123Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xingyingyuzhui-dsh-liquid-glass`
- Submission type: community curation
- Created by `xingyingyuzhui` — https://github.com/xingyingyuzhui
- Original source repository: https://github.com/xingyingyuzhui/dsh-liquid-glass
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.