### PR TITLE
catalog: add zhenyu98-dsh-context-doctor (community curation, created by @Zhenyu98)

### DIFF
--- a/catalog/plugins/zhenyu98-dsh-context-doctor.yaml
+++ b/catalog/plugins/zhenyu98-dsh-context-doctor.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: zhenyu98-dsh-context-doctor
+name: dsh-context-doctor
+description:
+  en: <p align="center" <sub Context Doctor renders in English with a restrained mono interface; the surrounding DSH shell follows its selected light, dark, or system theme.</sub </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - align
+  - center
+  - context
+  - doctor
+  - renders
+  - english
+  - restrained
+  - mono
+  - interface
+  - surrounding
+  - shell
+  - follows
+  - selected
+  - light
+  - dark
+  - system
+source:
+  repository: https://github.com/Zhenyu98/dsh-context-doctor
+  repositoryNodeId: R_kgDOT2fs-g
+  subpath: null
+  commit: 957d5de09402f882a18e556cae37076ee420b868
+creator:
+  github: Zhenyu98
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:50:15.446Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 18
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhenyu98-dsh-context-doctor`
- Submission type: community curation
- Created by `Zhenyu98` — https://github.com/Zhenyu98
- Original source repository: https://github.com/Zhenyu98/dsh-context-doctor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.