### PR TITLE
catalog: add br1nosense-dsh-project-manager (community curation, created by @br1nosense)

### DIFF
--- a/catalog/plugins/br1nosense-dsh-project-manager.yaml
+++ b/catalog/plugins/br1nosense-dsh-project-manager.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: br1nosense-dsh-project-manager
+name: "@dsh-user/dsh-project-manager"
+description:
+  en: A DSH plugin that manages development projects from the DSH web UI in a draggable floating window — add/remove projects, one-click start/stop/restart, hot-reload auto-restart on file changes, and real-time persistent logs.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - project-manager
+  - dev
+  - hot-reload
+  - dsh
+source:
+  repository: https://github.com/br1nosense/dsh-project-manager
+  repositoryNodeId: R_kgDOT5hu3g
+  subpath: null
+  commit: 48b0c57acf42470efb6304bbbbc1e0c10d48b484
+creator:
+  github: br1nosense
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:20.835Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `br1nosense-dsh-project-manager`
- Submission type: community curation
- Created by `br1nosense` — https://github.com/br1nosense
- Original source repository: https://github.com/br1nosense/dsh-project-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.