### PR TITLE
catalog: add chenyinrusi-dsh-llm-cost (community curation, created by @chenyinrusi)

### DIFF
--- a/catalog/plugins/chenyinrusi-dsh-llm-cost.yaml
+++ b/catalog/plugins/chenyinrusi-dsh-llm-cost.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: chenyinrusi-dsh-llm-cost
+name: dsh-llm-cost
+description:
+  en: "Per-turn, per-step LLM cost metering for DeepSeek Harness: a costUsage session projection, a cost line under each message, and an LLM+web price auto-maintenance tool."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cost
+  - pricing
+  - llm
+source:
+  repository: https://github.com/chenyinrusi/dsh-llm-cost
+  repositoryNodeId: R_kgDOT6Z_pg
+  subpath: null
+  commit: 2e325b61ac8be5d12284b1b38eb5624fc662c41f
+creator:
+  github: chenyinrusi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:19.896Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chenyinrusi-dsh-llm-cost`
- Submission type: community curation
- Created by `chenyinrusi` — https://github.com/chenyinrusi
- Original source repository: https://github.com/chenyinrusi/dsh-llm-cost
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.