### PR TITLE
catalog: add bob-bo1-stock-watch (community curation, created by @Bob-Bo1)

### DIFF
--- a/catalog/plugins/bob-bo1-stock-watch.yaml
+++ b/catalog/plugins/bob-bo1-stock-watch.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: bob-bo1-stock-watch
+name: stock-watch
+description:
+  en: powershell dsh plugin --profile web add github:Bob-Bo1/dsh-stock-watch
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - a-share
+  - stock
+source:
+  repository: https://github.com/Bob-Bo1/dsh-stock-watch
+  repositoryNodeId: R_kgDOT6988w
+  subpath: null
+  commit: 8b74366224b59cc8eed547d431e4f1da2029bc74
+creator:
+  github: Bob-Bo1
+package:
+  ecosystem: npm
+  name: stock-watch
+  version: 0.2.0
+  integrity: sha512-Nn7VmE4k5K/y7JL3i/7vKqT8PICp6YrCf+nP0XGUcCPms5UMNyhRATFc83Nw39b5gg02yuu+cPsjnpDOQHa2VA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:11.433Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bob-bo1-stock-watch`
- Submission type: community curation
- Created by `Bob-Bo1` — https://github.com/Bob-Bo1
- Original source repository: https://github.com/Bob-Bo1/dsh-stock-watch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.