### PR TITLE
catalog: add 1094-dsh-codebase-memory (community curation, created by @1094)

### DIFF
--- a/catalog/plugins/1094-dsh-codebase-memory.yaml
+++ b/catalog/plugins/1094-dsh-codebase-memory.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: 1094-dsh-codebase-memory
+name: dsh-codebase-memory
+description:
+  en: DSH bundle that bridges the Codebase Memory MCP code knowledge graph into DSH and can keep indexed repositories fresh with an optional debounced filesystem watcher.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - codebase-memory
+  - mcp
+  - knowledge-graph
+  - bundle-plugin
+  - watcher
+  - chokidar
+source:
+  repository: https://github.com/andyfan1094/dsh-codebase-memory
+  repositoryNodeId: R_kgDOT_RKjw
+  subpath: null
+  commit: c6c64183b6c9c16b2247364ee213c7dad6402ac5
+creator:
+  github: "1094"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:59.834Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1094-dsh-codebase-memory`
- Submission type: community curation
- Created by `1094` — https://github.com/1094
- Original source repository: https://github.com/andyfan1094/dsh-codebase-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.