### PR TITLE
catalog: add ch4acko3-bites-the-dsh (community curation, created by @CH4ACKO3)

### DIFF
--- a/catalog/plugins/ch4acko3-bites-the-dsh.yaml
+++ b/catalog/plugins/ch4acko3-bites-the-dsh.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: ch4acko3-bites-the-dsh
+name: "@ch4acko3/bites-the-dsh"
+description:
+  en: Read-only, scriptable session playback for the DeepSeek Harness WebUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - session-replay
+  - time-travel
+source:
+  repository: https://github.com/CH4ACKO3/bites-the-dsh
+  repositoryNodeId: R_kgDOT90QLg
+  subpath: null
+  commit: 60ad536d2423e8dfd9a1501e30d6aac17c44eca4
+creator:
+  github: CH4ACKO3
+package:
+  ecosystem: npm
+  name: "@ch4acko3/bites-the-dsh"
+  version: 0.2.1
+  integrity: sha512-g+xDo2yBTRHEngHvdHGJikwcDkDXqVZvm6Non1WukKTTdMVdWWYADXJuBe/8XtZi1RjikOFHAjRKGjhk2XcDdQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:49.454Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ch4acko3-bites-the-dsh`
- Submission type: community curation
- Created by `CH4ACKO3` — https://github.com/CH4ACKO3
- Original source repository: https://github.com/CH4ACKO3/bites-the-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.