### PR TITLE
catalog: add choi-peng-dsh-footer-order (community curation, created by @Choi-Peng)

### DIFF
--- a/catalog/plugins/choi-peng-dsh-footer-order.yaml
+++ b/catalog/plugins/choi-peng-dsh-footer-order.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: choi-peng-dsh-footer-order
+name: "@choi-p/dsh-footer-order"
+description:
+  en: "DSH web sidebar footer action ordering: force the sidebar.footer.action slot into a vertical stack (display: contents → flex column) and let users configure the top-to-bottom order of the entries."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - sidebar
+  - footer
+  - order
+  - layout
+source:
+  repository: https://github.com/Choi-Peng/dsh-footer-order
+  repositoryNodeId: R_kgDOT74q6A
+  subpath: null
+  commit: ccd67ace488a6b53bc5a70a213c093b1d5669573
+creator:
+  github: Choi-Peng
+package:
+  ecosystem: npm
+  name: "@choi-p/dsh-footer-order"
+  version: 0.2.0
+  integrity: sha512-0bReRzYMNcfNwZPZK5yOnU4bgB8nBMEUVkNOfpQYHzho8pkdnjgbXgObSR+jxRQJvi66IXXwrBIG98zhDvDqAg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:23.740Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `choi-peng-dsh-footer-order`
- Submission type: community curation
- Created by `Choi-Peng` — https://github.com/Choi-Peng
- Original source repository: https://github.com/Choi-Peng/dsh-footer-order
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.