### PR TITLE
catalog: add ai-scarlett-dsh-build-plugin (community curation, created by @AI-Scarlett)

### DIFF
--- a/catalog/plugins/ai-scarlett-dsh-build-plugin.yaml
+++ b/catalog/plugins/ai-scarlett-dsh-build-plugin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ai-scarlett-dsh-build-plugin
+name: dsh-build-plugin
+description:
+  en: DSH Skill adapter for the build-dsh-plugin development workflow
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - skill
+  - adapter
+  - build
+  - development
+  - workflow
+  - dsh
+source:
+  repository: https://github.com/AI-Scarlett/build-dsh-plugin
+  repositoryNodeId: R_kgDOT75Rjg
+  subpath: null
+  commit: 4ab970f35e7e0a95bcb42c851e8efceaf1977df9
+creator:
+  github: AI-Scarlett
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:50.243Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ai-scarlett-dsh-build-plugin`
- Submission type: community curation
- Created by `AI-Scarlett` — https://github.com/AI-Scarlett
- Original source repository: https://github.com/AI-Scarlett/build-dsh-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.