### PR TITLE
catalog: add 00080000-dsh-project-memory (community curation, created by @00080000)

### DIFF
--- a/catalog/plugins/00080000-dsh-project-memory.yaml
+++ b/catalog/plugins/00080000-dsh-project-memory.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: 00080000-dsh-project-memory
+name: dsh-project-memory
+description:
+  en: "Persistent project memory for dsh agents: index docs (PDF/Markdown/text) and code symbols into a searchable per-workspace store, recall them with cited sources, and keep experience entries (problems - solutions) searchable on demand."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - project-memory
+  - rag
+  - codebase
+  - cordis
+source:
+  repository: https://github.com/00080000/dsh-project-memory
+  repositoryNodeId: R_kgDOT9RapQ
+  subpath: null
+  commit: 338b96e73786967c6486a6507940bd393b0a7203
+creator:
+  github: "00080000"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:14:03.099Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `00080000-dsh-project-memory`
- Submission type: community curation
- Created by `00080000` — https://github.com/00080000
- Original source repository: https://github.com/00080000/dsh-project-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.