### PR TITLE
catalog: add evilirving-dsh-context-proxy (community curation, created by @EvilIrving)

### DIFF
--- a/catalog/plugins/evilirving-dsh-context-proxy.yaml
+++ b/catalog/plugins/evilirving-dsh-context-proxy.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: evilirving-dsh-context-proxy
+name: dsh-context-proxy
+description:
+  en: "Thin on-demand context-retrieval layer for DeepSeek Harness: context query / context slice / context grep tools over the sessionQuery and subprocess seams."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - thin
+  - demand
+  - context
+  - retrieval
+  - layer
+  - query
+  - slice
+  - grep
+  - tools
+  - over
+  - sessionquery
+  - subprocess
+  - seams
+  - dsh
+source:
+  repository: https://github.com/EvilIrving/dsh-context-proxy
+  repositoryNodeId: R_kgDOT39bcg
+  subpath: null
+  commit: 1e1965f51ace195272697ff55b9dc8d43798e6a6
+creator:
+  github: EvilIrving
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:57.511Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `evilirving-dsh-context-proxy`
- Submission type: community curation
- Created by `EvilIrving` — https://github.com/EvilIrving
- Original source repository: https://github.com/EvilIrving/dsh-context-proxy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.