### PR TITLE
catalog: add aks1st-dsh-sysmon (community curation, created by @AKS1st)

### DIFF
--- a/catalog/plugins/aks1st-dsh-sysmon.yaml
+++ b/catalog/plugins/aks1st-dsh-sysmon.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: aks1st-dsh-sysmon
+name: dsh-sysmon
+description:
+  en: sh dsh plugin --profile web add github:AKS1st/dsh-sysmon dsh web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web-ui
+  - system-monitor
+  - cpu
+  - memory
+  - disk
+source:
+  repository: https://github.com/AKS1st/dsh-sysmon
+  repositoryNodeId: R_kgDOT4nZ3w
+  subpath: null
+  commit: 59d08c303d4575a28e9d35f701cbd3e4f9483724
+creator:
+  github: AKS1st
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:04.953Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aks1st-dsh-sysmon`
- Submission type: community curation
- Created by `AKS1st` — https://github.com/AKS1st
- Original source repository: https://github.com/AKS1st/dsh-sysmon
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.