### PR TITLE
catalog: add cocofhu00-skillhub (community curation, created by @cocofhu00)

### DIFF
--- a/catalog/plugins/cocofhu00-skillhub.yaml
+++ b/catalog/plugins/cocofhu00-skillhub.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: cocofhu00-skillhub
+name: "@cocofhu/skillhub"
+description:
+  en: sh dsh plugin --profile web add @cocofhu/skillhub
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - skillhub
+  - skills
+source:
+  repository: https://github.com/cocofhu/skillhub
+  repositoryNodeId: R_kgDOT5giJg
+  subpath: null
+  commit: d9ea8c39fadc2737d04f178fce8420c4c6407f47
+creator:
+  github: cocofhu00
+package:
+  ecosystem: npm
+  name: "@cocofhu/skillhub"
+  version: 0.2.13
+  integrity: sha512-/1G/Sn6uoP3S5SPLHyt675XAouFIAXvu2JEL8vV6tUmDvL1IB1RH33Nbcc2taa/AIrJxXfUxUAlo8+slCMdBqw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:23.791Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cocofhu00-skillhub`
- Submission type: community curation
- Created by `cocofhu00` — https://github.com/cocofhu00
- Original source repository: https://github.com/cocofhu/skillhub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.