### PR TITLE
catalog: add aks1st-dock-markdown (community curation, created by @AKS1st)

### DIFF
--- a/catalog/plugins/aks1st-dock-markdown.yaml
+++ b/catalog/plugins/aks1st-dock-markdown.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: aks1st-dock-markdown
+name: dock-markdown
+description:
+  en: "Markdown viewer for the dock file explorer: renders .md/.markdown/.mdx files with a one-click switch to the text editor."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web-ui
+  - markdown
+  - viewer
+  - dock
+source:
+  repository: https://github.com/AKS1st/dock-markdown
+  repositoryNodeId: R_kgDOT-ZKiA
+  subpath: null
+  commit: 236aa0897c670faab545c0e40b13a4fec466bf15
+creator:
+  github: AKS1st
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:23.803Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aks1st-dock-markdown`
- Submission type: community curation
- Created by `AKS1st` — https://github.com/AKS1st
- Original source repository: https://github.com/AKS1st/dock-markdown
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.