### PR TITLE
catalog: add alloyplane-dsh-eye-upload (community curation, created by @AlloyPlane)

### DIFF
--- a/catalog/plugins/alloyplane-dsh-eye-upload.yaml
+++ b/catalog/plugins/alloyplane-dsh-eye-upload.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: alloyplane-dsh-eye-upload
+name: dsh-eye-upload
+description:
+  en: powershell git clone https://github.com/AlloyPlane/dsh-eye-upload.git D:/xd/dsh-eye-upload
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - vision
+  - image
+  - image-understanding
+  - image-upload
+  - multimodal
+  - eyes
+  - ocr
+  - screenshot
+  - mcp
+source:
+  repository: https://github.com/AlloyPlane/dsh-eye-upload
+  repositoryNodeId: R_kgDOT7g3gw
+  subpath: null
+  commit: 6ff952b1e1233748054a572c0c1ab1fce96bf43b
+creator:
+  github: AlloyPlane
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:57.103Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alloyplane-dsh-eye-upload`
- Submission type: community curation
- Created by `AlloyPlane` — https://github.com/AlloyPlane
- Original source repository: https://github.com/AlloyPlane/dsh-eye-upload
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.