### PR TITLE
catalog: add 1byteone-dsh-plugin-nlbi (community curation, created by @1byteone)

### DIFF
--- a/catalog/plugins/1byteone-dsh-plugin-nlbi.yaml
+++ b/catalog/plugins/1byteone-dsh-plugin-nlbi.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: 1byteone-dsh-plugin-nlbi
+name: dsh-plugin-nlbi
+description:
+  en: Natural-language data queries + BI reports for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - nlbi
+  - text2sql
+  - nl2sql
+  - bi
+  - dashboard
+  - metrics
+  - olap
+  - mysql
+  - database
+  - sql
+  - chart
+  - echarts
+  - report
+source:
+  repository: https://github.com/1byteone/dsh-plugin-nlbi
+  repositoryNodeId: R_kgDOUBYNyg
+  subpath: null
+  commit: 232f9243029add39dd18a368de45d8326aca178f
+creator:
+  github: 1byteone
+package:
+  ecosystem: npm
+  name: dsh-plugin-nlbi
+  version: 0.2.1
+  integrity: sha512-5opADs5YuPXrYxL26CA9xeqZdOSaK1IzBKmIfjYqHoq5ZT/ukpglKJO0mGKnHSIkjcemwS7kOmFGcUZuKMnUNw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:51.758Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1byteone-dsh-plugin-nlbi`
- Submission type: community curation
- Created by `1byteone` — https://github.com/1byteone
- Original source repository: https://github.com/1byteone/dsh-plugin-nlbi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.