### PR TITLE
catalog: add dongwenxiu83-web-dsh-friendly-steps (community curation, created by @dongwenxiu83-web)

### DIFF
--- a/catalog/plugins/dongwenxiu83-web-dsh-friendly-steps.yaml
+++ b/catalog/plugins/dongwenxiu83-web-dsh-friendly-steps.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: dongwenxiu83-web-dsh-friendly-steps
+name: dsh-friendly-steps
+description:
+  en: Friendly process collapse for the DeepSeek Harness Web GUI — hides technical Think / tool-call rows behind a small summary pill, for non-technical readers. 100% presentation-only CSS + a createRoot pill on document.body ; zero interference with React rendering.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - web-ui
+source:
+  repository: https://github.com/dongwenxiu83-web/dsh-friendly-steps
+  repositoryNodeId: R_kgDOT8ay6Q
+  subpath: null
+  commit: b370e3f2891660875632f9ba43682cb4baaa452d
+creator:
+  github: dongwenxiu83-web
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:40.144Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dongwenxiu83-web-dsh-friendly-steps`
- Submission type: community curation
- Created by `dongwenxiu83-web` — https://github.com/dongwenxiu83-web
- Original source repository: https://github.com/dongwenxiu83-web/dsh-friendly-steps
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.