### PR TITLE
catalog: add jnrobin139-dsh-dingo (community curation, created by @jnrobin139)

### DIFF
--- a/catalog/plugins/jnrobin139-dsh-dingo.yaml
+++ b/catalog/plugins/jnrobin139-dsh-dingo.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: jnrobin139-dsh-dingo
+name: dsh-dingo
+description:
+  en: Ding + Go — sound reminders + one-click jump for DeepSeek Harness (DSH).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - notification
+  - alert
+  - tone
+  - reminder
+  - interjection
+  - session
+source:
+  repository: https://github.com/february2015/dsh-dingo
+  repositoryNodeId: R_kgDOT5UVcw
+  subpath: null
+  commit: 9f2274ce29c342c36584ff2ef52b30d399c14cfd
+creator:
+  github: jnrobin139
+package:
+  ecosystem: npm
+  name: dsh-dingo
+  version: 1.0.0
+  integrity: sha512-58CL3/jOnPd7RbFeRTsLJ5wnAoONOhA2a2JgzFx6HKMNnhC0YNfzt/qyWo9eadckbwwb8ZOftcTHyZR9ZuxtdA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:54:10.531Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jnrobin139-dsh-dingo`
- Submission type: community curation
- Created by `jnrobin139` — https://github.com/jnrobin139
- Original source repository: https://github.com/february2015/dsh-dingo
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.