### PR TITLE
catalog: add literaf-dsh-research (community curation, created by @literaf)

### DIFF
--- a/catalog/plugins/literaf-dsh-research.yaml
+++ b/catalog/plugins/literaf-dsh-research.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: literaf-dsh-research
+name: dsh-research
+description:
+  en: "The research plugin market inside DeepSeek Harness: browse a curated index of literature, reference, writing and workbench plugins in Settings and install them with one click — 科研插件市场，在设置里浏览并一键安装。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - market
+  - research
+  - academic
+source:
+  repository: https://github.com/dsh-research/dsh-research
+  repositoryNodeId: R_kgDOT6RJ4w
+  subpath: null
+  commit: 60210c4700266494e7c40d67042234e10abe2c20
+creator:
+  github: literaf
+package:
+  ecosystem: npm
+  name: dsh-research
+  version: 0.4.2
+  integrity: sha512-oJBLlIwLdUlbaDbmOeTjPnSsEuDT7o48C8R1ieEAbP9K6r3jqCFvTaGMzK6++cIaz+FfK3wx6knl/e1VUmqa/g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:00.304Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `literaf-dsh-research`
- Submission type: community curation
- Created by `literaf` — https://github.com/literaf
- Original source repository: https://github.com/dsh-research/dsh-research
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.