### PR TITLE
catalog: add don738110198-dsh-session-integrity (community curation, created by @DON738110198)

### DIFF
--- a/catalog/plugins/don738110198-dsh-session-integrity.yaml
+++ b/catalog/plugins/don738110198-dsh-session-integrity.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: don738110198-dsh-session-integrity
+name: dsh-session-integrity
+description:
+  en: Diagnose DeepSeek Harness session integrity failures and continue from safe recovery boundaries
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - agent
+  - session-integrity
+  - dsh
+source:
+  repository: https://github.com/DON738110198/dsh-session-integrity
+  repositoryNodeId: R_kgDOT-SuVw
+  subpath: null
+  commit: 3d8cad4802f753b1f76e7b9c16873e2c9c302333
+creator:
+  github: DON738110198
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:45.383Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `don738110198-dsh-session-integrity`
- Submission type: community curation
- Created by `DON738110198` — https://github.com/DON738110198
- Original source repository: https://github.com/DON738110198/dsh-session-integrity
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.