### PR TITLE
catalog: add jesse-dsh-docker-bundle (community curation, created by @jesse)

### DIFF
--- a/catalog/plugins/jesse-dsh-docker-bundle.yaml
+++ b/catalog/plugins/jesse-dsh-docker-bundle.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jesse-dsh-docker-bundle
+name: "@dsh-docker/bundle"
+description:
+  en: "dsh-docker — typed, guarded container control for DSH: structured docker/compose tools, project-aware targeting, an approval gate for destructive ops, service-health context, and a replayable status-table renderer"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - docker
+  - docker-compose
+  - containers
+  - devops
+  - infrastructure
+source:
+  repository: https://github.com/Jesse-njx/dsh-docker
+  repositoryNodeId: R_kgDOT3oJlQ
+  subpath: null
+  commit: 8fe414f419f8403384f9907cdad739481fda8600
+creator:
+  github: jesse
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:56:08.122Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jesse-dsh-docker-bundle`
- Submission type: community curation
- Created by `jesse` — https://github.com/jesse
- Original source repository: https://github.com/Jesse-njx/dsh-docker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.