### PR TITLE
catalog: add armywas-dsh-failure-lens (community curation, created by @ArmyWas)

### DIFF
--- a/catalog/plugins/armywas-dsh-failure-lens.yaml
+++ b/catalog/plugins/armywas-dsh-failure-lens.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: armywas-dsh-failure-lens
+name: dsh-failure-lens
+description:
+  en: Deterministic DeepSeek Harness Web client plugin that explains the Windows-sandbox spawn EPERM failure as a distinct Conversation Node.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-client
+  - sandbox
+  - windows
+  - eperm
+source:
+  repository: https://github.com/ArmyWas/dsh-failure-lens
+  repositoryNodeId: R_kgDOT8oCWw
+  subpath: null
+  commit: 81af34adefc918ec52e71f3974b4ef076d6af48b
+creator:
+  github: ArmyWas
+package:
+  ecosystem: npm
+  name: dsh-failure-lens
+  version: 0.2.2
+  integrity: sha512-XAYz6opem7MO8EomuTd1FVISTmJKMXxAlf9lX8wEdumoF9UrclSQS+j/mrfKn7QnDBvD2Ut0LaCB18QzJcTRxA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:53.361Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `armywas-dsh-failure-lens`
- Submission type: community curation
- Created by `ArmyWas` — https://github.com/ArmyWas
- Original source repository: https://github.com/ArmyWas/dsh-failure-lens
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.