### PR TITLE
catalog: add yejiming-dsh-gomoku (community curation, created by @yejiming)

### DIFF
--- a/catalog/plugins/yejiming-dsh-gomoku.yaml
+++ b/catalog/plugins/yejiming-dsh-gomoku.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: yejiming-dsh-gomoku
+name: "@yejiming/dsh-gomoku"
+description:
+  en: "Gomoku (five-in-a-row) for the dsh web GUI: AI move routes, model catalog, and default prompt (node half) plus the conversation-view tab with the board (browser half)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - gomoku
+  - five
+  - move
+  - routes
+  - model
+  - catalog
+  - default
+  - prompt
+  - node
+  - half
+  - plus
+  - conversation
+  - view
+  - board
+  - browser
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-gomoku
+  repositoryNodeId: R_kgDOTyepUw
+  subpath: null
+  commit: 5b27af9808f5bd8f2d753dfdf6157d86a54a4947
+creator:
+  github: yejiming
+package:
+  ecosystem: npm
+  name: "@yejiming/dsh-gomoku"
+  version: 0.0.1
+  integrity: sha512-XRk2o8MNM8uWhTEUI+Na/gZFq4NiPP2KGTDDs/syVkn0mv/iCywQmeMVW1IA3ZLICZdpwUjlszYMwrdda36q1Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:24.204Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 14
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yejiming-dsh-gomoku`
- Submission type: community curation
- Created by `yejiming` — https://github.com/yejiming
- Original source repository: https://github.com/omdsh-dev/dsh-gomoku
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.