### PR TITLE
catalog: add aerince-dsh-models-dev-reasoning (community curation, created by @aerince)

### DIFF
--- a/catalog/plugins/aerince-dsh-models-dev-reasoning.yaml
+++ b/catalog/plugins/aerince-dsh-models-dev-reasoning.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: aerince-dsh-models-dev-reasoning
+name: dsh-models-dev-reasoning
+description:
+  en: Add models.dev reasoning levels to unconfigured third-party DeepSeek Harness models.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - models-dev
+  - reasoning
+source:
+  repository: https://github.com/aerince/dsh-models-dev-reasoning
+  repositoryNodeId: R_kgDOT5OuJg
+  subpath: null
+  commit: c781d555bbe7f4343cb7750dd6e1f9e1b4876069
+creator:
+  github: aerince
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:23.251Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aerince-dsh-models-dev-reasoning`
- Submission type: community curation
- Created by `aerince` — https://github.com/aerince
- Original source repository: https://github.com/aerince/dsh-models-dev-reasoning
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.