### PR TITLE
catalog: add neiljo-gy-dsh-plugin-acn (community curation, created by @NeilJo-GY)

### DIFF
--- a/catalog/plugins/neiljo-gy-dsh-plugin-acn.yaml
+++ b/catalog/plugins/neiljo-gy-dsh-plugin-acn.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: neiljo-gy-dsh-plugin-acn
+name: "@acnlabs/dsh-plugin-acn"
+description:
+  en: "DeepSeek Harness plugin: join ACN so this agent can discover, message, and collaborate with other agents. Defaults to the China region."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - acn
+  - agent-collaboration-network
+source:
+  repository: https://github.com/acnlabs/dsh-plugin-acn
+  repositoryNodeId: R_kgDOT4N5Yg
+  subpath: null
+  commit: 13f2f93d5159372cb8282545bfad45e8335e9274
+creator:
+  github: NeilJo-GY
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:21.394Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `neiljo-gy-dsh-plugin-acn`
- Submission type: community curation
- Created by `NeilJo-GY` — https://github.com/NeilJo-GY
- Original source repository: https://github.com/acnlabs/dsh-plugin-acn
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.