### PR TITLE
catalog: add contributors-dsh-tool-policy (community curation, created by @contributors)

### DIFF
--- a/catalog/plugins/contributors-dsh-tool-policy.yaml
+++ b/catalog/plugins/contributors-dsh-tool-policy.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: contributors-dsh-tool-policy
+name: dsh-tool-policy
+description:
+  en: Allow, ask, or deny DeepSeek Harness tool calls before execution
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - agent-security
+  - tool-governance
+  - guardrails
+  - dsh
+source:
+  repository: https://github.com/Drifter-yh/dsh-tool-policy
+  repositoryNodeId: R_kgDOT3b2_w
+  subpath: null
+  commit: e6f43c255345a6f6bbab66ee8c053a2e5457e3c7
+creator:
+  github: contributors
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:34.075Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `contributors-dsh-tool-policy`
- Submission type: community curation
- Created by `contributors` — https://github.com/contributors
- Original source repository: https://github.com/Drifter-yh/dsh-tool-policy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.