### PR TITLE
catalog: add 764475881-dsh-chat-width (community curation, created by @764475881)

### DIFF
--- a/catalog/plugins/764475881-dsh-chat-width.yaml
+++ b/catalog/plugins/764475881-dsh-chat-width.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 764475881-dsh-chat-width
+name: dsh-chat-width
+description:
+  en: bash dsh plugin --profile web add github:764475881/dsh-chat-width
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - chat-width
+  - ui
+source:
+  repository: https://github.com/764475881/dsh-chat-width
+  repositoryNodeId: R_kgDOT9SZBQ
+  subpath: null
+  commit: 9737a8d4e46064e5236d343d63ebfd62b5abd8c2
+creator:
+  github: "764475881"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:29.163Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `764475881-dsh-chat-width`
- Submission type: community curation
- Created by `764475881` — https://github.com/764475881
- Original source repository: https://github.com/764475881/dsh-chat-width
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.