### PR TITLE
catalog: add yejiming-dsh-data-agent (community curation, created by @yejiming)

### DIFF
--- a/catalog/plugins/yejiming-dsh-data-agent.yaml
+++ b/catalog/plugins/yejiming-dsh-data-agent.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: yejiming-dsh-data-agent
+name: "@yejiming/dsh-data-agent"
+description:
+  en: "Data Agent for DSH Web and TUI: shared database connections, a masked TUI form, secure credential references, SQL tools, and the data-agent preset"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - data
+  - agent
+  - shared
+  - database
+  - connections
+  - masked
+  - form
+  - secure
+  - credential
+  - references
+  - tools
+  - preset
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-data-agent
+  repositoryNodeId: R_kgDOT1colw
+  subpath: null
+  commit: 7caa266c1036d7e3b42d4bc710350c1406b56957
+creator:
+  github: yejiming
+package:
+  ecosystem: npm
+  name: "@yejiming/dsh-data-agent"
+  version: 0.0.13
+  integrity: sha512-J4DHMlw5Z/XwXdreR6nMIXQ4pbzcu+gUAgBJnuDP0KMOKFGOOTin1/mrQHnoyozBAH1H4zX8KEtBkXvc6NlyAQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:29.062Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 152
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yejiming-dsh-data-agent`
- Submission type: community curation
- Created by `yejiming` — https://github.com/yejiming
- Original source repository: https://github.com/omdsh-dev/dsh-data-agent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.