### PR TITLE
catalog: add agentforce314-dsh-cctui (community curation, created by @agentforce314)

### DIFF
--- a/catalog/plugins/agentforce314-dsh-cctui.yaml
+++ b/catalog/plugins/agentforce314-dsh-cctui.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: agentforce314-dsh-cctui
+name: dsh-cctui
+description:
+  en: Claude-Code-style terminal UI for deepseek-harness, ported from clawcodex ui-tui
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - claude
+  - code
+  - style
+  - terminal
+  - ported
+  - clawcodex
+  - dsh
+source:
+  repository: https://github.com/agentforce314/dsh-ccTUI
+  repositoryNodeId: R_kgDOT8LGKw
+  subpath: null
+  commit: a19f0fa8c02e59079d4117f09976abbdb7293f09
+creator:
+  github: agentforce314
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:25.249Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `agentforce314-dsh-cctui`
- Submission type: community curation
- Created by `agentforce314` — https://github.com/agentforce314
- Original source repository: https://github.com/agentforce314/dsh-ccTUI
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.