### PR TITLE
catalog: add dominic789654-dsh-viz (community curation, created by @Dominic789654)

### DIFF
--- a/catalog/plugins/dominic789654-dsh-viz.yaml
+++ b/catalog/plugins/dominic789654-dsh-viz.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: dominic789654-dsh-viz
+name: dsh-viz
+description:
+  en: "Visualization tool for DeepSeek Harness: chart render turns structured data into a self-contained ECharts HTML artifact inside the active workspace."
+  evidencePath: plugins/dsh-viz/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - visualization
+  - tool
+  - chart
+  - render
+  - turns
+  - structured
+  - data
+  - self
+  - contained
+  - echarts
+  - html
+  - artifact
+  - inside
+  - active
+  - workspace
+  - dsh
+source:
+  repository: https://github.com/Dominic789654/awesome-deepseek-harness
+  repositoryNodeId: R_kgDOT3adrQ
+  subpath: plugins/dsh-viz
+  commit: 43a625cb31e8197354ddfcc93a9e65eb37e55f2c
+creator:
+  github: Dominic789654
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: plugins/dsh-viz/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:23.247Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dominic789654-dsh-viz`
- Submission type: community curation
- Created by `Dominic789654` — https://github.com/Dominic789654
- Original source repository: https://github.com/Dominic789654/awesome-deepseek-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.