### PR TITLE
catalog: add cynch18-dsh-profile-plugin-switch (community curation, created by @cynch18)

### DIFF
--- a/catalog/plugins/cynch18-dsh-profile-plugin-switch.yaml
+++ b/catalog/plugins/cynch18-dsh-profile-plugin-switch.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: cynch18-dsh-profile-plugin-switch
+name: dsh-profile-plugin-switch
+description:
+  en: "DeepSeek Harness (DSH) web plugin: toggle any plugin on/off from the GUI, live, without restarting the server."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - toggle
+  - live
+  - without
+  - restarting
+  - server
+  - dsh
+source:
+  repository: https://github.com/cynch18/plugin-switch
+  repositoryNodeId: R_kgDOT4l72Q
+  subpath: null
+  commit: 8a0df71f0eacd410f70d3dc7166450b84998b2e8
+creator:
+  github: cynch18
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:26.234Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cynch18-dsh-profile-plugin-switch`
- Submission type: community curation
- Created by `cynch18` — https://github.com/cynch18
- Original source repository: https://github.com/cynch18/plugin-switch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.