### PR TITLE
catalog: add yxxbc-dsh-balance-plugin (community curation, created by @yxxbc)

### DIFF
--- a/catalog/plugins/yxxbc-dsh-balance-plugin.yaml
+++ b/catalog/plugins/yxxbc-dsh-balance-plugin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yxxbc-dsh-balance-plugin
+name: dsh-balance-plugin
+description:
+  en: A DeepSeek Harness (DSH) plugin — balance monitoring · official top-up link · Miyu-style usage statistics · third-party plugin manager
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - balance
+  - usage
+  - quota
+source:
+  repository: https://github.com/yxxbc/dsh-balance-plugin
+  repositoryNodeId: R_kgDOT42JHw
+  subpath: null
+  commit: 321737d33f5a839424804cd1c171d6d1ce9fe852
+creator:
+  github: yxxbc
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:48:52.927Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 54
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yxxbc-dsh-balance-plugin`
- Submission type: community curation
- Created by `yxxbc` — https://github.com/yxxbc
- Original source repository: https://github.com/yxxbc/dsh-balance-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.