### PR TITLE
catalog: add czx2244-dsh-bilibili (community curation, created by @CZX2244)

### DIFF
--- a/catalog/plugins/czx2244-dsh-bilibili.yaml
+++ b/catalog/plugins/czx2244-dsh-bilibili.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: czx2244-dsh-bilibili
+name: dsh-bilibili
+description:
+  en: "DeepSeek Harness tool plugin: analyze Bilibili videos — transcript first, subtitle-driven keyframes, model summaries"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - bilibili
+  - video
+  - tool
+  - cordis
+source:
+  repository: https://github.com/CZX2244/dsh-bilibili
+  repositoryNodeId: R_kgDOT4HLgA
+  subpath: null
+  commit: b4a02753469d0e4368fe827a49fa76c5e8735737
+creator:
+  github: CZX2244
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:11.231Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `czx2244-dsh-bilibili`
- Submission type: community curation
- Created by `CZX2244` — https://github.com/CZX2244
- Original source repository: https://github.com/CZX2244/dsh-bilibili
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.