### PR TITLE
catalog: add cmskl-dsh-plugin-observatory (community curation, created by @CMSKL)

### DIFF
--- a/catalog/plugins/cmskl-dsh-plugin-observatory.yaml
+++ b/catalog/plugins/cmskl-dsh-plugin-observatory.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: cmskl-dsh-plugin-observatory
+name: dsh-plugin-observatory
+description:
+  en: Independent DSH plugin compatibility audit and bounded Loader lifecycle observation
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - independent
+  - compatibility
+  - audit
+  - bounded
+  - loader
+  - lifecycle
+  - observation
+  - dsh
+source:
+  repository: https://github.com/CMSKL/dsh-plugin-observatory
+  repositoryNodeId: R_kgDOT6qUZQ
+  subpath: null
+  commit: 3fc8f9aeda53e292774a7826338d39504bec97ba
+creator:
+  github: CMSKL
+package:
+  ecosystem: npm
+  name: dsh-plugin-observatory
+  version: 0.1.0
+  integrity: sha512-1LncuNot4JLoL67U36637Y34C21PzfeTQ/pLMBWfIw7ecCZQaCLECvput7P7FdpnWDO15QfACH2QUCyWeqbmdg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:14.289Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cmskl-dsh-plugin-observatory`
- Submission type: community curation
- Created by `CMSKL` — https://github.com/CMSKL
- Original source repository: https://github.com/CMSKL/dsh-plugin-observatory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.