### PR TITLE
catalog: add 534119219-messaging-core (community curation, created by @534119219)

### DIFF
--- a/catalog/plugins/534119219-messaging-core.yaml
+++ b/catalog/plugins/534119219-messaging-core.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: 534119219-messaging-core
+name: messaging-core
+description:
+  en: "DSH messaging gateway core: platform adapter registry, chat-to-session mapping, outbound session/event routing, authorization, and messaging tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - messaging
+  - gateway
+  - core
+  - platform
+  - adapter
+  - registry
+  - chat
+  - session
+  - mapping
+  - outbound
+  - event
+  - routing
+  - authorization
+  - tools
+  - dsh
+source:
+  repository: https://github.com/534119219/dsh-messaging
+  repositoryNodeId: R_kgDOT56pYQ
+  subpath: packages/messaging-core
+  commit: f1c3399ef40e3f419161d153e997d6f30576a627
+creator:
+  github: "534119219"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/messaging-core/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:33.715Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `534119219-messaging-core`
- Submission type: community curation
- Created by `534119219` — https://github.com/534119219
- Original source repository: https://github.com/534119219/dsh-messaging
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.