### PR TITLE
catalog: add bx33661-dsh-omv (community curation, created by @bx33661)

### DIFF
--- a/catalog/plugins/bx33661-dsh-omv.yaml
+++ b/catalog/plugins/bx33661-dsh-omv.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: bx33661-dsh-omv
+name: dsh-omv
+description:
+  en: "OMV Audit Desk: an evidence-first vulnerability audit workbench for DeepSeek Harness"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - security-audit
+  - vulnerability-research
+  - oh-my-vul
+  - dsh
+source:
+  repository: https://github.com/bx33661/dsh-omv
+  repositoryNodeId: R_kgDOT6CtpA
+  subpath: null
+  commit: e8d3e488ec8ba0223f48d0d65dc61e8f1fc203e3
+creator:
+  github: bx33661
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:13.199Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bx33661-dsh-omv`
- Submission type: community curation
- Created by `bx33661` — https://github.com/bx33661
- Original source repository: https://github.com/bx33661/dsh-omv
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.