### PR TITLE
catalog: add boheastill-phone-eye (community curation, created by @boheastill)

### DIFF
--- a/catalog/plugins/boheastill-phone-eye.yaml
+++ b/catalog/plugins/boheastill-phone-eye.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: boheastill-phone-eye
+name: phone-eye
+description:
+  en: Let your AI agent see and operate a real Android phone — vision + UI-tree fusion over adb, for any MCP client
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - agent
+  - operate
+  - real
+  - android
+  - phone
+  - vision
+  - tree
+  - fusion
+  - over
+  - client
+  - dsh
+source:
+  repository: https://github.com/boheastill/phone-eye
+  repositoryNodeId: R_kgDOUDsvMw
+  subpath: null
+  commit: acd3ea1243d1e6aced6202500db70a1d9acad7ed
+creator:
+  github: boheastill
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:26.401Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `boheastill-phone-eye`
- Submission type: community curation
- Created by `boheastill` — https://github.com/boheastill
- Original source repository: https://github.com/boheastill/phone-eye
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.