### PR TITLE
catalog: add b1lli-dsh-learning-bundle (community curation, created by @B1lli)

### DIFF
--- a/catalog/plugins/b1lli-dsh-learning-bundle.yaml
+++ b/catalog/plugins/b1lli-dsh-learning-bundle.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: b1lli-dsh-learning-bundle
+name: dsh-learning-bundle
+description:
+  en: "A proof-carrying correction loop for DSH: explicit adoption, scoped recall, and reconstructable delivery."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - correction-learning
+  - agent-memory
+  - agent-learning
+  - llm-evaluation
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/B1lli/dsh-learning-bundle
+  repositoryNodeId: R_kgDOUA1kBA
+  subpath: null
+  commit: 9271370b333cbc9d124a8a9fd8283c37bf9a4b77
+creator:
+  github: B1lli
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:19.916Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `b1lli-dsh-learning-bundle`
- Submission type: community curation
- Created by `B1lli` — https://github.com/B1lli
- Original source repository: https://github.com/B1lli/dsh-learning-bundle
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.