### PR TITLE
catalog: add shuaicfr-dsh-session-recovery (community curation, created by @ShuAICFR)

### DIFF
--- a/catalog/plugins/shuaicfr-dsh-session-recovery.yaml
+++ b/catalog/plugins/shuaicfr-dsh-session-recovery.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: shuaicfr-dsh-session-recovery
+name: dsh-session-recovery
+description:
+  en: Recover deleted/corrupted dsh sessions (session.jsonl.zstd) and memory (memory.db) straight from the raw disk. Battle-tested recovery manual + scripts + a /session-repair command plugin for the dsh web UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session-recovery
+  - data-recovery
+  - zstd
+  - sqlite
+  - forensics
+source:
+  repository: https://github.com/Coprexist/dsh-session-recovery
+  repositoryNodeId: R_kgDOT6LxvQ
+  subpath: null
+  commit: 4f8b877fdc23e982c4e0d452e447b44bdd78b36e
+creator:
+  github: ShuAICFR
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:50:18.786Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shuaicfr-dsh-session-recovery`
- Submission type: community curation
- Created by `ShuAICFR` — https://github.com/ShuAICFR
- Original source repository: https://github.com/Coprexist/dsh-session-recovery
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.