### PR TITLE
catalog: add baisbt-dsh-greater-clarity (community curation, created by @Baisbt)

### DIFF
--- a/catalog/plugins/baisbt-dsh-greater-clarity.yaml
+++ b/catalog/plugins/baisbt-dsh-greater-clarity.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: baisbt-dsh-greater-clarity
+name: "@dsh-external/dsh-greater-clarity"
+description:
+  en: sh dsh plugin --profile web add github:Baisbt/dsh-GreaterClarity-plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - conversation
+  - export
+  - markdown
+  - avatar
+source:
+  repository: https://github.com/Baisbt/dsh-GreaterClarity-plugin
+  repositoryNodeId: R_kgDOUBUXUA
+  subpath: null
+  commit: dcb241c299d2d2b46d42d05c5b90e47a18bd9996
+creator:
+  github: Baisbt
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:10.859Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baisbt-dsh-greater-clarity`
- Submission type: community curation
- Created by `Baisbt` — https://github.com/Baisbt
- Original source repository: https://github.com/Baisbt/dsh-GreaterClarity-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.