### PR TITLE
catalog: add oneeme-plugin-directory (community curation, created by @OneeMe)

### DIFF
--- a/catalog/plugins/oneeme-plugin-directory.yaml
+++ b/catalog/plugins/oneeme-plugin-directory.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: oneeme-plugin-directory
+name: "@dsh-pub/plugin-directory"
+description:
+  en: Browse the bilingual dsh.pub plugin registry inside DeepSeek Harness.
+  evidencePath: apps/dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - browse
+  - bilingual
+  - registry
+  - inside
+  - dsh
+source:
+  repository: https://github.com/dsh-pub/dsh-pub
+  repositoryNodeId: R_kgDOT3f3kg
+  subpath: apps/dsh-plugin
+  commit: 2ec7f87a15226cbf31e313bb6b5b1c534571927c
+creator:
+  github: OneeMe
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: apps/dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:47.556Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `oneeme-plugin-directory`
- Submission type: community curation
- Created by `OneeMe` — https://github.com/OneeMe
- Original source repository: https://github.com/dsh-pub/dsh-pub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.