### PR TITLE
catalog: add cookiesheep-whale-on-desk (community curation, created by @cookiesheep)

### DIFF
--- a/catalog/plugins/cookiesheep-whale-on-desk.yaml
+++ b/catalog/plugins/cookiesheep-whale-on-desk.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: cookiesheep-whale-on-desk
+name: whale-on-desk
+description:
+  en: A pixel-art whale desktop companion for DeepSeek Harness — it swims while your agents work and taps the glass when an approval is waiting.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - desktop-pet
+  - web-ui
+  - cordis
+source:
+  repository: https://github.com/cookiesheep/whale-on-desk
+  repositoryNodeId: R_kgDOT6A-KA
+  subpath: null
+  commit: d50a2e45eddcb6cd1483820f9c4c1e8991913581
+creator:
+  github: cookiesheep
+package:
+  ecosystem: npm
+  name: whale-on-desk
+  version: 3.0.0
+  integrity: sha512-g5KIb8OS7Pc8tn/er0lmba8BVpEeTgwY3qIrnAuyHdFBSfYoxcd8sTHnXgkYy+RaWQrYLRBccoo9K8KB9SEBUA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:44.473Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cookiesheep-whale-on-desk`
- Submission type: community curation
- Created by `cookiesheep` — https://github.com/cookiesheep
- Original source repository: https://github.com/cookiesheep/whale-on-desk
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.