### PR TITLE
catalog: add niejingchuan-dsh-bailinghub (community curation, created by @niejingchuan)

### DIFF
--- a/catalog/plugins/niejingchuan-dsh-bailinghub.yaml
+++ b/catalog/plugins/niejingchuan-dsh-bailinghub.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: niejingchuan-dsh-bailinghub
+name: dsh-bailinghub
+description:
+  en: Use DeepSeek Harness to submit and follow governed business tasks through BailingHub.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - bailinghub
+  - mcp
+  - ai-agent-governance
+  - business-system-automation
+  - human-in-the-loop
+  - audit-trail
+  - self-hosted
+source:
+  repository: https://github.com/bailinghub/bailinghub-dsh-plugin
+  repositoryNodeId: R_kgDOT8FmCg
+  subpath: null
+  commit: e0b7ac83e0812be592206c183370106a52511405
+creator:
+  github: niejingchuan
+package:
+  ecosystem: npm
+  name: dsh-bailinghub
+  version: 0.1.1
+  integrity: sha512-e97xIZaxCkDNvfgYNEvYiYHy2IK/QelB+1SqTYSZPNHvPcZNIb88nTXSBuhJHGWI0BURfpH6mgE2g6tOJaTcjw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:47:46.366Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `niejingchuan-dsh-bailinghub`
- Submission type: community curation
- Created by `niejingchuan` — https://github.com/niejingchuan
- Original source repository: https://github.com/bailinghub/bailinghub-dsh-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.