### PR TITLE
catalog: add acegent-dsdragpasteall (community curation, created by @Acegent)

### DIFF
--- a/catalog/plugins/acegent-dsdragpasteall.yaml
+++ b/catalog/plugins/acegent-dsdragpasteall.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: acegent-dsdragpasteall
+name: dsdragpasteall
+description:
+  en: bash pnpm add "file:/Users/acegent/Documents/ds 插件/dsDragPasteALL"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - bash
+  - pnpm
+  - file
+  - users
+  - acegent
+  - documents
+  - dsdragpasteall
+  - dsh
+source:
+  repository: https://github.com/balue8246-maker/dsDragPasteALL
+  repositoryNodeId: R_kgDOT9u0cw
+  subpath: null
+  commit: 5f41459a5a6366f956f4ee2d0a98a0a342a8e61e
+creator:
+  github: Acegent
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:52.900Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `acegent-dsdragpasteall`
- Submission type: community curation
- Created by `Acegent` — https://github.com/Acegent
- Original source repository: https://github.com/balue8246-maker/dsDragPasteALL
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.