### PR TITLE
catalog: add evilirving-dsh-proof (community curation, created by @EvilIrving)

### DIFF
--- a/catalog/plugins/evilirving-dsh-proof.yaml
+++ b/catalog/plugins/evilirving-dsh-proof.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: evilirving-dsh-proof
+name: dsh-proof
+description:
+  en: "Independent read-only acceptance layer for DeepSeek Harness: spawns a read-only verifier before each top-level turn closes and steers gaps back into the agent."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - independent
+  - read
+  - only
+  - acceptance
+  - layer
+  - spawns
+  - verifier
+  - before
+  - each
+  - level
+  - turn
+  - closes
+  - steers
+  - gaps
+  - back
+  - agent
+source:
+  repository: https://github.com/EvilIrving/dsh-proof
+  repositoryNodeId: R_kgDOT39bJw
+  subpath: null
+  commit: 7e5fb648ac9361e6705b4e139dda9da8fdb5eaac
+creator:
+  github: EvilIrving
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:44.024Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `evilirving-dsh-proof`
- Submission type: community curation
- Created by `EvilIrving` — https://github.com/EvilIrving
- Original source repository: https://github.com/EvilIrving/dsh-proof
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.