### PR TITLE
catalog: add 988hj7tczd-oss-dsh-modernize-code (community curation, created by @988hj7tczd-oss)

### DIFF
--- a/catalog/plugins/988hj7tczd-oss-dsh-modernize-code.yaml
+++ b/catalog/plugins/988hj7tczd-oss-dsh-modernize-code.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 988hj7tczd-oss-dsh-modernize-code
+name: dsh-modernize-code
+description:
+  en: preflight ──► assess ──► map ──► transform（逐块循环）
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - skill
+  - legacy-code
+  - modernization
+  - refactoring
+  - migration
+source:
+  repository: https://github.com/988hj7tczd-oss/dsh-modernize-code
+  repositoryNodeId: R_kgDOUCa2Xg
+  subpath: null
+  commit: 4d110103666fde9515b9a8077b7e0458d00023a8
+creator:
+  github: 988hj7tczd-oss
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:56.705Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `988hj7tczd-oss-dsh-modernize-code`
- Submission type: community curation
- Created by `988hj7tczd-oss` — https://github.com/988hj7tczd-oss
- Original source repository: https://github.com/988hj7tczd-oss/dsh-modernize-code
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.