### PR TITLE
catalog: add caizhihaoczh-dsh-profile-multica (community curation, created by @caizhihaoczh)

### DIFF
--- a/catalog/plugins/caizhihaoczh-dsh-profile-multica.yaml
+++ b/catalog/plugins/caizhihaoczh-dsh-profile-multica.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: caizhihaoczh-dsh-profile-multica
+name: dsh-profile-multica
+description:
+  en: Installable Multica JSONL bridge profile for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - multica
+  - agent
+  - dsh
+source:
+  repository: https://github.com/caizhihaoczh/dsh-profile-multica
+  repositoryNodeId: R_kgDOT8hhCg
+  subpath: null
+  commit: fd7bc2fcf0d52c52b6d12fc42790e34562d8b5af
+creator:
+  github: caizhihaoczh
+package:
+  ecosystem: npm
+  name: dsh-profile-multica
+  version: 0.1.0
+  integrity: sha512-Xe0dSjJ/A/bMw7Djg0ctdYr7W7MC+vr2ikAchRxOLJFbqtR/CnPSV/vclR/luLaGIGix9r1iXcPIyux2fZGEhg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:25.141Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `caizhihaoczh-dsh-profile-multica`
- Submission type: community curation
- Created by `caizhihaoczh` — https://github.com/caizhihaoczh
- Original source repository: https://github.com/caizhihaoczh/dsh-profile-multica
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.