### PR TITLE
catalog: add caoyiwei850-dsh-ssh-ops (community curation, created by @caoyiwei850)

### DIFF
--- a/catalog/plugins/caoyiwei850-dsh-ssh-ops.yaml
+++ b/catalog/plugins/caoyiwei850-dsh-ssh-ops.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: caoyiwei850-dsh-ssh-ops
+name: dsh-ssh-ops
+description:
+  en: "SSH ops and database tools for DSH Web UI: connect to remote servers via SSH terminal/SFTP/tunnels, and connect to MySQL/PostgreSQL/Redis/MongoDB databases. Host half manages sessions with ssh2; client half renders the terminal and database panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - deepseek-harness
+  - ssh
+  - terminal
+  - xterm
+  - ops
+  - sftp
+  - database
+  - mysql
+  - redis
+  - mongodb
+source:
+  repository: https://github.com/caoyiwei850/dsh-ssh-ops
+  repositoryNodeId: R_kgDOT5TyDw
+  subpath: null
+  commit: 262127b8e28f64267dbb3c85c4a8cb3e3a80c6f6
+creator:
+  github: caoyiwei850
+package:
+  ecosystem: npm
+  name: dsh-ssh-ops
+  version: 0.2.12
+  integrity: sha512-f3fZKgiyIkqSu8fz/4Kl0n4WKcus39ysHupCVKc03IeEyZRr95Bs8j3c+ULXJpbdT5t5fx/mfzDIxA7V6UOsjg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:45:53.266Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `caoyiwei850-dsh-ssh-ops`
- Submission type: community curation
- Created by `caoyiwei850` — https://github.com/caoyiwei850
- Original source repository: https://github.com/caoyiwei850/dsh-ssh-ops
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.