### PR TITLE
catalog: add asianfleet-dsh-message-copy-enhance (community curation, created by @Asianfleet)

### DIFF
--- a/catalog/plugins/asianfleet-dsh-message-copy-enhance.yaml
+++ b/catalog/plugins/asianfleet-dsh-message-copy-enhance.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: asianfleet-dsh-message-copy-enhance
+name: dsh-message-copy-enhance
+description:
+  en: Copy dsh assistant output as Markdown, preserving links, LaTeX sources and code fences.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - client-plugin
+  - markdown
+  - copy
+  - clipboard
+  - latex
+source:
+  repository: https://github.com/Asianfleet/dsh-message-copy-enhance
+  repositoryNodeId: R_kgDOT7_tlQ
+  subpath: null
+  commit: 9d8595501224621db5942fadddcbdb0efceba686
+creator:
+  github: Asianfleet
+package:
+  ecosystem: npm
+  name: dsh-message-copy-enhance
+  version: 0.2.1
+  integrity: sha512-qhPX55oH1dvI2i6VddLnCSeQ5X9P4ZIkEMOOA2GNJ66lpGRE4VQ1qbB5rNA4oybtZ9KYVUnqIhB3skf5fqeWVw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:48:57.238Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `asianfleet-dsh-message-copy-enhance`
- Submission type: community curation
- Created by `Asianfleet` — https://github.com/Asianfleet
- Original source repository: https://github.com/Asianfleet/dsh-message-copy-enhance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.