### PR TITLE
catalog: add eternalnight996-dsh-ui-agents-pixe (community curation, created by @EternalNight996)

### DIFF
--- a/catalog/plugins/eternalnight996-dsh-ui-agents-pixe.yaml
+++ b/catalog/plugins/eternalnight996-dsh-ui-agents-pixe.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: eternalnight996-dsh-ui-agents-pixe
+name: dsh-ui-agents-pixe
+description:
+  en: sh npx @deepseek-ai/dsh plugin --profile web add dsh-ui-agents-pixe
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agents-pixe
+  - pixel-office
+  - roles
+  - agency-agents
+source:
+  repository: https://github.com/EternalNight996/dsh-ui-agents-pixe
+  repositoryNodeId: R_kgDOT7T9uQ
+  subpath: null
+  commit: db57eaeee8783e6ea3fb19aac7fe69062f469183
+creator:
+  github: EternalNight996
+package:
+  ecosystem: npm
+  name: dsh-ui-agents-pixe
+  version: 1.0.3
+  integrity: sha512-fgkUKwza01lYZAh/rKWmZRNnrdCPUBoGaFere0QWSavz8XyHFijUdbjiEVryrz6vMNOIWHRTempZssarE+cpAQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:50.996Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `eternalnight996-dsh-ui-agents-pixe`
- Submission type: community curation
- Created by `EternalNight996` — https://github.com/EternalNight996
- Original source repository: https://github.com/EternalNight996/dsh-ui-agents-pixe
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.