### PR TITLE
catalog: add a903067276-rgb-dsh-todo-guard (community curation, created by @a903067276-rgb)

### DIFF
--- a/catalog/plugins/a903067276-rgb-dsh-todo-guard.yaml
+++ b/catalog/plugins/a903067276-rgb-dsh-todo-guard.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: a903067276-rgb-dsh-todo-guard
+name: dsh-todo-guard
+description:
+  en: "Reliable todo panel for DSH: survives restarts, verifies completion evidence"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - todo
+  - verification
+source:
+  repository: https://github.com/a903067276-rgb/dsh-todo-guard
+  repositoryNodeId: R_kgDOT9ELOQ
+  subpath: null
+  commit: 495e0d388ddbcbba72edbf80f707fe7bf4c39f4d
+creator:
+  github: a903067276-rgb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:40.121Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `a903067276-rgb-dsh-todo-guard`
- Submission type: community curation
- Created by `a903067276-rgb` — https://github.com/a903067276-rgb
- Original source repository: https://github.com/a903067276-rgb/dsh-todo-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.