### PR TITLE
catalog: add anacondakc-dsh-douyin (community curation, created by @AnacondaKC)

### DIFF
--- a/catalog/plugins/anacondakc-dsh-douyin.yaml
+++ b/catalog/plugins/anacondakc-dsh-douyin.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: anacondakc-dsh-douyin
+name: dsh-douyin
+description:
+  en: sh dsh plugin --profile web add /path/to/DSH-douyin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - profile
+  - path
+  - douyin
+  - dsh
+source:
+  repository: https://github.com/AnacondaKC/dsh-douyin
+  repositoryNodeId: R_kgDOT26DJA
+  subpath: null
+  commit: 2f28338b29503f20d159b1f0123a985530134b6a
+creator:
+  github: AnacondaKC
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:45:39.155Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `anacondakc-dsh-douyin`
- Submission type: community curation
- Created by `AnacondaKC` — https://github.com/AnacondaKC
- Original source repository: https://github.com/AnacondaKC/dsh-douyin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.