### PR TITLE
catalog: add 534119219-chicheng-peak (community curation, created by @534119219)

### DIFF
--- a/catalog/plugins/534119219-chicheng-peak.yaml
+++ b/catalog/plugins/534119219-chicheng-peak.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 534119219-chicheng-peak
+name: chicheng-peak
+description:
+  en: sh dsh plugin --profile web add D:\Harness\chicheng-peak
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - peak
+  - valley
+  - reminder
+  - push
+source:
+  repository: https://github.com/534119219/chicheng-peak
+  repositoryNodeId: R_kgDOT6dW6A
+  subpath: null
+  commit: b89dc9a63eb270736fae63e43445b421477c02ab
+creator:
+  github: "534119219"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:27.616Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `534119219-chicheng-peak`
- Submission type: community curation
- Created by `534119219` — https://github.com/534119219
- Original source repository: https://github.com/534119219/chicheng-peak
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.