### PR TITLE
catalog: add beijingwahw-dsh-proactive (community curation, created by @beijingwahw)

### DIFF
--- a/catalog/plugins/beijingwahw-dsh-proactive.yaml
+++ b/catalog/plugins/beijingwahw-dsh-proactive.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: beijingwahw-dsh-proactive
+name: dsh-proactive
+description:
+  en: "Proactive Intelligence scheduling plugin — a multi-model collaborative scheduling system for the DeepSeek Harness (DSH) ecosystem: it perceives, decides, and evolves on its own, with a built-in Scientist / Theorist dual mind and a cognitive energy symbiosis economy . English 中文"
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - scheduler
+  - autonomous
+  - llm
+  - dsh
+source:
+  repository: https://github.com/beijingwahw/dsh-proactive
+  repositoryNodeId: R_kgDOT5nmEg
+  subpath: null
+  commit: 3a642192ade80fa0ef5e8ced048c5e604c1cbd06
+creator:
+  github: beijingwahw
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:14.197Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `beijingwahw-dsh-proactive`
- Submission type: community curation
- Created by `beijingwahw` — https://github.com/beijingwahw
- Original source repository: https://github.com/beijingwahw/dsh-proactive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.