### PR TITLE
catalog: add ceelog-dsh-plugin-setting-mcp (community curation, created by @Ceelog)

### DIFF
--- a/catalog/plugins/ceelog-dsh-plugin-setting-mcp.yaml
+++ b/catalog/plugins/ceelog-dsh-plugin-setting-mcp.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: ceelog-dsh-plugin-setting-mcp
+name: "@opendsh/dsh-plugin-setting-mcp"
+description:
+  en: "DSH web plugin: manage MCP servers from the settings panel (view, edit, remove, enable/disable) with hot reload on save"
+  evidencePath: src/plugins/dsh-plugin-setting-mcp/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - manage
+  - servers
+  - settings
+  - panel
+  - view
+  - edit
+  - remove
+  - enable
+  - disable
+  - reload
+  - save
+  - dsh
+source:
+  repository: https://github.com/Ceelog/dsh-plugins
+  repositoryNodeId: R_kgDOT4PyVw
+  subpath: src/plugins/dsh-plugin-setting-mcp
+  commit: 0fb761bed6b5068e3a997d26f1d4e9bad352c4be
+creator:
+  github: Ceelog
+package:
+  ecosystem: npm
+  name: "@opendsh/dsh-plugin-setting-mcp"
+  version: 0.1.0
+  integrity: sha512-md69FzqHFva/HsJFXPVgB2AFl97xQoAwfhXJmdlPzhecHqUWeaKbggnt82SaKilOOQ4qjTxizqVF79759XFtaw==
+dsh:
+  profiles:
+    - web
+  evidencePath: src/plugins/dsh-plugin-setting-mcp/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:35.819Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ceelog-dsh-plugin-setting-mcp`
- Submission type: community curation
- Created by `Ceelog` — https://github.com/Ceelog
- Original source repository: https://github.com/Ceelog/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.