### PR TITLE
catalog: add cheng-cheng9669-dsh-cache-precision (community curation, created by @Cheng-cheng9669)

### DIFF
--- a/catalog/plugins/cheng-cheng9669-dsh-cache-precision.yaml
+++ b/catalog/plugins/cheng-cheng9669-dsh-cache-precision.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: cheng-cheng9669-dsh-cache-precision
+name: dsh-cache-precision
+description:
+  en: In-place three-decimal cache-hit percentage plus a widened composer stats line for DSH Web.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cache-hit
+  - token-usage
+source:
+  repository: https://github.com/Cheng-cheng9669/dsh-cache-precision
+  repositoryNodeId: R_kgDOT5Vs6g
+  subpath: null
+  commit: 70ef04a27b50b4b48764e792a6e21ca58afc8bda
+creator:
+  github: Cheng-cheng9669
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:15.239Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cheng-cheng9669-dsh-cache-precision`
- Submission type: community curation
- Created by `Cheng-cheng9669` — https://github.com/Cheng-cheng9669
- Original source repository: https://github.com/Cheng-cheng9669/dsh-cache-precision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.