### PR TITLE
catalog: add a903067276-rgb-dsh-backup (community curation, created by @a903067276-rgb)

### DIFF
--- a/catalog/plugins/a903067276-rgb-dsh-backup.yaml
+++ b/catalog/plugins/a903067276-rgb-dsh-backup.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: a903067276-rgb-dsh-backup
+name: dsh-backup
+description:
+  en: Automated backups of DSH sessions, config and custom directories — scheduled or manual, packed as tgz with rotation
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - backup
+  - automation
+source:
+  repository: https://github.com/a903067276-rgb/dsh-backup
+  repositoryNodeId: R_kgDOT-N9tQ
+  subpath: null
+  commit: 40216c55e078136a246547bd5cce6c79c78fb060
+creator:
+  github: a903067276-rgb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:58.099Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `a903067276-rgb-dsh-backup`
- Submission type: community curation
- Created by `a903067276-rgb` — https://github.com/a903067276-rgb
- Original source repository: https://github.com/a903067276-rgb/dsh-backup
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.