### PR TITLE
catalog: add 863683348-dsh-plugin-local-life (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-plugin-local-life.yaml
+++ b/catalog/plugins/863683348-dsh-plugin-local-life.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: 863683348-dsh-plugin-local-life
+name: dsh-plugin-local-life
+description:
+  en: "Local-life toolkit for DeepSeek Harness agents: budget planning, bill splitting, unit-price and discount math, common unit conversions (incl. jin/li/chi, C/F), expense-ledger summaries, loan amortization (equal-payment / equal-principal), and trip checklists"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - bundle
+  - local
+  - life
+  - budget
+  - split
+  - convert
+  - ledger
+  - amortization
+  - loan
+source:
+  repository: https://github.com/863683348/dsh-plugin-local-life
+  repositoryNodeId: R_kgDOT6veZA
+  subpath: null
+  commit: c8ac78a15e5638ddf90bb275f93fe94a44c29936
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-plugin-local-life
+  version: 0.2.0
+  integrity: sha512-GmpnSAJiEm6QhEb0DeuEN5r4bs0FmG7qnSK6vssCFygO3utSmW/UA76jqNUsaPyMczmYmjNDRkMwZpgXldGDnA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:49.900Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-plugin-local-life`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-plugin-local-life
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.