### PR TITLE
catalog: add beijingwahw-dsh-nuke-plugin (community curation, created by @beijingwahw)

### DIFF
--- a/catalog/plugins/beijingwahw-dsh-nuke-plugin.yaml
+++ b/catalog/plugins/beijingwahw-dsh-nuke-plugin.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: beijingwahw-dsh-nuke-plugin
+name: dsh-nuke-plugin
+description:
+  en: bash dsh plugin add beijingwahw/dsh-nuke-plugin --profile web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - nuke
+  - cleanup
+  - transaction
+source:
+  repository: https://github.com/beijingwahw/dsh-nuke-plugin
+  repositoryNodeId: R_kgDOT7NzMA
+  subpath: null
+  commit: 9d3708f3f821678b39c75e0532f20da655e812bf
+creator:
+  github: beijingwahw
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:12.422Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `beijingwahw-dsh-nuke-plugin`
- Submission type: community curation
- Created by `beijingwahw` — https://github.com/beijingwahw
- Original source repository: https://github.com/beijingwahw/dsh-nuke-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.