### PR TITLE
catalog: add 030611-dsh-verification-receipt (community curation, created by @030611)

### DIFF
--- a/catalog/plugins/030611-dsh-verification-receipt.yaml
+++ b/catalog/plugins/030611-dsh-verification-receipt.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: 030611-dsh-verification-receipt
+name: dsh-verification-receipt
+description:
+  en: Privacy-minimal heuristic per-turn execution summaries for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - verification
+  - observability
+  - privacy
+  - dsh
+source:
+  repository: https://github.com/030611/dsh-verification-receipt
+  repositoryNodeId: R_kgDOT3mdsA
+  subpath: null
+  commit: 92f63a9022e1840b147152ae340276ad5ff5d98b
+creator:
+  github: "030611"
+package:
+  ecosystem: npm
+  name: dsh-verification-receipt
+  version: 0.1.0
+  integrity: sha512-V/gAvMeSMvaE52WK3BnJlEmfXiKkZH+/YJB0gKTzTsQY+AeWSEUkwc5iCaHBXjxyCk/agnVs9wxrOvkMk9iKmA==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:13:53.507Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `030611-dsh-verification-receipt`
- Submission type: community curation
- Created by `030611` — https://github.com/030611
- Original source repository: https://github.com/030611/dsh-verification-receipt
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.