### PR TITLE
catalog: add dami9527-dsh-image-pathify (community curation, created by @dami9527)

### DIFF
--- a/catalog/plugins/dami9527-dsh-image-pathify.yaml
+++ b/catalog/plugins/dami9527-dsh-image-pathify.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: dami9527-dsh-image-pathify
+name: dsh-image-pathify
+description:
+  en: "DeepSeek Harness plugin: let text-only models receive pasted images, and analyze them with a built-in OpenAI-compatible vision tool"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - vision
+  - image
+source:
+  repository: https://github.com/dami9527/dsh-image-pathify
+  repositoryNodeId: R_kgDOT5KEpg
+  subpath: null
+  commit: 5abd3d47a7df80f6dd498168e307765821e92d2e
+creator:
+  github: dami9527
+package:
+  ecosystem: npm
+  name: dsh-image-pathify
+  version: 0.1.5
+  integrity: sha512-9XkD3BjCgD6OtKF/kWO25yhMSyCFCeacez2InB5Df3kdKd8/FnclCq95AyvSJz13C00gTqwc9t9Z399F2uIStw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:48.995Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dami9527-dsh-image-pathify`
- Submission type: community curation
- Created by `dami9527` — https://github.com/dami9527
- Original source repository: https://github.com/dami9527/dsh-image-pathify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.