### PR TITLE
catalog: add aikenfra-dsh-alive (community curation, created by @AikenFra)

### DIFF
--- a/catalog/plugins/aikenfra-dsh-alive.yaml
+++ b/catalog/plugins/aikenfra-dsh-alive.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: aikenfra-dsh-alive
+name: dsh-alive
+description:
+  en: An always-visible ● Online / ● Offline indicator in the conversation header, auto-refreshed every 15 seconds. It costs zero tokens — the browser simply polls a process-local HTTP endpoint.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - status
+  - online
+  - health
+  - indicator
+  - heartbeat
+source:
+  repository: https://github.com/AikenFra/dsh-alive
+  repositoryNodeId: R_kgDOT5yVkg
+  subpath: null
+  commit: b89e53b51e5380900d0b298cbe1e768b5b940a84
+creator:
+  github: AikenFra
+package:
+  ecosystem: npm
+  name: dsh-alive
+  version: 0.1.1
+  integrity: sha512-j5Z7ZLc8DOJI9vyU4MZWr6RsWiYbXnY0XicU6/rCb5yQpE1oHgoOwrPtvcTJAHdhv4erzceb108Vfpkk+1EIXg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:53.365Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aikenfra-dsh-alive`
- Submission type: community curation
- Created by `AikenFra` — https://github.com/AikenFra
- Original source repository: https://github.com/AikenFra/dsh-alive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.