### PR TITLE
catalog: add a1113622001-dsh-auto-update (community curation, created by @a1113622001)

### DIFF
--- a/catalog/plugins/a1113622001-dsh-auto-update.yaml
+++ b/catalog/plugins/a1113622001-dsh-auto-update.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: a1113622001-dsh-auto-update
+name: dsh-auto-update
+description:
+  en: "DeepSeek Harness (cordis) plugin: self-update for the harness launcher — checks npm for a newer @deepseek-ai/dsh, stages it, and applies it on harness exit (or update-and-restart from the web panel)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - self-update
+  - update
+  - web
+source:
+  repository: https://github.com/a1113622001/dsh-auto-update
+  repositoryNodeId: R_kgDOT9vhxQ
+  subpath: null
+  commit: 1aacb3b51fdc016668cc0375ea31ce40db02e455
+creator:
+  github: a1113622001
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:06.686Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `a1113622001-dsh-auto-update`
- Submission type: community curation
- Created by `a1113622001` — https://github.com/a1113622001
- Original source repository: https://github.com/a1113622001/dsh-auto-update
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.