### PR TITLE
catalog: add cz1900-suanzhang-dsh (community curation, created by @CZ1900)

### DIFF
--- a/catalog/plugins/cz1900-suanzhang-dsh.yaml
+++ b/catalog/plugins/cz1900-suanzhang-dsh.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: cz1900-suanzhang-dsh
+name: suanzhang-dsh
+description:
+  en: "A little \"bookkeeper\" for DeepSeek Harness (dsh): your balance, today's spending, and how much each model step costs — all crystal clear, no more guessing."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - billing
+  - cost
+  - suanzhang
+source:
+  repository: https://github.com/CZ1900/suanzhang-dsh
+  repositoryNodeId: R_kgDOT9L--A
+  subpath: null
+  commit: 79cd9cd793326b3069679cbfc2dc5558af35c842
+creator:
+  github: CZ1900
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:26.486Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cz1900-suanzhang-dsh`
- Submission type: community curation
- Created by `CZ1900` — https://github.com/CZ1900
- Original source repository: https://github.com/CZ1900/suanzhang-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.