### PR TITLE
catalog: add crazygummies-dsh-neo-skin (community curation, created by @CrazyGummies)

### DIFF
--- a/catalog/plugins/crazygummies-dsh-neo-skin.yaml
+++ b/catalog/plugins/crazygummies-dsh-neo-skin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: crazygummies-dsh-neo-skin
+name: dsh-neo-skin
+description:
+  en: Neo-brutalism skin for DeepSeek Harness Web UI — stacks hard-border / high-contrast --dsw-alias- token overrides (DS-native blue + black-white + green + orange) on top of the built-in light/dark palettes.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - client-plugin
+  - theme
+  - skin
+  - neo-brutalism
+source:
+  repository: https://github.com/0nt-one/dsh-neo-skin
+  repositoryNodeId: R_kgDOT5r_Aw
+  subpath: null
+  commit: fe5ef0e671fab5ab8c8700013f3966eb9642455f
+creator:
+  github: CrazyGummies
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:14:00.286Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `crazygummies-dsh-neo-skin`
- Submission type: community curation
- Created by `CrazyGummies` — https://github.com/CrazyGummies
- Original source repository: https://github.com/0nt-one/dsh-neo-skin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.