### PR TITLE
catalog: add cuboteam-dsh-plugin-dit (community curation, created by @cuboteam)

### DIFF
--- a/catalog/plugins/cuboteam-dsh-plugin-dit.yaml
+++ b/catalog/plugins/cuboteam-dsh-plugin-dit.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: cuboteam-dsh-plugin-dit
+name: dsh-plugin-dit
+description:
+  en: Dual-protocol DIT.ai provider and first-run onboarding for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dit
+  - ai-gateway
+  - openai-compatible
+  - anthropic-messages
+  - dsh
+source:
+  repository: https://github.com/cuboteam/dsh-plugin-dit
+  repositoryNodeId: R_kgDOT77NeQ
+  subpath: null
+  commit: efe42f034237e3ad79d55995b3f0830d7ff83a4f
+creator:
+  github: cuboteam
+package:
+  ecosystem: npm
+  name: dsh-plugin-dit
+  version: 0.2.1
+  integrity: sha512-JOQ37z7GOKOIxgzTm/0CwZRY0uvbtrenykp5NFsdLzlt5xWokLawOIfvIZl/TzbZ6bUrCF+pi9YfEBzXwEDFQQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:22.992Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cuboteam-dsh-plugin-dit`
- Submission type: community curation
- Created by `cuboteam` — https://github.com/cuboteam
- Original source repository: https://github.com/cuboteam/dsh-plugin-dit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.