### PR TITLE
catalog: add cavan-ou-dsh-flash-godmode (community curation, created by @Cavan-Ou)

### DIFF
--- a/catalog/plugins/cavan-ou-dsh-flash-godmode.yaml
+++ b/catalog/plugins/cavan-ou-dsh-flash-godmode.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: cavan-ou-dsh-flash-godmode
+name: dsh-flash-godmode
+description:
+  en: "V4 Flash \"god mode\" for DeepSeek Harness: w7 persona anchoring + first-turn tool anchoring + complexity-dispatched guidance — turn Flash's unstable thinking into reproducible capability."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - cordis
+  - flash
+  - godmode
+  - opencode-go
+  - dsh-plugin
+source:
+  repository: https://github.com/Cavan-Ou/dsh-flash-godmode
+  repositoryNodeId: R_kgDOT8ajwQ
+  subpath: null
+  commit: 394aaad0669f913eb5559c2cedf963b7f38aeda0
+creator:
+  github: Cavan-Ou
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:32.307Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cavan-ou-dsh-flash-godmode`
- Submission type: community curation
- Created by `Cavan-Ou` — https://github.com/Cavan-Ou
- Original source repository: https://github.com/Cavan-Ou/dsh-flash-godmode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.