### PR TITLE
catalog: add yelebai-dsh-plugin-marketplace (community curation, created by @YELEBAI)

### DIFF
--- a/catalog/plugins/yelebai-dsh-plugin-marketplace.yaml
+++ b/catalog/plugins/yelebai-dsh-plugin-marketplace.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: yelebai-dsh-plugin-marketplace
+name: dsh-plugin-marketplace
+description:
+  en: Verified DSH plugin marketplace with guided-install Agents, direct self-update, discovery and install management
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - verified
+  - marketplace
+  - guided
+  - install
+  - agents
+  - direct
+  - self
+  - update
+  - discovery
+  - management
+  - dsh
+source:
+  repository: https://github.com/YELEBAI/dsh-plugin-marketplace
+  repositoryNodeId: R_kgDOT3zrGQ
+  subpath: null
+  commit: 01fdf83400449008ef54984a59d345e37be4b2f9
+creator:
+  github: YELEBAI
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:00.007Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 20
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yelebai-dsh-plugin-marketplace`
- Submission type: community curation
- Created by `YELEBAI` — https://github.com/YELEBAI
- Original source repository: https://github.com/YELEBAI/dsh-plugin-marketplace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.