### PR TITLE
catalog: add zrui-c-dsh-computer-use (community curation, created by @ZRui-C)

### DIFF
--- a/catalog/plugins/zrui-c-dsh-computer-use.yaml
+++ b/catalog/plugins/zrui-c-dsh-computer-use.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zrui-c-dsh-computer-use
+name: dsh-computer-use
+description:
+  en: Text-first browser and background macOS computer use for DSH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - computer-use
+  - macos
+  - browser-automation
+  - accessibility
+  - desktop-automation
+  - agent-tools
+source:
+  repository: https://github.com/ZRui-C/dsh-computer-use
+  repositoryNodeId: R_kgDOT4SWEQ
+  subpath: null
+  commit: 0b0a0844018b56a6a8e95aefea6529004b8341c4
+creator:
+  github: ZRui-C
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-23T04:49:54.051Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 21
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zrui-c-dsh-computer-use`
- Submission type: community curation
- Created by `ZRui-C` — https://github.com/ZRui-C
- Original source repository: https://github.com/ZRui-C/dsh-computer-use
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.