### PR TITLE
catalog: add crazygummies-dsh-voice-input-web (community curation, created by @CrazyGummies)

### DIFF
--- a/catalog/plugins/crazygummies-dsh-voice-input-web.yaml
+++ b/catalog/plugins/crazygummies-dsh-voice-input-web.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: crazygummies-dsh-voice-input-web
+name: dsh-voice-input-web
+description:
+  en: "Voice input for DeepSeek Harness Web UI: a mic button in the composer tool row that uses the browser's Web Speech API (Chrome/Edge) to transcribe speech directly into the message draft. Zero dependencies, no API keys."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - client-plugin
+  - voice
+  - voice-input
+  - speech-to-text
+  - stt
+  - mic
+  - web-speech-api
+source:
+  repository: https://github.com/0nt-one/dsh-voice-input
+  repositoryNodeId: R_kgDOT5sDPQ
+  subpath: null
+  commit: c2fceee6a865a8466f3909d3896172f0f2fad2fa
+creator:
+  github: CrazyGummies
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:13:55.927Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `crazygummies-dsh-voice-input-web`
- Submission type: community curation
- Created by `CrazyGummies` — https://github.com/CrazyGummies
- Original source repository: https://github.com/0nt-one/dsh-voice-input
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.