### PR TITLE
catalog: add cnchenkai-dsh-web-search-brave (community curation, created by @cnChenKai)

### DIFF
--- a/catalog/plugins/cnchenkai-dsh-web-search-brave.yaml
+++ b/catalog/plugins/cnchenkai-dsh-web-search-brave.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: cnchenkai-dsh-web-search-brave
+name: dsh-web-search-brave
+description:
+  en: Brave Search-backed WebSearchProvider for the DeepSeek Harness web seam (ctx.web)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - web-search
+  - brave
+  - search
+  - agent
+source:
+  repository: https://github.com/cnChenKai/dsh-web-search-brave
+  repositoryNodeId: R_kgDOT4ajzg
+  subpath: null
+  commit: 9b9943e08b62ff2f904be4f91098a604259bf2a3
+creator:
+  github: cnChenKai
+package:
+  ecosystem: npm
+  name: dsh-web-search-brave
+  version: 0.2.3
+  integrity: sha512-enx3j1whcQNQMfrUQHg2vpNkb3rfoXhRHYzd29wBPdUuyRil/8JbnrNswPAzJW6wd7ozJjt+0no0HZ1JY1QCHg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:02.762Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cnchenkai-dsh-web-search-brave`
- Submission type: community curation
- Created by `cnChenKai` — https://github.com/cnChenKai
- Original source repository: https://github.com/cnChenKai/dsh-web-search-brave
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.