### PR TITLE
catalog: add evilirving-dsh-repro (community curation, created by @EvilIrving)

### DIFF
--- a/catalog/plugins/evilirving-dsh-repro.yaml
+++ b/catalog/plugins/evilirving-dsh-repro.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: evilirving-dsh-repro
+name: dsh-repro
+description:
+  en: Export a minimal, secret-scrubbed, replayable problem bundle for DeepSeek Harness via the /repro command.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - export
+  - minimal
+  - secret
+  - scrubbed
+  - replayable
+  - problem
+  - bundle
+  - repro
+  - command
+  - dsh
+source:
+  repository: https://github.com/EvilIrving/dsh-repro
+  repositoryNodeId: R_kgDOT39b3g
+  subpath: null
+  commit: e51736ba583830462e0cca4d808ec3e0b7001bcd
+creator:
+  github: EvilIrving
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:46.681Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `evilirving-dsh-repro`
- Submission type: community curation
- Created by `EvilIrving` — https://github.com/EvilIrving
- Original source repository: https://github.com/EvilIrving/dsh-repro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.