### PR TITLE
catalog: add cerebrixos-tuningengines-dsh-plugin (community curation, created by @cerebrixos)

### DIFF
--- a/catalog/plugins/cerebrixos-tuningengines-dsh-plugin.yaml
+++ b/catalog/plugins/cerebrixos-tuningengines-dsh-plugin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: cerebrixos-tuningengines-dsh-plugin
+name: tuningengines-dsh-plugin
+description:
+  en: Tuning Engines governance, trace export, and runtime intelligence for DeepSeek Harness.
+  evidencePath: packages/tuningengines-dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - agent-observability
+  - agent-governance
+  - tuning-engines
+  - dsh
+source:
+  repository: https://github.com/cerebrixos-org/tuning-engines-cli
+  repositoryNodeId: R_kgDORnVBVQ
+  subpath: packages/tuningengines-dsh-plugin
+  commit: 7cdfc8944c34fe23e2ddb882c82f805cbc0d6ece
+creator:
+  github: cerebrixos
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/tuningengines-dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:45.253Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cerebrixos-tuningengines-dsh-plugin`
- Submission type: community curation
- Created by `cerebrixos` — https://github.com/cerebrixos
- Original source repository: https://github.com/cerebrixos-org/tuning-engines-cli
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.