### PR TITLE
catalog: add math-modeling-gatecraft (community curation, created by @Math-Modeling)

### DIFF
--- a/catalog/plugins/math-modeling-gatecraft.yaml
+++ b/catalog/plugins/math-modeling-gatecraft.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: math-modeling-gatecraft
+name: gatecraft
+description:
+  en: A gated math-modeling skill suite (8 skills + a DSH preset) for DeepSeek Harness. No mindless end-to-end automation — the agent solves and verifies; you think and decide at every stage gate, producing modeling results with your own taste.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - math-modeling
+  - cumcm
+  - huashubei
+  - skills
+  - agent
+  - workflow
+  - dsh
+source:
+  repository: https://github.com/Crayonnan/dsh-math-modeling-skills-Gatecraft-
+  repositoryNodeId: R_kgDOT5xUrA
+  subpath: null
+  commit: db3f32fed4005e776a7fd6bacfddcce18f1d7d84
+creator:
+  github: Math-Modeling
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:18.618Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `math-modeling-gatecraft`
- Submission type: community curation
- Created by `Math-Modeling` — https://github.com/Math-Modeling
- Original source repository: https://github.com/Crayonnan/dsh-math-modeling-skills-Gatecraft-
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.