### PR TITLE
catalog: add birat-chapagain-dsh-codex-oauth (community curation, created by @birat-chapagain)

### DIFF
--- a/catalog/plugins/birat-chapagain-dsh-codex-oauth.yaml
+++ b/catalog/plugins/birat-chapagain-dsh-codex-oauth.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: birat-chapagain-dsh-codex-oauth
+name: dsh-codex-oauth
+description:
+  en: "DeepSeek Harness plugin: use your OpenAI Codex (ChatGPT Plus/Pro) subscription through OAuth."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - codex
+  - openai
+  - oauth
+  - chatgpt
+  - dsh
+source:
+  repository: https://github.com/birat-chapagain/dsh-codex-oauth
+  repositoryNodeId: R_kgDOT9niMg
+  subpath: null
+  commit: 2d6ce52407db73cc2642e50d41fdc982a6f676b0
+creator:
+  github: birat-chapagain
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:57.665Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `birat-chapagain-dsh-codex-oauth`
- Submission type: community curation
- Created by `birat-chapagain` — https://github.com/birat-chapagain
- Original source repository: https://github.com/birat-chapagain/dsh-codex-oauth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.