### PR TITLE
catalog: add 54xkeee-dsh-youreyes (community curation, created by @54xkeee)

### DIFF
--- a/catalog/plugins/54xkeee-dsh-youreyes.yaml
+++ b/catalog/plugins/54xkeee-dsh-youreyes.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: 54xkeee-dsh-youreyes
+name: dsh-youreyes
+description:
+  en: "Eyes for text-only DeepSeek on DeepSeek Harness: image understanding via Antigravity IDE quota (default, flash/pro), OpenAI-compatible VLM endpoints, Gemini API, or local Ollama — model-invokable vision tool, wrapper adapters for deepseek/opencode-go, evidence memory, and a polished client panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - image
+  - image-understanding
+  - image-recognition
+  - multimodal
+  - ocr
+  - vlm
+  - gemini
+  - ollama
+  - antigravity
+source:
+  repository: https://github.com/54xkeee/dsh-youreyes
+  repositoryNodeId: R_kgDOT5MtqQ
+  subpath: null
+  commit: 86f02fa124cd158438e4d9290625d2f8dd610967
+creator:
+  github: 54xkeee
+package:
+  ecosystem: npm
+  name: dsh-youreyes
+  version: 0.1.0
+  integrity: sha512-Q+gr3iN1a3Bp4fK+eOsVleujLpbCjyBtQ+IRX+Gx4ZOOG09pPrBp9NDASdGfVvVGNjdWPwbntk6pe7B2W34I9Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:14.098Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `54xkeee-dsh-youreyes`
- Submission type: community curation
- Created by `54xkeee` — https://github.com/54xkeee
- Original source repository: https://github.com/54xkeee/dsh-youreyes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.