### PR TITLE
catalog: add ceilcelia-dsh-eli-mode (community curation, created by @CeilCelia)

### DIFF
--- a/catalog/plugins/ceilcelia-dsh-eli-mode.yaml
+++ b/catalog/plugins/ceilcelia-dsh-eli-mode.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ceilcelia-dsh-eli-mode
+name: dsh-eli-mode
+description:
+  en: Eli Mode is an agent preset for DeepSeek Harness (DSH) built around wiki-driven long-term memory and skills , on an extremely minimal Harness setup.
+  evidencePath: packages/eli-mode/README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - agent
+  - preset
+  - knowledge-base
+  - wiki
+source:
+  repository: https://github.com/CeilCelia/dsh-eli-mode
+  repositoryNodeId: R_kgDOT5KsEQ
+  subpath: packages/eli-mode
+  commit: ce91cf781400daf33c4f9675e526cf41a27ad27c
+creator:
+  github: CeilCelia
+package:
+  ecosystem: npm
+  name: dsh-eli-mode
+  version: 0.1.10
+  integrity: sha512-CwRtQsXK2PoP/mGNbbTqLTYnhpV0PY/OeNXXoaODpyJlhLHzqS3/YUDZw21U9p44Rq1lnVVn4l7iLpdfZRI0eg==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/eli-mode/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:42.475Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ceilcelia-dsh-eli-mode`
- Submission type: community curation
- Created by `CeilCelia` — https://github.com/CeilCelia
- Original source repository: https://github.com/CeilCelia/dsh-eli-mode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.