### PR TITLE
catalog: add zhu168-dsh-save-money (community curation, created by @zhu168)

### DIFF
--- a/catalog/plugins/zhu168-dsh-save-money.yaml
+++ b/catalog/plugins/zhu168-dsh-save-money.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: zhu168-dsh-save-money
+name: dsh-save-money
+description:
+  en: DSH save-money plugin — time-window auto pause/resume for peak/off-peak API pricing (TypeScript sources, i18n zh/en).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - save
+  - money
+  - time
+  - window
+  - auto
+  - pause
+  - resume
+  - peak
+  - pricing
+  - typescript
+  - sources
+  - i18n
+  - dsh
+source:
+  repository: https://github.com/zhu168/dsh-save-money
+  repositoryNodeId: R_kgDOT5O9jQ
+  subpath: null
+  commit: 81061ef3706fb5c7793e1c0e4652b43cf3c17727
+creator:
+  github: zhu168
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T06:55:51.992Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 33
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhu168-dsh-save-money`
- Submission type: community curation
- Created by `zhu168` — https://github.com/zhu168
- Original source repository: https://github.com/zhu168/dsh-save-money
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.