### PR TITLE
catalog: add ayahunter-dsh-trail-bundle (community curation, created by @ayahunter)

### DIFF
--- a/catalog/plugins/ayahunter-dsh-trail-bundle.yaml
+++ b/catalog/plugins/ayahunter-dsh-trail-bundle.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: ayahunter-dsh-trail-bundle
+name: dsh-trail-bundle
+description:
+  en: Patch bundle that mounts dsh-trail and disables the shipped trajectory view.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - patch
+  - bundle
+  - mounts
+  - trail
+  - disables
+  - shipped
+  - trajectory
+  - view
+  - dsh
+source:
+  repository: https://github.com/ayahunter/dsh-trail
+  repositoryNodeId: R_kgDOT5lbTA
+  subpath: packages/bundle
+  commit: 65a662f283d0138396b8a44c9293d3f4f29dac7f
+creator:
+  github: ayahunter
+package:
+  ecosystem: npm
+  name: dsh-trail-bundle
+  version: 0.1.1
+  integrity: sha512-DYuotctu6HvOIaYQfEvGlun8RWfO/JAEKNBUanB5ib5UtsXaOW4PRUByiaNtW9zsFtHGRFFf1v/r9i+eaLZGNA==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:14:12.692Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ayahunter-dsh-trail-bundle`
- Submission type: community curation
- Created by `ayahunter` — https://github.com/ayahunter
- Original source repository: https://github.com/ayahunter/dsh-trail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.