### PR TITLE
catalog: add asher-2000-dsh-expert-mode (community curation, created by @Asher-2000)

### DIFF
--- a/catalog/plugins/asher-2000-dsh-expert-mode.yaml
+++ b/catalog/plugins/asher-2000-dsh-expert-mode.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: asher-2000-dsh-expert-mode
+name: dsh-expert-mode
+description:
+  en: "DSH agent preset: chief coordinator + 11 domain-expert subagents with automatic task delegation (专家模式)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - agent-preset
+  - expert-mode
+  - multi-agent
+  - subagent
+  - dsh-plugin
+source:
+  repository: https://github.com/Asher-2000/dsh-expert-mode
+  repositoryNodeId: R_kgDOT4-ZqA
+  subpath: null
+  commit: af2ff6be540a59e2fabdbd4dd8330db166b3b2a2
+creator:
+  github: Asher-2000
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:45:41.275Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `asher-2000-dsh-expert-mode`
- Submission type: community curation
- Created by `Asher-2000` — https://github.com/Asher-2000
- Original source repository: https://github.com/Asher-2000/dsh-expert-mode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.