### PR TITLE
catalog: add bil812-dsh-balance-tasks (community curation, created by @Bil812)

### DIFF
--- a/catalog/plugins/bil812-dsh-balance-tasks.yaml
+++ b/catalog/plugins/bil812-dsh-balance-tasks.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: bil812-dsh-balance-tasks
+name: dsh-balance-tasks
+description:
+  en: sh dsh plugin --profile web add <本目录
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - balance
+  - quota
+  - cost
+  - estimate
+source:
+  repository: https://github.com/Bil812/dsh-balance-tasks
+  repositoryNodeId: R_kgDOT8knwQ
+  subpath: null
+  commit: e5f3c832fcf2afdfaf50990939c8d378cdce7457
+creator:
+  github: Bil812
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:54.692Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bil812-dsh-balance-tasks`
- Submission type: community curation
- Created by `Bil812` — https://github.com/Bil812
- Original source repository: https://github.com/Bil812/dsh-balance-tasks
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.