### PR TITLE
catalog: add soolaugust-dsh-cli (community curation, created by @soolaugust)

### DIFF
--- a/catalog/plugins/soolaugust-dsh-cli.yaml
+++ b/catalog/plugins/soolaugust-dsh-cli.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: soolaugust-dsh-cli
+name: "@deepseek-ai/dsh-cli"
+description:
+  en: "The dsh interactive terminal bundle: a REPL driver over dsh-base with session resume and a terminal UI"
+  evidencePath: packages/bundle/cli/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - interactive
+  - terminal
+  - bundle
+  - repl
+  - driver
+  - over
+  - base
+  - session
+  - resume
+  - dsh
+source:
+  repository: https://github.com/soolaugust/deepseek-harness-cli
+  repositoryNodeId: R_kgDOT359UQ
+  subpath: packages/bundle/cli
+  commit: 16acd8438b8494e45d010fe2d1a3950d854c8762
+creator:
+  github: soolaugust
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/bundle/cli/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:14:59.454Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `soolaugust-dsh-cli`
- Submission type: community curation
- Created by `soolaugust` — https://github.com/soolaugust
- Original source repository: https://github.com/soolaugust/deepseek-harness-cli
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.