### PR TITLE
catalog: add claude-dsh-plugin-mission-control (community curation, created by @claude)

### DIFF
--- a/catalog/plugins/claude-dsh-plugin-mission-control.yaml
+++ b/catalog/plugins/claude-dsh-plugin-mission-control.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: claude-dsh-plugin-mission-control
+name: dsh-plugin-mission-control
+description:
+  en: DeepSeek-Harness (dsh) plugin that streams sessions, turns, and tool activity to a JARVIS Mission Control board
+  evidencePath: integrations/deepseek-harness/dsh-plugin-mission-control/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - mission-control
+  - jarvis
+source:
+  repository: https://github.com/Asif2BD/JARVIS-Mission-Control-DeepSeek
+  repositoryNodeId: R_kgDOT7znPw
+  subpath: integrations/deepseek-harness/dsh-plugin-mission-control
+  commit: e1098371bee137a5676ddd8e7b82b9b222a55bb8
+creator:
+  github: claude
+package:
+  ecosystem: npm
+  name: dsh-plugin-mission-control
+  version: 0.2.1
+  integrity: sha512-bjw79GBSvZQG/sQ41u0KgHQ3irdrA8KguLKVfNm6YUVwwI4/y8Viy/eTU+9Nx3IeUoLbjKuETxttxm+o1XFC4A==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: integrations/deepseek-harness/dsh-plugin-mission-control/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:36.427Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `claude-dsh-plugin-mission-control`
- Submission type: community curation
- Created by `claude` — https://github.com/claude
- Original source repository: https://github.com/Asif2BD/JARVIS-Mission-Control-DeepSeek
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.