### PR TITLE
catalog: add bpc-oss-dsh-routed-subagent (community curation, created by @bpc-oss)

### DIFF
--- a/catalog/plugins/bpc-oss-dsh-routed-subagent.yaml
+++ b/catalog/plugins/bpc-oss-dsh-routed-subagent.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: bpc-oss-dsh-routed-subagent
+name: dsh-routed-subagent
+description:
+  en: "Global DeepSeek Harness plugin: subagent routed — run a one-shot subagent fully mounted on ANY agent preset, from ANY session, with per-call model/provider override, a model-availability pre-check, and external CLI engines (codex / claude / codebuddy)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - agent-preset
+  - subagent
+  - delegation
+  - multi-agent
+source:
+  repository: https://github.com/bpc-oss/dsh-routed-subagent
+  repositoryNodeId: R_kgDOT8nbDQ
+  subpath: null
+  commit: f0e2c9361dab2b7c386f207d8d2cbc07239dfa3f
+creator:
+  github: bpc-oss
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:08.703Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bpc-oss-dsh-routed-subagent`
- Submission type: community curation
- Created by `bpc-oss` — https://github.com/bpc-oss
- Original source repository: https://github.com/bpc-oss/dsh-routed-subagent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.