### PR TITLE
catalog: add duoasa-dsh-plugin-preview (community curation, created by @Duoasa)

### DIFF
--- a/catalog/plugins/duoasa-dsh-plugin-preview.yaml
+++ b/catalog/plugins/duoasa-dsh-plugin-preview.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: duoasa-dsh-plugin-preview
+name: "@deepviewer/dsh-plugin-preview"
+description:
+  en: Workspace-scoped code and static web preview for DeepViewer
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - workspace
+  - scoped
+  - code
+  - static
+  - preview
+  - deepviewer
+  - dsh
+source:
+  repository: https://github.com/Duoasa/DeepViewer
+  repositoryNodeId: R_kgDOT5RwvA
+  subpath: apps/deepviewer-desktop/dsh-plugins/preview
+  commit: a9e89a0b9313e58010076c345f53101b3267f31c
+creator:
+  github: Duoasa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: apps/deepviewer-desktop/dsh-plugins/preview/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:54.348Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `duoasa-dsh-plugin-preview`
- Submission type: community curation
- Created by `Duoasa` — https://github.com/Duoasa
- Original source repository: https://github.com/Duoasa/DeepViewer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.