### PR TITLE
catalog: add baisama-cloud-dsh-conflict-guardian (community curation, created by @baisama-cloud)

### DIFF
--- a/catalog/plugins/baisama-cloud-dsh-conflict-guardian.yaml
+++ b/catalog/plugins/baisama-cloud-dsh-conflict-guardian.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: baisama-cloud-dsh-conflict-guardian
+name: dsh-conflict-guardian
+description:
+  en: Detects DSH plugin conflicts (duplicate mounts, failed/pending plugins, duplicate config row ids) at startup, auto-stops or restores the affected plugins, and shows a conflict report popup in the web UI. DSH 启动时检测插件冲突，自动停用/恢复冲突插件，并在 Web 界面弹出冲突报告。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - conflict
+  - conflict-detection
+  - stability
+  - loader
+  - guard
+  - web-ui
+source:
+  repository: https://github.com/baisama-cloud/dsh-conflict-guardian
+  repositoryNodeId: R_kgDOT8gPzA
+  subpath: null
+  commit: a40d98904be6b16034ec43b3b159a94f8449b806
+creator:
+  github: baisama-cloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:51.378Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baisama-cloud-dsh-conflict-guardian`
- Submission type: community curation
- Created by `baisama-cloud` — https://github.com/baisama-cloud
- Original source repository: https://github.com/baisama-cloud/dsh-conflict-guardian
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.