### PR TITLE
catalog: add alondan-dsh-notifications (community curation, created by @AlonDan)

### DIFF
--- a/catalog/plugins/alondan-dsh-notifications.yaml
+++ b/catalog/plugins/alondan-dsh-notifications.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: alondan-dsh-notifications
+name: dsh-notifications
+description:
+  en: Sound notifications for DSH agent interactions
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - sound
+  - notifications
+  - agent
+  - interactions
+  - dsh
+source:
+  repository: https://github.com/AlonDan/dsh-notifications
+  repositoryNodeId: R_kgDOUEyU9Q
+  subpath: null
+  commit: 9f59e38c15dec27b0f2ff92afee1857940d71b5d
+creator:
+  github: AlonDan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:33.575Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alondan-dsh-notifications`
- Submission type: community curation
- Created by `AlonDan` — https://github.com/AlonDan
- Original source repository: https://github.com/AlonDan/dsh-notifications
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.