### PR TITLE
catalog: add akush99-dsh-balance-chip (community curation, created by @AKUSH99)

### DIFF
--- a/catalog/plugins/akush99-dsh-balance-chip.yaml
+++ b/catalog/plugins/akush99-dsh-balance-chip.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: akush99-dsh-balance-chip
+name: dsh-balance-chip
+description:
+  en: DeepSeek API balance in the DSH sidebar footer – live status dot plus amount, 60s refresh, key stays local.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - balance
+  - usage
+  - billing
+source:
+  repository: https://github.com/AKUSH99/dsh-balance-chip
+  repositoryNodeId: R_kgDOUEutsA
+  subpath: null
+  commit: a2080e0f5024f95d35439988107183f024ba034d
+creator:
+  github: AKUSH99
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:06.327Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `akush99-dsh-balance-chip`
- Submission type: community curation
- Created by `AKUSH99` — https://github.com/AKUSH99
- Original source repository: https://github.com/AKUSH99/dsh-balance-chip
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.