### PR TITLE
catalog: add asd13006-dsh-multi-lang-ui (community curation, created by @asd13006)

### DIFF
--- a/catalog/plugins/asd13006-dsh-multi-lang-ui.yaml
+++ b/catalog/plugins/asd13006-dsh-multi-lang-ui.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: asd13006-dsh-multi-lang-ui
+name: dsh-multi-lang-ui
+description:
+  en: A DSH plugin that adds multiple languages to the DeepSeek Harness Web UI language options — 繁體中文, 日本語, 한국어, Français, Deutsch, Español . Known UI strings use hand-polished translations (each language translated from the English baseline); any new / updated / third-party strings fall back to English (or, for 繁體中文, a run
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh
+  - locale
+  - i18n
+  - localization
+  - multilingual
+  - traditional-chinese
+  - zh-tw
+  - japanese
+  - korean
+  - french
+  - german
+  - spanish
+source:
+  repository: https://github.com/asd13006/dsh-multi-lang-ui
+  repositoryNodeId: R_kgDOT51MDg
+  subpath: null
+  commit: 6d8de399f8f2a4121282d34c93cbfc5de1391428
+creator:
+  github: asd13006
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:55.388Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `asd13006-dsh-multi-lang-ui`
- Submission type: community curation
- Created by `asd13006` — https://github.com/asd13006
- Original source repository: https://github.com/asd13006/dsh-multi-lang-ui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.