### PR TITLE
catalog: add a1073097082-dsh-model-search (community curation, created by @a1073097082)

### DIFF
--- a/catalog/plugins/a1073097082-dsh-model-search.yaml
+++ b/catalog/plugins/a1073097082-dsh-model-search.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: a1073097082-dsh-model-search
+name: dsh-model-search
+description:
+  en: Add searchable filtering to the DeepSeek Harness model selector.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - model
+  - search
+source:
+  repository: https://github.com/a1073097082/dsh-model-search
+  repositoryNodeId: R_kgDOT5MJ5Q
+  subpath: null
+  commit: 8a6293a62a19142538830ac898ab62fcfa27f4a8
+creator:
+  github: a1073097082
+package:
+  ecosystem: npm
+  name: dsh-model-search
+  version: 0.1.0
+  integrity: sha512-ca+zjs2y2SC6VwWbKis68KPJxt3ivHQpT5cn01EoYQl1HunJbM7uk8d9OkvjSrMeVDVN5SpzcFhVsSuSGK39tg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:15.959Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `a1073097082-dsh-model-search`
- Submission type: community curation
- Created by `a1073097082` — https://github.com/a1073097082
- Original source repository: https://github.com/a1073097082/dsh-model-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.