### PR TITLE
catalog: add dhicoc-dsh-codex-web-search-mcp (community curation, created by @dhicoc)

### DIFF
--- a/catalog/plugins/dhicoc-dsh-codex-web-search-mcp.yaml
+++ b/catalog/plugins/dhicoc-dsh-codex-web-search-mcp.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: dhicoc-dsh-codex-web-search-mcp
+name: "@dhicoc/dsh-codex-web-search-mcp"
+description:
+  en: "dsh plugin: register codex-web-search-mcp (model-independent OpenAI Codex / Grok web search & deep research MCP server) as a native dsh MCP tool set (mcp codex-web-search )."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - mcp
+  - codex
+  - grok
+  - web-search
+  - deep-research
+  - search
+source:
+  repository: https://github.com/dhicoc/dsh-codex-web-search-mcp
+  repositoryNodeId: R_kgDOT6DMZQ
+  subpath: null
+  commit: 926c6d15a9a656dbdcb0c399b3007c8e1f303d56
+creator:
+  github: dhicoc
+package:
+  ecosystem: npm
+  name: "@dhicoc/dsh-codex-web-search-mcp"
+  version: 1.0.2
+  integrity: sha512-sLDmuw3CaZW9AIFlQflJ/1bTM1Ux8eBubmYKBkMwqxSOJ1Ig2/A9y7KeLlymXTfEJHH+G9rIVkhXS5Ny9uNd/Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:34.229Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dhicoc-dsh-codex-web-search-mcp`
- Submission type: community curation
- Created by `dhicoc` — https://github.com/dhicoc
- Original source repository: https://github.com/dhicoc/dsh-codex-web-search-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.