### PR TITLE
catalog: add alfredchaos-dsh-usage-panel (community curation, created by @AlfredChaos)

### DIFF
--- a/catalog/plugins/alfredchaos-dsh-usage-panel.yaml
+++ b/catalog/plugins/alfredchaos-dsh-usage-panel.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: alfredchaos-dsh-usage-panel
+name: dsh-usage-panel
+description:
+  en: Token usage statistics for DeepSeek Harness, shown as a page under Settings → Usage in the web GUI. The plugin aggregates persisted session logs (incrementally, via the session-projection mechanism) and never writes anything back.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - token-usage
+  - agent-analytics
+  - typescript
+  - usage-statistics
+source:
+  repository: https://github.com/AlfredChaos/dsh-usage-panel
+  repositoryNodeId: R_kgDOT5NANw
+  subpath: null
+  commit: 12ac109bc6213bdbca539e3199e7338fcac020ed
+creator:
+  github: AlfredChaos
+package:
+  ecosystem: npm
+  name: dsh-usage-panel
+  version: 0.2.0
+  integrity: sha512-f/e8x9Z4uUkiYsdUH4Mo0TuLAmm9H0PGh5DiYmQr7DipeBVyoOUU0R0NsX9rtWFGekUqj94t55WCo9H7klkQBA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:06.727Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alfredchaos-dsh-usage-panel`
- Submission type: community curation
- Created by `AlfredChaos` — https://github.com/AlfredChaos
- Original source repository: https://github.com/AlfredChaos/dsh-usage-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.