### PR TITLE
catalog: add baixianger-dsh-chat (community curation, created by @baixianger)

### DIFF
--- a/catalog/plugins/baixianger-dsh-chat.yaml
+++ b/catalog/plugins/baixianger-dsh-chat.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: baixianger-dsh-chat
+name: dsh-chat
+description:
+  en: Web group chat for local and woven DeepSeek Harness sessions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - chat
+  - agent
+  - conversation
+  - mesh
+source:
+  repository: https://github.com/baixianger/dsh-chat
+  repositoryNodeId: R_kgDOT7j34w
+  subpath: null
+  commit: 77d93dc9ccf6778a02d4a55b5d8df97d35c83f84
+creator:
+  github: baixianger
+package:
+  ecosystem: npm
+  name: dsh-chat
+  version: 0.1.0-rc.29
+  integrity: sha512-jNGWt87U58aQOJQvulgFZtv/sPsGWBOsUp/O3r4vVb+oJFyH2m6yuH+zUK+2vBlrH0VAp5Dni8AymcoZxhYkUg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:48.517Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baixianger-dsh-chat`
- Submission type: community curation
- Created by `baixianger` — https://github.com/baixianger
- Original source repository: https://github.com/baixianger/dsh-chat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.