### PR TITLE
catalog: add apageoflove-dsh-changeproof (community curation, created by @Apageoflove)

### DIFF
--- a/catalog/plugins/apageoflove-dsh-changeproof.yaml
+++ b/catalog/plugins/apageoflove-dsh-changeproof.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: apageoflove-dsh-changeproof
+name: dsh-changeproof
+description:
+  en: ChangeProof - change-relevance + evidence-freshness quality plugin for DeepSeek Harness (DSH)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - changeproof
+  - test-coverage
+  - changed-line-coverage
+  - code-verification
+  - test-impact-analysis
+  - quality-gate
+  - verification
+  - agent-tools
+  - llm-agent
+  - typescript
+  - nodejs
+  - javascript
+source:
+  repository: https://github.com/Apageoflove/DSH-changeproof
+  repositoryNodeId: R_kgDOT5C8Kw
+  subpath: null
+  commit: c377901280feeec3b8c2673a55354fa7d65eb196
+creator:
+  github: Apageoflove
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:45:52.394Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `apageoflove-dsh-changeproof`
- Submission type: community curation
- Created by `Apageoflove` — https://github.com/Apageoflove
- Original source repository: https://github.com/Apageoflove/DSH-changeproof
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.