### PR TITLE
catalog: add 863683348-dsh-plugin-education (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-plugin-education.yaml
+++ b/catalog/plugins/863683348-dsh-plugin-education.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: 863683348-dsh-plugin-education
+name: dsh-plugin-education
+description:
+  en: "Education toolkit for DeepSeek Harness agents: lesson-plan skeletons by grade band, quiz validation, analytic rubrics, grading sheets, study plans, flashcards, and text readability levels"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - bundle
+  - education
+  - lesson
+  - quiz
+  - flashcard
+  - rubric
+  - grading
+  - study-plan
+source:
+  repository: https://github.com/863683348/dsh-plugin-education
+  repositoryNodeId: R_kgDOT6veOw
+  subpath: null
+  commit: 438c832ff920df461523d58cbc6b6aa606e1db03
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-plugin-education
+  version: 0.2.0
+  integrity: sha512-xil/ylk7NfkGHjG4bJWHS7jPRSJ+U97jLnmBRTipW85T/e3nGDbbKffu+P5LaWfYnlNLviFF5DJ1NUS7IM34YA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:44.955Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-plugin-education`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-plugin-education
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.