### PR TITLE
catalog: add jadon7-dsh-codex-taskboard (community curation, created by @jadon7)

### DIFF
--- a/catalog/plugins/jadon7-dsh-codex-taskboard.yaml
+++ b/catalog/plugins/jadon7-dsh-codex-taskboard.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: jadon7-dsh-codex-taskboard
+name: dsh-codex-taskboard
+description:
+  en: This directory is an installable DeepSeek Harness bundle. It adds a Taskboard entry to the Harness sidebar and opens the active installed Codex Taskboard runtime.
+  evidencePath: integrations/deepseek-harness/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - directory
+  - installable
+  - bundle
+  - adds
+  - taskboard
+  - entry
+  - sidebar
+  - opens
+  - active
+  - installed
+  - codex
+  - runtime
+  - dsh
+source:
+  repository: https://github.com/chuspeeism/dashi-taskboard
+  repositoryNodeId: R_kgDOTiXtVw
+  subpath: integrations/deepseek-harness
+  commit: a423e05dd574844a7bcac1da729abd2ec87ecc35
+creator:
+  github: jadon7
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: integrations/deepseek-harness/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:49:42.960Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jadon7-dsh-codex-taskboard`
- Submission type: community curation
- Created by `jadon7` — https://github.com/jadon7
- Original source repository: https://github.com/chuspeeism/dashi-taskboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.