### PR TITLE
catalog: add yang478-dsh-deep-research (community curation, created by @yang478)

### DIFF
--- a/catalog/plugins/yang478-dsh-deep-research.yaml
+++ b/catalog/plugins/yang478-dsh-deep-research.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: yang478-dsh-deep-research
+name: "@dsh-external/dsh-deep-research"
+description:
+  en: "Deep Research orchestrator extension for DeepSeek Harness: an adaptive cybernetics/information-theory deep research tool on the official workflow engine, reusing built-in web search/web fetch."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deep
+  - research
+  - orchestrator
+  - extension
+  - adaptive
+  - cybernetics
+  - information
+  - theory
+  - tool
+  - official
+  - workflow
+  - engine
+  - reusing
+  - built
+  - search
+  - fetch
+source:
+  repository: https://github.com/omdsh-dev/dsh-deep-research
+  repositoryNodeId: R_kgDOTvZrZw
+  subpath: null
+  commit: c0b329e02cd0195f810a7c3608cb58701a7fe0f1
+creator:
+  github: yang478
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:09.704Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 18
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yang478-dsh-deep-research`
- Submission type: community curation
- Created by `yang478` — https://github.com/yang478
- Original source repository: https://github.com/omdsh-dev/dsh-deep-research
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.