### PR TITLE
catalog: add bainianlaoyao-windows-bash (community curation, created by @bainianlaoyao)

### DIFF
--- a/catalog/plugins/bainianlaoyao-windows-bash.yaml
+++ b/catalog/plugins/bainianlaoyao-windows-bash.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: bainianlaoyao-windows-bash
+name: windows-bash
+description:
+  en: "Make Git Bash the only terminal tool for DeepSeek Harness on Windows: enables the bash executor and tool on win32, disables PowerShell (pwsh) everywhere, ships standard-bash/code-bash/cordis-bash agent presets, and sets the sandbox/approval defaults Git Bash's cygwin runtime needs."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - git-bash
+  - windows
+  - terminal
+  - pwsh
+  - bash
+source:
+  repository: https://github.com/bainianlaoyao/bash-on-windows
+  repositoryNodeId: R_kgDOT5teDw
+  subpath: null
+  commit: c6d1ce19cae7ae5aff15aea640228f6a3c952a0d
+creator:
+  github: bainianlaoyao
+package:
+  ecosystem: npm
+  name: windows-bash
+  version: 0.1.0
+  integrity: sha512-Q9SAepD2jol1TKWhyax+vG0a69B1ed1nI4qTlgtroiWxMHQ55fWjnccjHu9EUrUEvrzZvKgmpe9vd61xnaHp2w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:49.167Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bainianlaoyao-windows-bash`
- Submission type: community curation
- Created by `bainianlaoyao` — https://github.com/bainianlaoyao
- Original source repository: https://github.com/bainianlaoyao/bash-on-windows
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.