### PR TITLE
catalog: add chplus0-dsh-shell-command (community curation, created by @CHplus0)

### DIFF
--- a/catalog/plugins/chplus0-dsh-shell-command.yaml
+++ b/catalog/plugins/chplus0-dsh-shell-command.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: chplus0-dsh-shell-command
+name: dsh-shell-command
+description:
+  en: "DeepSeek Harness (DSH) plugin: a /! command trigger (run one command, analyze output, inspired by Claude Code's ! gesture) and a /terminal command (interactive PTY popup with on-demand history reference)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - shell
+  - command
+  - slash-command
+  - terminal
+  - claude-code
+source:
+  repository: https://github.com/CHplus0/dsh-shell-command
+  repositoryNodeId: R_kgDOT6OTFA
+  subpath: null
+  commit: 741bba45e5bf5f03e8c78b7fc907a4666ff8bc98
+creator:
+  github: CHplus0
+package:
+  ecosystem: npm
+  name: dsh-shell-command
+  version: 0.1.0
+  integrity: sha512-KaA6muSlpByrveTBDxfzHikdQfjn39bsDuAyD6kRDdUeIyK/KnAYHoKhPVjEPQxRNGr4K7+717hRJG0+umysrA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:01.264Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chplus0-dsh-shell-command`
- Submission type: community curation
- Created by `CHplus0` — https://github.com/CHplus0
- Original source repository: https://github.com/CHplus0/dsh-shell-command
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.