### PR TITLE
catalog: add eightfs-dsh-git-rescue (community curation, created by @EIGHTfs)

### DIFF
--- a/catalog/plugins/eightfs-dsh-git-rescue.yaml
+++ b/catalog/plugins/eightfs-dsh-git-rescue.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: eightfs-dsh-git-rescue
+name: dsh-git-rescue
+description:
+  en: Agent 工具 ： git rescue status / git rescue init / git rescue backup / git rescue log / git rescue rollback / git rescue push / git rescue restart / git rescue repair / git rescue rescue env / git rescue boot autostart / git rescue link recovery
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - agent
+  - rescue
+  - status
+  - init
+  - backup
+  - rollback
+  - push
+  - restart
+  - repair
+  - boot
+  - autostart
+  - link
+  - recovery
+  - dsh
+source:
+  repository: https://github.com/EIGHTfs/dsh-git-rescue
+  repositoryNodeId: R_kgDOT_fhKQ
+  subpath: null
+  commit: 151618459d4144b8739c5eabead0954e57069579
+creator:
+  github: EIGHTfs
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:01.589Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `eightfs-dsh-git-rescue`
- Submission type: community curation
- Created by `EIGHTfs` — https://github.com/EIGHTfs
- Original source repository: https://github.com/EIGHTfs/dsh-git-rescue
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.