### PR TITLE
catalog: add sjh9714-dsh-clippy (community curation, created by @sjh9714)

### DIFF
--- a/catalog/plugins/sjh9714-dsh-clippy.yaml
+++ b/catalog/plugins/sjh9714-dsh-clippy.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: sjh9714-dsh-clippy
+name: dsh-clippy
+description:
+  en: Office assistant pet for the dsh web GUI. Clippy reacts to real agent state, interrupts risky messages with classic options, and opens the illegal operation dialog on failed turns.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - office
+  - assistant
+  - clippy
+  - reacts
+  - real
+  - agent
+  - state
+  - interrupts
+  - risky
+  - messages
+  - classic
+  - options
+  - opens
+  - illegal
+  - operation
+  - dialog
+source:
+  repository: https://github.com/sjh9714/clippy-harness
+  repositoryNodeId: R_kgDOT41tRg
+  subpath: plugin
+  commit: 21a77d8d1daa3429636305b56cfb2d0258286c2c
+creator:
+  github: sjh9714
+package:
+  ecosystem: npm
+  name: dsh-clippy
+  version: 0.2.1
+  integrity: sha512-GAa0vO2+RwsNpT/Fstyu9NFl4JJS75FHNOV5dqnMQP1PkeUCFKmWtJJq8e/QYiAlYnPR6ho+qYLJxl1YRRPYTw==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:56:16.034Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sjh9714-dsh-clippy`
- Submission type: community curation
- Created by `sjh9714` — https://github.com/sjh9714
- Original source repository: https://github.com/sjh9714/clippy-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.