### PR TITLE
catalog: add buhuikongpan-dsh-project-context (community curation, created by @buhuikongpan)

### DIFF
--- a/catalog/plugins/buhuikongpan-dsh-project-context.yaml
+++ b/catalog/plugins/buhuikongpan-dsh-project-context.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: buhuikongpan-dsh-project-context
+name: dsh-project-context
+description:
+  en: "<project context Working directory \"<cwd \" is now a project: all files belong here. Build a mental model first, don't read everything: inspect structure/size, then entry/README, follow the call chain. Code is ground truth; docs are reference. Empty directory → new project, files live here. Report understanding and plan"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - project-context
+  - workspace
+source:
+  repository: https://github.com/buhuikongpan/dsh-project-context
+  repositoryNodeId: R_kgDOT79FIg
+  subpath: null
+  commit: 89e2b9d575a9defe8131c6cb992b9e7b1787c395
+creator:
+  github: buhuikongpan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:11.325Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `buhuikongpan-dsh-project-context`
- Submission type: community curation
- Created by `buhuikongpan` — https://github.com/buhuikongpan
- Original source repository: https://github.com/buhuikongpan/dsh-project-context
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.