### PR TITLE
catalog: add 988hj7tczd-oss-harness-github (community curation, created by @988hj7tczd-oss)

### DIFF
--- a/catalog/plugins/988hj7tczd-oss-harness-github.yaml
+++ b/catalog/plugins/988hj7tczd-oss-harness-github.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: 988hj7tczd-oss-harness-github
+name: harness-github
+description:
+  en: "DeepSeek Harness GitHub plugin: review PRs, triage issues, debug Actions CI, handle review feedback, and prepare code changes for review — via gh CLI or REST, no extra sign-in required."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - pull-request
+  - code-review
+  - ci
+  - issues
+  - actions
+source:
+  repository: https://github.com/988hj7tczd-oss/harness-github
+  repositoryNodeId: R_kgDOUBdGyw
+  subpath: null
+  commit: 6bb9803f787b4ee4fa66f28fa8c889369ce28d2e
+creator:
+  github: 988hj7tczd-oss
+package:
+  ecosystem: npm
+  name: harness-github
+  version: 0.1.0
+  integrity: sha512-UKzroMAAqIgBiZG6Jdinrq7+65yQvWv1ng6vOEa7RAgOdTGgx24FQFfRWW5cfL5Knxag6AdZWzzESn0+7eonIQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:40.039Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `988hj7tczd-oss-harness-github`
- Submission type: community curation
- Created by `988hj7tczd-oss` — https://github.com/988hj7tczd-oss
- Original source repository: https://github.com/988hj7tczd-oss/harness-github
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.