### PR TITLE
catalog: add 863683348-dsh-recipe (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-recipe.yaml
+++ b/catalog/plugins/863683348-dsh-recipe.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: 863683348-dsh-recipe
+name: dsh-recipe
+description:
+  en: "Scenario bundles of dsh plugins ('插件界的 dotfiles'): a recipe tool that lists, searches, applies and composes ready-made plugin environments with ordered install sequences"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - recipe
+  - bundle
+  - environment
+source:
+  repository: https://github.com/863683348/dsh-recipe
+  repositoryNodeId: R_kgDOT6qmFA
+  subpath: null
+  commit: 2fc268f5ee28f293c560b22999d3dec228897fa8
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-recipe
+  version: 0.1.0
+  integrity: sha512-nLi/hc6dJ90s0YXLwmyAgtnqVB5kNeaeAvPolVk+kyPTjY8qeDFip9JV6zvbroUsTKa7P04dN3p6jL5Ynjl94w==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:56.240Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-recipe`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-recipe
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.