### PR TITLE
catalog: add eighthundreds-dsh-plannotator (community curation, created by @eightHundreds)

### DIFF
--- a/catalog/plugins/eighthundreds-dsh-plannotator.yaml
+++ b/catalog/plugins/eighthundreds-dsh-plannotator.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: eighthundreds-dsh-plannotator
+name: dsh-plannotator
+description:
+  en: Opens the official Plannotator app to review the agent's plan — annotate, approve, or send it back.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - plannotator
+  - plan-review
+  - cordis
+source:
+  repository: https://github.com/eightHundreds/dsh-plannotator
+  repositoryNodeId: R_kgDOT7LsUA
+  subpath: null
+  commit: 372c19fd39a9cb427170ecf944c1278a6751f144
+creator:
+  github: eightHundreds
+package:
+  ecosystem: npm
+  name: dsh-plannotator
+  version: 0.2.0
+  integrity: sha512-oTE2ij7xQ6t7rCfqzPx+x0SISTg7iiGlvD/HR+PlqRPjjV8mKyvOw7jrDoS3sMxdtBG5bGPaxxZzDRjLqnRbiA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT OR Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:03.843Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `eighthundreds-dsh-plannotator`
- Submission type: community curation
- Created by `eightHundreds` — https://github.com/eightHundreds
- Original source repository: https://github.com/eightHundreds/dsh-plannotator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.