### PR TITLE
catalog: add causebefore-dsh-pomodoro (community curation, created by @causebefore)

### DIFF
--- a/catalog/plugins/causebefore-dsh-pomodoro.yaml
+++ b/catalog/plugins/causebefore-dsh-pomodoro.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: causebefore-dsh-pomodoro
+name: dsh-pomodoro
+description:
+  en: A DeepSeek Harness Web Pomodoro plugin with configurable focus and break intervals, sidebar access, and a draggable floating panel
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - pomodoro
+  - productivity
+  - timer
+source:
+  repository: https://github.com/causebefore/dsh-pomodoro
+  repositoryNodeId: R_kgDOT3vThA
+  subpath: null
+  commit: 67b151943f3af1c23d19783a8b0b08a378e460cc
+creator:
+  github: causebefore
+package:
+  ecosystem: npm
+  name: dsh-pomodoro
+  version: 0.4.2
+  integrity: sha512-9HQSt2j5tzc3c1ZN0ochNwiW/+pTaP4CfTZMQqGmNA0vpyg5i8hxT8eSwFtOfycoXhe+W59S/f80Pf+5TWnIHw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:13.444Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `causebefore-dsh-pomodoro`
- Submission type: community curation
- Created by `causebefore` — https://github.com/causebefore
- Original source repository: https://github.com/causebefore/dsh-pomodoro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.