### PR TITLE
catalog: add cindyguyuehu123-dsh-webchatlike (community curation, created by @cindyguyuehu123)

### DIFF
--- a/catalog/plugins/cindyguyuehu123-dsh-webchatlike.yaml
+++ b/catalog/plugins/cindyguyuehu123-dsh-webchatlike.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: cindyguyuehu123-dsh-webchatlike
+name: dsh-webchatlike
+description:
+  en: "Web-chat-like message actions for DeepSeek Harness: edit-and-resend your prompt and regenerate answers in place, with a deepseek.com-style <i/N version pager on every versioned message."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - chat
+  - webchat
+  - regenerate
+  - edit
+  - version
+  - web-ui
+source:
+  repository: https://github.com/cindyguyuehu123/dsh-webchatlike
+  repositoryNodeId: R_kgDOT4i9XA
+  subpath: null
+  commit: 365c7077b2c0125c9bbd8691ec7fbb5b8e8aa268
+creator:
+  github: cindyguyuehu123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:45:43.794Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cindyguyuehu123-dsh-webchatlike`
- Submission type: community curation
- Created by `cindyguyuehu123` — https://github.com/cindyguyuehu123
- Original source repository: https://github.com/cindyguyuehu123/dsh-webchatlike
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.