### PR TITLE
catalog: add bill9109-dsh-webbridge (community curation, created by @bill9109)

### DIFF
--- a/catalog/plugins/bill9109-dsh-webbridge.yaml
+++ b/catalog/plugins/bill9109-dsh-webbridge.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: bill9109-dsh-webbridge
+name: "@bill9109/dsh-webbridge"
+description:
+  en: "Kimi WebBridge host plugin for DeepSeek Harness: model tools that drive the user's REAL browser (navigate, snapshot, click, fill, evaluate, screenshot, network inspection, tab management) through the local kimi-webbridge daemon"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - kimi
+  - webbridge
+  - browser
+  - browser-automation
+  - model-tools
+  - dsh
+source:
+  repository: https://github.com/bill9109/dsh-webbridge
+  repositoryNodeId: R_kgDOTzPN2A
+  subpath: null
+  commit: fb6fa96fed4b78f68ab0464c360dc4036105d0d8
+creator:
+  github: bill9109
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:09.756Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bill9109-dsh-webbridge`
- Submission type: community curation
- Created by `bill9109` — https://github.com/bill9109
- Original source repository: https://github.com/bill9109/dsh-webbridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.