### PR TITLE
catalog: add 0qwq0-dsh-discord-richpresence (community curation, created by @0QwQ0)

### DIFF
--- a/catalog/plugins/0qwq0-dsh-discord-richpresence.yaml
+++ b/catalog/plugins/0qwq0-dsh-discord-richpresence.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 0qwq0-dsh-discord-richpresence
+name: dsh-discord-richpresence
+description:
+  en: Push vague or rich, user-configurable DSH interaction states to the local Discord client as Rich Presence.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - discord
+  - rich-presence
+  - rpc
+source:
+  repository: https://github.com/0QwQ0/dsh-discord-richpresence
+  repositoryNodeId: R_kgDOUAtDCw
+  subpath: null
+  commit: f697074a3bc5181c4b30a8e72166bd5a1ff4cf98
+creator:
+  github: 0QwQ0
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:50.229Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `0qwq0-dsh-discord-richpresence`
- Submission type: community curation
- Created by `0QwQ0` — https://github.com/0QwQ0
- Original source repository: https://github.com/0QwQ0/dsh-discord-richpresence
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.