### PR TITLE
catalog: add deveuper-dsh-vision-ds (community curation, created by @deveuper)

### DIFF
--- a/catalog/plugins/deveuper-dsh-vision-ds.yaml
+++ b/catalog/plugins/deveuper-dsh-vision-ds.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: deveuper-dsh-vision-ds
+name: dsh-vision-ds
+description:
+  en: "visionDS: DeepSeek Harness 视觉技能包。vision-ds（默认入口，API 超时自动回退本地）/ vision-ds-local（离线 OCR）/ vision-ds-api（API 识别）/ vision-setting（配置中枢）。Vision skills for DeepSeek Harness: vision-ds default entry with offline fallback, vision-ds-local offline OCR, vision-ds-api API recognition, vision-setting configuration."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - skill
+  - vision
+  - ocr
+  - vlm
+source:
+  repository: https://github.com/deveuper/visionDS
+  repositoryNodeId: R_kgDOT3knAg
+  subpath: null
+  commit: af8030c398f57a6c8a94dc165a0ab4d6c0ba99b5
+creator:
+  github: deveuper
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:31.921Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `deveuper-dsh-vision-ds`
- Submission type: community curation
- Created by `deveuper` — https://github.com/deveuper
- Original source repository: https://github.com/deveuper/visionDS
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.