### PR TITLE
catalog: add b-tq-dsh-wallpaper (community curation, created by @B-TQ)

### DIFF
--- a/catalog/plugins/b-tq-dsh-wallpaper.yaml
+++ b/catalog/plugins/b-tq-dsh-wallpaper.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: b-tq-dsh-wallpaper
+name: "@b-tq/dsh-wallpaper"
+description:
+  en: bash dsh plugin --profile web add "github:B-TQ/dsh-wallpaper"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - wallpaper
+  - wallpaper-engine
+source:
+  repository: https://github.com/B-TQ/dsh-wallpaper
+  repositoryNodeId: R_kgDOT7FakA
+  subpath: null
+  commit: 3a70868a203464c4e6281816f452b4faa6730a01
+creator:
+  github: B-TQ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:09.220Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `b-tq-dsh-wallpaper`
- Submission type: community curation
- Created by `B-TQ` — https://github.com/B-TQ
- Original source repository: https://github.com/B-TQ/dsh-wallpaper
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.