### PR TITLE
catalog: add chengzhi43-dsh-file (community curation, created by @chengzhi43)

### DIFF
--- a/catalog/plugins/chengzhi43-dsh-file.yaml
+++ b/catalog/plugins/chengzhi43-dsh-file.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: chengzhi43-dsh-file
+name: dsh-file
+description:
+  en: <p align="center" <a href="https://github.com/chengzhi43/dsh-file" GitHub</a · <a href=" installation" Installation</a · <a href=" themes" Theme import/export</a · <a href=" faq" FAQ</a · <a href="https://github.com/chengzhi43/dsh-file/issues" Issues</a · <a href="https://github.com/chengzhi43/dsh-file/releases" Releas
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - align
+  - center
+  - href
+  - chengzhi43
+  - file
+  - installation
+  - themes
+  - theme
+  - import
+  - export
+  - issues
+  - releases
+  - releas
+  - dsh
+source:
+  repository: https://github.com/chengzhi43/dsh-file
+  repositoryNodeId: R_kgDOT52cOQ
+  subpath: null
+  commit: 3ff26d055ad3453bbe04c779b2d9b21ae785ca0a
+creator:
+  github: chengzhi43
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:18.631Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chengzhi43-dsh-file`
- Submission type: community curation
- Created by `chengzhi43` — https://github.com/chengzhi43
- Original source repository: https://github.com/chengzhi43/dsh-file
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.