### PR TITLE
catalog: add zhijun-dai-dsh-catppuccin (community curation, created by @zhijun-dai)

### DIFF
--- a/catalog/plugins/zhijun-dai-dsh-catppuccin.yaml
+++ b/catalog/plugins/zhijun-dai-dsh-catppuccin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zhijun-dai-dsh-catppuccin
+name: dsh-catppuccin
+description:
+  en: "🐱 Soothing pastel theme for DeepSeek Harness: the four Catppuccin flavors (Latte, Frappé, Macchiato, Mocha) registered into the built-in theme runtime"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - catppuccin
+  - skin
+  - web-ui
+source:
+  repository: https://github.com/zhijun-dai/Catppuccin-dsh-theme
+  repositoryNodeId: R_kgDOT4cdqg
+  subpath: null
+  commit: 9885d3e7ee93ad4c972e92be4b6f301105e73eb4
+creator:
+  github: zhijun-dai
+package:
+  ecosystem: npm
+  name: dsh-catppuccin
+  version: 0.2.1
+  integrity: sha512-jHIB4oeHD07iIIl4kpbZ0n+5FzhGTzWd/jkbY9aWH5PILAostlFyt0NE4G+KDJsxG3kC/oiAUE8qM6j+Sx6LEQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:51:04.706Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhijun-dai-dsh-catppuccin`
- Submission type: community curation
- Created by `zhijun-dai` — https://github.com/zhijun-dai
- Original source repository: https://github.com/zhijun-dai/Catppuccin-dsh-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.