### PR TITLE
catalog: add berserk0501-dsh-soundscape (community curation, created by @berserk0501)

### DIFF
--- a/catalog/plugins/berserk0501-dsh-soundscape.yaml
+++ b/catalog/plugins/berserk0501-dsh-soundscape.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: berserk0501-dsh-soundscape
+name: "@dsh-external/dsh-soundscape"
+description:
+  en: "- GET/POST /api/dsh-soundscape/config - GET /api/dsh-soundscape/sounds - POST /api/dsh-soundscape/play-test - POST /api/dsh-soundscape/rescan - POST /api/dsh-soundscape/open-sounds-folder"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - post
+  - soundscape
+  - config
+  - sounds
+  - play
+  - test
+  - rescan
+  - open
+  - folder
+  - dsh
+source:
+  repository: https://github.com/berserk0501/dsh-soundscape
+  repositoryNodeId: R_kgDOUE7J1w
+  subpath: null
+  commit: 9e1c9589eefcd125e34c6e25f15e5c636e32cf26
+creator:
+  github: berserk0501
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:23.453Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `berserk0501-dsh-soundscape`
- Submission type: community curation
- Created by `berserk0501` — https://github.com/berserk0501
- Original source repository: https://github.com/berserk0501/dsh-soundscape
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.