### PR TITLE
catalog: add dominic789654-dsh-research-loop (community curation, created by @Dominic789654)

### DIFF
--- a/catalog/plugins/dominic789654-dsh-research-loop.yaml
+++ b/catalog/plugins/dominic789654-dsh-research-loop.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dominic789654-dsh-research-loop
+name: dsh-research-loop
+description:
+  en: "Auto-research loop for DeepSeek Harness: a durable research log tool (append-only JSONL per topic) plus a skill that drives a plan → search → read → synthesize loop with explicit stop conditions."
+  evidencePath: plugins/dsh-research-loop/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - auto
+  - research
+  - loop
+  - durable
+  - tool
+  - append
+  - only
+  - jsonl
+  - topic
+  - plus
+  - skill
+  - drives
+  - plan
+  - search
+  - read
+  - synthesize
+source:
+  repository: https://github.com/Dominic789654/awesome-deepseek-harness
+  repositoryNodeId: R_kgDOT3adrQ
+  subpath: plugins/dsh-research-loop
+  commit: 43a625cb31e8197354ddfcc93a9e65eb37e55f2c
+creator:
+  github: Dominic789654
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: plugins/dsh-research-loop/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:23.247Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dominic789654-dsh-research-loop`
- Submission type: community curation
- Created by `Dominic789654` — https://github.com/Dominic789654
- Original source repository: https://github.com/Dominic789654/awesome-deepseek-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.