### PR TITLE
catalog: add bpc-oss-dsh-plugin-chrome-faithful (community curation, created by @bpc-oss)

### DIFF
--- a/catalog/plugins/bpc-oss-dsh-plugin-chrome-faithful.yaml
+++ b/catalog/plugins/bpc-oss-dsh-plugin-chrome-faithful.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: bpc-oss-dsh-plugin-chrome-faithful
+name: "@bpc-oss/dsh-plugin-chrome-faithful"
+description:
+  en: First-party DeepSeek Harness bundle for exact-profile Chrome control through Chrome Faithful.
+  evidencePath: packages/dsh-plugin-chrome-faithful/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - first
+  - party
+  - bundle
+  - exact
+  - profile
+  - chrome
+  - control
+  - through
+  - faithful
+  - dsh
+source:
+  repository: https://github.com/bpc-oss/chrome-faithful
+  repositoryNodeId: R_kgDOT4KPiQ
+  subpath: packages/dsh-plugin-chrome-faithful
+  commit: c827885fbab4763e12f926d311c59a931f0892f2
+creator:
+  github: bpc-oss
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-plugin-chrome-faithful/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:29.395Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bpc-oss-dsh-plugin-chrome-faithful`
- Submission type: community curation
- Created by `bpc-oss` — https://github.com/bpc-oss
- Original source repository: https://github.com/bpc-oss/chrome-faithful
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.