### PR TITLE
catalog: add acebang0303-dsh-quick-launch (community curation, created by @acebang0303)

### DIFF
--- a/catalog/plugins/acebang0303-dsh-quick-launch.yaml
+++ b/catalog/plugins/acebang0303-dsh-quick-launch.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: acebang0303-dsh-quick-launch
+name: dsh-quick-launch
+description:
+  en: sh git clone https://github.com/acebang0303/dsh-quick-launch cd <harness dsh plugin --profile web add ../dsh-quick-launch
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - clone
+  - acebang0303
+  - quick
+  - launch
+  - profile
+  - dsh
+source:
+  repository: https://github.com/acebang0303/dsh-quick-launch
+  repositoryNodeId: R_kgDOT8HblQ
+  subpath: null
+  commit: 205327a2b17ee9ca7836db7554358bb540be8389
+creator:
+  github: acebang0303
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: (MIT AND CC-BY-NC-SA-4.0)
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:43.840Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `acebang0303-dsh-quick-launch`
- Submission type: community curation
- Created by `acebang0303` — https://github.com/acebang0303
- Original source repository: https://github.com/acebang0303/dsh-quick-launch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.