### PR TITLE
catalog: add azwosile-dsh-highres-vision (community curation, created by @azwosile)

### DIFF
--- a/catalog/plugins/azwosile-dsh-highres-vision.yaml
+++ b/catalog/plugins/azwosile-dsh-highres-vision.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: azwosile-dsh-highres-vision
+name: dsh-highres-vision
+description:
+  en: "DeepSeek Harness vision enhancer: raises image limits to official values and provides high-resolution tiled image reading via a dedicated tool."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - vision
+  - enhancer
+  - raises
+  - image
+  - limits
+  - official
+  - values
+  - high
+  - resolution
+  - tiled
+  - reading
+  - dedicated
+  - tool
+  - dsh
+source:
+  repository: https://github.com/azwosile/dsh-highres-vision
+  repositoryNodeId: R_kgDOUC5kSg
+  subpath: null
+  commit: a0e1c7a7b291a1d653abae00a731527beeec7ec6
+creator:
+  github: azwosile
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:06.508Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `azwosile-dsh-highres-vision`
- Submission type: community curation
- Created by `azwosile` — https://github.com/azwosile
- Original source repository: https://github.com/azwosile/dsh-highres-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.