### PR TITLE
catalog: add aaravarr-dsh-ssh (community curation, created by @aaravarr)

### DIFF
--- a/catalog/plugins/aaravarr-dsh-ssh.yaml
+++ b/catalog/plugins/aaravarr-dsh-ssh.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: aaravarr-dsh-ssh
+name: "@dsh-ssh/dsh-ssh"
+description:
+  en: "SSH remote workspace for DeepSeek Harness: ssh2 connection pool, host settings, and routed bash/fs/search tools"
+  evidencePath: packages/dsh-ssh/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - remote
+  - workspace
+  - ssh2
+  - connection
+  - pool
+  - host
+  - settings
+  - routed
+  - bash
+  - search
+  - tools
+  - dsh
+source:
+  repository: https://github.com/dsh-ssh/dsh-ssh
+  repositoryNodeId: R_kgDOT5grag
+  subpath: packages/dsh-ssh
+  commit: 77fa7de1827120645047c1844a0d0f934fd1e63a
+creator:
+  github: aaravarr
+package:
+  ecosystem: npm
+  name: "@dsh-ssh/dsh-ssh"
+  version: 0.1.2
+  integrity: sha512-kTNNTZA2Z8HD5i2kk3qeCrf6u7cKCogySZRAghdDb0P5jZaHb4QwA1MhmqyqhiwzHept+WvKMxAQboeODIPJYw==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-ssh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:50.057Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aaravarr-dsh-ssh`
- Submission type: community curation
- Created by `aaravarr` — https://github.com/aaravarr
- Original source repository: https://github.com/dsh-ssh/dsh-ssh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.