### PR TITLE
catalog: add alnita-m-dsh-almost-full-access (community curation, created by @Alnita-M)

### DIFF
--- a/catalog/plugins/alnita-m-dsh-almost-full-access.yaml
+++ b/catalog/plugins/alnita-m-dsh-almost-full-access.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: alnita-m-dsh-almost-full-access
+name: dsh-almost-full-access
+description:
+  en: bash npx --yes github:Alnita-M/dsh-Almost Full Access
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - permission
+  - approval
+  - security
+  - almost-full-access
+source:
+  repository: https://github.com/Alnita-M/dsh-Almost_Full_Access
+  repositoryNodeId: R_kgDOT6I3zg
+  subpath: null
+  commit: 851ccc6d25547c82b646993bf59225d1b6b7b43b
+creator:
+  github: Alnita-M
+package:
+  ecosystem: npm
+  name: dsh-almost-full-access
+  version: 1.1.0
+  integrity: sha512-nye4wtotV3rIll5la9c8nKEOZTbeC/7wBEgc8QV2zEi2FuPWme/WWVyy7TCUL6zEi5/19hAeSopuiF1uV/Fo5g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:30.841Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alnita-m-dsh-almost-full-access`
- Submission type: community curation
- Created by `Alnita-M` — https://github.com/Alnita-M
- Original source repository: https://github.com/Alnita-M/dsh-Almost_Full_Access
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.