### PR TITLE
catalog: add alloyplane-dsh-f12-inspector (community curation, created by @AlloyPlane)

### DIFF
--- a/catalog/plugins/alloyplane-dsh-f12-inspector.yaml
+++ b/catalog/plugins/alloyplane-dsh-f12-inspector.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: alloyplane-dsh-f12-inspector
+name: dsh-f12-inspector
+description:
+  en: 'An element inspection plugin for the DSH (DeepSeek Harness) web UI: it brings a browser-style "F12 inspect element" workflow into the right details column , with a built-in workspace file tree and an HTML editor.'
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - f12
+  - devtools
+  - inspector
+  - element
+  - selector
+  - xpath
+  - filetree
+  - editor
+source:
+  repository: https://github.com/AlloyPlane/dsh-f12-inspector
+  repositoryNodeId: R_kgDOT9pcRQ
+  subpath: null
+  commit: 1297142e5100c0c1ba463e9fa162600b33055553
+creator:
+  github: AlloyPlane
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:59.912Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alloyplane-dsh-f12-inspector`
- Submission type: community curation
- Created by `AlloyPlane` — https://github.com/AlloyPlane
- Original source repository: https://github.com/AlloyPlane/dsh-f12-inspector
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.