### PR TITLE
catalog: add codeanqiang-ma-dsh-superpowers (community curation, created by @codeAnqiang-ma)

### DIFF
--- a/catalog/plugins/codeanqiang-ma-dsh-superpowers.yaml
+++ b/catalog/plugins/codeanqiang-ma-dsh-superpowers.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: codeanqiang-ma-dsh-superpowers
+name: dsh-superpowers
+description:
+  en: "Superpowers (obra/superpowers) for DeepSeek Harness: the software-development methodology skills plus their session bootstrap, as a dsh plugin"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - superpowers
+  - skills
+  - tdd
+  - agent
+  - dsh
+source:
+  repository: https://github.com/codeAnqiang-ma/dsh-superpowers
+  repositoryNodeId: R_kgDOT3fRfQ
+  subpath: null
+  commit: 9511c7b961faafb35f31e6b0e297524bf377aeaf
+creator:
+  github: codeAnqiang-ma
+package:
+  ecosystem: npm
+  name: dsh-superpowers
+  version: 0.1.0
+  integrity: sha512-/BT4/Kb93rav1sgcw67Kz40BHyA6oL9t91JyL6Eubs3oSBYIN0BQpRXwmz1cMBY2HidTmee8XfPHEmRsd9xHjQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:20.479Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `codeanqiang-ma-dsh-superpowers`
- Submission type: community curation
- Created by `codeAnqiang-ma` — https://github.com/codeAnqiang-ma
- Original source repository: https://github.com/codeAnqiang-ma/dsh-superpowers
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.