### PR TITLE
catalog: add ch1bug-dsh-skill-fuzzy (community curation, created by @ch1bug)

### DIFF
--- a/catalog/plugins/ch1bug-dsh-skill-fuzzy.yaml
+++ b/catalog/plugins/ch1bug-dsh-skill-fuzzy.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ch1bug-dsh-skill-fuzzy
+name: dsh-skill-fuzzy
+description:
+  en: "Codex-style fuzzy skill search for the DeepSeek Harness Web GUI: /bug, /diag, /regression all find diagnosing-bugs in the / skill menu."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - fuzzy
+  - skill
+  - search
+  - dsh
+source:
+  repository: https://github.com/ch1bug/dsh-skill-fuzzy
+  repositoryNodeId: R_kgDOT5Ji2A
+  subpath: null
+  commit: 1ece049595d140855d63e18d7e21ac237b127d7c
+creator:
+  github: ch1bug
+package:
+  ecosystem: npm
+  name: dsh-skill-fuzzy
+  version: 0.1.0
+  integrity: sha512-TRzGJvT3WK3I4uLw/cOMajoygCcFh5VdU2nEytKlVmM4rnoHfmBBgojyaGFEa47EWEFJrcSmVEuE/dFuWFtHgg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:47.024Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ch1bug-dsh-skill-fuzzy`
- Submission type: community curation
- Created by `ch1bug` — https://github.com/ch1bug
- Original source repository: https://github.com/ch1bug/dsh-skill-fuzzy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.