### PR TITLE
catalog: add ankye-dsh-tool-image-generation (community curation, created by @ankye)

### DIFF
--- a/catalog/plugins/ankye-dsh-tool-image-generation.yaml
+++ b/catalog/plugins/ankye-dsh-tool-image-generation.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: ankye-dsh-tool-image-generation
+name: "@deepseek-ai/dsh-tool-image-generation"
+description:
+  en: Model-facing image-generation tool with a settings-selected channel and normalized parameters
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - model
+  - facing
+  - image
+  - generation
+  - tool
+  - settings
+  - selected
+  - channel
+  - normalized
+  - parameters
+  - dsh
+source:
+  repository: https://github.com/ankye/dsh-image-generation
+  repositoryNodeId: R_kgDOT9CedQ
+  subpath: packages/tool-image-generation
+  commit: afb003964eccbf866b9b452dee41cc584d5209cc
+creator:
+  github: ankye
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/tool-image-generation/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:45.036Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ankye-dsh-tool-image-generation`
- Submission type: community curation
- Created by `ankye` — https://github.com/ankye
- Original source repository: https://github.com/ankye/dsh-image-generation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.