### PR TITLE
catalog: add demacia1314-dsh-universal-attachments (community curation, created by @demacia1314)

### DIFF
--- a/catalog/plugins/demacia1314-dsh-universal-attachments.yaml
+++ b/catalog/plugins/demacia1314-dsh-universal-attachments.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: demacia1314-dsh-universal-attachments
+name: dsh-universal-attachments
+description:
+  en: ⭐ Drag-and-drop uploads&ensp;·&ensp;⭐ Remote-friendly&ensp;·&ensp;⭐ Any file type
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - attachments
+  - file-upload
+  - folder-upload
+  - drag-and-drop
+  - remote-upload
+  - dsh
+source:
+  repository: https://github.com/demacia1314/dsh-airdrop
+  repositoryNodeId: R_kgDOT7sPnw
+  subpath: null
+  commit: 05e6b924764f8ab6561467dbecff12978fd4940c
+creator:
+  github: demacia1314
+package:
+  ecosystem: npm
+  name: dsh-universal-attachments
+  version: 0.1.1
+  integrity: sha512-176ZZRoEo5WnQURO3fTiWfjXJ/7XPB1QZM6uiUeqRb+AB7qF3HL+8GIzpoBJ49Hk3V+3n/xtn2Z+NsuaC/6X0w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:29.954Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `demacia1314-dsh-universal-attachments`
- Submission type: community curation
- Created by `demacia1314` — https://github.com/demacia1314
- Original source repository: https://github.com/demacia1314/dsh-airdrop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.