### PR TITLE
catalog: add angeloszou-dsh-pdf-reader (community curation, created by @AngelosZou)

### DIFF
--- a/catalog/plugins/angeloszou-dsh-pdf-reader.yaml
+++ b/catalog/plugins/angeloszou-dsh-pdf-reader.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: angeloszou-dsh-pdf-reader
+name: dsh-pdf-reader
+description:
+  en: "DeepSeek Harness plugin: content-aware PDF reading tools for vision models (pdf scan / pdf read page / pdf render region). Detects figures (vector+raster), tables, math, and two-column layout per page, then routes text pages to extraction and figure/table/math pages to high-DPI region crops rendered for read image — av"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - pdf
+  - vision
+  - pdf-reader
+  - ocr
+  - figure
+  - table
+  - pymupdf
+source:
+  repository: https://github.com/AngelosZou/dsh-pdf-reader
+  repositoryNodeId: R_kgDOUDtPFg
+  subpath: null
+  commit: ffecd361b7f2803fdccd1cf92149aad3e11a3271
+creator:
+  github: AngelosZou
+package:
+  ecosystem: npm
+  name: dsh-pdf-reader
+  version: 0.2.0
+  integrity: sha512-f8y3pp6eVobnqNHhWUwYRS13CzSxvbwifD2OSeaQNP+cCLd8wLGD4tOILlL3RLD3MPcmzyo0rxJz8+Jg8S1mQw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:02.931Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `angeloszou-dsh-pdf-reader`
- Submission type: community curation
- Created by `AngelosZou` — https://github.com/AngelosZou
- Original source repository: https://github.com/AngelosZou/dsh-pdf-reader
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.