### PR TITLE
catalog: add asakumizy-graph-monitor (community curation, created by @asakumizy)

### DIFF
--- a/catalog/plugins/asakumizy-graph-monitor.yaml
+++ b/catalog/plugins/asakumizy-graph-monitor.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: asakumizy-graph-monitor
+name: graph-monitor
+description:
+  en: "Graph Monitor plugin for DeepSeek Harness: define and customize GRAPH workflows, then visualize each node live as it executes — Waku-agent style topology chart with animated node/edge status, clickable node details, and a desktop trajectory-like monitor view."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - graph
+  - monitor
+  - define
+  - customize
+  - workflows
+  - visualize
+  - each
+  - node
+  - live
+  - executes
+  - waku
+  - agent
+  - style
+  - topology
+  - chart
+  - animated
+source:
+  repository: https://github.com/asakumizy/dsh-graph-monitor
+  repositoryNodeId: R_kgDOT8LOpw
+  subpath: null
+  commit: 163bf5440a1837d9030fa0cfd7912ee7259c7abe
+creator:
+  github: asakumizy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:12.727Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `asakumizy-graph-monitor`
- Submission type: community curation
- Created by `asakumizy` — https://github.com/asakumizy
- Original source repository: https://github.com/asakumizy/dsh-graph-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.