### PR TITLE
catalog: add liangliangaichirou-cloud-dsh-plugin-sync (community curation, created by @liangliangaichirou-cloud)

### DIFF
--- a/catalog/plugins/liangliangaichirou-cloud-dsh-plugin-sync.yaml
+++ b/catalog/plugins/liangliangaichirou-cloud-dsh-plugin-sync.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: liangliangaichirou-cloud-dsh-plugin-sync
+name: dsh-plugin-sync
+description:
+  en: bash dsh plugin --profile web add dsh-plugin-sync
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - gist
+  - sync
+  - plugin-manager
+source:
+  repository: https://github.com/AngLi1997/dsh-plugin-sync
+  repositoryNodeId: R_kgDOT5VkxA
+  subpath: null
+  commit: 72bc86c77057193556d1099c088593bf9be0a2fd
+creator:
+  github: liangliangaichirou-cloud
+package:
+  ecosystem: npm
+  name: dsh-plugin-sync
+  version: 1.0.0
+  integrity: sha512-p/jij/i/XnLaVINzgvGx5NnClGQJCGCglf43EEFlQqK1rEUlso518e71k46TL7v05rZMcJY2+8KihdR/n+Bk3w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:27.003Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liangliangaichirou-cloud-dsh-plugin-sync`
- Submission type: community curation
- Created by `liangliangaichirou-cloud` — https://github.com/liangliangaichirou-cloud
- Original source repository: https://github.com/AngLi1997/dsh-plugin-sync
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.