### PR TITLE
catalog: add bpc-oss-dsh-verification (community curation, created by @bpc-oss)

### DIFF
--- a/catalog/plugins/bpc-oss-dsh-verification.yaml
+++ b/catalog/plugins/bpc-oss-dsh-verification.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: bpc-oss-dsh-verification
+name: "@bpc-oss/dsh-verification"
+description:
+  en: "Verification engine for DeepSeek Harness: claim - evidence - verdict - completion gate (ported from Bobby's conscience layer)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - verification
+  - agent
+  - acceptance-criteria
+  - evidence
+  - completion-gate
+  - bobby
+source:
+  repository: https://github.com/bpc-oss/dsh-verification
+  repositoryNodeId: R_kgDOT7BQig
+  subpath: packages/dsh-verification
+  commit: 1afaf79aceaf02f9d83804a12f4d31e936152377
+creator:
+  github: bpc-oss
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: packages/dsh-verification/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:10.859Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bpc-oss-dsh-verification`
- Submission type: community curation
- Created by `bpc-oss` — https://github.com/bpc-oss
- Original source repository: https://github.com/bpc-oss/dsh-verification
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.