### PR TITLE
catalog: add alone-tree-dsh-skill-mcp-manager (community curation, created by @alone-tree)

### DIFF
--- a/catalog/plugins/alone-tree-dsh-skill-mcp-manager.yaml
+++ b/catalog/plugins/alone-tree-dsh-skill-mcp-manager.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: alone-tree-dsh-skill-mcp-manager
+name: dsh-skill-mcp-manager
+description:
+  en: "能力库 (Capability) — one-stop visual management of DSH Skills & MCP: on-demand MCP loading, in-session hot reload, and SKILL/MCP descriptions viewable in the plugin."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - capability
+  - ability-library
+  - mcp
+  - skill
+  - catalog
+  - cordis
+source:
+  repository: https://github.com/alone-tree/dsh-skill-mcp-manager
+  repositoryNodeId: R_kgDOT9UuUw
+  subpath: null
+  commit: 4d07d3d75c00e332b3fae1fc1e65a4fbcd4e1a61
+creator:
+  github: alone-tree
+package:
+  ecosystem: npm
+  name: dsh-skill-mcp-manager
+  version: 1.0.0
+  integrity: sha512-DLWzAs4O7b2GEae8pu3Eim1Rm074+l175+DukOb/IE0zIvSKFc+siCAw88JC9OxlvuJ+isGuoXgEsfj+gKUSiQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:32.707Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alone-tree-dsh-skill-mcp-manager`
- Submission type: community curation
- Created by `alone-tree` — https://github.com/alone-tree
- Original source repository: https://github.com/alone-tree/dsh-skill-mcp-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.