### PR TITLE
catalog: add zuozewei-dsh-skill-7d-git-commit (community curation, created by @zuozewei)

### DIFF
--- a/catalog/plugins/zuozewei-dsh-skill-7d-git-commit.yaml
+++ b/catalog/plugins/zuozewei-dsh-skill-7d-git-commit.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zuozewei-dsh-skill-7d-git-commit
+name: "@7dgroup/dsh-skill-7d-git-commit"
+description:
+  en: Installable composition bundle contributing the 7DGroup git commit message skill to DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - installable
+  - composition
+  - bundle
+  - contributing
+  - 7dgroup
+  - commit
+  - message
+  - skill
+  - dsh
+source:
+  repository: https://github.com/7dgroup-ai/dsh-skill-7d-git-commit
+  repositoryNodeId: R_kgDOT68Eiw
+  subpath: null
+  commit: 557e05f51f85fb4d4b9f6ed8cedfce02350e7bd6
+creator:
+  github: zuozewei
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T17:46:31.297Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zuozewei-dsh-skill-7d-git-commit`
- Submission type: community curation
- Created by `zuozewei` — https://github.com/zuozewei
- Original source repository: https://github.com/7dgroup-ai/dsh-skill-7d-git-commit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.