### PR TITLE
catalog: add 791813037-dsh-story (community curation, created by @791813037)

### DIFF
--- a/catalog/plugins/791813037-dsh-story.yaml
+++ b/catalog/plugins/791813037-dsh-story.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: 791813037-dsh-story
+name: dsh-story
+description:
+  en: Installable DeepSeek Harness bundle for execution-path observability and deterministic diagnostics
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - installable
+  - bundle
+  - execution
+  - path
+  - observability
+  - deterministic
+  - diagnostics
+  - dsh
+source:
+  repository: https://github.com/791813037/dsh-story
+  repositoryNodeId: R_kgDOT6ErEQ
+  subpath: packages/bundle
+  commit: 9cb7df15c8fc669f544e08aeb6a6a2c8d33f63a0
+creator:
+  github: "791813037"
+package:
+  ecosystem: npm
+  name: dsh-story
+  version: 0.1.0
+  integrity: sha512-ZeMp5gzyr7aB9Vgh7obMnR3VKUSrjGMmThMvUnT/PABRvYE5wlSiSszuua1ONsUxmzxxVbNOVA+/qFMlgGvewg==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:14:09.312Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `791813037-dsh-story`
- Submission type: community curation
- Created by `791813037` — https://github.com/791813037
- Original source repository: https://github.com/791813037/dsh-story
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.