### PR TITLE
catalog: add dhicoc-dsh-theme-mineradio (community curation, created by @dhicoc)

### DIFF
--- a/catalog/plugins/dhicoc-dsh-theme-mineradio.yaml
+++ b/catalog/plugins/dhicoc-dsh-theme-mineradio.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: dhicoc-dsh-theme-mineradio
+name: dsh-theme-mineradio
+description:
+  en: "Mineradio: a cinematic private-visual-radio glass theme for the Web surface — champagne glow, fluid or wallpaper backdrop, unified corners, and motion"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - mineradio
+  - cinematic
+  - private
+  - visual
+  - radio
+  - glass
+  - theme
+  - surface
+  - champagne
+  - glow
+  - fluid
+  - wallpaper
+  - backdrop
+  - unified
+  - corners
+  - motion
+source:
+  repository: https://github.com/dhicoc/dsh-theme-mineradio
+  repositoryNodeId: R_kgDOT7EPfg
+  subpath: null
+  commit: cb6bf301cf756c0b59f2acb325a539c2eac85027
+creator:
+  github: dhicoc
+package:
+  ecosystem: npm
+  name: dsh-theme-mineradio
+  version: 2.0.1
+  integrity: sha512-CVBVH32PgGsSljckurp0V4XfFpIYa9OP63WifAH3NBLAPFqvFXV7motjVrjtuuuI/jYQKkcI5Tacqus9KdYtwg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:36.443Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dhicoc-dsh-theme-mineradio`
- Submission type: community curation
- Created by `dhicoc` — https://github.com/dhicoc
- Original source repository: https://github.com/dhicoc/dsh-theme-mineradio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.