### PR TITLE
catalog: add 1mlightyears-dsh-theme-synthwave (community curation, created by @1MLightyears)

### DIFF
--- a/catalog/plugins/1mlightyears-dsh-theme-synthwave.yaml
+++ b/catalog/plugins/1mlightyears-dsh-theme-synthwave.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: 1mlightyears-dsh-theme-synthwave
+name: "@1mlightyears/dsh-theme-synthwave"
+description:
+  en: "DSH Synthwave theme plugin: neon glow hover/focus, translucent panels over image/video background, configurable blur, fontScale root font-size."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - theme
+  - synthwave
+  - background
+  - video
+source:
+  repository: https://github.com/1MLightyears/dsh-theme-synthwave
+  repositoryNodeId: R_kgDOT5_gxg
+  subpath: null
+  commit: f418fcb15674638defd4a4793e5f530346a8c25e
+creator:
+  github: 1MLightyears
+package:
+  ecosystem: npm
+  name: "@1mlightyears/dsh-theme-synthwave"
+  version: 0.1.0
+  integrity: sha512-cnQnP10RTlM0ByIIqTioUooDT1FSoFyCMsVDUhHxx4EeHuKkmO0ojTIY0Xki8LShYlKayOMHcAyRXJGfl6AGsw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:28.093Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1mlightyears-dsh-theme-synthwave`
- Submission type: community curation
- Created by `1MLightyears` — https://github.com/1MLightyears
- Original source repository: https://github.com/1MLightyears/dsh-theme-synthwave
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.