### PR TITLE
catalog: add cnchenkai-dsh-web-search-tavily (community curation, created by @cnChenKai)

### DIFF
--- a/catalog/plugins/cnchenkai-dsh-web-search-tavily.yaml
+++ b/catalog/plugins/cnchenkai-dsh-web-search-tavily.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: cnchenkai-dsh-web-search-tavily
+name: dsh-web-search-tavily
+description:
+  en: Tavily-backed WebSearchProvider for the DeepSeek Harness web seam (ctx.web) - keyless mode supported, no API key required
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - web-search
+  - tavily
+  - search
+  - agent
+source:
+  repository: https://github.com/cnChenKai/dsh-web-search-tavily
+  repositoryNodeId: R_kgDOT4ajnA
+  subpath: null
+  commit: 0645debb3b27157b1645bbd3b6645d99affed8d1
+creator:
+  github: cnChenKai
+package:
+  ecosystem: npm
+  name: dsh-web-search-tavily
+  version: 0.2.2
+  integrity: sha512-8tBela5e85mEJA9TGzJ9QFZNYLGuLoZzot7pXTfFOEP+0bgE0CdmMb6uZbqbtlvgRPfyeuD4Ux8CUsiKPjObzg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:18.331Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cnchenkai-dsh-web-search-tavily`
- Submission type: community curation
- Created by `cnChenKai` — https://github.com/cnChenKai
- Original source repository: https://github.com/cnChenKai/dsh-web-search-tavily
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.