### PR TITLE
catalog: add alpacachen-dsh-kanban (community curation, created by @alpacachen)

### DIFF
--- a/catalog/plugins/alpacachen-dsh-kanban.yaml
+++ b/catalog/plugins/alpacachen-dsh-kanban.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: alpacachen-dsh-kanban
+name: "@alpacachen/dsh-kanban"
+description:
+  en: "A kanban board plugin for DeepSeek Harness: a 'Board' tab in conversations plus 14 kanban AI tools, per-workspace isolation and disk persistence. Built with React, TypeScript, dnd-kit, shadcn/ui and Tailwind CSS."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - kanban
+source:
+  repository: https://github.com/alpacachen/dsh-kanban
+  repositoryNodeId: R_kgDOT-NGcA
+  subpath: null
+  commit: 11125dd4459231cc640dfe2ed39e86f22dba7456
+creator:
+  github: alpacachen
+package:
+  ecosystem: npm
+  name: "@alpacachen/dsh-kanban"
+  version: 1.3.2
+  integrity: sha512-ZB6O8SOuecHfgXirfa0HuZ98SaPkM+f21kx9GMygymgiWaCW0SCSJwhEEmwL5hwlDJieZooxqWN1kQIX1Z+WSQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:01.722Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alpacachen-dsh-kanban`
- Submission type: community curation
- Created by `alpacachen` — https://github.com/alpacachen
- Original source repository: https://github.com/alpacachen/dsh-kanban
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.