### PR TITLE
catalog: add aberter0x3f-dsh-custom-enter-key (community curation, created by @aberter0x3f)

### DIFF
--- a/catalog/plugins/aberter0x3f-dsh-custom-enter-key.yaml
+++ b/catalog/plugins/aberter0x3f-dsh-custom-enter-key.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: aberter0x3f-dsh-custom-enter-key
+name: "@dsh-external/dsh-custom-enter-key"
+description:
+  en: Standalone composer plugin that configures Enter, Ctrl/Cmd+Enter, and Shift+Enter independently (newline, queue send, or interject send) and replaces the built-in busy-Enter preference
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - standalone
+  - composer
+  - configures
+  - enter
+  - ctrl
+  - shift
+  - independently
+  - newline
+  - queue
+  - send
+  - interject
+  - replaces
+  - built
+  - busy
+  - preference
+  - dsh
+source:
+  repository: https://github.com/aberter0x3f/dsh-custom-enter-key
+  repositoryNodeId: R_kgDOT4GOsA
+  subpath: null
+  commit: c6554d64c586c5f79d86076afd84bdb2b60532f6
+creator:
+  github: aberter0x3f
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:42.498Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aberter0x3f-dsh-custom-enter-key`
- Submission type: community curation
- Created by `aberter0x3f` — https://github.com/aberter0x3f
- Original source repository: https://github.com/aberter0x3f/dsh-custom-enter-key
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.