### PR TITLE
catalog: add dk33333333-dsh-deepseek-quota-left (community curation, created by @dk33333333)

### DIFF
--- a/catalog/plugins/dk33333333-dsh-deepseek-quota-left.yaml
+++ b/catalog/plugins/dk33333333-dsh-deepseek-quota-left.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: dk33333333-dsh-deepseek-quota-left
+name: dsh-deepseek-quota-left
+description:
+  en: DeepSeek API quota widget for the dsh web GUI — left-edge collapsed handle, click to expand; official balance, today's consumption and conversation cost. Fork of dsh-deepseek-quota.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - quota
+  - balance
+  - web
+source:
+  repository: https://github.com/dk33333333/dsh-deepseek-quota-left
+  repositoryNodeId: R_kgDOT5uYOg
+  subpath: null
+  commit: a486b75b6ff025b4d1738d6f866071893775fc18
+creator:
+  github: dk33333333
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:21.032Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dk33333333-dsh-deepseek-quota-left`
- Submission type: community curation
- Created by `dk33333333` — https://github.com/dk33333333
- Original source repository: https://github.com/dk33333333/dsh-deepseek-quota-left
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.