### PR TITLE
catalog: add keeplost-dsh-auth-app (community curation, created by @KeepLost)

### DIFF
--- a/catalog/plugins/keeplost-dsh-auth-app.yaml
+++ b/catalog/plugins/keeplost-dsh-auth-app.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: keeplost-dsh-auth-app
+name: "@deepseek-ai/dsh-auth-app"
+description:
+  en: One-shot local device and API-client Grant management profile for the DeepSeek Harness
+  evidencePath: packages/bundle/auth-app/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - shot
+  - local
+  - device
+  - client
+  - grant
+  - management
+  - profile
+  - dsh
+source:
+  repository: https://github.com/KeepLost/harniverse
+  repositoryNodeId: R_kgDOT4fM6A
+  subpath: packages/bundle/auth-app
+  commit: f39ec547c29f309d8c0b8883cbec9076d69bce0c
+creator:
+  github: KeepLost
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/bundle/auth-app/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:14:15.133Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `keeplost-dsh-auth-app`
- Submission type: community curation
- Created by `KeepLost` — https://github.com/KeepLost
- Original source repository: https://github.com/KeepLost/harniverse
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.