### PR TITLE
catalog: add bf185003-dsh-favicon-status (community curation, created by @bf185003)

### DIFF
--- a/catalog/plugins/bf185003-dsh-favicon-status.yaml
+++ b/catalog/plugins/bf185003-dsh-favicon-status.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: bf185003-dsh-favicon-status
+name: dsh-favicon-status
+description:
+  en: "Browser tab status indicator: paints the document favicon from the sessions list projection (green done / amber waiting / blue running, spinning while work executes) so a backgrounded dsh web tab still shows task state"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - browser
+  - status
+  - indicator
+  - paints
+  - document
+  - favicon
+  - sessions
+  - list
+  - projection
+  - green
+  - done
+  - amber
+  - waiting
+  - blue
+  - running
+  - spinning
+source:
+  repository: https://github.com/bf185003/dsh-favicon-status
+  repositoryNodeId: R_kgDOT_W52w
+  subpath: null
+  commit: ca73548d7c93bd84e1da06510200972af9c6b1b0
+creator:
+  github: bf185003
+package:
+  ecosystem: npm
+  name: dsh-favicon-status
+  version: 0.1.0-rc.5
+  integrity: sha512-oHWyCVp3hOCOfs6sz5hjH59FbK/EZdFnEVrD2uV7zpDv/AVtKUTduQstk7nJLrzjnXE0ebl4fOEmktgXB1+5eg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:24.804Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bf185003-dsh-favicon-status`
- Submission type: community curation
- Created by `bf185003` — https://github.com/bf185003
- Original source repository: https://github.com/bf185003/dsh-favicon-status
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.