### PR TITLE
catalog: add baisama-cloud-dsh-custom-brand (community curation, created by @baisama-cloud)

### DIFF
--- a/catalog/plugins/baisama-cloud-dsh-custom-brand.yaml
+++ b/catalog/plugins/baisama-cloud-dsh-custom-brand.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: baisama-cloud-dsh-custom-brand
+name: dsh-custom-brand
+description:
+  en: "Customizable brand area for the DeepSeek Harness web GUI: replace the whale logo and the DeepSeek wordmark with local images, and edit the HARNESS badge text — double-click to change, right-click to reset. 自定义 DSH 左上角品牌区：logo 与 DeepSeek 文字可换本地图片，HARNESS 徽章文字可双击编辑。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - brand
+  - logo
+  - customization
+  - web-ui
+source:
+  repository: https://github.com/baisama-cloud/dsh-custom-brand
+  repositoryNodeId: R_kgDOT5Revg
+  subpath: null
+  commit: 5914e93ed19e258c706f8ee2a90936460006658c
+creator:
+  github: baisama-cloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:04.755Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baisama-cloud-dsh-custom-brand`
- Submission type: community curation
- Created by `baisama-cloud` — https://github.com/baisama-cloud
- Original source repository: https://github.com/baisama-cloud/dsh-custom-brand
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.