### PR TITLE
catalog: add aks1st-dock (community curation, created by @AKS1st)

### DIFF
--- a/catalog/plugins/aks1st-dock.yaml
+++ b/catalog/plugins/aks1st-dock.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: aks1st-dock
+name: dock
+description:
+  en: "DSH Web workbench base: a VSCode-style layout shell (activity bar, side bar, editor area, panel, status bar) with a registry service (ctx.workbench) that feature plugins use to mount panels, editor views, activity items, status items and commands."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web-ui
+  - workbench
+  - dock
+  - layout
+source:
+  repository: https://github.com/AKS1st/dock
+  repositoryNodeId: R_kgDOT-ZJmA
+  subpath: null
+  commit: 3b381abef94df14dd13f733f545b503b27552156
+creator:
+  github: AKS1st
+package:
+  ecosystem: npm
+  name: dock
+  version: 0.1.0
+  integrity: sha512-+wClRNj+M9iWSw1aX1PL9Kkr/xf0NadTmr5rDhjdTQ/cCrDpf60pScrGkW+Zv+pX2PTxNw3BoT5fZV2biVwgLg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:54.838Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aks1st-dock`
- Submission type: community curation
- Created by `AKS1st` — https://github.com/AKS1st
- Original source repository: https://github.com/AKS1st/dock
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.