### PR TITLE
catalog: add xiaohucao-kongmu-im-bridge (community curation, created by @xiaohucao)

### DIFF
--- a/catalog/plugins/xiaohucao-kongmu-im-bridge.yaml
+++ b/catalog/plugins/xiaohucao-kongmu-im-bridge.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: xiaohucao-kongmu-im-bridge
+name: kongmu-im-bridge
+description:
+  en: sh dsh plugin --profile web add kongmu-im kongmu-im-feishu -w
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - im-bridge
+  - feishu
+  - lark
+  - ai-agent
+  - remote-approval
+  - kongmu
+source:
+  repository: https://github.com/caoxiaohu7745-bot/kongmu-im-bridge
+  repositoryNodeId: R_kgDOT5TN2A
+  subpath: null
+  commit: 85b692e57e66defbde19109bd83ebac88113a751
+creator:
+  github: xiaohucao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-24T23:48:27.006Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaohucao-kongmu-im-bridge`
- Submission type: community curation
- Created by `xiaohucao` — https://github.com/xiaohucao
- Original source repository: https://github.com/caoxiaohu7745-bot/kongmu-im-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.