### PR TITLE
catalog: add codehz-dsh-better-code (community curation, created by @codehz)

### DIFF
--- a/catalog/plugins/codehz-dsh-better-code.yaml
+++ b/catalog/plugins/codehz-dsh-better-code.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: codehz-dsh-better-code
+name: "@codehz/dsh-better-code"
+description:
+  en: Optional run code env binding and env-aware browser rendering for DeepSeek Harness Code Mode
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - optional
+  - code
+  - binding
+  - aware
+  - browser
+  - rendering
+  - mode
+  - dsh
+source:
+  repository: https://github.com/codehz/dsh-better-code
+  repositoryNodeId: R_kgDOT8GD5g
+  subpath: null
+  commit: 040ea2b9f2dfc7a16104a488e31ff4401dd0f793
+creator:
+  github: codehz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:09.679Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `codehz-dsh-better-code`
- Submission type: community curation
- Created by `codehz` — https://github.com/codehz
- Original source repository: https://github.com/codehz/dsh-better-code
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.