### PR TITLE
catalog: add boooooooer-dsh-balance-and-cost (community curation, created by @boooooooer)

### DIFF
--- a/catalog/plugins/boooooooer-dsh-balance-and-cost.yaml
+++ b/catalog/plugins/boooooooer-dsh-balance-and-cost.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: boooooooer-dsh-balance-and-cost
+name: dsh-balance-and-cost
+description:
+  en: sh dsh plugin --profile web add github:boooooooer/dsh-balance-and-cost
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - balance
+  - cost
+  - usage
+  - tokens
+source:
+  repository: https://github.com/boooooooer/dsh-balance-and-cost
+  repositoryNodeId: R_kgDOT7RtIg
+  subpath: null
+  commit: 22846b82fc5431eaf3fd53817782c06de1b30023
+creator:
+  github: boooooooer
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:04.302Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `boooooooer-dsh-balance-and-cost`
- Submission type: community curation
- Created by `boooooooer` — https://github.com/boooooooer
- Original source repository: https://github.com/boooooooer/dsh-balance-and-cost
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.