### PR TITLE
catalog: add br1nosense-dsh-wxauto (community curation, created by @br1nosense)

### DIFF
--- a/catalog/plugins/br1nosense-dsh-wxauto.yaml
+++ b/catalog/plugins/br1nosense-dsh-wxauto.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: br1nosense-dsh-wxauto
+name: "@dsh-user/dsh-wxauto"
+description:
+  en: A DSH skill plugin built on wxauto4 (free tier, supports WeChat 4.1.x).
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - wechat
+  - wxauto
+  - notify
+  - skill
+  - dsh
+source:
+  repository: https://github.com/br1nosense/dsh-wxauto-plugin
+  repositoryNodeId: R_kgDOT5RaQg
+  subpath: null
+  commit: 52e1b6e319b372289edcd3c79be66b7937b33481
+creator:
+  github: br1nosense
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:31.983Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `br1nosense-dsh-wxauto`
- Submission type: community curation
- Created by `br1nosense` — https://github.com/br1nosense
- Original source repository: https://github.com/br1nosense/dsh-wxauto-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.