### PR TITLE
catalog: add alexazhuravl-dsh-write-gate (community curation, created by @alexazhuravl)

### DIFF
--- a/catalog/plugins/alexazhuravl-dsh-write-gate.yaml
+++ b/catalog/plugins/alexazhuravl-dsh-write-gate.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: alexazhuravl-dsh-write-gate
+name: dsh-write-gate
+description:
+  en: "Commitment write-gate for AI coding agents: two-tier (deterministic + LLM judge) pre-execution policy. Engine-agnostic core with a DeepSeek Harness (dsh) adapter."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - guardrails
+  - ai-agents
+  - agent-safety
+  - policy
+  - dsh
+source:
+  repository: https://github.com/couldbeme/dsh-write-gate
+  repositoryNodeId: R_kgDOT7fI1A
+  subpath: null
+  commit: de8c58100574a23df8e729e884661bc5fa60b8ec
+creator:
+  github: alexazhuravl
+package:
+  ecosystem: npm
+  name: dsh-write-gate
+  version: 0.1.1
+  integrity: sha512-djO6QWSOYJdI7pmbbftgQctFtUX4U8OOQVQ98yh9GkwgjfUx8Q65V6x11v+P+mP4aG+v9Y1dMVgceidX65dsYQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:20.871Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alexazhuravl-dsh-write-gate`
- Submission type: community curation
- Created by `alexazhuravl` — https://github.com/alexazhuravl
- Original source repository: https://github.com/couldbeme/dsh-write-gate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.