### PR TITLE
catalog: add beizi6-dsh-theme-plugin (community curation, created by @BeiZi6)

### DIFF
--- a/catalog/plugins/beizi6-dsh-theme-plugin.yaml
+++ b/catalog/plugins/beizi6-dsh-theme-plugin.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: beizi6-dsh-theme-plugin
+name: dsh-theme-plugin
+description:
+  en: "DSH Web GUI theme studio with presets and per-mode customization: accent, background, foreground, fonts, translucent sidebar, and contrast. Overrides CSS tokens in every served index.html via the official webServer.tapIndex seam."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - theme
+  - web-gui
+  - css-tokens
+source:
+  repository: https://github.com/BeiZi6/dsh-theme-plugin
+  repositoryNodeId: R_kgDOT4iY7g
+  subpath: null
+  commit: b3e7e143532c4b6df71da753d2336bb018949d2a
+creator:
+  github: BeiZi6
+package:
+  ecosystem: npm
+  name: dsh-theme-plugin
+  version: 0.1.0
+  integrity: sha512-vgUGV/L8PLDCuxO00EtydMSmN/lPLfrGkBSkt/wIfcFe+0KAm+RnETIMxBJN+7d16veL6+cWqz46prkS0QGe8w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:06.428Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `beizi6-dsh-theme-plugin`
- Submission type: community curation
- Created by `BeiZi6` — https://github.com/BeiZi6
- Original source repository: https://github.com/BeiZi6/dsh-theme-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.