### PR TITLE
catalog: add asherliner-dsh-memory-connect (community curation, created by @asherliner)

### DIFF
--- a/catalog/plugins/asherliner-dsh-memory-connect.yaml
+++ b/catalog/plugins/asherliner-dsh-memory-connect.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: asherliner-dsh-memory-connect
+name: "@deepseek-ai/dsh-memory-connect"
+description:
+  en: Cross-session memory plugin for DSH — auto-extraction, semantic recall, scheduled maintenance, LLM-powered consolidation, context explosion prevention, global Soul identity
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - memory
+  - cross-session
+  - recall
+  - consolidation
+  - soul
+  - identity
+source:
+  repository: https://github.com/Asher-2000/dsh-memory-connect
+  repositoryNodeId: R_kgDOT9OJIA
+  subpath: null
+  commit: 41d71fdd419b8179ef677528a3d01fa7a427128a
+creator:
+  github: asherliner
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:10.274Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `asherliner-dsh-memory-connect`
- Submission type: community curation
- Created by `asherliner` — https://github.com/asherliner
- Original source repository: https://github.com/Asher-2000/dsh-memory-connect
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.