### PR TITLE
catalog: add zhujunpeng12-dsh-memory-system (community curation, created by @zhujunpeng12)

### DIFF
--- a/catalog/plugins/zhujunpeng12-dsh-memory-system.yaml
+++ b/catalog/plugins/zhujunpeng12-dsh-memory-system.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zhujunpeng12-dsh-memory-system
+name: "@zhujunpeng12/dsh-memory-system"
+description:
+  en: "Local-first persistent memory infrastructure for DeepSeek Harness: bounded hot-memory bootstrap, explainable cold recall (exact + Chinese BM25), lease-lock transactional writes, read-only governance, and trajectory review. DSH plugin host; Python stdlib + Markdown core. Zero database / vector service / external service"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - memory
+  - memory-system
+  - agent-memory
+  - local-first
+  - obsidian
+source:
+  repository: https://github.com/zhujunpeng12/dsh-memory-system
+  repositoryNodeId: R_kgDOT4-qXQ
+  subpath: null
+  commit: 71d48bd105a91d0196e6c7489839dabd049182d4
+creator:
+  github: zhujunpeng12
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:52:14.438Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhujunpeng12-dsh-memory-system`
- Submission type: community curation
- Created by `zhujunpeng12` — https://github.com/zhujunpeng12
- Original source repository: https://github.com/zhujunpeng12/dsh-memory-system
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.