### PR TITLE
catalog: add bramblexu-dsh-prompt-profile (community curation, created by @BrambleXu)

### DIFF
--- a/catalog/plugins/bramblexu-dsh-prompt-profile.yaml
+++ b/catalog/plugins/bramblexu-dsh-prompt-profile.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: bramblexu-dsh-prompt-profile
+name: dsh-prompt-profile
+description:
+  en: Reusable prompt profiles with per-turn model selection for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - prompt-template
+  - model-profile
+  - dsh
+source:
+  repository: https://github.com/BrambleXu/dsh-prompt-profile
+  repositoryNodeId: R_kgDOT33qDA
+  subpath: null
+  commit: c205d44e88e64b5126fa2615a7122e684e3af7f5
+creator:
+  github: BrambleXu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:06.503Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bramblexu-dsh-prompt-profile`
- Submission type: community curation
- Created by `BrambleXu` — https://github.com/BrambleXu
- Original source repository: https://github.com/BrambleXu/dsh-prompt-profile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.