### PR TITLE
catalog: add billychen123-qdd (community curation, created by @BillyChen123)

### DIFF
--- a/catalog/plugins/billychen123-qdd.yaml
+++ b/catalog/plugins/billychen123-qdd.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: billychen123-qdd
+name: qdd
+description:
+  en: Question-Driven Discovery CLI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - question
+  - driven
+  - discovery
+  - dsh
+source:
+  repository: https://github.com/BillyChen123/qdd
+  repositoryNodeId: R_kgDOSpREuw
+  subpath: null
+  commit: f5d2c93c6c5067c0c71a3ce135234d594e64edbe
+creator:
+  github: BillyChen123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:45:50.430Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `billychen123-qdd`
- Submission type: community curation
- Created by `BillyChen123` — https://github.com/BillyChen123
- Original source repository: https://github.com/BillyChen123/qdd
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.