### PR TITLE
catalog: add 173787247-dsh-wsl-net (community curation, created by @173787247)

### DIFF
--- a/catalog/plugins/173787247-dsh-wsl-net.yaml
+++ b/catalog/plugins/173787247-dsh-wsl-net.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: 173787247-dsh-wsl-net
+name: dsh-wsl-net
+description:
+  en: "DeepSeek Harness tool: diagnose WSL/Windows proxy, Node 24 fetch, and DeepSeek/npm reachability."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - wsl
+  - proxy
+  - dsh
+source:
+  repository: https://github.com/173787247/dsh-wsl-net
+  repositoryNodeId: R_kgDOT87-WQ
+  subpath: null
+  commit: 66f7122a0d2d5de648edc6467e68ab51708b0518
+creator:
+  github: "173787247"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:26.155Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `173787247-dsh-wsl-net`
- Submission type: community curation
- Created by `173787247` — https://github.com/173787247
- Original source repository: https://github.com/173787247/dsh-wsl-net
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.