### PR TITLE
catalog: add lams001-dsh-zagens-office (community curation, created by @lams001)

### DIFF
--- a/catalog/plugins/lams001-dsh-zagens-office.yaml
+++ b/catalog/plugins/lams001-dsh-zagens-office.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lams001-dsh-zagens-office
+name: dsh-zagens-office
+description:
+  en: "DeepSeek Harness plugin: office schema / office write / office edit / office read via the local zagens-office CLI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - office
+  - schema
+  - write
+  - edit
+  - read
+  - local
+  - zagens
+  - dsh
+source:
+  repository: https://github.com/didclawapp-ai/DSH-Office
+  repositoryNodeId: R_kgDOT5JB-Q
+  subpath: null
+  commit: d4569418d5123bec63bf6e843ae7c7de7b749ea7
+creator:
+  github: lams001
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:49:29.412Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lams001-dsh-zagens-office`
- Submission type: community curation
- Created by `lams001` — https://github.com/lams001
- Original source repository: https://github.com/didclawapp-ai/DSH-Office
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.