### PR TITLE
catalog: add altairpaca-dsh-computer-use-windows (community curation, created by @Altairpaca)

### DIFF
--- a/catalog/plugins/altairpaca-dsh-computer-use-windows.yaml
+++ b/catalog/plugins/altairpaca-dsh-computer-use-windows.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: altairpaca-dsh-computer-use-windows
+name: dsh-computer-use-windows
+description:
+  en: "Windows Computer Use for DeepSeek Harness: window-bound screenshots, robust OCR, verified clicks, pure-OCR mode, pluggable vision models."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - computer-use
+  - windows
+  - ocr
+  - automation
+source:
+  repository: https://github.com/Altairpaca/dsh-computer-use-windows
+  repositoryNodeId: R_kgDOT4pBHg
+  subpath: null
+  commit: 65eeb2bd3aa5c631d7134fd5ab94d82992aedb30
+creator:
+  github: Altairpaca
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:03.752Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `altairpaca-dsh-computer-use-windows`
- Submission type: community curation
- Created by `Altairpaca` — https://github.com/Altairpaca
- Original source repository: https://github.com/Altairpaca/dsh-computer-use-windows
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.