### PR TITLE
catalog: add ankye-dsh-tool-use-browser (community curation, created by @ankye)

### DIFF
--- a/catalog/plugins/ankye-dsh-tool-use-browser.yaml
+++ b/catalog/plugins/ankye-dsh-tool-use-browser.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: ankye-dsh-tool-use-browser
+name: "@deepseek-ai/dsh-tool-use-browser"
+description:
+  en: "Codex-style local browser automation: open / interact / screenshot / extract / eval via Playwright (headless or CDP to your Chrome)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - codex
+  - style
+  - local
+  - browser
+  - automation
+  - open
+  - interact
+  - screenshot
+  - extract
+  - eval
+  - playwright
+  - headless
+  - chrome
+  - dsh
+source:
+  repository: https://github.com/ankye/dsh_use_browser
+  repositoryNodeId: R_kgDOT9GPSw
+  subpath: packages/use-browser
+  commit: 975a746522205f72ca407b65dca8532dfa11f46d
+creator:
+  github: ankye
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: packages/use-browser/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:38.495Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ankye-dsh-tool-use-browser`
- Submission type: community curation
- Created by `ankye` — https://github.com/ankye
- Original source repository: https://github.com/ankye/dsh_use_browser
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.