### PR TITLE
catalog: add 007m7-dsh-cli-app (community curation, created by @007M7)

### DIFF
--- a/catalog/plugins/007m7-dsh-cli-app.yaml
+++ b/catalog/plugins/007m7-dsh-cli-app.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: 007m7-dsh-cli-app
+name: "@deepseek-ai/dsh-cli-app"
+description:
+  en: The DeepSeek Harness local interactive terminal UI with commands, sessions, authentication, and Agent tools
+  evidencePath: packages/bundle/cli-app/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - local
+  - interactive
+  - terminal
+  - commands
+  - sessions
+  - authentication
+  - agent
+  - tools
+  - dsh
+source:
+  repository: https://github.com/007M7/DeepCode
+  repositoryNodeId: R_kgDOT3cLfQ
+  subpath: packages/bundle/cli-app
+  commit: a0edf49d2e41adfa573bf3c5656f0cafee3caf45
+creator:
+  github: 007M7
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/bundle/cli-app/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:15:21.038Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `007m7-dsh-cli-app`
- Submission type: community curation
- Created by `007M7` — https://github.com/007M7
- Original source repository: https://github.com/007M7/DeepCode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.