### PR TITLE
catalog: add auuduu-dsh-zai-coding-models (community curation, created by @auuduu)

### DIFF
--- a/catalog/plugins/auuduu-dsh-zai-coding-models.yaml
+++ b/catalog/plugins/auuduu-dsh-zai-coding-models.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: auuduu-dsh-zai-coding-models
+name: dsh-zai-coding-models
+description:
+  en: "DeepSeek Harness bridge plugin: exposes the newest Zhipu/Z.AI coding-plan models (e.g. glm-5.3) on the zai-coding-cn route before the bundled pi-ai catalog catches up."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - zai
+  - zhipu
+  - glm
+  - glm-5-3
+  - coding-plan
+source:
+  repository: https://github.com/auuduu/dsh-zai-coding-models
+  repositoryNodeId: R_kgDOT-Mfvw
+  subpath: null
+  commit: f09d69a7eaa4016b6db9c24069ebd7fa989d0823
+creator:
+  github: auuduu
+package:
+  ecosystem: npm
+  name: dsh-zai-coding-models
+  version: 0.1.0
+  integrity: sha512-4Jd8ynwbkblwcinMu0/ZsEvefk9PY6tWybXv2wIAenktrxLFJEXe9SE/rBtitXB/qA4a3eaGjlgZvArYAGn6Ww==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:41.480Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `auuduu-dsh-zai-coding-models`
- Submission type: community curation
- Created by `auuduu` — https://github.com/auuduu
- Original source repository: https://github.com/auuduu/dsh-zai-coding-models
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.