### PR TITLE
catalog: add aik358-dsh-draw-gacha (community curation, created by @Aik358)

### DIFF
--- a/catalog/plugins/aik358-dsh-draw-gacha.yaml
+++ b/catalog/plugins/aik358-dsh-draw-gacha.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: aik358-dsh-draw-gacha
+name: "@a9i5k4/dsh-draw-gacha"
+description:
+  en: bash dsh plugin --profile web add @a9i5k4/dsh-draw-gacha
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - gacha
+  - just-for-fun
+  - web-ui
+source:
+  repository: https://github.com/Aik358/dsh-draw-gacha
+  repositoryNodeId: R_kgDOT56NwA
+  subpath: null
+  commit: 154b43f54d4d03d9178d6a470685dc886bc4579a
+creator:
+  github: Aik358
+package:
+  ecosystem: npm
+  name: "@a9i5k4/dsh-draw-gacha"
+  version: 0.1.6
+  integrity: sha512-QXkAAi61FinARO+dlZAKp7l3lS/mXqGTyoFMXfyzaIgNTiRidFZJp1kWTHuPNLWQO0q7C2VC9cUQ80MnrZMgCg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:51.633Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aik358-dsh-draw-gacha`
- Submission type: community curation
- Created by `Aik358` — https://github.com/Aik358
- Original source repository: https://github.com/Aik358/dsh-draw-gacha
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.