### PR TITLE
catalog: add timer-u-dsh-tool-gitbash (community curation, created by @Timer-u)

### DIFF
--- a/catalog/plugins/timer-u-dsh-tool-gitbash.yaml
+++ b/catalog/plugins/timer-u-dsh-tool-gitbash.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: timer-u-dsh-tool-gitbash
+name: dsh-tool-gitbash
+description:
+  en: 用于替代原生pwsh的gitbash Model-facing Git Bash tool for Windows (replaces pwsh/WSL-bash)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - pwsh
+  - gitbash
+  - model
+  - facing
+  - bash
+  - tool
+  - windows
+  - replaces
+  - dsh
+source:
+  repository: https://github.com/buhuikongpan/dsh-win-gitbash
+  repositoryNodeId: R_kgDOT4-tBg
+  subpath: null
+  commit: 113539ca62e904567756a3e227dc4010e8902d77
+creator:
+  github: Timer-u
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:45:56.756Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `timer-u-dsh-tool-gitbash`
- Submission type: community curation
- Created by `Timer-u` — https://github.com/Timer-u
- Original source repository: https://github.com/buhuikongpan/dsh-win-gitbash
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.