### PR TITLE
catalog: add bobby-sheng-dshget-plugin (community curation, created by @bobby-sheng)

### DIFF
--- a/catalog/plugins/bobby-sheng-dshget-plugin.yaml
+++ b/catalog/plugins/bobby-sheng-dshget-plugin.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: bobby-sheng-dshget-plugin
+name: dshget-plugin
+description:
+  en: Search, inspect, update, and install DeepSeek Harness plugins from the DSH Get catalog.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-directory
+  - plugin-manager
+source:
+  repository: https://github.com/bobby-sheng/dshget-plugin
+  repositoryNodeId: R_kgDOT89Jhg
+  subpath: null
+  commit: 971b7a5700f323ec92e56aa29d39b4a25e36befa
+creator:
+  github: bobby-sheng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:02.234Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bobby-sheng-dshget-plugin`
- Submission type: community curation
- Created by `bobby-sheng` — https://github.com/bobby-sheng
- Original source repository: https://github.com/bobby-sheng/dshget-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.