### PR TITLE
catalog: add 030611-dsh-telemetry-redactor (community curation, created by @030611)

### DIFF
--- a/catalog/plugins/030611-dsh-telemetry-redactor.yaml
+++ b/catalog/plugins/030611-dsh-telemetry-redactor.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: 030611-dsh-telemetry-redactor
+name: dsh-telemetry-redactor
+description:
+  en: Export-copy redaction for DeepSeek Harness session telemetry
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - telemetry
+  - redaction
+  - privacy
+  - security
+source:
+  repository: https://github.com/030611/dsh-telemetry-redactor
+  repositoryNodeId: R_kgDOT3mW9g
+  subpath: null
+  commit: 811b0b1abf424e57045ab5a5eaa203660ca43908
+creator:
+  github: "030611"
+package:
+  ecosystem: npm
+  name: dsh-telemetry-redactor
+  version: 0.1.0
+  integrity: sha512-e/C2uA4UKCFAKprwwOk9inaoWb+YLbZMQik3j6nKTyuE1yv0slq5Hm9ql6qY0rt5gKCSWsiosdIUDkwhYsR/VA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:13:57.946Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `030611-dsh-telemetry-redactor`
- Submission type: community curation
- Created by `030611` — https://github.com/030611
- Original source repository: https://github.com/030611/dsh-telemetry-redactor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.