### PR TITLE
catalog: add jesse-njx-dsh-memory-bundle (community curation, created by @Jesse-njx)

### DIFF
--- a/catalog/plugins/jesse-njx-dsh-memory-bundle.yaml
+++ b/catalog/plugins/jesse-njx-dsh-memory-bundle.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jesse-njx-dsh-memory-bundle
+name: "@dsh-memory/bundle"
+description:
+  en: "dsh-memory — cited memory over DSH's lossless session log: post-session distillation into human-auditable markdown files, a compact recall index, memory read/memory expand tools, and a dsh-memory CLI"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - agent-memory
+  - session-log
+source:
+  repository: https://github.com/Jesse-njx/dsh-memory
+  repositoryNodeId: R_kgDOT3jnJQ
+  subpath: null
+  commit: 2eed97da7f95f24e03e7a2f0a64606d55f61ffff
+creator:
+  github: Jesse-njx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:56:02.998Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jesse-njx-dsh-memory-bundle`
- Submission type: community curation
- Created by `Jesse-njx` — https://github.com/Jesse-njx
- Original source repository: https://github.com/Jesse-njx/dsh-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.