### PR TITLE
catalog: add andyyang12345-dsh-butler-memory (community curation, created by @AndyYang12345)

### DIFF
--- a/catalog/plugins/andyyang12345-dsh-butler-memory.yaml
+++ b/catalog/plugins/andyyang12345-dsh-butler-memory.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: andyyang12345-dsh-butler-memory
+name: dsh-butler-memory
+description:
+  en: "DSH bundle: wire the Butler Memory MCP server (agent tools) and add a Web memory panel (view/search/candidates)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - bundle
+  - wire
+  - butler
+  - memory
+  - server
+  - agent
+  - tools
+  - panel
+  - view
+  - search
+  - candidates
+  - dsh
+source:
+  repository: https://github.com/AndyYang12345/dsh-butler-memory
+  repositoryNodeId: R_kgDOT6CoUA
+  subpath: null
+  commit: e42413cfe0b52699641098f524081cf84785498c
+creator:
+  github: AndyYang12345
+package:
+  ecosystem: npm
+  name: dsh-butler-memory
+  version: 0.1.5
+  integrity: sha512-i5gWjct76N5Rh9tryZaZdfH+z+xXcTDdNyE4oNuXkKo9j2U324EnfZCSYmUi9QVwGo5BP0TFVVq2N2Gw6EQ1xQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:07.494Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `andyyang12345-dsh-butler-memory`
- Submission type: community curation
- Created by `AndyYang12345` — https://github.com/AndyYang12345
- Original source repository: https://github.com/AndyYang12345/dsh-butler-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.