### PR TITLE
catalog: add ankye-dsh-client-ui-vision (community curation, created by @ankye)

### DIFF
--- a/catalog/plugins/ankye-dsh-client-ui-vision.yaml
+++ b/catalog/plugins/ankye-dsh-client-ui-vision.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ankye-dsh-client-ui-vision
+name: "@deepseek-ai/dsh-client-ui-vision"
+description:
+  en: Vision image-recognition settings card for the configurable-plugins tab
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - vision
+  - image
+  - recognition
+  - settings
+  - card
+  - configurable
+  - dsh
+source:
+  repository: https://github.com/ankye/dsh-client-vision
+  repositoryNodeId: R_kgDOT8_cYA
+  subpath: packages/ui-vision
+  commit: 25be426f1468c8e217a6538d4f49d9e72e1aff9b
+creator:
+  github: ankye
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/ui-vision/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:40.430Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ankye-dsh-client-ui-vision`
- Submission type: community curation
- Created by `ankye` — https://github.com/ankye
- Original source repository: https://github.com/ankye/dsh-client-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.