### PR TITLE
catalog: add edge-echo-dsh-mcp-bridge (community curation, created by @Edge-Echo)

### DIFF
--- a/catalog/plugins/edge-echo-dsh-mcp-bridge.yaml
+++ b/catalog/plugins/edge-echo-dsh-mcp-bridge.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: edge-echo-dsh-mcp-bridge
+name: dsh-mcp-bridge
+description:
+  en: "Curated, verified MCP server bundle for DeepSeek Harness (dsh): one install brings demo, memory, filesystem, GitHub, Playwright and remote HTTP MCP servers, with a connectivity verifier and CI checks."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - dsh-bundle
+  - deepseek-harness
+  - mcp
+  - model-context-protocol
+  - cordis
+source:
+  repository: https://github.com/Edge-Echo/dsh-mcp-bridge
+  repositoryNodeId: R_kgDOT4pRrw
+  subpath: null
+  commit: 77cc8eae48495055f5392046b9f2317cc72fdc5c
+creator:
+  github: Edge-Echo
+package:
+  ecosystem: npm
+  name: dsh-mcp-bridge
+  version: 0.1.3
+  integrity: sha512-iyhhAp8q5cf0nv9HmOtroIS3xGDQURiXCOEIYCuVP6YPI14w5p8vWisem18MgVSbHsDICHMOsdL2MlwOtNWUDQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:13.846Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `edge-echo-dsh-mcp-bridge`
- Submission type: community curation
- Created by `Edge-Echo` — https://github.com/Edge-Echo
- Original source repository: https://github.com/Edge-Echo/dsh-mcp-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.