### PR TITLE
catalog: add featherhunter-dsh-prompt (community curation, created by @FeatherHunter)

### DIFF
--- a/catalog/plugins/featherhunter-dsh-prompt.yaml
+++ b/catalog/plugins/featherhunter-dsh-prompt.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: featherhunter-dsh-prompt
+name: dsh-prompt
+description:
+  en: bash npm install -g @deepseek-ai/dsh
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - prompt
+  - prompts
+  - templates
+  - prompt-templates
+  - preset-prompts
+  - ai
+  - llm
+  - toolbox
+source:
+  repository: https://github.com/FeatherHunter/dsh-prompt
+  repositoryNodeId: R_kgDOT522BQ
+  subpath: null
+  commit: 6803c80e8d5d37e15aadbc80a4fa4613ac2f1fd4
+creator:
+  github: FeatherHunter
+package:
+  ecosystem: npm
+  name: dsh-prompt
+  version: 0.1.3
+  integrity: sha512-dfcK/A8FaNTCTlLVDB2cUgg+37hA3+Xzk1Qn8r4L5zR2muxzsaUxXKtSsFSgP9nun25DMfR8KCRyldco33ybKA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:10.380Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `featherhunter-dsh-prompt`
- Submission type: community curation
- Created by `FeatherHunter` — https://github.com/FeatherHunter
- Original source repository: https://github.com/FeatherHunter/dsh-prompt
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.