### PR TITLE
catalog: add duyanta123-dsh-data-insight (community curation, created by @duyanta123)

### DIFF
--- a/catalog/plugins/duyanta123-dsh-data-insight.yaml
+++ b/catalog/plugins/duyanta123-dsh-data-insight.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: duyanta123-dsh-data-insight
+name: dsh-data-insight
+description:
+  en: "DSH (DeepSeek Harness) data-insight skill plugin: turn raw data (CSV / pasted table / SQL results / DuckDB) into a structured Markdown report with business conclusions, metrics and charts."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - data-analysis
+  - data-insight
+  - analytics
+  - report
+  - csv
+  - duckdb
+  - skills
+source:
+  repository: https://github.com/duyanta123/dsh-data-insight
+  repositoryNodeId: R_kgDOT59UoA
+  subpath: null
+  commit: 7f0195f832b5eb64e56d6208f3ec4d3cf973dcce
+creator:
+  github: duyanta123
+package:
+  ecosystem: npm
+  name: dsh-data-insight
+  version: 0.1.1
+  integrity: sha512-/6Hann3xa0gESWHJSDcjezvaoswvS9fvecRhDK8H285fw1RiesX2EF858q3H0dBVoggBB/WGApgJO9tYfBHmfA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:02.868Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `duyanta123-dsh-data-insight`
- Submission type: community curation
- Created by `duyanta123` — https://github.com/duyanta123
- Original source repository: https://github.com/duyanta123/dsh-data-insight
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.