### PR TITLE
catalog: add drscrewdriver-dsh-input-traffic (community curation, created by @drscrewdriver)

### DIFF
--- a/catalog/plugins/drscrewdriver-dsh-input-traffic.yaml
+++ b/catalog/plugins/drscrewdriver-dsh-input-traffic.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: drscrewdriver-dsh-input-traffic
+name: dsh-input-traffic
+description:
+  en: "Busy-time input queue for the DeepSeek Harness web GUI: three-tier (now/next/later) planning, queue editing with drag-to-reorder and concurrency protection, interject (steer) and interrupt, batch clear with confirm, session freeze - a cordis client plugin, no dsh source changes, no PR required"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - busy
+  - time
+  - input
+  - queue
+  - three
+  - tier
+  - next
+  - later
+  - planning
+  - editing
+  - drag
+  - reorder
+  - concurrency
+  - protection
+  - interject
+  - steer
+source:
+  repository: https://github.com/drscrewdriver/dsh-input-traffic
+  repositoryNodeId: R_kgDOT7E4VA
+  subpath: null
+  commit: 74beb2360920ee519315aee6e07ca00bb0449db5
+creator:
+  github: drscrewdriver
+package:
+  ecosystem: npm
+  name: dsh-input-traffic
+  version: 0.2.6
+  integrity: sha512-j2t/0vfA8e3xOLzTlkWIu+Fj2kugy41A/LHuIcv//6DzMI3mRj+W56kAU7Jtut+HjjPWALKvZIRw80qitTF99A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:56.101Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `drscrewdriver-dsh-input-traffic`
- Submission type: community curation
- Created by `drscrewdriver` — https://github.com/drscrewdriver
- Original source repository: https://github.com/drscrewdriver/dsh-input-traffic
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.