### PR TITLE
catalog: add cheesehaqi-dsh-qq-onebot-bridge (community curation, created by @cheesehaqi)

### DIFF
--- a/catalog/plugins/cheesehaqi-dsh-qq-onebot-bridge.yaml
+++ b/catalog/plugins/cheesehaqi-dsh-qq-onebot-bridge.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: cheesehaqi-dsh-qq-onebot-bridge
+name: dsh-qq-onebot-bridge
+description:
+  en: "QQ ↔ DeepSeek Harness agent bridge over OneBot v11 (reverse WebSocket): per-group/per-user session grouping, @-quote voice speech-to-text (GLM-ASR / OpenAI-compatible), quote & image resolution, face/sticker tools, /new /status commands. Independent bundle; remove anytime: dsh plugin --profile web remove dsh-qq-onebot-"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - qq
+  - onebot
+  - onebot-v11
+  - napcat
+  - bridge
+  - speech-to-text
+  - asr
+source:
+  repository: https://github.com/cheesehaqi/dsh-qq-onebot-bridge
+  repositoryNodeId: R_kgDOT_tlOQ
+  subpath: null
+  commit: 432ee2b28ec2d7d473defd82ecd7aa5f309c3f47
+creator:
+  github: cheesehaqi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:19.954Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cheesehaqi-dsh-qq-onebot-bridge`
- Submission type: community curation
- Created by `cheesehaqi` — https://github.com/cheesehaqi
- Original source repository: https://github.com/cheesehaqi/dsh-qq-onebot-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.