### PR TITLE
catalog: add chuantianml-dsh-local-share (community curation, created by @ChuanTianML)

### DIFF
--- a/catalog/plugins/chuantianml-dsh-local-share.yaml
+++ b/catalog/plugins/chuantianml-dsh-local-share.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: chuantianml-dsh-local-share
+name: dsh-local-share
+description:
+  en: Local, privacy-first Markdown and self-contained HTML sharing for DeepSeek Harness sessions
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - local-first
+  - session-export
+  - session-sharing
+  - markdown
+  - privacy
+  - dsh
+source:
+  repository: https://github.com/ChuanTianML/dsh-local-share
+  repositoryNodeId: R_kgDOT36gew
+  subpath: null
+  commit: 54ea15c7a76bb387f05a6811a5461852f2ea7ad6
+creator:
+  github: ChuanTianML
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:49:41.053Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chuantianml-dsh-local-share`
- Submission type: community curation
- Created by `ChuanTianML` — https://github.com/ChuanTianML
- Original source repository: https://github.com/ChuanTianML/dsh-local-share
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.