### PR TITLE
catalog: add chuantianml-dsh-prompt-for-me (community curation, created by @ChuanTianML)

### DIFF
--- a/catalog/plugins/chuantianml-dsh-prompt-for-me.yaml
+++ b/catalog/plugins/chuantianml-dsh-prompt-for-me.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: chuantianml-dsh-prompt-for-me
+name: dsh-prompt-for-me
+description:
+  en: Context-aware next-message suggestions for the DeepSeek Harness composer, always reviewed by the user before sending.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - prompt
+  - composer
+  - copilot
+source:
+  repository: https://github.com/ChuanTianML/prompt-for-me
+  repositoryNodeId: R_kgDOT50BWQ
+  subpath: null
+  commit: fed9aa42bf9a80aad1d239ffa632e1de9d8f93a9
+creator:
+  github: ChuanTianML
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:46:21.901Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chuantianml-dsh-prompt-for-me`
- Submission type: community curation
- Created by `ChuanTianML` — https://github.com/ChuanTianML
- Original source repository: https://github.com/ChuanTianML/prompt-for-me
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.