### PR TITLE
catalog: add akimiya-z-dsh-codex-guard (community curation, created by @Akimiya-z)

### DIFF
--- a/catalog/plugins/akimiya-z-dsh-codex-guard.yaml
+++ b/catalog/plugins/akimiya-z-dsh-codex-guard.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: akimiya-z-dsh-codex-guard
+name: dsh-codex-guard
+description:
+  en: "DeepSeek Harness tool: pre-submit hygiene checks (TODO leftovers, hardcoded secrets, commit subjects) for agent-authored pull requests."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - codex-guard
+  - code-review
+  - quality-gate
+source:
+  repository: https://github.com/Akimiya-z/codex-guard
+  repositoryNodeId: R_kgDOT-yddw
+  subpath: dsh
+  commit: 7bf02b7f5e42ed401a277a19495f1c9f0d379742
+creator:
+  github: Akimiya-z
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:04.403Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `akimiya-z-dsh-codex-guard`
- Submission type: community curation
- Created by `Akimiya-z` — https://github.com/Akimiya-z
- Original source repository: https://github.com/Akimiya-z/codex-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.