### PR TITLE
catalog: add ctwctw9999-dsh-agent-preset-router (community curation, created by @CTWCTW9999)

### DIFF
--- a/catalog/plugins/ctwctw9999-dsh-agent-preset-router.yaml
+++ b/catalog/plugins/ctwctw9999-dsh-agent-preset-router.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ctwctw9999-dsh-agent-preset-router
+name: dsh-agent-preset-router
+description:
+  en: "自动模式 Auto Mode: an AI pre-judgment layer for DeepSeek Harness — a flash-model router that picks the best agent preset (standard/code/minimal/cordis) for each new session and lets the user confirm before execution."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - agent-preset
+  - auto-mode
+  - router
+  - classifier
+source:
+  repository: https://github.com/CTWCTW9999/dsh-agent-preset-router
+  repositoryNodeId: R_kgDOT7-Qrg
+  subpath: null
+  commit: 59fe55da4c8eb5659493c132c9f3d9ce2343ab7a
+creator:
+  github: CTWCTW9999
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:20.590Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ctwctw9999-dsh-agent-preset-router`
- Submission type: community curation
- Created by `CTWCTW9999` — https://github.com/CTWCTW9999
- Original source repository: https://github.com/CTWCTW9999/dsh-agent-preset-router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.