### PR TITLE
catalog: add 863683348-dsh-plugin-verify (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-plugin-verify.yaml
+++ b/catalog/plugins/863683348-dsh-plugin-verify.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: 863683348-dsh-plugin-verify
+name: dsh-plugin-verify
+description:
+  en: "Verification toolkit for DeepSeek Harness agents: evidence-based claim checking against workspace files with line citations, config file validation (JSON/YAML), HTTP URL status checks, npm package checks and GitHub repo submission-readiness checks — complementary to dsh-plugin-gate"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - verify
+  - validation
+  - claim
+  - check
+  - audit
+  - npm
+source:
+  repository: https://github.com/863683348/dsh-plugin-verify
+  repositoryNodeId: R_kgDOT6wuFg
+  subpath: null
+  commit: 58337381fb08874e88553b84a5aafa96acaf0c02
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-plugin-verify
+  version: 1.0.0
+  integrity: sha512-Eu+8dUfEQXAkWnF2OuuY3b5mu1IYCoIaUsDoS9ncTOC4Kd/kcCWZTQ9ESBtm4JgnFSLUu/URv/VFbWgW6uLNXA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:53.587Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-plugin-verify`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-plugin-verify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.