### PR TITLE
catalog: add botonj-dsh-windtunnel (community curation, created by @BotonJ)

### DIFF
--- a/catalog/plugins/botonj-dsh-windtunnel.yaml
+++ b/catalog/plugins/botonj-dsh-windtunnel.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: botonj-dsh-windtunnel
+name: dsh-windtunnel
+description:
+  en: DSH 插件风洞 — contract regression harness for DeepSeek Harness plugin bundles. Scripted-adapter driving, isolated child processes, session-event assertions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - testing
+  - regression
+  - ci
+source:
+  repository: https://github.com/BotonJ/dsh-windtunnel
+  repositoryNodeId: R_kgDOT4jLrg
+  subpath: null
+  commit: c5b8f9604bca5c6d336d3b5a4ba2f4f26417ead9
+creator:
+  github: BotonJ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:04.657Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `botonj-dsh-windtunnel`
- Submission type: community curation
- Created by `BotonJ` — https://github.com/BotonJ
- Original source repository: https://github.com/BotonJ/dsh-windtunnel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.