### PR TITLE
catalog: add 121103qwq-dsh-vision-sidecar (community curation, created by @121103qwq)

### DIFF
--- a/catalog/plugins/121103qwq-dsh-vision-sidecar.yaml
+++ b/catalog/plugins/121103qwq-dsh-vision-sidecar.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: 121103qwq-dsh-vision-sidecar
+name: dsh-vision-sidecar
+description:
+  en: Add no-key hosted or OpenAI-compatible vision to DeepSeek Harness while keeping the configured reasoning model
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - vision
+  - glm
+  - openai-compatible
+  - vlm
+  - dsh
+source:
+  repository: https://github.com/121103qwq/dsh-vision-sidecar
+  repositoryNodeId: R_kgDOT3o81Q
+  subpath: null
+  commit: bf020d8acfb9bea251f9ab9f5a8978d395d41805
+creator:
+  github: 121103qwq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:13:46.754Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `121103qwq-dsh-vision-sidecar`
- Submission type: community curation
- Created by `121103qwq` — https://github.com/121103qwq
- Original source repository: https://github.com/121103qwq/dsh-vision-sidecar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.