### PR TITLE
catalog: add chaos-hyper-dsh-econ-tools (community curation, created by @Chaos-Hyper)

### DIFF
--- a/catalog/plugins/chaos-hyper-dsh-econ-tools.yaml
+++ b/catalog/plugins/chaos-hyper-dsh-econ-tools.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: chaos-hyper-dsh-econ-tools
+name: dsh-econ-tools
+description:
+  en: "A DeepSeek Harness plugin providing 6 ready-to-use econometrics tools covering the full research workflow: method selection, data preparation, model specification, empirical analysis, robustness checks, and result reporting."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - dsh-plugin
+  - econometrics
+source:
+  repository: https://github.com/Chaos-Hyper/dsh-econ-tools
+  repositoryNodeId: R_kgDOT9OxoQ
+  subpath: null
+  commit: 1d3d25a9e1a1d56f58a4becc49cb0603629e93a1
+creator:
+  github: Chaos-Hyper
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:17.991Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chaos-hyper-dsh-econ-tools`
- Submission type: community curation
- Created by `Chaos-Hyper` — https://github.com/Chaos-Hyper
- Original source repository: https://github.com/Chaos-Hyper/dsh-econ-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.