### PR TITLE
docs: realign published counts 877 → 974

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Creator-first discovery and one-command installation for **DeepSeek Harness (DSH
   <a href="https://dsh-plugins.omniroute.online">Browse, search and install every plugin on the website →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](LICENSE)
@@ -120,7 +120,7 @@ repository carries the public catalog data, schema and policies they both consum
 
 ## Catalog status
 
-**877 plugins merged.** Every plugin enters through an individually reviewed pull request, one at
+**974 plugins merged.** Every plugin enters through an individually reviewed pull request, one at
 a time, from the original creator repository, with a pinned source commit and explicit
 attribution.
 

--- a/docs/i18n/ar/README.md
+++ b/docs/i18n/ar/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">تصفَّح جميع الإضافات وابحث عنها وثبّتها من الموقع ←</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -119,7 +119,7 @@
 
 ## حالة الكتالوج
 
-**تم دمج 877 إضافة.** تدخل كل إضافة عبر طلب سحب يُراجَع بشكل فردي، واحدًا تلو الآخر، من مستودع
+**تم دمج 974 إضافة.** تدخل كل إضافة عبر طلب سحب يُراجَع بشكل فردي، واحدًا تلو الآخر، من مستودع
 المُنشئ الأصلي، مع التزام مصدر مثبَّت ونسب صريح.
 
 ## 🚀 تثبيت واجهة سطر الأوامر
@@ -332,4 +332,4 @@ YAML التحريرية الوصفية مُخصَّصة للملكية العا�
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/az/README.md
+++ b/docs/i18n/az/README.md
@@ -16,7 +16,7 @@ Yaradıcı-önləşdirilmiş kəşf və **DeepSeek Harness (DSH)** əlavələri 
   <a href="https://dsh-plugins.omniroute.online">Bütün əlavələrə veb saytda baxın, axtarın və quraşdırın →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -118,7 +118,7 @@ hər ikisinin istifadə etdiyi ictimai kataloq məlumatlarını, sxemi və siyas
 
 ## Kataloq statusu
 
-**877 əlavə birləşdirildi.** Hər əlavə orijinal yaradıcı repozitoriyasından, sabitlənmiş mənbə
+**974 əlavə birləşdirildi.** Hər əlavə orijinal yaradıcı repozitoriyasından, sabitlənmiş mənbə
 commit-i və aydın atribusiya ilə, bir-bir, ayrıca nəzərdən keçirilən pull request vasitəsilə daxil
 olur.
 
@@ -337,4 +337,4 @@ loqoları və ekran görüntüləri öz orijinal sahiblərinin və lisenziyalar�
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/bg/README.md
+++ b/docs/i18n/bg/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">Разгледайте, търсете и инсталирайте всеки плъгин на уебсайта →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -113,7 +113,7 @@
 
 ## Състояние на каталога
 
-**877 обединени плъгина.** Всеки плъгин влиза чрез отделно прегледан pull request, един по един, от хранилището на оригиналния създател, с фиксиран изходен комит и изрично приписване.
+**974 обединени плъгина.** Всеки плъгин влиза чрез отделно прегледан pull request, един по един, от хранилището на оригиналния създател, с фиксиран изходен комит и изрично приписване.
 
 ## 🚀 Инсталирайте CLI
 
@@ -287,4 +287,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/bn/README.md
+++ b/docs/i18n/bn/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">ওয়েবসাইটে সব প্লাগইন ব্রাউজ, সার্চ এবং ইনস্টল করুন →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -119,7 +119,7 @@
 
 ## ক্যাটালগের অবস্থা
 
-**৮৭৭টি প্লাগইন মার্জ হয়েছে।** প্রতিটি প্লাগইন একটি করে, মূল নির্মাতার রিপোজিটরি থেকে, একটি পৃথকভাবে পর্যালোচিত পুল
+**৯৭৪টি প্লাগইন মার্জ হয়েছে।** প্রতিটি প্লাগইন একটি করে, মূল নির্মাতার রিপোজিটরি থেকে, একটি পৃথকভাবে পর্যালোচিত পুল
 রিকোয়েস্টের মাধ্যমে, একটি পিন করা সোর্স কমিট এবং স্পষ্ট কৃতিত্ব-সহ প্রবেশ করে।
 
 ## 🚀 CLI ইনস্টল করুন
