### PR TITLE
catalog: add jesse-dsh-tmuxctl-bundle (community curation, created by @jesse)

### DIFF
--- a/catalog/plugins/jesse-dsh-tmuxctl-bundle.yaml
+++ b/catalog/plugins/jesse-dsh-tmuxctl-bundle.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jesse-dsh-tmuxctl-bundle
+name: "@dsh-tmuxctl/bundle"
+description:
+  en: "dsh-tmuxctl — the control plane for tmux: list, drive, capture, split, swap, run, and watch the panes you already have open, with safety by default"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - tmux
+  - terminal
+  - pane-control
+  - tmux-watch
+  - conversation-node
+source:
+  repository: https://github.com/Jesse-njx/dsh-tmuxctl
+  repositoryNodeId: R_kgDOT3o6WQ
+  subpath: null
+  commit: 1804d3956cef2f823edf792c711e6cbc4c4ec20b
+creator:
+  github: jesse
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:56:13.243Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jesse-dsh-tmuxctl-bundle`
- Submission type: community curation
- Created by `jesse` — https://github.com/jesse
- Original source repository: https://github.com/Jesse-njx/dsh-tmuxctl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.