### PR TITLE
catalog: add elohia-dsh-plugin-image-input (community curation, created by @Elohia)

### DIFF
--- a/catalog/plugins/elohia-dsh-plugin-image-input.yaml
+++ b/catalog/plugins/elohia-dsh-plugin-image-input.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: elohia-dsh-plugin-image-input
+name: dsh-plugin-image-input
+description:
+  en: sh dsh plugin --profile web add D:\path\to\dsh-plugin-image-input
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - profile
+  - path
+  - image
+  - input
+  - dsh
+source:
+  repository: https://github.com/Elohia/dsh-plugin-image-input
+  repositoryNodeId: R_kgDOT48LRA
+  subpath: null
+  commit: a96667f6b1445322892ae52d9c9e6c210300b0ec
+creator:
+  github: Elohia
+package:
+  ecosystem: npm
+  name: dsh-plugin-image-input
+  version: 0.1.1
+  integrity: sha512-pUXVpaVU3lr4N/WLsMtdLe3WUG6AZbmSUx9vY9zhqY8JbNW40roUS/iQP+y8omheQnDGPqACDalUl5li9QiYEg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:05.856Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `elohia-dsh-plugin-image-input`
- Submission type: community curation
- Created by `Elohia` — https://github.com/Elohia
- Original source repository: https://github.com/Elohia/dsh-plugin-image-input
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.