### PR TITLE
catalog: add fatmind-dsh-plugin-browser-use (community curation, created by @fatmind)

### DIFF
--- a/catalog/plugins/fatmind-dsh-plugin-browser-use.yaml
+++ b/catalog/plugins/fatmind-dsh-plugin-browser-use.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: fatmind-dsh-plugin-browser-use
+name: dsh-plugin-browser-use
+description:
+  en: "webclaw3 browser tools for dsh: drive your own logged-in Chrome via the webclaw3 relay (wc3 tools)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - webclaw3
+  - browser
+  - tools
+  - drive
+  - logged
+  - chrome
+  - relay
+  - dsh
+source:
+  repository: https://github.com/fatmind/dsh-plugin-browser-use
+  repositoryNodeId: R_kgDOT6OY1A
+  subpath: packages/browser-use
+  commit: d411f65580e7e55142e5d32375b279a4b7221183
+creator:
+  github: fatmind
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/browser-use/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:54:01.952Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fatmind-dsh-plugin-browser-use`
- Submission type: community curation
- Created by `fatmind` — https://github.com/fatmind
- Original source repository: https://github.com/fatmind/dsh-plugin-browser-use
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.