### PR TITLE
catalog: add 534119219-chicheng-cron (community curation, created by @534119219)

### DIFF
--- a/catalog/plugins/534119219-chicheng-cron.yaml
+++ b/catalog/plugins/534119219-chicheng-cron.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 534119219-chicheng-cron
+name: chicheng-cron
+description:
+  en: sh dsh plugin --profile web add github:534119219/chicheng-cron
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - cron
+  - scheduler
+  - scheduled-tasks
+source:
+  repository: https://github.com/534119219/chicheng-cron
+  repositoryNodeId: R_kgDOT57N-g
+  subpath: null
+  commit: 31a8627ebf9af56d30c2e385f0f72ee22cc78a08
+creator:
+  github: "534119219"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:12.194Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `534119219-chicheng-cron`
- Submission type: community curation
- Created by `534119219` — https://github.com/534119219
- Original source repository: https://github.com/534119219/chicheng-cron
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.