### PR TITLE
catalog: add baisama-cloud-dsh-galgame-generator (community curation, created by @baisama-cloud)

### DIFF
--- a/catalog/plugins/baisama-cloud-dsh-galgame-generator.yaml
+++ b/catalog/plugins/baisama-cloud-dsh-galgame-generator.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: baisama-cloud-dsh-galgame-generator
+name: dsh-galgame-generator
+description:
+  en: "Galgame generator for DeepSeek Harness (DSH): give it a script document plus character/background/BGM/animation assets in the workspace (img human/, img bg/, audio/, img cg/) and it builds a playable visual-novel web page with configurable save slots, speaker-following multi-pose sprites, [表情]/[位置]/[退场] stage control, "
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - galgame
+  - visual-novel
+  - web-ui
+  - novel
+source:
+  repository: https://github.com/baisama-cloud/dsh-galgame-generator
+  repositoryNodeId: R_kgDOT7NVtA
+  subpath: null
+  commit: b5568ca55e72725e54eef30a5299f195f05f5810
+creator:
+  github: baisama-cloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:25.773Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baisama-cloud-dsh-galgame-generator`
- Submission type: community curation
- Created by `baisama-cloud` — https://github.com/baisama-cloud
- Original source repository: https://github.com/baisama-cloud/dsh-galgame-generator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.