### PR TITLE
catalog: add charliedreemur-dsh-agentdebugx (community curation, created by @CharlieDreemur)

### DIFF
--- a/catalog/plugins/charliedreemur-dsh-agentdebugx.yaml
+++ b/catalog/plugins/charliedreemur-dsh-agentdebugx.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: charliedreemur-dsh-agentdebugx
+name: dsh-agentdebugx
+description:
+  en: DeepSeek Harness plugin bridge for AgentDebugX diagnostics
+  evidencePath: integrations/dsh-agentdebugx/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - agentdebugx
+  - agent-debugging
+  - observability
+  - dsh
+source:
+  repository: https://github.com/AgentDebugX/AgentDebugX
+  repositoryNodeId: R_kgDOTUt9cw
+  subpath: integrations/dsh-agentdebugx
+  commit: de5f2e770f7bd5bdb22288ff572bfd30d560521a
+creator:
+  github: CharlieDreemur
+package:
+  ecosystem: npm
+  name: dsh-agentdebugx
+  version: 0.1.0
+  integrity: sha512-ait0JS3IClC2usEkQL2WXanuhU0Zte919uLvyTjg1O4xuuNFPnipND9LfNw1w4XEGhbpImcmzKrGgBtYLGVXkg==
+dsh:
+  profiles:
+    - web
+  evidencePath: integrations/dsh-agentdebugx/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:02.679Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `charliedreemur-dsh-agentdebugx`
- Submission type: community curation
- Created by `CharlieDreemur` — https://github.com/CharlieDreemur
- Original source repository: https://github.com/AgentDebugX/AgentDebugX
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.