### PR TITLE
catalog: add alpacachen-dsh-simple-worktree (community curation, created by @alpacachen)

### DIFF
--- a/catalog/plugins/alpacachen-dsh-simple-worktree.yaml
+++ b/catalog/plugins/alpacachen-dsh-simple-worktree.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: alpacachen-dsh-simple-worktree
+name: "@alpacachen/dsh-simple-worktree"
+description:
+  en: A minimal worktree manager with one button and one dialog for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - git
+  - worktree
+source:
+  repository: https://github.com/alpacachen/dsh-worktree
+  repositoryNodeId: R_kgDOT_cJNg
+  subpath: null
+  commit: 18c54e16b71474d9cee046ca84c22d5ecc8d9cc5
+creator:
+  github: alpacachen
+package:
+  ecosystem: npm
+  name: "@alpacachen/dsh-simple-worktree"
+  version: 1.0.2
+  integrity: sha512-EJcxfSqgokXO3ghOOgXNAjXlV8sXCtnL0eZQLka83/HJITIQ0esPALra7T6TfN9UoAHKXTMt+ePMkgeT+0OM4A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:13.406Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alpacachen-dsh-simple-worktree`
- Submission type: community curation
- Created by `alpacachen` — https://github.com/alpacachen
- Original source repository: https://github.com/alpacachen/dsh-worktree
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.