### PR TITLE
catalog: add ayingqaq-dsh-web-launcher (community curation, created by @ayingQAQ)

### DIFF
--- a/catalog/plugins/ayingqaq-dsh-web-launcher.yaml
+++ b/catalog/plugins/ayingqaq-dsh-web-launcher.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: ayingqaq-dsh-web-launcher
+name: dsh-web-launcher
+description:
+  en: 由 DSH 管理的 Windows 一键启动器｜Desktop launcher bundle for DeepSeek Harness Web.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - deepseek-harness
+  - launcher
+  - windows
+source:
+  repository: https://github.com/ayingQAQ/dsh-web-launcher
+  repositoryNodeId: R_kgDOT4qYSw
+  subpath: null
+  commit: d1065186df86208647b36a9e1b66fcf315748a7e
+creator:
+  github: ayingQAQ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:44.828Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ayingqaq-dsh-web-launcher`
- Submission type: community curation
- Created by `ayingQAQ` — https://github.com/ayingQAQ
- Original source repository: https://github.com/ayingQAQ/dsh-web-launcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.