### PR TITLE
catalog: add br1nosense-dsh-vision-solution (community curation, created by @br1nosense)

### DIFF
--- a/catalog/plugins/br1nosense-dsh-vision-solution.yaml
+++ b/catalog/plugins/br1nosense-dsh-vision-solution.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: br1nosense-dsh-vision-solution
+name: "@dsh-user/dsh-vision-solution"
+description:
+  en: "image reasoning: race(agnes-2.5-flash, agnes-2.0-flash, glm, glm-thinking) - custom-1 - custom-2 - custom-3 - local ocr: baidu-ocr - windows-ocr - vision reasoning document: mineru flash - mineru extract"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - ocr
+  - skill
+  - dsh
+source:
+  repository: https://github.com/br1nosense/dsh-vision-solution
+  repositoryNodeId: R_kgDOT4qMng
+  subpath: null
+  commit: 6a2056ab24862a1144ab6b551c9887195079972d
+creator:
+  github: br1nosense
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:23.487Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `br1nosense-dsh-vision-solution`
- Submission type: community curation
- Created by `br1nosense` — https://github.com/br1nosense
- Original source repository: https://github.com/br1nosense/dsh-vision-solution
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.