### PR TITLE
catalog: add 1624318455-dsh-plugin-tavily (community curation, created by @1624318455)

### DIFF
--- a/catalog/plugins/1624318455-dsh-plugin-tavily.yaml
+++ b/catalog/plugins/1624318455-dsh-plugin-tavily.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: 1624318455-dsh-plugin-tavily
+name: "@dsh-external/dsh-plugin-tavily"
+description:
+  en: Professional Tavily-backed web search provider for DeepSeek Harness — full request parameters in a WebUI settings card, yaml-first priority, and API connectivity test
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - professional
+  - tavily
+  - backed
+  - search
+  - provider
+  - full
+  - request
+  - parameters
+  - webui
+  - settings
+  - card
+  - yaml
+  - first
+  - priority
+  - connectivity
+  - test
+source:
+  repository: https://github.com/1624318455/dsh-plugin-tavily
+  repositoryNodeId: R_kgDOT401Iw
+  subpath: null
+  commit: 04e096d0b465e86c971bc276155f52fb2e501abc
+creator:
+  github: "1624318455"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:13:42.193Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1624318455-dsh-plugin-tavily`
- Submission type: community curation
- Created by `1624318455` — https://github.com/1624318455
- Original source repository: https://github.com/1624318455/dsh-plugin-tavily
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.