### PR TITLE
catalog: add yzend-dsh-plugin-marketplace (community curation, created by @yzend)

### DIFF
--- a/catalog/plugins/yzend-dsh-plugin-marketplace.yaml
+++ b/catalog/plugins/yzend-dsh-plugin-marketplace.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yzend-dsh-plugin-marketplace
+name: "@springbrand/dsh-plugin-marketplace"
+description:
+  en: A visual plugin marketplace for DeepSeek Harness profiles.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - marketplace
+source:
+  repository: https://github.com/springbrand-lab/dsh-plugin-market
+  repositoryNodeId: R_kgDOT5aw8g
+  subpath: null
+  commit: 183527a7c700ed2fb2f2698197756fec9227a6d4
+creator:
+  github: yzend
+package:
+  ecosystem: npm
+  name: "@springbrand/dsh-plugin-marketplace"
+  version: 1.0.8
+  integrity: sha512-ILtmUFJh7T5ihVGmdyZDOOZYhVEbZKVAJm9AKBqHN6ZBPtdEbrK1Mh/FFgLEK/u685GpfsY1e0Ah68cw/3PD6Q==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:08.473Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yzend-dsh-plugin-marketplace`
- Submission type: community curation
- Created by `yzend` — https://github.com/yzend
- Original source repository: https://github.com/springbrand-lab/dsh-plugin-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.