### PR TITLE
catalog: add doncelee229-cmyk-dsh-plugin-approval-alert (community curation, created by @doncelee229-cmyk)

### DIFF
--- a/catalog/plugins/doncelee229-cmyk-dsh-plugin-approval-alert.yaml
+++ b/catalog/plugins/doncelee229-cmyk-dsh-plugin-approval-alert.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: doncelee229-cmyk-dsh-plugin-approval-alert
+name: dsh-plugin-approval-alert
+description:
+  en: DeepSeek Harness 审批提醒插件 · Approval Alert for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - approval
+  - notification
+  - alert
+  - web-notifications
+  - workspace
+source:
+  repository: https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert
+  repositoryNodeId: R_kgDOT4XLKA
+  subpath: null
+  commit: 8c25a602ef9aabc61f886714b443ba9ce7831c77
+creator:
+  github: doncelee229-cmyk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:38.562Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `doncelee229-cmyk-dsh-plugin-approval-alert`
- Submission type: community curation
- Created by `doncelee229-cmyk` — https://github.com/doncelee229-cmyk
- Original source repository: https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.