### PR TITLE
catalog: add che-year-dsh-unidoc (community curation, created by @Che-Year)

### DIFF
--- a/catalog/plugins/che-year-dsh-unidoc.yaml
+++ b/catalog/plugins/che-year-dsh-unidoc.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: che-year-dsh-unidoc
+name: dsh-unidoc
+description:
+  en: 'A document preview / edit / management plugin for DeepSeek Harness. It provides a VSCode-style "Document Center" workbench inside the DSH Web GUI: a file tree on the left, click-to-preview, editable code & Markdown with Ctrl/Cmd+S save; and exposes three document tools ( doc read / doc edit / doc create ) to agents, le'
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - document-center
+  - preview
+  - markdown
+  - code-editor
+source:
+  repository: https://github.com/Che-Year/dsh-unidoc
+  repositoryNodeId: R_kgDOT8lFJw
+  subpath: null
+  commit: 97af5928d926065452306a419dd15a13247c0d36
+creator:
+  github: Che-Year
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:38.136Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `che-year-dsh-unidoc`
- Submission type: community curation
- Created by `Che-Year` — https://github.com/Che-Year
- Original source repository: https://github.com/Che-Year/dsh-unidoc
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.