### PR TITLE
catalog: add chael-chael-dsh-reference-anything (community curation, created by @Chael-Chael)

### DIFF
--- a/catalog/plugins/chael-chael-dsh-reference-anything.yaml
+++ b/catalog/plugins/chael-chael-dsh-reference-anything.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: chael-chael-dsh-reference-anything
+name: dsh-reference-anything
+description:
+  en: Reference locally mirrored ChatGPT, Claude, Gemini, DeepSeek, Grok, and Kimi conversations from DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - reference
+  - locally
+  - mirrored
+  - chatgpt
+  - claude
+  - gemini
+  - grok
+  - kimi
+  - conversations
+  - dsh
+source:
+  repository: https://github.com/Chael-Chael/dsh-reference-anything
+  repositoryNodeId: R_kgDOT6D6CQ
+  subpath: null
+  commit: bfd7cc82303a068446e34dcb6cf7d1205064ab75
+creator:
+  github: Chael-Chael
+package:
+  ecosystem: npm
+  name: dsh-reference-anything
+  version: 0.3.1
+  integrity: sha512-X2Dn8mcndtCHpMoIJdWz5OlznNM0novl/xImpCrfXUo1Z61Nt6Y2t0usCVDfcTiM7mZ91GyhZznRzhusqieETg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:45:59.340Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chael-chael-dsh-reference-anything`
- Submission type: community curation
- Created by `Chael-Chael` — https://github.com/Chael-Chael
- Original source repository: https://github.com/Chael-Chael/dsh-reference-anything
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.