### PR TITLE
catalog: add abcdefgxw-dsh-toolbox-web (community curation, created by @AbcdefgXW)

### DIFF
--- a/catalog/plugins/abcdefgxw-dsh-toolbox-web.yaml
+++ b/catalog/plugins/abcdefgxw-dsh-toolbox-web.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: abcdefgxw-dsh-toolbox-web
+name: dsh-toolbox-web
+description:
+  en: "A toolbox plugin for dsh (DeepSeek Harness): session management / trash bin / subdirectory management / full-text search / preset editing / config editing / archive management."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - toolbox
+  - session
+  - search
+  - heartbeat
+  - chat
+source:
+  repository: https://github.com/AbcdefgXW/dsh-toolbox-web
+  repositoryNodeId: R_kgDOT5Y3Pw
+  subpath: null
+  commit: 101f49d392d56a490c06573444d0870167a82dae
+creator:
+  github: AbcdefgXW
+package:
+  ecosystem: npm
+  name: dsh-toolbox-web
+  version: 0.1.12
+  integrity: sha512-eRHb24QBURPBsmbCwZgjwpCZSfVAlJSVnDOX3BYK0oZjVJlNt9k9IGsJay8bkBh30125eGSTN5bZR8cloRaBgw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:19.330Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `abcdefgxw-dsh-toolbox-web`
- Submission type: community curation
- Created by `AbcdefgXW` — https://github.com/AbcdefgXW
- Original source repository: https://github.com/AbcdefgXW/dsh-toolbox-web
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.