### PR TITLE
catalog: add chriszhangwg-dsh-codex-meter (community curation, created by @ChrisZhangWG)

### DIFF
--- a/catalog/plugins/chriszhangwg-dsh-codex-meter.yaml
+++ b/catalog/plugins/chriszhangwg-dsh-codex-meter.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: chriszhangwg-dsh-codex-meter
+name: dsh-codex-meter
+description:
+  en: "Native DSH Settings → Usage page for DeepSeek API: balance, official token and cost analysis, trends, context warnings, and live API activity."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - codex
+  - meter
+  - balance
+  - tokens
+  - cost
+  - web
+source:
+  repository: https://github.com/ChrisZhangWG/dsh-codex-meter
+  repositoryNodeId: R_kgDOT586OQ
+  subpath: null
+  commit: 5f28607bbcebd9a77838386df9e0760c2d2be292
+creator:
+  github: ChrisZhangWG
+package:
+  ecosystem: npm
+  name: dsh-codex-meter
+  version: 1.2.2
+  integrity: sha512-d46GdCGRzTG5GZlhYY/2jaYK7EpSgqxlkbAQ7puHIpAlXnBEe7kYnr+1X9MFK2WFJr0v4XAqu+33s7uMtd2MvA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:39.417Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chriszhangwg-dsh-codex-meter`
- Submission type: community curation
- Created by `ChrisZhangWG` — https://github.com/ChrisZhangWG
- Original source repository: https://github.com/ChrisZhangWG/dsh-codex-meter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.