### PR TITLE
catalog: add cyphernaught-0x-dsh-subagent-model-router (community curation, created by @CypherNaught-0x)

### DIFF
--- a/catalog/plugins/cyphernaught-0x-dsh-subagent-model-router.yaml
+++ b/catalog/plugins/cyphernaught-0x-dsh-subagent-model-router.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: cyphernaught-0x-dsh-subagent-model-router
+name: dsh-subagent-model-router
+description:
+  en: Model-selectable subagents and guided model routing setup for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - subagent
+  - model-routing
+source:
+  repository: https://github.com/CypherNaught-0x/DSH-Subagent-Model-Router
+  repositoryNodeId: R_kgDOT7waCw
+  subpath: null
+  commit: d2c04c2634ad4047e7b9b419cdf43eab8f4a9172
+creator:
+  github: CypherNaught-0x
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:24.715Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cyphernaught-0x-dsh-subagent-model-router`
- Submission type: community curation
- Created by `CypherNaught-0x` — https://github.com/CypherNaught-0x
- Original source repository: https://github.com/CypherNaught-0x/DSH-Subagent-Model-Router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.