### PR TITLE
catalog: add anneheartrecord-deepseek-desk-pet (community curation, created by @anneheartrecord)

### DIFF
--- a/catalog/plugins/anneheartrecord-deepseek-desk-pet.yaml
+++ b/catalog/plugins/anneheartrecord-deepseek-desk-pet.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: anneheartrecord-deepseek-desk-pet
+name: deepseek-desk-pet
+description:
+  en: "Always-on-top DeepSeek Harness desk pet with a native menu and DIY skins. Shows what your agent is doing: working, waiting, finished, failed. Five skins, or make your own from one image. No dependencies."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - desktop-pet
+source:
+  repository: https://github.com/anneheartrecord/dsh-desk-pet
+  repositoryNodeId: R_kgDOT4VQxg
+  subpath: null
+  commit: 18bfb38316e5e4fe64f3c1fa50c5dd520776cfae
+creator:
+  github: anneheartrecord
+package:
+  ecosystem: npm
+  name: deepseek-desk-pet
+  version: 0.3.0
+  integrity: sha512-/HahtWen78Zdp9WVfbSY52cJivt1kOFW3MHNjUP4LhmjfsEheLPPEtloMMjHLopyS5kufk2uwuCJ6xABIVY7VQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:45:50.382Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `anneheartrecord-deepseek-desk-pet`
- Submission type: community curation
- Created by `anneheartrecord` — https://github.com/anneheartrecord
- Original source repository: https://github.com/anneheartrecord/dsh-desk-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.