### PR TITLE
catalog: add duyanta123-arch-doc (community curation, created by @duyanta123)

### DIFF
--- a/catalog/plugins/duyanta123-arch-doc.yaml
+++ b/catalog/plugins/duyanta123-arch-doc.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: duyanta123-arch-doc
+name: arch-doc
+description:
+  en: "DSH arch-doc skill plugin: analyze a codebase and generate architecture documentation (module responsibilities, dependencies, entry points and run methods)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - architecture
+  - documentation
+  - code-analysis
+  - dependency-graph
+  - skills
+source:
+  repository: https://github.com/duyanta123/arch-doc
+  repositoryNodeId: R_kgDOT6EW-g
+  subpath: null
+  commit: db89d3b1466e667626914fca538f52be7180ae4b
+creator:
+  github: duyanta123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:56.404Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `duyanta123-arch-doc`
- Submission type: community curation
- Created by `duyanta123` — https://github.com/duyanta123
- Original source repository: https://github.com/duyanta123/arch-doc
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.