### PR TITLE
catalog: add zuozewei-dsh-skill-7d-code-reviewer (community curation, created by @zuozewei)

### DIFF
--- a/catalog/plugins/zuozewei-dsh-skill-7d-code-reviewer.yaml
+++ b/catalog/plugins/zuozewei-dsh-skill-7d-code-reviewer.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: zuozewei-dsh-skill-7d-code-reviewer
+name: "@7dgroup/dsh-skill-7d-code-reviewer"
+description:
+  en: Installable composition bundle contributing the 7DGroup template-driven code review skill to DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - installable
+  - composition
+  - bundle
+  - contributing
+  - 7dgroup
+  - template
+  - driven
+  - code
+  - review
+  - skill
+  - dsh
+source:
+  repository: https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer
+  repositoryNodeId: R_kgDOT6ITAQ
+  subpath: null
+  commit: 21597116a3a0bcdf27b59c9f3c07739a459e5a91
+creator:
+  github: zuozewei
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:45:35.394Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zuozewei-dsh-skill-7d-code-reviewer`
- Submission type: community curation
- Created by `zuozewei` — https://github.com/zuozewei
- Original source repository: https://github.com/7dgroup-ai/dsh-skill-7d-code-reviewer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.