### PR TITLE
catalog: add chenbin-dev-dsh-auth-everying (community curation, created by @chenbin-dev)

### DIFF
--- a/catalog/plugins/chenbin-dev-dsh-auth-everying.yaml
+++ b/catalog/plugins/chenbin-dev-dsh-auth-everying.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: chenbin-dev-dsh-auth-everying
+name: dsh-auth-everying
+description:
+  en: Import local Codex / Grok / Claude / Copilot / Gemini login state into DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - oauth
+  - codex
+  - claude
+  - grok
+  - opencode
+  - dsh
+source:
+  repository: https://github.com/chenbin-dev/dsh-auth-everying
+  repositoryNodeId: R_kgDOT58gvw
+  subpath: null
+  commit: 27da010e03f1da4e7e2be523a4f3d46fe4b0394f
+creator:
+  github: chenbin-dev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:21.468Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chenbin-dev-dsh-auth-everying`
- Submission type: community curation
- Created by `chenbin-dev` — https://github.com/chenbin-dev
- Original source repository: https://github.com/chenbin-dev/dsh-auth-everying
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.