### PR TITLE
catalog: add badai147-dsh-ocgo-usage (community curation, created by @badai147)

### DIFF
--- a/catalog/plugins/badai147-dsh-ocgo-usage.yaml
+++ b/catalog/plugins/badai147-dsh-ocgo-usage.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: badai147-dsh-ocgo-usage
+name: "@badai147/dsh-ocgo-usage"
+description:
+  en: "OpenCode Go usage stats for the DeepSeek Harness Web GUI: compact bottom-left sidebar button with a hover detail card"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - opencode-go
+  - usage
+  - stats
+source:
+  repository: https://github.com/badai147/dsh-ocgo-usage
+  repositoryNodeId: R_kgDOT8Q3CA
+  subpath: null
+  commit: a0608f9215d1ced00c578869f510afec67b7fb8e
+creator:
+  github: badai147
+package:
+  ecosystem: npm
+  name: "@badai147/dsh-ocgo-usage"
+  version: 0.2.0
+  integrity: sha512-VEccYhEzduPGqXedDG7Y+xBLCstg6gvVsL2mNLSmFyzExiR23CF9HknPG5rgnzG0Vpb5+4/e5k/DEzptFQIBFQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:46.571Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `badai147-dsh-ocgo-usage`
- Submission type: community curation
- Created by `badai147` — https://github.com/badai147
- Original source repository: https://github.com/badai147/dsh-ocgo-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.