### PR TITLE
catalog: add huahai0202-dsh-better-archive (community curation, created by @huahai0202)

### DIFF
--- a/catalog/plugins/huahai0202-dsh-better-archive.yaml
+++ b/catalog/plugins/huahai0202-dsh-better-archive.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: huahai0202-dsh-better-archive
+name: dsh-better-archive
+description:
+  en: Sidebar Archived entry + archived-session panel with unarchive and delete, for the DeepSeek Harness web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - ui
+  - archive
+  - unarchive
+  - session
+source:
+  repository: https://github.com/huahai0202/dsh-better-archive
+  repositoryNodeId: R_kgDOT4LTXQ
+  subpath: null
+  commit: fa31fc486d35b1e270828fd068a240f1775fb992
+creator:
+  github: huahai0202
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:13:37.997Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huahai0202-dsh-better-archive`
- Submission type: community curation
- Created by `huahai0202` — https://github.com/huahai0202
- Original source repository: https://github.com/huahai0202/dsh-better-archive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.