### PR TITLE
catalog: add baconbao-dsh-mermaid-image-preview (community curation, created by @baconbao)

### DIFF
--- a/catalog/plugins/baconbao-dsh-mermaid-image-preview.yaml
+++ b/catalog/plugins/baconbao-dsh-mermaid-image-preview.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: baconbao-dsh-mermaid-image-preview
+name: "@baconbao/dsh-mermaid-image-preview"
+description:
+  en: A DeepSeek Harness Plugin for Previewing Mermaid Diagram by Images in Chat Sessions. View on GitHub (https://github.com/baconbao/dsh-mermaid-image-preview).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - previewing
+  - mermaid
+  - diagram
+  - images
+  - chat
+  - sessions
+  - view
+  - baconbao
+  - image
+  - preview
+  - dsh
+source:
+  repository: https://github.com/baconbao/dsh-mermaid-image-preview
+  repositoryNodeId: R_kgDOT5BLdA
+  subpath: null
+  commit: 56f804e6af6cc6d3bdbb479918bf9c6eff94e52c
+creator:
+  github: baconbao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:24.083Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baconbao-dsh-mermaid-image-preview`
- Submission type: community curation
- Created by `baconbao` — https://github.com/baconbao
- Original source repository: https://github.com/baconbao/dsh-mermaid-image-preview
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.