### PR TITLE
catalog: add ace140250-dsh-deepseek-balance (community curation, created by @ace140250)

### DIFF
--- a/catalog/plugins/ace140250-dsh-deepseek-balance.yaml
+++ b/catalog/plugins/ace140250-dsh-deepseek-balance.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: ace140250-dsh-deepseek-balance
+name: dsh-deepseek-balance
+description:
+  en: Real-time DeepSeek account balance display in the DSH web UI, via the official /user/balance API. API key is resolved from the DEEPSEEK API KEY credential.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - balance
+source:
+  repository: https://github.com/CN-Leo/dsh-deepseek-balance
+  repositoryNodeId: R_kgDOT6rDhg
+  subpath: null
+  commit: 0f15218466ee61cbfab831b6eda0bfcf6f5514a1
+creator:
+  github: ace140250
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:40.626Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ace140250-dsh-deepseek-balance`
- Submission type: community curation
- Created by `ace140250` — https://github.com/ace140250
- Original source repository: https://github.com/CN-Leo/dsh-deepseek-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.