### PR TITLE
catalog: add 863683348-dsh-starter-zh (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-dsh-starter-zh.yaml
+++ b/catalog/plugins/863683348-dsh-starter-zh.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: 863683348-dsh-starter-zh
+name: dsh-starter-zh
+description:
+  en: "dsh-starter-zh is a beginner starter pack for DeepSeek Harness: install it and your agent instantly gains a welcome flow, a 0→1 learning path, scenario-based plugin recommendations, and a self-check checklist — paired with the dsh-handbook-zh Chinese tutorial repo."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - bundle
+  - starter
+  - onboarding
+  - beginner
+  - tutorial
+source:
+  repository: https://github.com/863683348/dsh-starter-zh
+  repositoryNodeId: R_kgDOT6vLbg
+  subpath: null
+  commit: 77255cf2b842b662df390894bae884f85a7da9a5
+creator:
+  github: "863683348"
+package:
+  ecosystem: npm
+  name: dsh-starter-zh
+  version: 0.1.0
+  integrity: sha512-1trJ0ZzyXOfko4Me3ZDybH+WAxbVm4Mx/bTMZ8Q5s0clojZ1sbuj8fyBKtjHMvyTZV2lCvbiegnSZOx22Ob1RQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:00.593Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-dsh-starter-zh`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-starter-zh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.