### PR TITLE
catalog: add damonkoy-dsh-approve-for-me (community curation, created by @DamonKoy)

### DIFF
--- a/catalog/plugins/damonkoy-dsh-approve-for-me.yaml
+++ b/catalog/plugins/damonkoy-dsh-approve-for-me.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: damonkoy-dsh-approve-for-me
+name: dsh-approve-for-me
+description:
+  en: Automated approval review for DeepSeek Harness. Inspired by Codex 0.147's --approve-for-me (Guardian auto-review).
+  evidencePath: packages/dsh-approve-for-me/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - approval
+  - guardian
+  - security
+source:
+  repository: https://github.com/DamonKoy/dsh-plugins
+  repositoryNodeId: R_kgDOT5YuGg
+  subpath: packages/dsh-approve-for-me
+  commit: 48110ca2779b59d36edec46c8aff97b6a50322aa
+creator:
+  github: DamonKoy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-approve-for-me/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:27.198Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `damonkoy-dsh-approve-for-me`
- Submission type: community curation
- Created by `DamonKoy` — https://github.com/DamonKoy
- Original source repository: https://github.com/DamonKoy/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.