### PR TITLE
catalog: add dylan37670-plugin-panel (community curation, created by @Dylan37670)

### DIFF
--- a/catalog/plugins/dylan37670-plugin-panel.yaml
+++ b/catalog/plugins/dylan37670-plugin-panel.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: dylan37670-plugin-panel
+name: "@dsh-community/plugin-panel"
+description:
+  en: "Plugin Panel v6.11 閳?panel self-update: version check, update button and restart reminder."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-marketplace
+  - typescript
+source:
+  repository: https://github.com/Dylan37670/dsh-plugin-panel
+  repositoryNodeId: R_kgDOT5S0gQ
+  subpath: null
+  commit: 501eba40555d43b9aea47ff1cfc7a29db2f6d23b
+creator:
+  github: Dylan37670
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:37.224Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dylan37670-plugin-panel`
- Submission type: community curation
- Created by `Dylan37670` — https://github.com/Dylan37670
- Original source repository: https://github.com/Dylan37670/dsh-plugin-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.