### PR TITLE
catalog: add duyanta123-dsh-preset-scaffold (community curation, created by @duyanta123)

### DIFF
--- a/catalog/plugins/duyanta123-dsh-preset-scaffold.yaml
+++ b/catalog/plugins/duyanta123-dsh-preset-scaffold.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: duyanta123-dsh-preset-scaffold
+name: dsh-preset-scaffold
+description:
+  en: "DSH (DeepSeek Harness) scaffold plugin & preset: strict 5-phase init runbook, engineering standards, and six runnable starter templates (node-ts / react-vite / python / go / spring-boot / monorepo). 项目初始化脚手架预设：严格流程 + 工程规范 + 六套模板。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - scaffolding
+  - skills
+  - templates
+  - project-init
+  - agent
+source:
+  repository: https://github.com/duyanta123/dsh-preset-scaffold
+  repositoryNodeId: R_kgDOT5APUw
+  subpath: null
+  commit: 303d8b3e07efdbcc1b07365acaab870e6766bf08
+creator:
+  github: duyanta123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:58.220Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `duyanta123-dsh-preset-scaffold`
- Submission type: community curation
- Created by `duyanta123` — https://github.com/duyanta123
- Original source repository: https://github.com/duyanta123/dsh-preset-scaffold
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.