### PR TITLE
catalog: add edwindigital-dsh-web-search-microsoft-webiq (community curation, created by @EdwinDigital)

### DIFF
--- a/catalog/plugins/edwindigital-dsh-web-search-microsoft-webiq.yaml
+++ b/catalog/plugins/edwindigital-dsh-web-search-microsoft-webiq.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: edwindigital-dsh-web-search-microsoft-webiq
+name: "@edwindigital/dsh-web-search-microsoft-webiq"
+description:
+  en: Microsoft Web IQ search provider and configuration card for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - web-search
+  - microsoft-web-iq
+  - dsh
+source:
+  repository: https://github.com/EdwinDigital/dsh-web-search-microsoft-webiq
+  repositoryNodeId: R_kgDOT8b7QA
+  subpath: null
+  commit: 40d8cc7703a72844cd7b1644105b45e722c4e47b
+creator:
+  github: EdwinDigital
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:59.801Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `edwindigital-dsh-web-search-microsoft-webiq`
- Submission type: community curation
- Created by `EdwinDigital` — https://github.com/EdwinDigital
- Original source repository: https://github.com/EdwinDigital/dsh-web-search-microsoft-webiq
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.