### PR TITLE
catalog: add atropinoltt-dsh-guide-dog-autoload (community curation, created by @AtropinolTT)

### DIFF
--- a/catalog/plugins/atropinoltt-dsh-guide-dog-autoload.yaml
+++ b/catalog/plugins/atropinoltt-dsh-guide-dog-autoload.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: atropinoltt-dsh-guide-dog-autoload
+name: dsh-guide-dog-autoload
+description:
+  en: "DSH host plugin: auto-deploy the Guide Dog dynamic Cordis plugin (gdog- ) from disk sources whenever an agent session is created. Recovers the plugin after every DSH restart (dynamic plugin definitions are process-local)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - host
+  - auto
+  - deploy
+  - guide
+  - dynamic
+  - cordis
+  - gdog
+  - disk
+  - sources
+  - whenever
+  - agent
+  - session
+  - created
+  - recovers
+  - after
+  - every
+source:
+  repository: https://github.com/AtropinolTT/dsh-guide-dog
+  repositoryNodeId: R_kgDOT4Z74g
+  subpath: autoload
+  commit: fbd3a0584609722052710978214f8edceeb458a2
+creator:
+  github: AtropinolTT
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: autoload/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:38.950Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `atropinoltt-dsh-guide-dog-autoload`
- Submission type: community curation
- Created by `AtropinolTT` — https://github.com/AtropinolTT
- Original source repository: https://github.com/AtropinolTT/dsh-guide-dog
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.