### PR TITLE
catalog: add 1692775560-dsh-mimir (community curation, created by @1692775560)

### DIFF
--- a/catalog/plugins/1692775560-dsh-mimir.yaml
+++ b/catalog/plugins/1692775560-dsh-mimir.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: 1692775560-dsh-mimir
+name: dsh-mimir
+description:
+  en: Research-assistant plugin suite (literature search, research wiki, LaTeX compile, independent subagent review) for the DeepSeek Harness
+  evidencePath: packages/mimir/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - research
+  - arxiv
+  - latex
+  - zotero
+  - literature
+  - experiment-tracking
+  - dsh
+source:
+  repository: https://github.com/1692775560/dsh-Mimir-Academic-research
+  repositoryNodeId: R_kgDOT-o2-Q
+  subpath: packages/mimir
+  commit: 6d865381be69b1d352db39b4f06a7605f4e8cf56
+creator:
+  github: "1692775560"
+package:
+  ecosystem: npm
+  name: dsh-mimir
+  version: 0.14.1
+  integrity: sha512-R0V54hWG0FACo7QH1n59WQMBsCQhZXvNaFdGBpDd1UCUQBvjsa5AAPFhGK6vuUqF8R9okEzZPyVSghH5suwLLw==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/mimir/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:28.296Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1692775560-dsh-mimir`
- Submission type: community curation
- Created by `1692775560` — https://github.com/1692775560
- Original source repository: https://github.com/1692775560/dsh-Mimir-Academic-research
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.