### PR TITLE
catalog: add 1094-dsh-minimax-usage-pro (community curation, created by @1094)

### DIFF
--- a/catalog/plugins/1094-dsh-minimax-usage-pro.yaml
+++ b/catalog/plugins/1094-dsh-minimax-usage-pro.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 1094-dsh-minimax-usage-pro
+name: dsh-minimax-usage-pro
+description:
+  en: DSH Settings integration for MiniMax Token Plan usage, using Host webServer routes compatible with trusted bundle plugins and both MiniMax subscription key names.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - minimax
+  - minimax-usage
+  - token-plan
+  - bundle-plugin
+source:
+  repository: https://github.com/andyfan1094/dsh-minimax-usage-pro
+  repositoryNodeId: R_kgDOT_RTAw
+  subpath: null
+  commit: 3f68cdaa60d73d482bcd3d02890f728320f2d83e
+creator:
+  github: "1094"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:14.892Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1094-dsh-minimax-usage-pro`
- Submission type: community curation
- Created by `1094` — https://github.com/1094
- Original source repository: https://github.com/andyfan1094/dsh-minimax-usage-pro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.