### PR TITLE
catalog: add aokamoaki-dsh-startup-guard (community curation, created by @aokamoaki)

### DIFF
--- a/catalog/plugins/aokamoaki-dsh-startup-guard.yaml
+++ b/catalog/plugins/aokamoaki-dsh-startup-guard.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: aokamoaki-dsh-startup-guard
+name: dsh-startup-guard
+description:
+  en: "Boot-time guard for DeepSeek Harness: repairs corrupt session logs, snapshots manifests + linked sources, preflights bundle resolution and composition, vm-checks client artifacts, smokes host apply() in a child process and quarantines crash-causing bundles - so a broken plugin or corrupt log can never brick startup."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - startup
+  - guard
+  - preflight
+  - boot
+  - self-heal
+source:
+  repository: https://github.com/aokamoaki/dsh-startup-guard
+  repositoryNodeId: R_kgDOT51niQ
+  subpath: null
+  commit: 82cead84e795f04d33b3ff803b65d2de9dafa706
+creator:
+  github: aokamoaki
+package:
+  ecosystem: npm
+  name: dsh-startup-guard
+  version: 1.0.0
+  integrity: sha512-kOgSDr5r9wVxiqg/wnUOEv9xJYoX+d/13jHw9CpRn+gAPAQftE5jlFpslqXbWj6bnYTqfhV0916WYtZIfqJgKw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:10.980Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aokamoaki-dsh-startup-guard`
- Submission type: community curation
- Created by `aokamoaki` — https://github.com/aokamoaki
- Original source repository: https://github.com/aokamoaki/dsh-startup-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.