### PR TITLE
catalog: add yifanxuaaa-dsh-codex-coding-plan (community curation, created by @yifanxuaaa)

### DIFF
--- a/catalog/plugins/yifanxuaaa-dsh-codex-coding-plan.yaml
+++ b/catalog/plugins/yifanxuaaa-dsh-codex-coding-plan.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: yifanxuaaa-dsh-codex-coding-plan
+name: dsh-codex-coding-plan
+description:
+  en: Use an existing file-backed Codex ChatGPT login from DeepSeek Harness
+  evidencePath: coding-plan/codex/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - existing
+  - file
+  - backed
+  - codex
+  - chatgpt
+  - login
+  - dsh
+source:
+  repository: https://github.com/Ephemeral-AI-Lab/dsh-plugins
+  repositoryNodeId: R_kgDOT5uUvw
+  subpath: coding-plan/codex
+  commit: 0ff144aed9d9d9d6de3c45ba7f18cde2abe4d4a1
+creator:
+  github: yifanxuaaa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: coding-plan/codex/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:08.747Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yifanxuaaa-dsh-codex-coding-plan`
- Submission type: community curation
- Created by `yifanxuaaa` — https://github.com/yifanxuaaa
- Original source repository: https://github.com/Ephemeral-AI-Lab/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.