### PR TITLE
catalog: add 988hj7tczd-oss-dsh-im-qq (community curation, created by @988hj7tczd-oss)

### DIFF
--- a/catalog/plugins/988hj7tczd-oss-dsh-im-qq.yaml
+++ b/catalog/plugins/988hj7tczd-oss-dsh-im-qq.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: 988hj7tczd-oss-dsh-im-qq
+name: dsh-im-qq
+description:
+  en: bash export DSH QQ SECRET='你的AppSecret'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - im
+  - qq
+  - qqbot
+  - harness-desktop
+  - cua
+  - agent
+source:
+  repository: https://github.com/988hj7tczd-oss/dsh-im-qq
+  repositoryNodeId: R_kgDOT57KCA
+  subpath: null
+  commit: d1ae12486264359f9c516bb2cf0ed5e75e811d37
+creator:
+  github: 988hj7tczd-oss
+package:
+  ecosystem: npm
+  name: dsh-im-qq
+  version: 0.1.1
+  integrity: sha512-fZMvPRzmerryjAqi+98vWRocUIc+jknkznbSbPPjt3iMINkzzA6npct2FBjJhQYrLSlAVBuSccTCyAVz0cJvPw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:30.648Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `988hj7tczd-oss-dsh-im-qq`
- Submission type: community curation
- Created by `988hj7tczd-oss` — https://github.com/988hj7tczd-oss
- Original source repository: https://github.com/988hj7tczd-oss/dsh-im-qq
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.