### PR TITLE
catalog: add gu-zt-dsh-thought-buddy (community curation, created by @Gu-ZT)

### DIFF
--- a/catalog/plugins/gu-zt-dsh-thought-buddy.yaml
+++ b/catalog/plugins/gu-zt-dsh-thought-buddy.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: gu-zt-dsh-thought-buddy
+name: "@dsh-plugin/dsh-thought-buddy"
+description:
+  en: A DeepSeek Harness Web plugin that puts a dynamic little buddy — a GrokBot-style animated avatar with a synchronized typewriter status line — right in front of the "Deep diving..." indicator.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deep-diving
+  - grokbot
+  - avatar
+  - emoji
+source:
+  repository: https://github.com/dsh-plugins/dsh-thought-buddy
+  repositoryNodeId: R_kgDOT4-99g
+  subpath: null
+  commit: 3fcc172a38e1567a190ff644c581ff5ba4c8472a
+creator:
+  github: Gu-ZT
+package:
+  ecosystem: npm
+  name: "@dsh-plugin/dsh-thought-buddy"
+  version: 0.2.0
+  integrity: sha512-revaKFPIowUWgQkdJdA/k61AWj62N18tp8spb1kupiu5g9q5rmklB+JhJQEruU/LREkaIJ8g98ASm31szd9dtg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:58.239Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gu-zt-dsh-thought-buddy`
- Submission type: community curation
- Created by `Gu-ZT` — https://github.com/Gu-ZT
- Original source repository: https://github.com/dsh-plugins/dsh-thought-buddy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.