### PR TITLE
catalog: add alexyin-tongji-dsh-plugin-console (community curation, created by @AlexYin-Tongji)

### DIFF
--- a/catalog/plugins/alexyin-tongji-dsh-plugin-console.yaml
+++ b/catalog/plugins/alexyin-tongji-dsh-plugin-console.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: alexyin-tongji-dsh-plugin-console
+name: dsh-plugin-console
+description:
+  en: "DSH Plugin Console: a verified community catalog, profile manager, and Harness updater for DeepSeek Harness"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-manager
+  - plugin-console
+  - plugin-store
+  - cordis
+source:
+  repository: https://github.com/AlexYin-Tongji/dsh-plugin-console
+  repositoryNodeId: R_kgDOT6y94A
+  subpath: null
+  commit: d1645d1f20a2300d94f5d80318f30ae25d60d36b
+creator:
+  github: AlexYin-Tongji
+package:
+  ecosystem: npm
+  name: dsh-plugin-console
+  version: 0.3.0
+  integrity: sha512-ycBIyAMVA1uAIDCgrycD77247y0nlHYN5v1jmkbVyEzViPonjQpteYSQg3qNS4CDXkkdEstE6aAAxzGyVvbDhg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:28.349Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alexyin-tongji-dsh-plugin-console`
- Submission type: community curation
- Created by `AlexYin-Tongji` — https://github.com/AlexYin-Tongji
- Original source repository: https://github.com/AlexYin-Tongji/dsh-plugin-console
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.