### PR TITLE
catalog: add bill9109-dsh-conversation-share (community curation, created by @bill9109)

### DIFF
--- a/catalog/plugins/bill9109-dsh-conversation-share.yaml
+++ b/catalog/plugins/bill9109-dsh-conversation-share.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: bill9109-dsh-conversation-share
+name: "@bill9109/dsh-conversation-share"
+description:
+  en: Select a range of a DeepSeek Harness conversation and share it as a branded PNG long image, with draggable magnetically snapping range markers.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - web-ui
+  - conversation
+  - share
+  - screenshot
+  - png
+  - dsh
+source:
+  repository: https://github.com/bill9109/dsh-conversation-share
+  repositoryNodeId: R_kgDOT2mhRQ
+  subpath: null
+  commit: f582d8ec88e5bbc2519da48554c659874b8e1ac9
+creator:
+  github: bill9109
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:08.325Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bill9109-dsh-conversation-share`
- Submission type: community curation
- Created by `bill9109` — https://github.com/bill9109
- Original source repository: https://github.com/bill9109/dsh-conversation-share
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.