### PR TITLE
catalog: add adwmc-skill-protocol (community curation, created by @ADWMC)

### DIFF
--- a/catalog/plugins/adwmc-skill-protocol.yaml
+++ b/catalog/plugins/adwmc-skill-protocol.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: adwmc-skill-protocol
+name: "@dsh-security/skill-protocol"
+description:
+  en: Armor-piercing all-in-one security-analysis plugin for DeepSeek Harness
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - armor
+  - piercing
+  - security
+  - analysis
+  - dsh
+source:
+  repository: https://github.com/ADWMC/helm-d
+  repositoryNodeId: R_kgDOT4fdYg
+  subpath: packages/skill-protocol
+  commit: 50f2a2773ca3c092780e9424625dc8043dddf6c2
+creator:
+  github: ADWMC
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/skill-protocol/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:45.370Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `adwmc-skill-protocol`
- Submission type: community curation
- Created by `ADWMC` — https://github.com/ADWMC
- Original source repository: https://github.com/ADWMC/helm-d
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.