### PR TITLE
catalog: add angelyeye-dsh-cost-tracker (community curation, created by @Angelyeye)

### DIFF
--- a/catalog/plugins/angelyeye-dsh-cost-tracker.yaml
+++ b/catalog/plugins/angelyeye-dsh-cost-tracker.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: angelyeye-dsh-cost-tracker
+name: dsh-cost-tracker
+description:
+  en: "DeepSeek Harness (DSH) plugin: LLM token usage & cost tracking with a settings dashboard, agent tools, HTTP API and persistent storage."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - cordis
+  - llm
+  - token-usage
+  - cost-tracking
+source:
+  repository: https://github.com/Angelyeye/dsh-cost-tracker
+  repositoryNodeId: R_kgDOT8PGbg
+  subpath: null
+  commit: 2c2a450e6c9a52ab059ae6802ae7dbe449264838
+creator:
+  github: Angelyeye
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:04.523Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `angelyeye-dsh-cost-tracker`
- Submission type: community curation
- Created by `Angelyeye` — https://github.com/Angelyeye
- Original source repository: https://github.com/Angelyeye/dsh-cost-tracker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.