### PR TITLE
catalog: add bruce-yii-dsh-mock (community curation, created by @Bruce-Yii)

### DIFF
--- a/catalog/plugins/bruce-yii-dsh-mock.yaml
+++ b/catalog/plugins/bruce-yii-dsh-mock.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: bruce-yii-dsh-mock
+name: dsh-mock
+description:
+  en: Deterministic mock LLM adapter for DeepSeek Harness
+  evidencePath: mock/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deterministic
+  - mock
+  - adapter
+  - dsh
+source:
+  repository: https://github.com/Ephemeral-AI-Lab/dsh-plugins
+  repositoryNodeId: R_kgDOT5uUvw
+  subpath: mock
+  commit: 0ff144aed9d9d9d6de3c45ba7f18cde2abe4d4a1
+creator:
+  github: Bruce-Yii
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: mock/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:08.747Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bruce-yii-dsh-mock`
- Submission type: community curation
- Created by `Bruce-Yii` — https://github.com/Bruce-Yii
- Original source repository: https://github.com/Ephemeral-AI-Lab/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.