### PR TITLE
catalog: add beachanger-dsh-openclaw-acp (community curation, created by @BeAChanger)

### DIFF
--- a/catalog/plugins/beachanger-dsh-openclaw-acp.yaml
+++ b/catalog/plugins/beachanger-dsh-openclaw-acp.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: beachanger-dsh-openclaw-acp
+name: dsh-openclaw-acp
+description:
+  en: DeepSeek Harness bundle that exposes a profile as an OpenClaw-compatible ACP agent.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - openclaw
+  - wechat
+  - agent-client-protocol
+  - acp
+  - dsh
+source:
+  repository: https://github.com/BeAChanger/dsh-openclaw-acp
+  repositoryNodeId: R_kgDOT3jSPQ
+  subpath: null
+  commit: ac475fa1c81e350eda53edce9fdf1a3126c5b7b5
+creator:
+  github: BeAChanger
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:53.371Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `beachanger-dsh-openclaw-acp`
- Submission type: community curation
- Created by `BeAChanger` — https://github.com/BeAChanger
- Original source repository: https://github.com/BeAChanger/dsh-openclaw-acp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.