### PR TITLE
catalog: add a1113622001-dsh-session-stats-panel (community curation, created by @a1113622001)

### DIFF
--- a/catalog/plugins/a1113622001-dsh-session-stats-panel.yaml
+++ b/catalog/plugins/a1113622001-dsh-session-stats-panel.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: a1113622001-dsh-session-stats-panel
+name: dsh-session-stats-panel
+description:
+  en: "DeepSeek Harness (cordis) client plugin: a right-side session stats panel showing average cache-hit rate, session cost, runtime, request count and cumulative tokens (DeepSeek pricing)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - web
+  - ui
+  - session
+  - stats
+  - token-usage
+source:
+  repository: https://github.com/a1113622001/dsh-session-stats-panel
+  repositoryNodeId: R_kgDOT9vnNg
+  subpath: null
+  commit: 69bdeb0f45413f55a192f449ded8a7b7408a2789
+creator:
+  github: a1113622001
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:08.716Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `a1113622001-dsh-session-stats-panel`
- Submission type: community curation
- Created by `a1113622001` — https://github.com/a1113622001
- Original source repository: https://github.com/a1113622001/dsh-session-stats-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.