### PR TITLE
catalog: add 1094-dsh-winrm (community curation, created by @1094)

### DIFF
--- a/catalog/plugins/1094-dsh-winrm.yaml
+++ b/catalog/plugins/1094-dsh-winrm.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: 1094-dsh-winrm
+name: dsh-winrm
+description:
+  en: "Remote Windows administration for the dsh web GUI: WinRM/PowerShell Remoting host config store (~/.dsh/dsh-winrm.json), PowerShell exec / streaming console / service & process management / base64-chunked file transfer / cluster execution, plus agent tools (winrm list, winrm exec, winrm service, winrm process, winrm upl"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - windows
+  - winrm
+  - remote
+  - powershell
+  - bundle-plugin
+source:
+  repository: https://github.com/andyfan1094/dsh-winrm
+  repositoryNodeId: R_kgDOT_MkQA
+  subpath: null
+  commit: 220492f2ec7f420637ae9f7dfd00490f5640af49
+creator:
+  github: "1094"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:01.451Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1094-dsh-winrm`
- Submission type: community curation
- Created by `1094` — https://github.com/1094
- Original source repository: https://github.com/andyfan1094/dsh-winrm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.