### PR TITLE
catalog: add clarkzhao-dsh-airp (community curation, created by @clarkzhao)

### DIFF
--- a/catalog/plugins/clarkzhao-dsh-airp.yaml
+++ b/catalog/plugins/clarkzhao-dsh-airp.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: clarkzhao-dsh-airp
+name: dsh-airp
+description:
+  en: "AIRP engine for DeepSeek Harness: WorldKernel + DSH host adapter"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - airp
+source:
+  repository: https://github.com/clarkzhao/dsh-airp
+  repositoryNodeId: R_kgDOT8BNfQ
+  subpath: null
+  commit: a5936ebf3cc72ca7d42c5692c926d09c438cb2f9
+creator:
+  github: clarkzhao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:12.376Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `clarkzhao-dsh-airp`
- Submission type: community curation
- Created by `clarkzhao` — https://github.com/clarkzhao
- Original source repository: https://github.com/clarkzhao/dsh-airp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.