### PR TITLE
catalog: add adrianleb-dsh-tmux-cc (community curation, created by @adrianleb)

### DIFF
--- a/catalog/plugins/adrianleb-dsh-tmux-cc.yaml
+++ b/catalog/plugins/adrianleb-dsh-tmux-cc.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: adrianleb-dsh-tmux-cc
+name: dsh-tmux-cc
+description:
+  en: A persistent tmux control-mode cockpit for DeepSeek Harness Web.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - tmux
+  - control-mode
+  - terminal
+  - web-terminal
+  - xtermjs
+  - mobile
+source:
+  repository: https://github.com/adrianleb/dsh-tmux-cc
+  repositoryNodeId: R_kgDOUEFnHA
+  subpath: null
+  commit: e1c0daeca0edcc2fbe422486d61006a625140f59
+creator:
+  github: adrianleb
+package:
+  ecosystem: npm
+  name: dsh-tmux-cc
+  version: 0.5.3
+  integrity: sha512-wftpEv6efhHWsiaBR1Ft96+zTwtEVaucid+nuLZDQKBD2ehM8/T0hZ6P8hRPUIkDREsRUPvNyGC2Z7vUQSqt9w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:43.395Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `adrianleb-dsh-tmux-cc`
- Submission type: community curation
- Created by `adrianleb` — https://github.com/adrianleb
- Original source repository: https://github.com/adrianleb/dsh-tmux-cc
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.