### PR TITLE
catalog: add yifanxuaaa-dsh-grok-coding-plan (community curation, created by @yifanxuaaa)

### DIFF
--- a/catalog/plugins/yifanxuaaa-dsh-grok-coding-plan.yaml
+++ b/catalog/plugins/yifanxuaaa-dsh-grok-coding-plan.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: yifanxuaaa-dsh-grok-coding-plan
+name: dsh-grok-coding-plan
+description:
+  en: Use an existing Grok subscription login from DeepSeek Harness
+  evidencePath: coding-plan/grok/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - existing
+  - grok
+  - subscription
+  - login
+  - dsh
+source:
+  repository: https://github.com/Ephemeral-AI-Lab/dsh-plugins
+  repositoryNodeId: R_kgDOT5uUvw
+  subpath: coding-plan/grok
+  commit: 0ff144aed9d9d9d6de3c45ba7f18cde2abe4d4a1
+creator:
+  github: yifanxuaaa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: coding-plan/grok/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-26T19:53:08.747Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yifanxuaaa-dsh-grok-coding-plan`
- Submission type: community curation
- Created by `yifanxuaaa` — https://github.com/yifanxuaaa
- Original source repository: https://github.com/Ephemeral-AI-Lab/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.