### PR TITLE
catalog: add caseytso-analyze-image-tool (community curation, created by @CaseyTso)

### DIFF
--- a/catalog/plugins/caseytso-analyze-image-tool.yaml
+++ b/catalog/plugins/caseytso-analyze-image-tool.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: caseytso-analyze-image-tool
+name: analyze-image-tool
+description:
+  en: "A vision bridge for text-only DeepSeek Harness models: registers an analyze image tool that answers questions about images via ANY OpenAI-compatible vision/multimodal endpoint (SiliconFlow, DashScope, Zhipu, OpenRouter, Ollama, ...)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - vision
+  - vlm
+  - image
+  - multimodal
+  - openai-compatible
+  - ocr
+source:
+  repository: https://github.com/CaseyTso/dsh-analyze-image-tool
+  repositoryNodeId: R_kgDOT4I4SA
+  subpath: null
+  commit: 8e2f431616e4a5adbf8bb54c54d016df883d4c70
+creator:
+  github: CaseyTso
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:30.484Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `caseytso-analyze-image-tool`
- Submission type: community curation
- Created by `CaseyTso` — https://github.com/CaseyTso
- Original source repository: https://github.com/CaseyTso/dsh-analyze-image-tool
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.