### PR TITLE
catalog: add 863683348-dsh-plugin-translation (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-plugin-translation.yaml
+++ b/catalog/plugins/863683348-dsh-plugin-translation.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: 863683348-dsh-plugin-translation
+name: dsh-plugin-translation
+description:
+  en: "Translation toolkit for DeepSeek Harness agents: sentence segmentation, term/glossary extraction, a durable workspace glossary (add/get/remove), cross-segment terminology consistency checks, source-target QA, tone guides, and a durable translation memory"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - bundle
+  - translation
+  - glossary
+  - memo
+  - qa
+  - terminology
+  - consistency
+source:
+  repository: https://github.com/863683348/dsh-plugin-translation
+  repositoryNodeId: R_kgDOT6veCg
+  subpath: null
+  commit: 8a606715fb14b15e764d477bbba4f8d74106c54e
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-plugin-translation
+  version: 0.2.0
+  integrity: sha512-iAF69ih1uOlvhtywqnM8XyP4zqnn0FaCIdVK63W78jt/b7tbiEI4l91Jxu8C9mry0oi+Xy9Y6e8B+JL4ccUxJg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:37.968Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-plugin-translation`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-plugin-translation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.