### PR TITLE
catalog: add wha1echai-dsh-gateway-pack (community curation, created by @Wha1eChai)

### DIFF
--- a/catalog/plugins/wha1echai-dsh-gateway-pack.yaml
+++ b/catalog/plugins/wha1echai-dsh-gateway-pack.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: wha1echai-dsh-gateway-pack
+name: "@dshapps/dsh-gateway-pack"
+description:
+  en: One-install DSH Bundle for dsh-gateway
+  evidencePath: packages/pack/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - install
+  - bundle
+  - gateway
+  - dsh
+source:
+  repository: https://github.com/dshapps/dsh-gateway
+  repositoryNodeId: R_kgDOT4MBPQ
+  subpath: packages/pack
+  commit: 362ab9d4e944c2d488b8bfe89535531278370abf
+creator:
+  github: Wha1eChai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/pack/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:52:52.057Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wha1echai-dsh-gateway-pack`
- Submission type: community curation
- Created by `Wha1eChai` — https://github.com/Wha1eChai
- Original source repository: https://github.com/dshapps/dsh-gateway
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.