### PR TITLE
catalog: add damonkoy-dsh-secret-redactor (community curation, created by @DamonKoy)

### DIFF
--- a/catalog/plugins/damonkoy-dsh-secret-redactor.yaml
+++ b/catalog/plugins/damonkoy-dsh-secret-redactor.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: damonkoy-dsh-secret-redactor
+name: dsh-secret-redactor
+description:
+  en: "Sensitive-information redaction for DeepSeek Harness: masks API keys, bearer tokens, JWTs, private keys and configured secrets in every tool result shown to the model, plus a redact text tool and a redact RPC. · DSH 敏感信息脱敏插件：自动掩码工具输出中的 API key / token / 私钥 / 配置密钥。"
+  evidencePath: packages/dsh-secret-redactor/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - security
+  - redaction
+  - secret
+source:
+  repository: https://github.com/DamonKoy/dsh-plugins
+  repositoryNodeId: R_kgDOT5YuGg
+  subpath: packages/dsh-secret-redactor
+  commit: 48110ca2779b59d36edec46c8aff97b6a50322aa
+creator:
+  github: DamonKoy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-secret-redactor/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:27.198Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `damonkoy-dsh-secret-redactor`
- Submission type: community curation
- Created by `DamonKoy` — https://github.com/DamonKoy
- Original source repository: https://github.com/DamonKoy/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.