### PR TITLE
catalog: add 1e0zj-dsh-plugin-mall (community curation, created by @1e0zj)

### DIFF
--- a/catalog/plugins/1e0zj-dsh-plugin-mall.yaml
+++ b/catalog/plugins/1e0zj-dsh-plugin-mall.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: 1e0zj-dsh-plugin-mall
+name: "@1e0zj/dsh-plugin-mall"
+description:
+  en: "An open plugin marketplace for DeepSeek Harness (dsh): search every GitHub repo tagged topic:dsh-plugin , automatically verify which ones are real dsh plugins, install and update with one click."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - plugin-marketplace
+  - marketplace
+source:
+  repository: https://github.com/1e0zj/dsh-plugin-mall
+  repositoryNodeId: R_kgDOT5P8aw
+  subpath: null
+  commit: f292c92813f9b5c2b81ce9b590954f58fdeedd8c
+creator:
+  github: 1e0zj
+package:
+  ecosystem: npm
+  name: "@1e0zj/dsh-plugin-mall"
+  version: 0.3.5
+  integrity: sha512-ZfPwzf283KzEdjpsDpT/6tBGovNdOri9vzJ8hFWRuu/uvEqRZkVyC3aiZGCJ/1OYySUIFjvy4wnRs5Y1iAuS8w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:10.350Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1e0zj-dsh-plugin-mall`
- Submission type: community curation
- Created by `1e0zj` — https://github.com/1e0zj
- Original source repository: https://github.com/1e0zj/dsh-plugin-mall
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.