### PR TITLE
catalog: add caoqinnan-web-organize-workspace-sessions (community curation, created by @caoqinnan-web)

### DIFF
--- a/catalog/plugins/caoqinnan-web-organize-workspace-sessions.yaml
+++ b/catalog/plugins/caoqinnan-web-organize-workspace-sessions.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: caoqinnan-web-organize-workspace-sessions
+name: organize-workspace-sessions
+description:
+  en: "DSH Skill for organizing DeepSeek Harness workspace sessions: rename them as 类别｜主题 and report archive/rename/judgment suggestions. ChatGPT supported; Claude not supported."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - agent-skills
+  - session-management
+  - workspace
+  - conversation-management
+source:
+  repository: https://github.com/caoqinnan-web/organize-workspace-sessions
+  repositoryNodeId: R_kgDOT4bb-w
+  subpath: null
+  commit: b99ccf2b74293ba20c1c9215e74710673fa815de
+creator:
+  github: caoqinnan-web
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:35.959Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `caoqinnan-web-organize-workspace-sessions`
- Submission type: community curation
- Created by `caoqinnan-web` — https://github.com/caoqinnan-web
- Original source repository: https://github.com/caoqinnan-web/organize-workspace-sessions
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.