### PR TITLE
catalog: add baixianger-dsh-weave (community curation, created by @baixianger)

### DIFF
--- a/catalog/plugins/baixianger-dsh-weave.yaml
+++ b/catalog/plugins/baixianger-dsh-weave.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: baixianger-dsh-weave
+name: dsh-weave
+description:
+  en: A private, peer-to-peer weave protocol for connecting DeepSeek Harness nodes across machines.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - agent
+  - mesh
+  - iroh
+  - p2p
+  - quic
+source:
+  repository: https://github.com/baixianger/dsh-weave
+  repositoryNodeId: R_kgDOT7iuIw
+  subpath: null
+  commit: 50dd7ba90aa2011533c3c26dbd954a59484b8a30
+creator:
+  github: baixianger
+package:
+  ecosystem: npm
+  name: dsh-weave
+  version: 0.1.0-rc.12
+  integrity: sha512-54oFqdgy534BYulEj+dTBH9j6y2EEyvxibt1ByxvjIbh49865zWCNkU8pHd+HmrEQht6PKL6fWObADje2l4Svw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:50.641Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baixianger-dsh-weave`
- Submission type: community curation
- Created by `baixianger` — https://github.com/baixianger
- Original source repository: https://github.com/baixianger/dsh-weave
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.