### PR TITLE
catalog: add jesse-njx-dsh-routines-bundle (community curation, created by @Jesse-njx)

### DIFF
--- a/catalog/plugins/jesse-njx-dsh-routines-bundle.yaml
+++ b/catalog/plugins/jesse-njx-dsh-routines-bundle.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: jesse-njx-dsh-routines-bundle
+name: "@dsh-routines/bundle"
+description:
+  en: "dsh-routines — scheduled agents for DSH: run a prompt on a cron, get the digest where you already are (file digests, chatnode delivery, unattended-safe)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - scheduler
+  - cron
+  - automation
+  - headless
+source:
+  repository: https://github.com/Jesse-njx/dsh-routines
+  repositoryNodeId: R_kgDOT3kvPw
+  subpath: null
+  commit: f59b4f03e7b36648b804fd07e57a53e276da5d81
+creator:
+  github: Jesse-njx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:56:10.235Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jesse-njx-dsh-routines-bundle`
- Submission type: community curation
- Created by `Jesse-njx` — https://github.com/Jesse-njx
- Original source repository: https://github.com/Jesse-njx/dsh-routines
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.