### PR TITLE
catalog: add ethanz11-creat-dsh-billing-tui (community curation, created by @Ethanz11-creat)

### DIFF
--- a/catalog/plugins/ethanz11-creat-dsh-billing-tui.yaml
+++ b/catalog/plugins/ethanz11-creat-dsh-billing-tui.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: ethanz11-creat-dsh-billing-tui
+name: dsh-billing-tui
+description:
+  en: "[dsh]: https://github.com/deepseek-ai/dsh"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - billing
+  - tui
+  - cli
+  - terminal
+  - cordis
+  - token-usage
+  - peak-pricing
+  - ascii-art
+source:
+  repository: https://github.com/Ethanz11-creat/dsh-billing-tui
+  repositoryNodeId: R_kgDOT9F0Qw
+  subpath: null
+  commit: f853ddfff4e1bf9dbea9f8d59342043471cc9dcd
+creator:
+  github: Ethanz11-creat
+package:
+  ecosystem: npm
+  name: dsh-billing-tui
+  version: 0.1.0
+  integrity: sha512-T10boCXBguDtlnFQ+ZANmLpapuvvcsTeLiw0XSzStVbtaC0GGbrylLEqv+CPwRNdM7ZxSqsThdKffJqkHbk99Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:54.971Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ethanz11-creat-dsh-billing-tui`
- Submission type: community curation
- Created by `Ethanz11-creat` — https://github.com/Ethanz11-creat
- Original source repository: https://github.com/Ethanz11-creat/dsh-billing-tui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.