### PR TITLE
catalog: add bob-bo1-obsidian-workbench (community curation, created by @Bob-Bo1)

### DIFF
--- a/catalog/plugins/bob-bo1-obsidian-workbench.yaml
+++ b/catalog/plugins/bob-bo1-obsidian-workbench.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: bob-bo1-obsidian-workbench
+name: obsidian-workbench
+description:
+  en: powershell git clone https://github.com/Bob-Bo1/obsidian-workbench.git D:\Tools\obsidian-workbench dsh plugin --profile web add link:D:\Tools\obsidian-workbench
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - obsidian
+  - markdown
+  - vault
+source:
+  repository: https://github.com/Bob-Bo1/obsidian-workbench
+  repositoryNodeId: R_kgDOT698Iw
+  subpath: null
+  commit: b2ec41a0ad51ea9ea6fad85101619959b4b9c2f9
+creator:
+  github: Bob-Bo1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:59.269Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bob-bo1-obsidian-workbench`
- Submission type: community curation
- Created by `Bob-Bo1` — https://github.com/Bob-Bo1
- Original source repository: https://github.com/Bob-Bo1/obsidian-workbench
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.