### PR TITLE
catalog: add bill9109-dsh-101 (community curation, created by @bill9109)

### DIFF
--- a/catalog/plugins/bill9109-dsh-101.yaml
+++ b/catalog/plugins/bill9109-dsh-101.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: bill9109-dsh-101
+name: "@bill9109/dsh-101"
+description:
+  en: "A document-first reader profile bundle for DeepSeek Harness: curated, ordered, searchable, translatable reading of DSH's own documentation over dsh-base + dsh-web-app."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - dsh-profile
+  - reader
+  - documentation
+  - dsh
+source:
+  repository: https://github.com/bill9109/dsh-101
+  repositoryNodeId: R_kgDOTyglwA
+  subpath: null
+  commit: ae6b4addadfda63e6751b1bf929665733ba60b6c
+creator:
+  github: bill9109
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:45:48.007Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bill9109-dsh-101`
- Submission type: community curation
- Created by `bill9109` — https://github.com/bill9109
- Original source repository: https://github.com/bill9109/dsh-101
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.