### PR TITLE
catalog: add bramblexu-dsh-revdiff (community curation, created by @BrambleXu)

### DIFF
--- a/catalog/plugins/bramblexu-dsh-revdiff.yaml
+++ b/catalog/plugins/bramblexu-dsh-revdiff.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: bramblexu-dsh-revdiff
+name: dsh-revdiff
+description:
+  en: Native interactive diff review for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - code-review
+  - diff
+  - dsh
+source:
+  repository: https://github.com/BrambleXu/dsh-revdiff
+  repositoryNodeId: R_kgDOT33zCQ
+  subpath: null
+  commit: 90e7f41040ede308314395b06c51c218e18e4d47
+creator:
+  github: BrambleXu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:34.144Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bramblexu-dsh-revdiff`
- Submission type: community curation
- Created by `BrambleXu` — https://github.com/BrambleXu
- Original source repository: https://github.com/BrambleXu/dsh-revdiff
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.