### PR TITLE
catalog: add apheli0os-dsh-tool-orchestrate (community curation, created by @apheli0os)

### DIFF
--- a/catalog/plugins/apheli0os-dsh-tool-orchestrate.yaml
+++ b/catalog/plugins/apheli0os-dsh-tool-orchestrate.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: apheli0os-dsh-tool-orchestrate
+name: dsh-tool-orchestrate
+description:
+  en: Declarative task-DAG orchestration plugin for DeepSeek Harness workflows
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - orchestration
+  - workflow
+  - dag
+  - subagent
+source:
+  repository: https://github.com/apheli0os/deepseek-harness-orchestrate
+  repositoryNodeId: R_kgDOT5LmVA
+  subpath: null
+  commit: 6a1863dfabafa565bf7af160ce60e2749f4bad17
+creator:
+  github: apheli0os
+package:
+  ecosystem: npm
+  name: dsh-tool-orchestrate
+  version: 0.1.0
+  integrity: sha512-UVDAxYUHOZrdcQHnmrLBB1pg5+SgjdgGaO5Se3L57aWCiq/YmuMoSu6YqLVSAdo78dR1Zq4+I1pJfpiParyZQQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:51.516Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `apheli0os-dsh-tool-orchestrate`
- Submission type: community curation
- Created by `apheli0os` — https://github.com/apheli0os
- Original source repository: https://github.com/apheli0os/deepseek-harness-orchestrate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.