### PR TITLE
catalog: add 863683348-dsh-feed (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-feed.yaml
+++ b/catalog/plugins/863683348-dsh-feed.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: 863683348-dsh-feed
+name: dsh-feed
+description:
+  en: "Cross-ecosystem aggregation base ('聚合的聚合'): syncs the GitHub dsh-plugin topic + npm registry into one open JSON index, queried by model tools, a CLI (dsh-feed), and a minimal stdio MCP server"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - feed
+  - index
+  - aggregation
+  - mcp
+source:
+  repository: https://github.com/863683348/dsh-feed
+  repositoryNodeId: R_kgDOT6qtMg
+  subpath: null
+  commit: d9f59743c53d8a349f1deb2f18f70117a4014ef7
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-feed
+  version: 0.1.0
+  integrity: sha512-6Fezvq9ghroGwJ048ebPKUfAkFfrAQJNEDa4sata7HS88WhbDbhrTKcvyKdrpIuv7vCSXWFmaMbZADk2BQLksg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:35.490Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-feed`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-feed
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.