### PR TITLE
catalog: add bop11-dsh-plugin-video-player (community curation, created by @bop11)

### DIFF
--- a/catalog/plugins/bop11-dsh-plugin-video-player.yaml
+++ b/catalog/plugins/bop11-dsh-plugin-video-player.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: bop11-dsh-plugin-video-player
+name: dsh-plugin-video-player
+description:
+  en: <p align="center" <a href=" english" English</a &nbsp;&nbsp; &nbsp;&nbsp; <a href=" %E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87" 简体中文</a </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - video
+  - player
+  - streaming
+  - smb
+  - nas
+source:
+  repository: https://github.com/anitman/dsh-plugin-video-player
+  repositoryNodeId: R_kgDOT6lNNw
+  subpath: null
+  commit: d7436a80cdfcdc8eb28f864a63e14348e99ce816
+creator:
+  github: bop11
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:47:09.365Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bop11-dsh-plugin-video-player`
- Submission type: community curation
- Created by `bop11` — https://github.com/bop11
- Original source repository: https://github.com/anitman/dsh-plugin-video-player
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.