### PR TITLE
catalog: add knqiufan-powercontext-dsh (community curation, created by @knqiufan)

### DIFF
--- a/catalog/plugins/knqiufan-powercontext-dsh.yaml
+++ b/catalog/plugins/knqiufan-powercontext-dsh.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: knqiufan-powercontext-dsh
+name: powercontext-dsh
+description:
+  en: DeepSeek Harness plugin that connects to a PowerContext Server over HTTP for recall, memory, handoff, experience, and skills.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - connects
+  - powercontext
+  - server
+  - over
+  - recall
+  - memory
+  - handoff
+  - experience
+  - skills
+  - dsh
+source:
+  repository: https://github.com/knqiufan/powercontext-dsh
+  repositoryNodeId: R_kgDOT3nYHw
+  subpath: null
+  commit: 9c9f6386de898a5c3a7f0793f692e4968775b7a8
+creator:
+  github: knqiufan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:56:00.362Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `knqiufan-powercontext-dsh`
- Submission type: community curation
- Created by `knqiufan` — https://github.com/knqiufan
- Original source repository: https://github.com/knqiufan/powercontext-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.