### PR TITLE
catalog: add 863683348-your-plugin-name (community curation, created by @863683348)

### DIFF
--- a/catalog/plugins/863683348-your-plugin-name.yaml
+++ b/catalog/plugins/863683348-your-plugin-name.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: 863683348-your-plugin-name
+name: your-plugin-name
+description:
+  en: One line about what your dsh plugin does
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - line
+  - about
+  - what
+  - does
+  - dsh
+source:
+  repository: https://github.com/863683348/dsh-plugin-focus
+  repositoryNodeId: R_kgDOT6MG4w
+  subpath: skills/dsh-factory/templates/plugin-skeleton
+  commit: c6cf27b2f7ca01e6d3a0bf462846f0ddd61b8acd
+creator:
+  github: "863683348"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: skills/dsh-factory/templates/plugin-skeleton/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:35.067Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `863683348-your-plugin-name`
- Submission type: community curation
- Created by `863683348` — https://github.com/863683348
- Original source repository: https://github.com/863683348/dsh-plugin-focus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.