### PR TITLE
catalog: add ddtcorex-agent-dev-skills (community curation, created by @ddtcorex)

### DIFF
--- a/catalog/plugins/ddtcorex-agent-dev-skills.yaml
+++ b/catalog/plugins/ddtcorex-agent-dev-skills.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: ddtcorex-agent-dev-skills
+name: "@ddtcorex/agent-dev-skills"
+description:
+  en: Magento 2 development skills (8) with Govard/Laravel environment tooling (3), packaged as a Cordis plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - magento
+  - development
+  - skills
+  - govard
+  - laravel
+  - environment
+  - tooling
+  - packaged
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/ddtcorex/maestro-skills
+  repositoryNodeId: R_kgDOSnK4Jw
+  subpath: null
+  commit: aedbc8f0267fa3b56cafea68a68a27e873b46796
+creator:
+  github: ddtcorex
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:53.745Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ddtcorex-agent-dev-skills`
- Submission type: community curation
- Created by `ddtcorex` — https://github.com/ddtcorex
- Original source repository: https://github.com/ddtcorex/maestro-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.