### PR TITLE
catalog: add haakam21-dsh-agentmail (community curation, created by @Haakam21)

### DIFF
--- a/catalog/plugins/haakam21-dsh-agentmail.yaml
+++ b/catalog/plugins/haakam21-dsh-agentmail.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: haakam21-dsh-agentmail
+name: dsh-agentmail
+description:
+  en: Give a DeepSeek Harness agent its own email inbox, with inbound mail bound to per-thread sessions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - agentmail
+  - email
+  - agent
+  - inbox
+  - ai-agent
+source:
+  repository: https://github.com/agentmail-to/dsh-agentmail
+  repositoryNodeId: R_kgDOT6vL6w
+  subpath: null
+  commit: ea3b03dac5d71d836aa1f9c267b1563bbfb75bff
+creator:
+  github: Haakam21
+package:
+  ecosystem: npm
+  name: dsh-agentmail
+  version: 0.1.0
+  integrity: sha512-iMSdLui025J564GbCc7cBqrWlvsmXMXTAbk3cYJvqNl/dn7YlSAm2uyL5j2lX+Vtf7VhEcGW5IOstR2rrMwCRw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:47.939Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haakam21-dsh-agentmail`
- Submission type: community curation
- Created by `Haakam21` — https://github.com/Haakam21
- Original source repository: https://github.com/agentmail-to/dsh-agentmail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.