### PR TITLE
catalog: add 988hj7tczd-oss-dsh-math-olympiad (community curation, created by @988hj7tczd-oss)

### DIFF
--- a/catalog/plugins/988hj7tczd-oss-dsh-math-olympiad.yaml
+++ b/catalog/plugins/988hj7tczd-oss-dsh-math-olympiad.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: 988hj7tczd-oss-dsh-math-olympiad
+name: dsh-math-olympiad
+description:
+  en: 'DSH skill bundle: competition math (IMO/Putnam/USAMO/AIME) solved with a pure-reasoning pass, an adversarial verifier in a fresh subagent context attacking concrete failure modes, and calibrated confidence output (high / medium / honest "no confident solution"); optional LaTeX→PDF rendering.'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - skill
+  - math
+  - olympiad
+  - imo
+  - putnam
+  - proof-verification
+source:
+  repository: https://github.com/988hj7tczd-oss/dsh-math-olympiad
+  repositoryNodeId: R_kgDOUCa41A
+  subpath: null
+  commit: b04fadfeaf88f8f98ba09ab57e9379eb36f05ea0
+creator:
+  github: 988hj7tczd-oss
+package:
+  ecosystem: npm
+  name: dsh-math-olympiad
+  version: 0.1.0
+  integrity: sha512-Awcn6vUvr5UJlXes2aHlwoQxqevTOfPTWKddyJbjkZa7ynaqWVbUlDm7V81cryO418/+YHWtX/peqIMDqHsbTw==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:38.164Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `988hj7tczd-oss-dsh-math-olympiad`
- Submission type: community curation
- Created by `988hj7tczd-oss` — https://github.com/988hj7tczd-oss
- Original source repository: https://github.com/988hj7tczd-oss/dsh-math-olympiad
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.