### PR TITLE
catalog: add asdf17128-dshp (community curation, created by @asdf17128)

### DIFF
--- a/catalog/plugins/asdf17128-dshp.yaml
+++ b/catalog/plugins/asdf17128-dshp.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: asdf17128-dshp
+name: dshp
+description:
+  en: Manage DeepSeek Harness profiles — list, create, clone, and share a whole dsh setup as one portable file.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - profile
+  - cli
+source:
+  repository: https://github.com/asdf17128/dshp
+  repositoryNodeId: R_kgDOT3qgsg
+  subpath: null
+  commit: 7bf87ccd4ffd457977d079fa4ecf6defd9c57a1d
+creator:
+  github: asdf17128
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:14.457Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `asdf17128-dshp`
- Submission type: community curation
- Created by `asdf17128` — https://github.com/asdf17128
- Original source repository: https://github.com/asdf17128/dshp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.