### PR TITLE
catalog: add donnietangzhili-dsh-ops-console (community curation, created by @DonnieTangzhili)

### DIFF
--- a/catalog/plugins/donnietangzhili-dsh-ops-console.yaml
+++ b/catalog/plugins/donnietangzhili-dsh-ops-console.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: donnietangzhili-dsh-ops-console
+name: dsh-ops-console
+description:
+  en: bash dsh plugin --profile web add github:DonnieTangzhili/dsh-ops-console
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - bash
+  - profile
+  - donnietangzhili
+  - console
+  - dsh
+source:
+  repository: https://github.com/DonnieTangzhili/dsh-ops-console
+  repositoryNodeId: R_kgDOT-b0_g
+  subpath: null
+  commit: 02427ca3db5b370169c993bedd5374c007800ff6
+creator:
+  github: DonnieTangzhili
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:32.135Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `donnietangzhili-dsh-ops-console`
- Submission type: community curation
- Created by `DonnieTangzhili` — https://github.com/DonnieTangzhili
- Original source repository: https://github.com/DonnieTangzhili/dsh-ops-console
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.