@@ -324,4 +324,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/cs/README.md
+++ b/docs/i18n/cs/README.md
@@ -16,7 +16,7 @@ Objevování s prioritou pro tvůrce a instalace jedním příkazem pro pluginy 
   <a href="https://dsh-plugins.omniroute.online">Procházejte, vyhledávejte a instalujte všechny pluginy na webu →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -113,7 +113,7 @@ Web je udržován ze soukromého zdroje. CLI se nachází zde, pod [`cli/`](../.
 
 ## Stav katalogu
 
-**877 sloučených pluginů.** Každý plugin vstupuje prostřednictvím jednotlivě zkontrolovaného pull requestu, jeden po druhém, z repozitáře původního tvůrce, s fixovaným zdrojovým commitem a explicitním atributem.
+**974 sloučených pluginů.** Každý plugin vstupuje prostřednictvím jednotlivě zkontrolovaného pull requestu, jeden po druhém, z repozitáře původního tvůrce, s fixovaným zdrojovým commitem a explicitním atributem.
 
 ## 🚀 Instalace CLI
 
@@ -287,4 +287,4 @@ Dokumentace a šablony repozitáře jsou licencovány pod [MIT License](../../LI
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/da/README.md
+++ b/docs/i18n/da/README.md
@@ -16,7 +16,7 @@ Skaber-først opdagelse og installation med én kommando til **DeepSeek Harness 
   <a href="https://dsh-plugins.omniroute.online">Gennemse, søg og installér alle plugins på hjemmesiden →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@ repository indeholder de offentlige katalogdata, skemaet og de politikker, som b
 
 ## Katalogstatus
 
-**877 plugins mergede.** Hvert plugin kommer ind via en individuelt gennemgået pull request, ét
+**974 plugins mergede.** Hvert plugin kommer ind via en individuelt gennemgået pull request, ét
 ad gangen, fra skaberens oprindelige repository, med et fastlåst kilde-commit og eksplicit
 kreditering.
 
@@ -339,4 +339,4 @@ deres oprindelige ejere og licenser. Se [docs/CREDIT.md](../../docs/CREDIT.md) o
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -16,7 +16,7 @@ Creator-first-Entdeckung und Ein-Befehl-Installation für **DeepSeek Harness (DS
   <a href="https://dsh-plugins.omniroute.online">Alle Plugins auf der Website durchsuchen, suchen und installieren →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ die beide nutzen.
 
 ## Katalogstatus
 
-**877 Plugins zusammengeführt.** Jedes Plugin gelangt über einen einzeln geprüften Pull Request,
+**974 Plugins zusammengeführt.** Jedes Plugin gelangt über einen einzeln geprüften Pull Request,
 einen nach dem anderen, aus dem ursprünglichen Repository des Erstellers hinein, mit einem
 fixierten Quell-Commit und expliziter Zuschreibung.
 
@@ -344,4 +344,4 @@ verbleiben bei ihren ursprünglichen Eigentümern und Lizenzen. Siehe
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -16,7 +16,7 @@ Descubrimiento centrado en el creador e instalación con un solo comando para pl
   <a href="https://dsh-plugins.omniroute.online">Explora, busca e instala cualquier plugin en el sitio web →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ datos públicos del catálogo, el esquema y las políticas que consumen.
 
 ## Estado del catálogo
 
-**877 plugins integrados.** Cada plugin entra mediante una pull request revisada individualmente, de una en
+**974 plugins integrados.** Cada plugin entra mediante una pull request revisada individualmente, de una en
 una, desde el repositorio original del creador, con un commit de origen fijado y atribución explícita.
 
 ## 🚀 Instala la CLI
@@ -342,4 +342,4 @@ Consulta [docs/CREDIT.md](../../docs/CREDIT.md) y [docs/UNOFFICIAL.md](../../doc
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/fa/README.md
+++ b/docs/i18n/fa/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">همهٔ افزونه‌ها را در وب‌سایت مرور، جستجو و نصب کنید →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -119,7 +119,7 @@ JSON Schema منتشرشده اعتبارسنجی شده، از طریق یک pu
 
 ## وضعیت کاتالوگ
 
-**۸۷۷ افزونه ادغام شده است.** هر افزونه از طریق یک pull request بازبینی‌شدهٔ جداگانه، یکی‌یکی، از ریپازیتوری سازندهٔ
+**۹۷۴ افزونه ادغام شده است.** هر افزونه از طریق یک pull request بازبینی‌شدهٔ جداگانه، یکی‌یکی، از ریپازیتوری سازندهٔ
 اصلی، با یک کامیت منبع پین‌شده و اعتباردهی صریح وارد می‌شود.
 
 ## 🚀 نصب CLI
@@ -326,4 +326,4 @@ YAML تحت [CC0-1.0](../../LICENSE-CATALOG) وقف شده‌اند. کد، نا
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/fi/README.md
+++ b/docs/i18n/fi/README.md
@@ -16,7 +16,7 @@ Luojalähtöinen löytäminen ja yhden komennon asennus **DeepSeek Harness (DSH)
   <a href="https://dsh-plugins.omniroute.online">Selaa, hae ja asenna jokainen laajennus verkkosivustolla →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@ joita molemmat käyttävät.
 
 ## Katalogin tila
 
-**877 laajennusta yhdistetty.** Jokainen laajennus tulee mukaan yksilöllisesti tarkastetun pull
+**974 laajennusta yhdistetty.** Jokainen laajennus tulee mukaan yksilöllisesti tarkastetun pull
 requestin kautta, yksi kerrallaan, alkuperäisen luojan repositoriosta, kiinnitetyllä
 lähdekommitilla ja selkeällä tunnustuksella.
 
@@ -343,4 +343,4 @@ Katso [docs/CREDIT.md](../../docs/CREDIT.md) ja [docs/UNOFFICIAL.md](../../docs/
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -16,7 +16,7 @@ Découverte axée sur le créateur et installation en une seule commande pour le
   <a href="https://dsh-plugins.omniroute.online">Parcourez, recherchez et installez tous les plugins sur le site →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ consomment.
 
 ## Statut du catalogue
 
-**877 plugins fusionnés.** Chaque plugin entre via une pull request revue individuellement, une à
+**974 plugins fusionnés.** Chaque plugin entre via une pull request revue individuellement, une à
 la fois, depuis le dépôt du créateur original, avec un commit source épinglé et une attribution
 explicite.
 
@@ -346,4 +346,4 @@ Voir [docs/CREDIT.md](../../docs/CREDIT.md) et [docs/UNOFFICIAL.md](../../docs/U
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/gu/README.md
+++ b/docs/i18n/gu/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">વેબસાઇટ પર દરેક પ્લગિન બ્રાઉઝ, સર્ચ અને ઇન્સ્ટોલ કરો →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@
 
 ## કેટલોગ સ્ટેટસ
 
-**877 પ્લગિન્સ મર્જ થયા.** દરેક પ્લગિન એક વ્યક્તિગત રીતે રિવ્યૂ થયેલ પુલ રિક્વેસ્ટ દ્વારા, એક સમયે એક,
+**974 પ્લગિન્સ મર્જ થયા.** દરેક પ્લગિન એક વ્યક્તિગત રીતે રિવ્યૂ થયેલ પુલ રિક્વેસ્ટ દ્વારા, એક સમયે એક,
 મૂળ ક્રિએટર રિપોઝીટરીમાંથી, પિન કરેલા સોર્સ કમિટ અને સ્પષ્ટ
 એટ્રિબ્યુશન સાથે દાખલ થાય છે.
 
@@ -334,4 +334,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/he/README.md
+++ b/docs/i18n/he/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">עיינו, חפשו והתקינו כל תוסף באתר →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -119,7 +119,7 @@
 
 ## מצב הקטלוג
 
-**877 תוספים מוזגו.** כל תוסף נכנס דרך בקשת משיכה אחת שנבדקה בנפרד, אחד בכל פעם, ממאגר היוצר
+**974 תוספים מוזגו.** כל תוסף נכנס דרך בקשת משיכה אחת שנבדקה בנפרד, אחד בכל פעם, ממאגר היוצר
 המקורי, עם קומיט מקור מוצמד וקרדיט מפורש.
 
 ## 🚀 התקנת ה-CLI
@@ -327,4 +327,4 @@ README זה זמין ב-43 שפות תחת [`docs/i18n/`](../../docs/i18n) — �
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/hi/README.md
+++ b/docs/i18n/hi/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">वेबसाइट पर हर प्लगइन ब्राउज़, खोज और इंस्टॉल करें →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -119,7 +119,7 @@
 
 ## कैटलॉग स्थिति
 
-**877 प्लगइन मर्ज किए गए।** हर प्लगइन एक-एक करके, मूल निर्माता की रिपॉज़िटरी से, एक पिन किए गए सोर्स कमिट और स्पष्ट श्रेय
+**974 प्लगइन मर्ज किए गए।** हर प्लगइन एक-एक करके, मूल निर्माता की रिपॉज़िटरी से, एक पिन किए गए सोर्स कमिट और स्पष्ट श्रेय
 के साथ, एक अलग से समीक्षा किए गए पुल रिक्वेस्ट के माध्यम से आता है।
 
 ## 🚀 CLI इंस्टॉल करें
@@ -325,4 +325,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/hu/README.md
+++ b/docs/i18n/hu/README.md
@@ -16,7 +16,7 @@ Alkotó-központú felfedezés és egyparancsos telepítés a **DeepSeek Harness
   <a href="https://dsh-plugins.omniroute.online">Böngéssz, keress és telepíts minden bővítményt a weboldalon →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -122,7 +122,7 @@ szabályzatokat, amelyeket mindketten fogyasztanak.
 
 ## A katalógus állapota
 
-**877 bővítmény egyesítve.** Minden bővítmény egy egyedileg átvizsgált pull requesten keresztül
+**974 bővítmény egyesítve.** Minden bővítmény egy egyedileg átvizsgált pull requesten keresztül
 kerül be, egyenként, az eredeti alkotó repository-jából, rögzített forráscommittal és explicit
 jóváírással.
 
@@ -345,4 +345,4 @@ licenceik alatt. Lásd [docs/CREDIT.md](../../docs/CREDIT.md) és [docs/UNOFFICI
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/id/README.md
+++ b/docs/i18n/id/README.md
@@ -16,7 +16,7 @@ Penemuan yang mengutamakan kreator dan instalasi satu perintah untuk plugin **De
   <a href="https://dsh-plugins.omniroute.online">Jelajahi, cari, dan instal setiap plugin di situs web →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ dan kebijakan yang mereka konsumsi.
 
 ## Status katalog
 
-**877 plugin tergabung.** Setiap plugin masuk melalui satu pull request yang ditinjau secara
+**974 plugin tergabung.** Setiap plugin masuk melalui satu pull request yang ditinjau secara
 individual, satu per satu, dari repositori kreator asli, dengan commit sumber yang dipatok dan
 atribusi yang eksplisit.
 
@@ -338,4 +338,4 @@ Lihat [docs/CREDIT.md](../../docs/CREDIT.md) dan [docs/UNOFFICIAL.md](../../docs
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/in/README.md
+++ b/docs/i18n/in/README.md
@@ -16,7 +16,7 @@ Penemuan yang mengutamakan kreator dan instalasi satu perintah untuk plugin **De
   <a href="https://dsh-plugins.omniroute.online">Jelajahi, cari, dan instal setiap plugin di situs web →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ repositori ini memuat data katalog publik, skema, serta kebijakan yang dikonsums
 
 ## Status katalog
 
-**877 plugin tergabung.** Setiap plugin masuk melalui satu pull request yang ditinjau secara
+**974 plugin tergabung.** Setiap plugin masuk melalui satu pull request yang ditinjau secara
 individual, satu per satu, dari repositori kreator asli, dengan commit sumber yang dipatok dan
 atribusi yang eksplisit.
 
@@ -338,4 +338,4 @@ Lihat [docs/CREDIT.md](../../docs/CREDIT.md) dan [docs/UNOFFICIAL.md](../../docs
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/it/README.md
+++ b/docs/i18n/it/README.md
@@ -16,7 +16,7 @@ Scoperta orientata ai creatori e installazione con un solo comando per i plugin 
   <a href="https://dsh-plugins.omniroute.online">Sfoglia, cerca e installa ogni plugin sul sito →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ dati pubblici del catalogo, lo schema e le policy che essi consumano.
 
 ## Stato del catalogo
 
-**877 plugin uniti.** Ogni plugin entra tramite una pull request revisionata individualmente, una
+**974 plugin uniti.** Ogni plugin entra tramite una pull request revisionata individualmente, una
 alla volta, dal repository originale del creatore, con un commit sorgente fissato e attribuzione
 esplicita.
 
@@ -341,4 +341,4 @@ originali. Vedi [docs/CREDIT.md](../../docs/CREDIT.md) e [docs/UNOFFICIAL.md](..
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/ja/README.md
+++ b/docs/i18n/ja/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">ウェブサイトですべてのプラグインを閲覧・検索・インストール →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -113,7 +113,7 @@
 
 ## カタログの状況
 
-**877件のプラグインがマージ済み。** すべてのプラグインは、固定されたソースコミットと明示的なクレジットとともに、元のクリエイターのリポジトリから、1件ずつ個別にレビューされたプルリクエストを通じて登録されます。
+**974件のプラグインがマージ済み。** すべてのプラグインは、固定されたソースコミットと明示的なクレジットとともに、元のクリエイターのリポジトリから、1件ずつ個別にレビューされたプルリクエストを通じて登録されます。
 
 ## 🚀 CLIをインストール
 
@@ -287,4 +287,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">웹사이트에서 모든 플러그인을 둘러보고, 검색하고, 설치하세요 →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -113,7 +113,7 @@
 
 ## 카탈로그 현황
 
-**877개 플러그인 병합 완료.** 모든 플러그인은 원 크리에이터의 저장소로부터, 고정된 소스 커밋과 명시적인 출처 표시와 함께, 한 번에 하나씩 개별적으로 검토된 풀 리퀘스트를 통해 등록됩니다.
+**974개 플러그인 병합 완료.** 모든 플러그인은 원 크리에이터의 저장소로부터, 고정된 소스 커밋과 명시적인 출처 표시와 함께, 한 번에 하나씩 개별적으로 검토된 풀 리퀘스트를 통해 등록됩니다.
 
 ## 🚀 CLI 설치
 
@@ -287,4 +287,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/mr/README.md
+++ b/docs/i18n/mr/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">वेबसाइटवर प्रत्येक प्लगइन ब्राउझ करा, शोधा आणि इंस्टॉल करा →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ YAML फाइल आहे, प्रकाशित JSON स्कीमा �
 
 ## कॅटलॉगची स्थिती
 
-**877 प्लगइन विलीन झाले.** प्रत्येक प्लगइन एका स्वतंत्रपणे पुनरावलोकन केलेल्या पुल रिक्वेस्टद्वारे,
+**974 प्लगइन विलीन झाले.** प्रत्येक प्लगइन एका स्वतंत्रपणे पुनरावलोकन केलेल्या पुल रिक्वेस्टद्वारे,
 एका वेळी एक, मूळ निर्मात्याच्या रिपॉझिटरीमधून, निश्चित केलेल्या सोर्स कमिटसह आणि स्पष्ट श्रेयासह
 दाखल होतो.
 
@@ -337,4 +337,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/ms/README.md
+++ b/docs/i18n/ms/README.md
@@ -16,7 +16,7 @@ Penemuan mengutamakan pencipta dan pemasangan satu-arahan untuk pemalam **DeepSe
   <a href="https://dsh-plugins.omniroute.online">Layari, cari dan pasang setiap pemalam di laman web →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -122,7 +122,7 @@ digunakan oleh kedua-duanya.
 
 ## Status katalog
 
-**877 pemalam digabungkan.** Setiap pemalam masuk melalui satu pull request yang disemak
+**974 pemalam digabungkan.** Setiap pemalam masuk melalui satu pull request yang disemak
 secara individu, satu demi satu, daripada repositori asal pencipta, dengan komit sumber
 yang dipasak dan atribusi yang jelas.
 
@@ -341,4 +341,4 @@ Lihat [docs/CREDIT.md](../../docs/CREDIT.md) dan [docs/UNOFFICIAL.md](../../docs
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/nl/README.md
+++ b/docs/i18n/nl/README.md
@@ -16,7 +16,7 @@ Ontdekking met voorrang voor makers en installatie met één commando voor **Dee
   <a href="https://dsh-plugins.omniroute.online">Blader, zoek en installeer elke plugin op de website →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@ en deze repository bevat de publieke catalogusdata, het schema en het beleid dat
 
 ## Catalogusstatus
 
-**877 plugins samengevoegd.** Elke plugin komt binnen via een individueel beoordeelde pull
+**974 plugins samengevoegd.** Elke plugin komt binnen via een individueel beoordeelde pull
 request, één tegelijk, vanuit het oorspronkelijke repository van de maker, met een
 vastgepinde broncommit en expliciete attributie.
 
@@ -340,4 +340,4 @@ licenties. Zie [docs/CREDIT.md](../../docs/CREDIT.md) en [docs/UNOFFICIAL.md](..
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/no/README.md
+++ b/docs/i18n/no/README.md
@@ -16,7 +16,7 @@ Skaperfokusert oppdagelse og installasjon med én kommando for **DeepSeek Harnes
   <a href="https://dsh-plugins.omniroute.online">Bla gjennom, søk og installer alle plugins på nettsiden →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@ begge bruker.
 
 ## Katalogstatus
 
-**877 plugins sammenslått.** Hver plugin kommer inn gjennom en individuelt gjennomgått pull
+**974 plugins sammenslått.** Hver plugin kommer inn gjennom en individuelt gjennomgått pull
 request, én om gangen, fra skaperens opprinnelige repositorium, med en fastpinnet kildekommit
 og eksplisitt attribusjon.
 
@@ -340,4 +340,4 @@ lisenser. Se [docs/CREDIT.md](../../docs/CREDIT.md) og [docs/UNOFFICIAL.md](../.
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/phi/README.md
+++ b/docs/i18n/phi/README.md
@@ -16,7 +16,7 @@ Pagtuklas na unang inuuna ang mga lumikha at pag-install na isang-command para s
   <a href="https://dsh-plugins.omniroute.online">Mag-browse, maghanap, at mag-install ng bawat plugin sa website →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -123,7 +123,7 @@ schema, at mga patakarang ginagamit ng dalawa.
 
 ## Katayuan ng katalogo
 
-**877 na plugin ang na-merge.** Bawat plugin ay pumapasok sa pamamagitan ng isang isa-isang
+**974 na plugin ang na-merge.** Bawat plugin ay pumapasok sa pamamagitan ng isang isa-isang
 sinuring pull request, isa-isa, mula sa orihinal na repository ng lumikha, may nakapirming
 source commit at malinaw na attribution.
 
@@ -350,4 +350,4 @@ ay nananatili sa ilalim ng kanilang orihinal na may-ari at lisensya. Tingnan ang
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/pl/README.md
+++ b/docs/i18n/pl/README.md
@@ -16,7 +16,7 @@ Odkrywanie stawiające na pierwszym miejscu twórców i instalacja jedną komend
   <a href="https://dsh-plugins.omniroute.online">Przeglądaj, wyszukuj i instaluj każdą wtyczkę na stronie →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ katalogu, schemat i zasady, z których korzystają.
 
 ## Status katalogu
 
-**877 scalone wtyczki.** Każda wtyczka wchodzi przez indywidualnie zrecenzowany pull
+**974 scalone wtyczki.** Każda wtyczka wchodzi przez indywidualnie zrecenzowany pull
 request, po jednej naraz, z oryginalnego repozytorium twórcy, z przypiętym commitem
 źródłowym i wyraźną atrybucją.
 
@@ -340,4 +340,4 @@ i [docs/UNOFFICIAL.md](../../docs/UNOFFICIAL.md).
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/pt-BR/README.md
+++ b/docs/i18n/pt-BR/README.md
@@ -16,7 +16,7 @@ Descoberta com prioridade ao criador e instalação em um comando para plugins d
   <a href="https://dsh-plugins.omniroute.online">Explore, pesquise e instale qualquer plugin no site →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ este repositório carrega os dados públicos do catálogo, o esquema e as polít
 
 ## Status do catálogo
 
-**877 plugins mesclados.** Cada plugin entra por meio de um pull request revisado individualmente,
+**974 plugins mesclados.** Cada plugin entra por meio de um pull request revisado individualmente,
 um de cada vez, a partir do repositório original do criador, com um commit de origem fixado e
 atribuição explícita.
 
@@ -339,4 +339,4 @@ licenças originais. Veja [docs/CREDIT.md](../../docs/CREDIT.md) e [docs/UNOFFIC
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/pt/README.md
+++ b/docs/i18n/pt/README.md
@@ -16,7 +16,7 @@ Descoberta centrada no criador e instalação num único comando para plugins do
   <a href="https://dsh-plugins.omniroute.online">Navegue, pesquise e instale qualquer plugin no site →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@ consomem.
 
 ## Estado do catálogo
 
-**877 plugins integrados.** Cada plugin entra através de um pull request revisto individualmente,
+**974 plugins integrados.** Cada plugin entra através de um pull request revisto individualmente,
 um de cada vez, a partir do repositório original do criador, com um commit de origem fixado e
 atribuição explícita.
 
@@ -343,4 +343,4 @@ montante mantêm-se sob os seus proprietários e licenças originais. Veja
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/ro/README.md
+++ b/docs/i18n/ro/README.md
@@ -17,7 +17,7 @@ Descoperire centrată pe creatori și instalare cu o singură comandă pentru pl
   <a href="https://dsh-plugins.omniroute.online">Răsfoiește, caută și instalează orice plugin pe site →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -123,7 +123,7 @@ consumă.
 
 ## Starea catalogului
 
-**877 de pluginuri integrate.** Fiecare plugin intră printr-un pull request revizuit individual,
+**974 de pluginuri integrate.** Fiecare plugin intră printr-un pull request revizuit individual,
 unul câte unul, din repository-ul creatorului original, cu un commit sursă fixat și atribuire
 explicită.
 
@@ -346,4 +346,4 @@ rămân sub proprietarii și licențele lor originale. Vezi [docs/CREDIT.md](../
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">Просматривайте, ищите и устанавливайте любой плагин на сайте →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@ YAML-файл в `catalog/plugins/`, проверенный по опублик�
 
 ## Состояние каталога
 
-**877 плагина принято.** Каждый плагин попадает сюда через индивидуально отрецензированный pull
+**974 плагина принято.** Каждый плагин попадает сюда через индивидуально отрецензированный pull
 request, по одному за раз, из оригинального репозитория создателя, с закреплённым исходным
 коммитом и явным указанием авторства.
 
@@ -341,4 +341,4 @@ request'ы.
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/sk/README.md
+++ b/docs/i18n/sk/README.md
@@ -16,7 +16,7 @@ Objavovanie s dôrazom na tvorcov a inštalácia jedným príkazom pre pluginy *
   <a href="https://dsh-plugins.omniroute.online">Prehliadajte, vyhľadávajte a inštalujte všetky pluginy na webe →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@ využívajú.
 
 ## Stav katalógu
 
-**877 zlúčených pluginov.** Každý plugin vstupuje prostredníctvom individuálne posúdeného pull
+**974 zlúčených pluginov.** Každý plugin vstupuje prostredníctvom individuálne posúdeného pull
 requestu, jeden po druhom, z repozitára pôvodného tvorcu, s pripnutým zdrojovým commitom a
 explicitným pripísaním autorstva.
 
@@ -340,4 +340,4 @@ vlastníkmi a licenciami. Pozri [docs/CREDIT.md](../../docs/CREDIT.md) a
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/sv/README.md
+++ b/docs/i18n/sv/README.md
@@ -16,7 +16,7 @@ Kreatörsfokuserad upptäckt och installation med ett kommando för **DeepSeek H
   <a href="https://dsh-plugins.omniroute.online">Bläddra, sök och installera alla plugins på webbplatsen →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ repository innehåller den offentliga katalogdatan, schemat och policyerna som b
 
 ## Katalogstatus
 
-**877 plugins sammanslagna.** Varje plugin läggs till genom en individuellt granskad pull
+**974 plugins sammanslagna.** Varje plugin läggs till genom en individuellt granskad pull
 request, en i taget, från skaparens ursprungliga repository, med en fastnålad källcommit och
 tydlig attribution.
 
@@ -341,4 +341,4 @@ sina ursprungliga ägare och licenser. Se [docs/CREDIT.md](../../docs/CREDIT.md)
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/sw/README.md
+++ b/docs/i18n/sw/README.md
@@ -16,7 +16,7 @@ Ugunduzi unaotanguliza waumbaji na usakinishaji wa amri moja kwa programu-jalizi
   <a href="https://dsh-plugins.omniroute.online">Vinjari, tafuta na sakinisha kila programu-jalizi kwenye tovuti →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ na hazina hii inabeba data ya katalogi ya umma, schema na sera ambazo zote mbili
 
 ## Hali ya Katalogi
 
-**Programu-jalizi 877 zimeunganishwa.** Kila programu-jalizi inaingia kupitia pull request iliyokaguliwa
+**Programu-jalizi 974 zimeunganishwa.** Kila programu-jalizi inaingia kupitia pull request iliyokaguliwa
 kibinafsi, moja kwa wakati, kutoka hazina ya muumba wa asili, ikiwa na commit ya chanzo iliyobandikwa na
 utambuzi wa wazi.
 
@@ -336,4 +336,4 @@ Angalia [docs/CREDIT.md](../../docs/CREDIT.md) na [docs/UNOFFICIAL.md](../../doc
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/ta/README.md
+++ b/docs/i18n/ta/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">இணையதளத்தில் ஒவ்வொரு செருகுநிரலையும் உலாவவும், தேடவும், நிறுவவும் →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@ YAML கோப்பாகும், வெளியிடப்பட்ட JSO
 
 ## பட்டியல் நிலை
 
-**877 செருகுநிரல்கள் இணைக்கப்பட்டுள்ளன.** ஒவ்வொரு செருகுநிரலும் அசல் படைப்பாளர் களஞ்சியத்திலிருந்து,
+**974 செருகுநிரல்கள் இணைக்கப்பட்டுள்ளன.** ஒவ்வொரு செருகுநிரலும் அசல் படைப்பாளர் களஞ்சியத்திலிருந்து,
 பின்னிணைக்கப்பட்ட மூல commit-உடன், தெளிவான வரவு வழங்கலுடன், ஒரு நேரத்தில் ஒன்றாக தனித்தனியாக
 மதிப்பாய்வு செய்யப்பட்ட pull request மூலம் நுழைகிறது.
 
@@ -342,4 +342,4 @@ pull request திறப்பதற்கு முன் [CONTRIBUTING.md](..
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/te/README.md
+++ b/docs/i18n/te/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">వెబ్‌సైట్‌లో ప్రతి ప్లగిన్‌ను బ్రౌజ్ చేయండి, శోధించండి మరియు ఇన్‌స్టాల్ చేయండి →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@
 
 ## కేటలాగ్ స్థితి
 
-**877 ప్లగిన్‌లు మెర్జ్ చేయబడ్డాయి.** ప్రతి ప్లగిన్ ఒక వ్యక్తిగతంగా సమీక్షించిన పుల్ రిక్వెస్ట్ ద్వారా, ఒక్కొక్కటిగా,
+**974 ప్లగిన్‌లు మెర్జ్ చేయబడ్డాయి.** ప్రతి ప్లగిన్ ఒక వ్యక్తిగతంగా సమీక్షించిన పుల్ రిక్వెస్ట్ ద్వారా, ఒక్కొక్కటిగా,
 అసలు సృష్టికర్త రిపాజిటరీ నుండి, పిన్ చేయబడిన సోర్స్ కమిట్ మరియు స్పష్టమైన అట్రిబ్యూషన్‌తో ప్రవేశిస్తుంది.
 
 ## 🚀 CLIని ఇన్‌స్టాల్ చేయండి
@@ -334,4 +334,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">เรียกดู ค้นหา และติดตั้งปลั๊กอินทั้งหมดได้ที่เว็บไซต์ →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -117,7 +117,7 @@
 
 ## สถานะแคตตาล็อก
 
-**รวมปลั๊กอินแล้ว 877 รายการ** ทุกปลั๊กอินเข้าสู่แคตตาล็อกผ่านพูลรีเควสต์ที่รีวิวแยกทีละรายการ จากรีโพซิทอรีของผู้สร้างดั้งเดิม
+**รวมปลั๊กอินแล้ว 974 รายการ** ทุกปลั๊กอินเข้าสู่แคตตาล็อกผ่านพูลรีเควสต์ที่รีวิวแยกทีละรายการ จากรีโพซิทอรีของผู้สร้างดั้งเดิม
 พร้อมคอมมิตต้นทางที่ตรึงไว้และการให้เครดิตอย่างชัดเจน
 
 ## 🚀 ติดตั้ง CLI
@@ -323,4 +323,4 @@ README ฉบับนี้มีให้บริการ 43 ภาษาภ
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/tr/README.md
+++ b/docs/i18n/tr/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">Web sitesinde tüm eklentilere göz atın, arayın ve kurun →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -120,7 +120,7 @@ depo, ikisinin de tükettiği genel katalog verilerini, şemayı ve politikalar�
 
 ## Katalog durumu
 
-**877 eklenti birleştirildi.** Her eklenti, özgün üretici deposundan, sabitlenmiş bir kaynak
+**974 eklenti birleştirildi.** Her eklenti, özgün üretici deposundan, sabitlenmiş bir kaynak
 commit'i ve açık atıf ile, tek tek ve ayrı ayrı incelenmiş bir pull request üzerinden katalog'a
 girer.
 
@@ -341,4 +341,4 @@ lisansları altında kalır. Bkz. [docs/CREDIT.md](../../docs/CREDIT.md) ve
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/uk-UA/README.md
+++ b/docs/i18n/uk-UA/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">Переглядайте, шукайте та встановлюйте будь-який плагін на сайті →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -121,7 +121,7 @@
 
 ## Статус каталогу
 
-**Об'єднано 877 плагіни.** Кожен плагін потрапляє до каталогу через окремо розглянутий pull
+**Об'єднано 974 плагіни.** Кожен плагін потрапляє до каталогу через окремо розглянутий pull
 request, по одному за раз, із репозиторію оригінального автора, із закріпленим вихідним
 комітом і явною вказівкою авторства.
 
@@ -340,4 +340,4 @@ issue. Ніколи не надсилайте облікові дані, при�
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/ur/README.md
+++ b/docs/i18n/ur/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">ویب سائٹ پر تمام پلگ انز کو براؤز، تلاش اور انسٹال کریں →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -113,7 +113,7 @@
 
 ## کیٹلاگ کی صورتحال
 
-**877 پلگ ان ضم ہو چکے ہیں۔** ہر پلگ ان اصل تخلیق کار کی ریپوزٹری سے، ایک وقت میں ایک، ایک انفرادی طور پر جائزہ شدہ pull request کے ذریعے، ایک پن شدہ سورس کمٹ اور واضح انتساب کے ساتھ داخل ہوتا ہے۔
+**974 پلگ ان ضم ہو چکے ہیں۔** ہر پلگ ان اصل تخلیق کار کی ریپوزٹری سے، ایک وقت میں ایک، ایک انفرادی طور پر جائزہ شدہ pull request کے ذریعے، ایک پن شدہ سورس کمٹ اور واضح انتساب کے ساتھ داخل ہوتا ہے۔
 
 ## 🚀 CLI انسٹال کریں
 
@@ -287,4 +287,4 @@ pull request کھولنے سے پہلے [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/vi/README.md
+++ b/docs/i18n/vi/README.md
@@ -16,7 +16,7 @@ Khám phá và cài đặt plugin **DeepSeek Harness (DSH)** chỉ bằng một 
   <a href="https://dsh-plugins.omniroute.online">Duyệt, tìm kiếm và cài đặt mọi plugin trên website →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -119,7 +119,7 @@ dữ liệu danh mục công khai, schema và các chính sách mà cả hai đ�
 
 ## Trạng thái danh mục
 
-**Đã hợp nhất 877 plugin.** Mỗi plugin gia nhập danh mục qua một pull request được xét duyệt riêng, từng cái một, từ
+**Đã hợp nhất 974 plugin.** Mỗi plugin gia nhập danh mục qua một pull request được xét duyệt riêng, từng cái một, từ
 repository của nhà phát triển gốc, kèm commit nguồn đã ghim cố định và ghi công rõ ràng.
 
 ## 🚀 Cài đặt CLI
@@ -328,4 +328,4 @@ chụp màn hình ở nguồn gốc vẫn thuộc về chủ sở hữu và gi�
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">在网站上浏览、搜索并安装所有插件 →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -113,7 +113,7 @@
 
 ## 目录状态
 
-**已合并 877 个插件。** 每个插件都通过一次单独评审的拉取请求逐个纳入,来自原始创作者仓库,附带固定的源代码提交和明确署名。
+**已合并 974 个插件。** 每个插件都通过一次单独评审的拉取请求逐个纳入,来自原始创作者仓库,附带固定的源代码提交和明确署名。
 
 ## 🚀 安装 CLI
 
@@ -301,4 +301,4 @@ provenance:
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->

--- a/docs/i18n/zh-TW/README.md
+++ b/docs/i18n/zh-TW/README.md
@@ -16,7 +16,7 @@
   <a href="https://dsh-plugins.omniroute.online">在網站上瀏覽、搜尋並安裝所有外掛 →</a>
 </h3>
 
-[![Plugins](https://img.shields.io/badge/plugins-877_merged-3fb950)](https://dsh-plugins.omniroute.online)
+[![Plugins](https://img.shields.io/badge/plugins-974_merged-3fb950)](https://dsh-plugins.omniroute.online)
 [![npm](https://img.shields.io/npm/v/omni-dsh-plugins?label=CLI&color=cb3837&logo=npm)](https://www.npmjs.com/package/omni-dsh-plugins)
 [![Catalog validation](https://img.shields.io/github/actions/workflow/status/diegosouzapw/awesome-omni-dsh-plugins/validate-catalog.yml?label=catalog%20validation&logo=github)](https://github.com/diegosouzapw/awesome-omni-dsh-plugins/actions/workflows/validate-catalog.yml)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20CC0--1.0-blue)](../../LICENSE)
@@ -115,7 +115,7 @@
 
 ## 目錄狀態
 
-**已合併 877 個外掛。** 每個外掛皆透過一次單獨審查的提取請求逐一納入,來自原始創作者儲存庫,並附帶固定的來源提交與明確
+**已合併 974 個外掛。** 每個外掛皆透過一次單獨審查的提取請求逐一納入,來自原始創作者儲存庫,並附帶固定的來源提交與明確
 掛名。
 
 ## 🚀 安裝 CLI
@@ -308,4 +308,4 @@ monorepo 中的整合仍可被發現,但使用 `stars: null`,絕不繼承母專�
 
 </div>
 
-<!-- i18n-source-hash: b40d0d0c84b2bf9e2c7726942f36527572333d0b7a5cb86d91e31e8a18c67284 -->
+<!-- i18n-source-hash: 700f8a84d15b2a127f49b4eecfb0458b69f18ee4635aada00da6a451e4100da8 -->


### PR DESCRIPTION
Post-round realignment after round 3 of the auto-approval pipeline (97 catalog PRs, all merged): merged-count phrase and badge updated in the English README and all 42 translations (native digits included); Top 10 unchanged; all 420 translated documents re-stamped (freshness gate 420 current / 0 stale / 0 missing).