### PR TITLE
catalog: add aks1st-dock-files (community curation, created by @AKS1st)

### DIFF
--- a/catalog/plugins/aks1st-dock-files.yaml
+++ b/catalog/plugins/aks1st-dock-files.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: aks1st-dock-files
+name: dock-files
+description:
+  en: "File explorer for the DSH dock: browse the active conversation's working directory and open files in the registered file viewers."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web-ui
+  - files
+  - explorer
+  - dock
+source:
+  repository: https://github.com/AKS1st/dock-files
+  repositoryNodeId: R_kgDOT-ZJtg
+  subpath: null
+  commit: 1a947ef638fd6e758271e9613c3d67ba957da5e9
+creator:
+  github: AKS1st
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:18.595Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aks1st-dock-files`
- Submission type: community curation
- Created by `AKS1st` — https://github.com/AKS1st
- Original source repository: https://github.com/AKS1st/dock-files
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.