### PR TITLE
catalog: add tianhao8687-dsh-memoryos (community curation, created by @tianhao8687)

### DIFF
--- a/catalog/plugins/tianhao8687-dsh-memoryos.yaml
+++ b/catalog/plugins/tianhao8687-dsh-memoryos.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: tianhao8687-dsh-memoryos
+name: dsh-memoryos
+description:
+  en: Evidence-first long-term project memory for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-memory
+  - long-term-memory
+  - memoryos
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/tianhao8687/dsh-memoryos
+  repositoryNodeId: R_kgDOT6kA-g
+  subpath: null
+  commit: 5b55969a5b14dcfaeeec51a37db97ac2edca7144
+creator:
+  github: tianhao8687
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:56:22.159Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tianhao8687-dsh-memoryos`
- Submission type: community curation
- Created by `tianhao8687` — https://github.com/tianhao8687
- Original source repository: https://github.com/tianhao8687/dsh-memoryos
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.