### PR TITLE
catalog: add featherhunter-dsh-mattpocock-skills-deck (community curation, created by @FeatherHunter)

### DIFF
--- a/catalog/plugins/featherhunter-dsh-mattpocock-skills-deck.yaml
+++ b/catalog/plugins/featherhunter-dsh-mattpocock-skills-deck.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: featherhunter-dsh-mattpocock-skills-deck
+name: dsh-mattpocock-skills-deck
+description:
+  en: bash npm install -g @deepseek-ai/dsh
+  evidencePath: package/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - mattpocock
+  - skills
+  - wayfinder
+  - triage
+  - grilling
+  - handoff
+  - issue-tracker
+  - deck
+source:
+  repository: https://github.com/FeatherHunter/dsh-mattpocock-skills-deck
+  repositoryNodeId: R_kgDOT6kz3Q
+  subpath: package
+  commit: 2d52b951c6de66a4ae95d34016b0ceddc4acdeec
+creator:
+  github: FeatherHunter
+package:
+  ecosystem: npm
+  name: dsh-mattpocock-skills-deck
+  version: 1.6.19
+  integrity: sha512-hFX2JQ+Kj9iEu0z1DhKa7PbVNEekkqdwJH//RF0/Edgqh0AasKgUD5ZbhC6zVt61LxK1ZOLJPsyWey4QQnxqWA==
+dsh:
+  profiles:
+    - web
+  evidencePath: package/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:54:08.500Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `featherhunter-dsh-mattpocock-skills-deck`
- Submission type: community curation
- Created by `FeatherHunter` — https://github.com/FeatherHunter
- Original source repository: https://github.com/FeatherHunter/dsh-mattpocock-skills-deck
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.