### PR TITLE
catalog: add faukwaa-dsh-gap-feed (community curation, created by @faukwaa)

### DIFF
--- a/catalog/plugins/faukwaa-dsh-gap-feed.yaml
+++ b/catalog/plugins/faukwaa-dsh-gap-feed.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: faukwaa-dsh-gap-feed
+name: dsh-gap-feed
+description:
+  en: "dsh plugin: during long agent thinking, posts a hot-news or reminder message directly into the conversation stream."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - gap-feed
+  - thinking
+  - news
+source:
+  repository: https://github.com/faukwaa/dsh-gap-feed
+  repositoryNodeId: R_kgDOT8-2Xw
+  subpath: null
+  commit: 754cb1d3bfa6282ecd40d308e9bdc7ef21dbbdf0
+creator:
+  github: faukwaa
+package:
+  ecosystem: npm
+  name: dsh-gap-feed
+  version: 0.1.9
+  integrity: sha512-lOa6ssUKrcKiydaLjH17Pj8Hi/0QUR02lRLSpUggqEZkwFp/932KpZAR8hslU7pmz9WfiXqZrtr1fvix13HQsQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:54:05.572Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `faukwaa-dsh-gap-feed`
- Submission type: community curation
- Created by `faukwaa` — https://github.com/faukwaa
- Original source repository: https://github.com/faukwaa/dsh-gap-feed
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.