### PR TITLE
catalog: add azzygoatcoder-agent-useful-skills (community curation, created by @Azzygoatcoder)

### DIFF
--- a/catalog/plugins/azzygoatcoder-agent-useful-skills.yaml
+++ b/catalog/plugins/azzygoatcoder-agent-useful-skills.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: azzygoatcoder-agent-useful-skills
+name: agent-useful-skills
+description:
+  en: Modular AI research/engineering skill pack for DeepSeek Harness — security audit, paper workflows, dev workflow, storage analysis. Installable via dsh plugin add.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - skills
+  - claude-code
+  - security-audit
+  - paper-workflow
+source:
+  repository: https://github.com/Azzygoatcoder/agent-useful-skills
+  repositoryNodeId: R_kgDOS9bD5Q
+  subpath: null
+  commit: f1e82ebcb304e186880b057706d9a1a92ba65c49
+creator:
+  github: Azzygoatcoder
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:18.317Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `azzygoatcoder-agent-useful-skills`
- Submission type: community curation
- Created by `Azzygoatcoder` — https://github.com/Azzygoatcoder
- Original source repository: https://github.com/Azzygoatcoder/agent-useful-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.