### PR TITLE
catalog: add alexpeng07-dsh-custom-plugin (community curation, created by @AlexPeng07)

### DIFF
--- a/catalog/plugins/alexpeng07-dsh-custom-plugin.yaml
+++ b/catalog/plugins/alexpeng07-dsh-custom-plugin.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: alexpeng07-dsh-custom-plugin
+name: "@alexpeng/dsh-custom-plugin"
+description:
+  en: "Custom convenience suite for the dsh web GUI: background colors with weather FX, liquid glass, a per-user-message timeline rail with stars and branching, multi-level project folders, prompt library, conversation export (JSON / Markdown / PDF-with-images), Mermaid rendering, quote reply, DeepSeek balance and daily token"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - custom
+  - convenience
+  - suite
+  - background
+  - colors
+  - weather
+  - liquid
+  - glass
+  - user
+  - message
+  - timeline
+  - rail
+  - stars
+  - branching
+  - multi
+  - level
+source:
+  repository: https://github.com/AlexPeng07/dsh-custom-plugin
+  repositoryNodeId: R_kgDOUAvDdw
+  subpath: null
+  commit: 4646feff7e77f5e7f0716f836b4647e5741399d8
+creator:
+  github: AlexPeng07
+package:
+  ecosystem: npm
+  name: "@alexpeng/dsh-custom-plugin"
+  version: 0.1.5
+  integrity: sha512-tXrPxWuWHrG5ZHZuoByyyicyKRCI8X24KiqsWxH65qtMzHaxwL+/P938KgEmEUEibm/cUgRGm7IPDKGGV8Qv5A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:13.525Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alexpeng07-dsh-custom-plugin`
- Submission type: community curation
- Created by `AlexPeng07` — https://github.com/AlexPeng07
- Original source repository: https://github.com/AlexPeng07/dsh-custom-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.