### PR TITLE
catalog: add yuezengwu-dsh-explain (community curation, created by @yuezengwu)

### DIFF
--- a/catalog/plugins/yuezengwu-dsh-explain.yaml
+++ b/catalog/plugins/yuezengwu-dsh-explain.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: yuezengwu-dsh-explain
+name: dsh-explain
+description:
+  en: DSH learning-mode plugin with a global local-first learning thread.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - learning
+  - mode
+  - global
+  - local
+  - first
+  - thread
+  - dsh
+source:
+  repository: https://github.com/yuezengwu/dsh-explain
+  repositoryNodeId: R_kgDOT2IieA
+  subpath: null
+  commit: 99239d4aab7cec2073293514c8b910eb47c981c4
+creator:
+  github: yuezengwu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:03.601Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yuezengwu-dsh-explain`
- Submission type: community curation
- Created by `yuezengwu` — https://github.com/yuezengwu
- Original source repository: https://github.com/yuezengwu/dsh-explain
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.