### PR TITLE
catalog: add chancelu-dsh-llmwiki (community curation, created by @chancelu)

### DIFF
--- a/catalog/plugins/chancelu-dsh-llmwiki.yaml
+++ b/catalog/plugins/chancelu-dsh-llmwiki.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: chancelu-dsh-llmwiki
+name: dsh-llmwiki
+description:
+  en: Local Markdown wiki as long-term memory for DeepSeek Harness — ported from llmwiki
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - wiki
+  - obsidian
+  - rag
+  - agent
+  - dsh
+source:
+  repository: https://github.com/chancelu/dsh-llmwiki
+  repositoryNodeId: R_kgDOT3nzJA
+  subpath: null
+  commit: 9fe9479f976212fd8c8ae4673058a53376c4de2e
+creator:
+  github: chancelu
+package:
+  ecosystem: npm
+  name: dsh-llmwiki
+  version: 0.1.1
+  integrity: sha512-ZCOmK5JGomgvh18oOf7UgX5dI6z67V+vi/nXpQAerWSkaHn8nSE16ogM5Vs9OuYl7mlZJFvJuXzXdGpb4cfQhA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:37.600Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chancelu-dsh-llmwiki`
- Submission type: community curation
- Created by `chancelu` — https://github.com/chancelu
- Original source repository: https://github.com/chancelu/dsh-llmwiki
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.