### PR TITLE
catalog: add alvinunreal-dsh (community curation, created by @alvinunreal)

### DIFF
--- a/catalog/plugins/alvinunreal-dsh.yaml
+++ b/catalog/plugins/alvinunreal-dsh.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: alvinunreal-dsh
+name: "@open-pets/dsh"
+description:
+  en: <p align="center" <strong A desktop companion platform with pets, plugins, and optional local agent integrations.</strong </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - cordis
+  - openpets
+  - coding-agent
+source:
+  repository: https://github.com/alvinunreal/openpets
+  repositoryNodeId: R_kgDOSUOfoQ
+  subpath: packages/dsh
+  commit: 042844d8e3cd43d8984a2742865d100c3a7be4a4
+creator:
+  github: alvinunreal
+package:
+  ecosystem: npm
+  name: "@open-pets/dsh"
+  version: 3.3.0
+  integrity: sha512-9uaZjHcdc1a53nYFiTsuOu3/0j9f4zCwuVbpKEHZh2t8PFgWvLlIZkcfoJHzE6iOOOauSPWpBwUIH8dm2CozoA==
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:34.754Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alvinunreal-dsh`
- Submission type: community curation
- Created by `alvinunreal` — https://github.com/alvinunreal
- Original source repository: https://github.com/alvinunreal/openpets
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.