### PR TITLE
catalog: add 863683348-dsh-plugin-focus (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-plugin-focus.yaml
+++ b/catalog/plugins/863683348-dsh-plugin-focus.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: 863683348-dsh-plugin-focus
+name: dsh-plugin-focus
+description:
+  en: "Focus board for DeepSeek Harness agents: durable, model-maintained notes in the session workspace that pin the objective, constraints, and decisions across compaction and sessions — with automatic context injection, an archive on clear, and an optional read-only web panel"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - bundle
+  - focus
+  - memory
+  - context
+source:
+  repository: https://github.com/863683348/dsh-plugin-focus
+  repositoryNodeId: R_kgDOT6MG4w
+  subpath: null
+  commit: c6cf27b2f7ca01e6d3a0bf462846f0ddd61b8acd
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-plugin-focus
+  version: 1.0.1
+  integrity: sha512-c/12ZLLGaGfvh3xJCXOZ5ie1R0TTKAblq5bYIsCPNBJUbLylHPnPKL7mRCzWqXsQAGFmG9t3jpTTMfaKPrxFQA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:35.067Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-plugin-focus`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-plugin-focus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.