### PR TITLE
catalog: add codehz-dsh-custom-models (community curation, created by @codehz)

### DIFF
--- a/catalog/plugins/codehz-dsh-custom-models.yaml
+++ b/catalog/plugins/codehz-dsh-custom-models.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: codehz-dsh-custom-models
+name: dsh-custom-models
+description:
+  en: DSH custom model providers with per-model reasoning defaults and settings UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - custom
+  - model
+  - providers
+  - reasoning
+  - defaults
+  - settings
+  - dsh
+source:
+  repository: https://github.com/codehz/dsh-custom-models
+  repositoryNodeId: R_kgDOT4Yfeg
+  subpath: null
+  commit: e83ac606dcc1d12394e272b061a0cdc44011502f
+creator:
+  github: codehz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:11.659Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `codehz-dsh-custom-models`
- Submission type: community curation
- Created by `codehz` — https://github.com/codehz
- Original source repository: https://github.com/codehz/dsh-custom-models
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.