### PR TITLE
catalog: add shuaicfr-dsh-aischat (community curation, created by @ShuAICFR)

### DIFF
--- a/catalog/plugins/shuaicfr-dsh-aischat.yaml
+++ b/catalog/plugins/shuaicfr-dsh-aischat.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: shuaicfr-dsh-aischat
+name: dsh-aischat
+description:
+  en: bash pnpm install 或复用已有 node modules（frontend 下） node scripts/build.mjs 产出 lib/index.js + lib/client.js
+  evidencePath: dsh-aischat/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - aischat
+  - chat
+source:
+  repository: https://github.com/Coprexist/AIsChat
+  repositoryNodeId: R_kgDOS6BGrQ
+  subpath: dsh-aischat
+  commit: 8bd90c9a36e9bc196fadc25deaac21fd230119e8
+creator:
+  github: ShuAICFR
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-aischat/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:16.285Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shuaicfr-dsh-aischat`
- Submission type: community curation
- Created by `ShuAICFR` — https://github.com/ShuAICFR
- Original source repository: https://github.com/Coprexist/AIsChat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.