### PR TITLE
catalog: add alooshxl-dsh-session-pins (community curation, created by @alooshxl)

### DIFF
--- a/catalog/plugins/alooshxl-dsh-session-pins.yaml
+++ b/catalog/plugins/alooshxl-dsh-session-pins.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: alooshxl-dsh-session-pins
+name: "@dsh-external/dsh-session-pins"
+description:
+  en: Persistent pinned-session menu for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - persistent
+  - pinned
+  - session
+  - menu
+  - dsh
+source:
+  repository: https://github.com/alooshxl/dsh-session-pins
+  repositoryNodeId: R_kgDOT3waIQ
+  subpath: null
+  commit: eb8c25c1cc8728e54cf5940b6bc696f38b2d10bd
+creator:
+  github: alooshxl
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:08.451Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alooshxl-dsh-session-pins`
- Submission type: community curation
- Created by `alooshxl` — https://github.com/alooshxl
- Original source repository: https://github.com/alooshxl/dsh-session-pins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.