### PR TITLE
catalog: add 02muller25-api-balance (community curation, created by @02Muller25)

### DIFF
--- a/catalog/plugins/02muller25-api-balance.yaml
+++ b/catalog/plugins/02muller25-api-balance.yaml
@@ -1,0 +1,39 @@
+schemaVersion: 1
+id: 02muller25-api-balance
+name: api-balance
+description:
+  en: Real-time DeepSeek API account balance readout for the DeepSeek Harness web GUI (dsh web).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - balance
+source:
+  repository: https://github.com/02Muller25/dsh-api-balance
+  repositoryNodeId: R_kgDOT5D0eg
+  subpath: null
+  commit: c27c8b61acf97714ab08d99f97b7be3a9007e52e
+creator:
+  github: 02Muller25
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:13:44.405Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `02muller25-api-balance`
- Submission type: community curation
- Created by `02Muller25` — https://github.com/02Muller25
- Original source repository: https://github.com/02Muller25/dsh-api-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.