### PR TITLE
catalog: add cipher2026-dsh-deepcompute (community curation, created by @cipher2026)

### DIFF
--- a/catalog/plugins/cipher2026-dsh-deepcompute.yaml
+++ b/catalog/plugins/cipher2026-dsh-deepcompute.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: cipher2026-dsh-deepcompute
+name: dsh-deepcompute
+description:
+  en: help / shop / stats / era / save / export / import / reset [confirm]
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - help
+  - shop
+  - stats
+  - save
+  - export
+  - import
+  - reset
+  - confirm
+  - dsh
+source:
+  repository: https://github.com/cipher2026/dsh-idle-deepcompute
+  repositoryNodeId: R_kgDOT6zpwQ
+  subpath: null
+  commit: 09274a1f0feb4e258e3383268e0b0a1f6f4ca7dc
+creator:
+  github: cipher2026
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:49:44.327Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cipher2026-dsh-deepcompute`
- Submission type: community curation
- Created by `cipher2026` — https://github.com/cipher2026
- Original source repository: https://github.com/cipher2026/dsh-idle-deepcompute
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.