### PR TITLE
catalog: add amlyczz-dsh-agy-link (community curation, created by @amlyczz)

### DIFF
--- a/catalog/plugins/amlyczz-dsh-agy-link.yaml
+++ b/catalog/plugins/amlyczz-dsh-agy-link.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: amlyczz-dsh-agy-link
+name: dsh-agy-link
+description:
+  en: Google Antigravity (agy CLI) models for DeepSeek Harness — stream Gemini/Claude/GPT-OSS subscriptions into DSH with thinking, tool activity, token usage and in-GUI Google OAuth login.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - antigravity
+  - agy
+  - gemini
+source:
+  repository: https://github.com/amlyczz/dsh-agy-link
+  repositoryNodeId: R_kgDOT9ERkg
+  subpath: null
+  commit: 30f702145b1e577e714e3656236e8ad53f8b03b7
+creator:
+  github: amlyczz
+package:
+  ecosystem: npm
+  name: dsh-agy-link
+  version: 0.4.12
+  integrity: sha512-j9TjG9QHifIdW0nBRTgzSfJi7rAia/cl4vLgrNmOEaCCQysOb6KQf6pxC95drsODz9ZhDzGO6y5O0YjQEtFC6Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:45:46.334Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 13
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `amlyczz-dsh-agy-link`
- Submission type: community curation
- Created by `amlyczz` — https://github.com/amlyczz
- Original source repository: https://github.com/amlyczz/dsh-agy-link
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.