### PR TITLE
catalog: add deeptrial-dsh-bash-rtk (community curation, created by @DeepTrial)

### DIFF
--- a/catalog/plugins/deeptrial-dsh-bash-rtk.yaml
+++ b/catalog/plugins/deeptrial-dsh-bash-rtk.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: deeptrial-dsh-bash-rtk
+name: "@deeptrial/dsh-bash-rtk"
+description:
+  en: "DeepSeek Harness bash executor plugin that routes eligible commands through rtk (Rust Token Killer) to compress tool output and save tokens. Optional overlay: install, then enable via --patch."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - rtk
+  - token-compression
+  - bash
+  - shell
+  - cordis
+source:
+  repository: https://github.com/DeepTrial/dsh-bash-rtk
+  repositoryNodeId: R_kgDOT4O-Vg
+  subpath: null
+  commit: ddf95382252c96bcaba983e8a1c71ff66b79fc6b
+creator:
+  github: DeepTrial
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:48:57.042Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `deeptrial-dsh-bash-rtk`
- Submission type: community curation
- Created by `DeepTrial` — https://github.com/DeepTrial
- Original source repository: https://github.com/DeepTrial/dsh-bash-rtk
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.