### PR TITLE
catalog: add diqierjia-stratagate-dsh (community curation, created by @diqierjia)

### DIFF
--- a/catalog/plugins/diqierjia-stratagate-dsh.yaml
+++ b/catalog/plugins/diqierjia-stratagate-dsh.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: diqierjia-stratagate-dsh
+name: stratagate-dsh
+description:
+  en: Automatic local-first cross-session memory for DeepSeek Harness with source-traceable recall
+  evidencePath: integrations/deepseek-harness/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - agent-memory
+  - cross-session-memory
+  - persistent-memory
+  - project-memory
+  - conversation-memory
+  - long-term-memory
+  - local-first
+  - source-tracing
+  - evidence-gate
+  - dsh
+source:
+  repository: https://github.com/diqierjia/StrataGate-AgentMemory
+  repositoryNodeId: R_kgDOT0XE8Q
+  subpath: integrations/deepseek-harness
+  commit: 2f542bfe72b1cb3d887d7690ed6795446db09c5a
+creator:
+  github: diqierjia
+package:
+  ecosystem: npm
+  name: stratagate-dsh
+  version: 0.2.1
+  integrity: sha512-gFjG+sPJd37gBWxbRkKaShMiV9+SwPVbAeMgVz/lu4WY/GYWy6nRt+Nu0PoGRabq80dctqtmfgtDVkmPYZUK3w==
+dsh:
+  profiles:
+    - web
+  evidencePath: integrations/deepseek-harness/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:17.507Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `diqierjia-stratagate-dsh`
- Submission type: community curation
- Created by `diqierjia` — https://github.com/diqierjia
- Original source repository: https://github.com/diqierjia/StrataGate-AgentMemory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.