### PR TITLE
catalog: add aerince-dsh-active-context-pruning (community curation, created by @aerince)

### DIFF
--- a/catalog/plugins/aerince-dsh-active-context-pruning.yaml
+++ b/catalog/plugins/aerince-dsh-active-context-pruning.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: aerince-dsh-active-context-pruning
+name: dsh-active-context-pruning
+description:
+  en: Model-authored context pruning for DeepSeek Harness through the official compaction API.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - compaction
+  - context
+source:
+  repository: https://github.com/aerince/dsh-active-context-pruning
+  repositoryNodeId: R_kgDOT5QPLw
+  subpath: null
+  commit: d52b5f2acb44be9ee71e2a68e0178dd227a2f2ef
+creator:
+  github: aerince
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:45.818Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aerince-dsh-active-context-pruning`
- Submission type: community curation
- Created by `aerince` — https://github.com/aerince
- Original source repository: https://github.com/aerince/dsh-active-context-pruning
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.