### PR TITLE
catalog: add chouyong-dsh-fork-diff (community curation, created by @chouyong)

### DIFF
--- a/catalog/plugins/chouyong-dsh-fork-diff.yaml
+++ b/catalog/plugins/chouyong-dsh-fork-diff.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: chouyong-dsh-fork-diff
+name: dsh-fork-diff
+description:
+  en: Read-only side-by-side comparison for related DeepSeek Harness conversation forks.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - conversation
+  - fork
+  - diff
+source:
+  repository: https://github.com/chouyong/dsh-fork-diff
+  repositoryNodeId: R_kgDOT55kLQ
+  subpath: null
+  commit: 573b980623fe74a42b61dd85a49c12c84faabe2a
+creator:
+  github: chouyong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:49:37.863Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chouyong-dsh-fork-diff`
- Submission type: community curation
- Created by `chouyong` — https://github.com/chouyong
- Original source repository: https://github.com/chouyong/dsh-fork-diff
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.