### PR TITLE
catalog: add beijingwahw-dsh-companion (community curation, created by @beijingwahw)

### DIFF
--- a/catalog/plugins/beijingwahw-dsh-companion.yaml
+++ b/catalog/plugins/beijingwahw-dsh-companion.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: beijingwahw-dsh-companion
+name: dsh-companion
+description:
+  en: "- DeepSeek Harness = 0.1.0 - Node.js ^22.19 =24 - pnpm（ npm install -g pnpm ）"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - node
+  - pnpm
+  - install
+  - dsh
+source:
+  repository: https://github.com/beijingwahw/dsh-companion
+  repositoryNodeId: R_kgDOT41bAQ
+  subpath: null
+  commit: 3c36cfaf0d13f35789b5904c7adada618c48ab8e
+creator:
+  github: beijingwahw
+package:
+  ecosystem: npm
+  name: dsh-companion
+  version: 0.1.0
+  integrity: sha512-RfLsKaoC9Z2itlpLSMDxelH+E59vR+79fvgm6v03wgTj06QOaUdmIK+sRBQ9IlG5czFv403YHaMGfI/w+ZX+DA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:45:55.205Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `beijingwahw-dsh-companion`
- Submission type: community curation
- Created by `beijingwahw` — https://github.com/beijingwahw
- Original source repository: https://github.com/beijingwahw/dsh-companion
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.