### PR TITLE
catalog: add 0xrabit-dsh-crypto-portfolio (community curation, created by @0xRabit)

### DIFF
--- a/catalog/plugins/0xrabit-dsh-crypto-portfolio.yaml
+++ b/catalog/plugins/0xrabit-dsh-crypto-portfolio.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: 0xrabit-dsh-crypto-portfolio
+name: dsh-crypto-portfolio
+description:
+  en: Crypto portfolio tracker (BTC/EVM/Solana/Hyperliquid/CEX) as a DSH plugin. All private keys/wallets live in user-local JSON configs, never in this package.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - crypto
+  - portfolio
+  - tracker
+  - solana
+  - hyperliquid
+  - private
+  - keys
+  - wallets
+  - live
+  - user
+  - local
+  - json
+  - configs
+  - never
+  - package
+  - dsh
+source:
+  repository: https://github.com/0xRabit/dsh-crypto-portfolio
+  repositoryNodeId: R_kgDOUAihHA
+  subpath: null
+  commit: bd81f79422b7c41e38bbc0da671f5b2d49da00ad
+creator:
+  github: 0xRabit
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:26.073Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `0xrabit-dsh-crypto-portfolio`
- Submission type: community curation
- Created by `0xRabit` — https://github.com/0xRabit
- Original source repository: https://github.com/0xRabit/dsh-crypto-portfolio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.