### PR TITLE
catalog: add chengxiucdp-dsh-plugin-advisor (community curation, created by @ChengxiuCDP)

### DIFF
--- a/catalog/plugins/chengxiucdp-dsh-plugin-advisor.yaml
+++ b/catalog/plugins/chengxiucdp-dsh-plugin-advisor.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: chengxiucdp-dsh-plugin-advisor
+name: dsh-plugin-advisor
+description:
+  en: sh dsh plugin --profile web add -w github:ChengxiuCDP/dsh-plugin-advisor
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - plugin-discovery
+  - recommendation
+source:
+  repository: https://github.com/ChengxiuCDP/dsh-plugin-advisor
+  repositoryNodeId: R_kgDOT6ApVQ
+  subpath: null
+  commit: 9ae58851ee1c18f4abb72f92f6bf7fcc093fe1e5
+creator:
+  github: ChengxiuCDP
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:16.994Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chengxiucdp-dsh-plugin-advisor`
- Submission type: community curation
- Created by `ChengxiuCDP` — https://github.com/ChengxiuCDP
- Original source repository: https://github.com/ChengxiuCDP/dsh-plugin-advisor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.