### PR TITLE
catalog: add bob-bo1-deepseek-balance (community curation, created by @Bob-Bo1)

### DIFF
--- a/catalog/plugins/bob-bo1-deepseek-balance.yaml
+++ b/catalog/plugins/bob-bo1-deepseek-balance.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: bob-bo1-deepseek-balance
+name: deepseek-balance
+description:
+  en: powershell npx @deepseek-ai/dsh plugin --profile web add github:Bob-Bo1/dsh-deepseek-balance
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - powershell
+  - profile
+  - balance
+  - dsh
+source:
+  repository: https://github.com/Bob-Bo1/dsh-deepseek-balance
+  repositoryNodeId: R_kgDOT67wiA
+  subpath: null
+  commit: 88940a6bf159218b5828c79e6ab3b94fd116324f
+creator:
+  github: Bob-Bo1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:57.484Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bob-bo1-deepseek-balance`
- Submission type: community curation
- Created by `Bob-Bo1` — https://github.com/Bob-Bo1
- Original source repository: https://github.com/Bob-Bo1/dsh-deepseek-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.