### PR TITLE
catalog: add codehz-dsh-restart-request (community curation, created by @codehz)

### DIFF
--- a/catalog/plugins/codehz-dsh-restart-request.yaml
+++ b/catalog/plugins/codehz-dsh-restart-request.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: codehz-dsh-restart-request
+name: dsh-restart-request
+description:
+  en: Ask the user to restart the DeepSeek Harness backend without killing the active agent from a shell tool
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - user
+  - restart
+  - backend
+  - without
+  - killing
+  - active
+  - agent
+  - shell
+  - tool
+  - dsh
+source:
+  repository: https://github.com/codehz/dsh-restart-request
+  repositoryNodeId: R_kgDOT6U_Tw
+  subpath: null
+  commit: 9b5ec4ea203c55da13a8d8f5040cf226230cf42d
+creator:
+  github: codehz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:13.843Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `codehz-dsh-restart-request`
- Submission type: community curation
- Created by `codehz` — https://github.com/codehz
- Original source repository: https://github.com/codehz/dsh-restart-request
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.