### PR TITLE
catalog: add elohia-dsh-plugin-mm-vision (community curation, created by @Elohia)

### DIFF
--- a/catalog/plugins/elohia-dsh-plugin-mm-vision.yaml
+++ b/catalog/plugins/elohia-dsh-plugin-mm-vision.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: elohia-dsh-plugin-mm-vision
+name: dsh-plugin-mm-vision
+description:
+  en: mm-vision (通感编码器) for DeepSeek Harness — give any text-only LLM the ability to see images via structured spatial text encoding. Registers the mm vision tool.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - vision
+  - multimodal
+  - synesthesia
+  - kline
+  - chart
+  - mcp
+source:
+  repository: https://github.com/Elohia/dsh-plugin-mm-vision
+  repositoryNodeId: R_kgDOT3_URg
+  subpath: null
+  commit: b69fa6ec8018e10b017645d5232f480f0f8354f3
+creator:
+  github: Elohia
+package:
+  ecosystem: npm
+  name: dsh-plugin-mm-vision
+  version: 0.1.1
+  integrity: sha512-Cio9cgTvnRIR3j7NQ7XSsdUokzn+LXKLNDUwZBe8TYoBUzaZREStckq3eDD+s8rbHN9L+uGgOPeyJPYHjSXU6Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:42.092Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `elohia-dsh-plugin-mm-vision`
- Submission type: community curation
- Created by `Elohia` — https://github.com/Elohia
- Original source repository: https://github.com/Elohia/dsh-plugin-mm-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.