### PR TITLE
catalog: add 863683348-dsh-gov (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-gov.yaml
+++ b/catalog/plugins/863683348-dsh-gov.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: 863683348-dsh-gov
+name: dsh-gov
+description:
+  en: "Agent governance suite for DeepSeek Harness (enterprise companion): policy-based tool gating (allow/deny/ask), structured JSONL audit trail, and per-agent token quotas against the host token meter — state under $DSH HOME/gov"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - governance
+  - compliance
+  - audit
+  - security
+  - quota
+  - cost
+  - enterprise
+source:
+  repository: https://github.com/863683348/dsh-gov
+  repositoryNodeId: R_kgDOT6ug-w
+  subpath: null
+  commit: af5f32b43bd694c1c654028828bf425d417fdb19
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-gov
+  version: 0.1.0
+  integrity: sha512-9fYgeJlPrOsOe47bexTRsetmJwk9w7Ss2Gm+3dOvp0WXj5vWM+X79DlzFRRQ6as9OIeOHkUK8YeOvlVs1clrXA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:37.491Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-gov`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-gov
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.