### PR TITLE
catalog: add chinosk6-dsh-roleplay (community curation, created by @chinosk6)

### DIFF
--- a/catalog/plugins/chinosk6-dsh-roleplay.yaml
+++ b/catalog/plugins/chinosk6-dsh-roleplay.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: chinosk6-dsh-roleplay
+name: dsh-roleplay
+description:
+  en: Role-play conversations, character-card authoring and image generation for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - roleplay
+  - character-card
+source:
+  repository: https://github.com/chinosk6/dsh-roleplay
+  repositoryNodeId: R_kgDOT4_i7Q
+  subpath: null
+  commit: 035a2bbc602a0c60ca38508cdffb9cb07dd6fb26
+creator:
+  github: chinosk6
+package:
+  ecosystem: npm
+  name: dsh-roleplay
+  version: 0.2.6
+  integrity: sha512-JTGwNAS5txT9pqQbzFsLnAu87BTqlAVLp/KqrWLPQtGWOAGjCwlujaMjYAvYjBXbqwaiI33vYhPLZoCcW0jt9Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:21.682Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chinosk6-dsh-roleplay`
- Submission type: community curation
- Created by `chinosk6` — https://github.com/chinosk6
- Original source repository: https://github.com/chinosk6/dsh-roleplay
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.