### PR TITLE
catalog: add bpshil-litkit-dsh (community curation, created by @bpshil)

### DIFF
--- a/catalog/plugins/bpshil-litkit-dsh.yaml
+++ b/catalog/plugins/bpshil-litkit-dsh.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: bpshil-litkit-dsh
+name: "@bpshil/litkit-dsh"
+description:
+  en: DeepSeek Harness (dsh) plugin adapter for litkit — academic literature search, citation audit, and download tools in any dsh profile.
+  evidencePath: adapters/dsh/README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - deepseek-harness
+  - litkit
+  - literature
+  - academic
+  - search
+source:
+  repository: https://github.com/bpc-oss/litkit-search
+  repositoryNodeId: R_kgDOT5Zo_A
+  subpath: adapters/dsh
+  commit: 6f59d560fafed22519c109a41cce88d69eb4e3da
+creator:
+  github: bpshil
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: adapters/dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:18.184Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bpshil-litkit-dsh`
- Submission type: community curation
- Created by `bpshil` — https://github.com/bpshil
- Original source repository: https://github.com/bpc-oss/litkit-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.