### PR TITLE
catalog: add aga-j-dsh-mini-games (community curation, created by @aga-j)

### DIFF
--- a/catalog/plugins/aga-j-dsh-mini-games.yaml
+++ b/catalog/plugins/aga-j-dsh-mini-games.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: aga-j-dsh-mini-games
+name: dsh-mini-games
+description:
+  en: "Pure-frontend mini-game collection for the DeepSeek Harness web details panel: guess-the-number, 2048, minesweeper. No host half, no backend."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-client-plugin
+  - mini-games
+  - "2048"
+  - minesweeper
+  - guess-number
+source:
+  repository: https://github.com/aga-j/dsh-mini-games
+  repositoryNodeId: R_kgDOT9BqWg
+  subpath: null
+  commit: f7910a8784aa863b152f7e93f21af8c33fc495e4
+creator:
+  github: aga-j
+package:
+  ecosystem: npm
+  name: dsh-mini-games
+  version: 0.1.2
+  integrity: sha512-iIiL/C5dRLh1xogddrLlJ8beDDkdNzSsjPColUdjgqgNpTG3OAy5ge1jK1bJOdkXBLpPgT227kwwo2ajSJRk/g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:12.868Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aga-j-dsh-mini-games`
- Submission type: community curation
- Created by `aga-j` — https://github.com/aga-j
- Original source repository: https://github.com/aga-j/dsh-mini-games
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.