### PR TITLE
catalog: add yangyang20220519-dsh (community curation, created by @yangyang20220519)

### DIFF
--- a/catalog/plugins/yangyang20220519-dsh.yaml
+++ b/catalog/plugins/yangyang20220519-dsh.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: yangyang20220519-dsh
+name: "@co-engram/dsh"
+description:
+  en: "Co-Engram team memory plugin for DeepSeek Harness (dsh): native Cordis tools + dynamic prompt-signals injection."
+  evidencePath: packages/dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - memory
+  - ai-memory
+  - agent-memory
+  - engram
+  - cordis
+source:
+  repository: https://github.com/Co-Engram/Co-Engram
+  repositoryNodeId: R_kgDOTGNIGw
+  subpath: packages/dsh-plugin
+  commit: 86e4074565038d7ec9faf0345ba35141cc36b59a
+creator:
+  github: yangyang20220519
+package:
+  ecosystem: npm
+  name: "@co-engram/dsh"
+  version: 0.1.1
+  integrity: sha512-Bz0RknEDwb3FVRKR+4iMAhPDadC7aL4TLZdPlY/rXVebInaD7OjKpIhFx65No3peXrJACxYZGCJwjRfzUWPFQg==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:51:07.605Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangyang20220519-dsh`
- Submission type: community curation
- Created by `yangyang20220519` — https://github.com/yangyang20220519
- Original source repository: https://github.com/Co-Engram/Co-Engram
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.