### PR TITLE
catalog: add dd2673-dsh-cross-session-agent (community curation, created by @dd2673)

### DIFF
--- a/catalog/plugins/dd2673-dsh-cross-session-agent.yaml
+++ b/catalog/plugins/dd2673-dsh-cross-session-agent.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: dd2673-dsh-cross-session-agent
+name: dsh-cross-session-agent
+description:
+  en: Unofficial bounded peer discovery, messaging, receipts, and safe context projection for DeepSeek Harness agents.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - agent
+  - multi-agent
+  - cross-session
+  - context
+  - dsh
+source:
+  repository: https://github.com/dd2673/dsh-cross-session-agent
+  repositoryNodeId: R_kgDOT5Wqlw
+  subpath: null
+  commit: f0f7c3d6ab66c66f19472ae33220bad4613724d4
+creator:
+  github: dd2673
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:14.572Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dd2673-dsh-cross-session-agent`
- Submission type: community curation
- Created by `dd2673` — https://github.com/dd2673
- Original source repository: https://github.com/dd2673/dsh-cross-session-agent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.