### PR TITLE
catalog: add f0909172434-dsh-plugin-verified-search (community curation, created by @f0909172434)

### DIFF
--- a/catalog/plugins/f0909172434-dsh-plugin-verified-search.yaml
+++ b/catalog/plugins/f0909172434-dsh-plugin-verified-search.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: f0909172434-dsh-plugin-verified-search
+name: dsh-plugin-verified-search
+description:
+  en: Verified current-source search workflow for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - web-search
+  - freshness
+  - dsh
+source:
+  repository: https://github.com/f0909172434/dsh-plugin-verified-search
+  repositoryNodeId: R_kgDOT3sYig
+  subpath: null
+  commit: 928012033c9da4eb01b4b8f8f701786980d3e75e
+creator:
+  github: f0909172434
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:48.608Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `f0909172434-dsh-plugin-verified-search`
- Submission type: community curation
- Created by `f0909172434` — https://github.com/f0909172434
- Original source repository: https://github.com/f0909172434/dsh-plugin-verified-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.