### PR TITLE
catalog: add bill9109-dsh-drag-and-drop (community curation, created by @bill9109)

### DIFF
--- a/catalog/plugins/bill9109-dsh-drag-and-drop.yaml
+++ b/catalog/plugins/bill9109-dsh-drag-and-drop.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: bill9109-dsh-drag-and-drop
+name: "@omdsh-dev/dsh-drag-and-drop"
+description:
+  en: Drag local files into the DSH Web UI and insert their original filesystem paths without uploading or copying them
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - web-ui
+  - drag-and-drop
+  - file-path
+  - filesystem
+  - dsh
+source:
+  repository: https://github.com/bill9109/dsh-drag-and-drop
+  repositoryNodeId: R_kgDOTvWbPQ
+  subpath: null
+  commit: 09088d6890866eda57adee6864cd2fbf8281f679
+creator:
+  github: bill9109
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:55:57.916Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 21
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bill9109-dsh-drag-and-drop`
- Submission type: community curation
- Created by `bill9109` — https://github.com/bill9109
- Original source repository: https://github.com/bill9109/dsh-drag-and-drop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.