### PR TITLE
catalog: add 534119219-chicheng-push (community curation, created by @534119219)

### DIFF
--- a/catalog/plugins/534119219-chicheng-push.yaml
+++ b/catalog/plugins/534119219-chicheng-push.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: 534119219-chicheng-push
+name: chicheng-push
+description:
+  en: sh dsh plugin --profile web add chicheng-push
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - push
+  - notify
+  - notification
+  - serverchan
+  - pushplus
+  - bark
+  - dingtalk
+  - wecom
+  - telegram
+  - feishu
+  - lark
+  - webhook
+source:
+  repository: https://github.com/534119219/chicheng-push
+  repositoryNodeId: R_kgDOT5hQdQ
+  subpath: null
+  commit: 2aa2b8273183bc91f4cf6d12b1f7121bbee751da
+creator:
+  github: "534119219"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:45:58.687Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `534119219-chicheng-push`
- Submission type: community curation
- Created by `534119219` — https://github.com/534119219
- Original source repository: https://github.com/534119219/chicheng-push
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.