### PR TITLE
catalog: add andiii208-dsh-ultramath (community curation, created by @Andiii208)

### DIFF
--- a/catalog/plugins/andiii208-dsh-ultramath.yaml
+++ b/catalog/plugins/andiii208-dsh-ultramath.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: andiii208-dsh-ultramath
+name: dsh-ultramath
+description:
+  en: bash dsh plugin --profile web add github:Andiii208/dsh-ultramath
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - math-modeling
+  - cumcm
+  - mcm
+  - ultramath
+source:
+  repository: https://github.com/Andiii208/dsh-ultramath
+  repositoryNodeId: R_kgDOT7hxow
+  subpath: null
+  commit: dc0e4d60fd674e4f24ae9b5dfc137e98cf540580
+creator:
+  github: Andiii208
+package:
+  ecosystem: npm
+  name: dsh-ultramath
+  version: 0.3.0
+  integrity: sha512-y2vOZSGh1t43eecPpeNLsay4xQW31KpLqEVqfTRrtd1/3nANkXUh6sVPUnEqJl2ad/pEJg0AsgPY4qsg2Wc+ag==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:05.925Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `andiii208-dsh-ultramath`
- Submission type: community curation
- Created by `Andiii208` — https://github.com/Andiii208
- Original source repository: https://github.com/Andiii208/dsh-ultramath
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.