### PR TITLE
catalog: add a3boy-dsh-web-tools (community curation, created by @A3Boy)

### DIFF
--- a/catalog/plugins/a3boy-dsh-web-tools.yaml
+++ b/catalog/plugins/a3boy-dsh-web-tools.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: a3boy-dsh-web-tools
+name: dsh-web-tools
+description:
+  en: Unified multi-provider web search and fetch for DeepSeek Harness — BYOK, per-provider credential pools, quota & health monitoring, deterministic fallback, native settings UI, and self-hosted search
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - unified
+  - multi
+  - provider
+  - search
+  - fetch
+  - byok
+  - credential
+  - pools
+  - quota
+  - health
+  - monitoring
+  - deterministic
+  - fallback
+  - native
+  - settings
+  - self
+source:
+  repository: https://github.com/A3Boy/dsh-web-tools
+  repositoryNodeId: R_kgDOT5XWrA
+  subpath: null
+  commit: e664521d51c4e6fa738e79126bf2e78e2cc62455
+creator:
+  github: A3Boy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:37:59.603Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 22
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `a3boy-dsh-web-tools`
- Submission type: community curation
- Created by `A3Boy` — https://github.com/A3Boy
- Original source repository: https://github.com/A3Boy/dsh-web-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.