### PR TITLE
catalog: add 1helloman1-dsh-usage-dashboard-plus (community curation, created by @1HelloMan1)

### DIFF
--- a/catalog/plugins/1helloman1-dsh-usage-dashboard-plus.yaml
+++ b/catalog/plugins/1helloman1-dsh-usage-dashboard-plus.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: 1helloman1-dsh-usage-dashboard-plus
+name: dsh-usage-dashboard-plus
+description:
+  en: "DeepSeek Harness (dsh) web plugin: API balance + today's spend sidebar widget, /api/dsh-usage route, external vision-call accounting (JSONL usage log), plus a full per-session usage dashboard (call log, per-model stats, cache rate, CSV export) via the usageDashboard session projection — merged from dsh-stats-dashboard."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - balance
+  - usage
+  - cost
+  - web
+  - vision
+  - dashboard
+  - call-log
+  - stats
+  - projection
+source:
+  repository: https://github.com/1HelloMan1/dsh-usage-dashboard-plus
+  repositoryNodeId: R_kgDOT4OUiQ
+  subpath: null
+  commit: b198d5da62a17cb0ee2bb27e7b04aa71f4cd47d3
+creator:
+  github: 1HelloMan1
+package:
+  ecosystem: npm
+  name: dsh-usage-dashboard-plus
+  version: 0.2.4
+  integrity: sha512-N/0bFvjvqrQhq6ovwGpAdbVOh/ONFDca1h721CS2JkLapVKPgC0ly/XUc416H925vk4Xfne+f+F8yJlTgjZSDQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:45:56.685Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1helloman1-dsh-usage-dashboard-plus`
- Submission type: community curation
- Created by `1HelloMan1` — https://github.com/1HelloMan1
- Original source repository: https://github.com/1HelloMan1/dsh-usage-dashboard-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.