### PR TITLE
catalog: add chendefine-dsh-web-fetch-playwright (community curation, created by @chendefine)

### DIFF
--- a/catalog/plugins/chendefine-dsh-web-fetch-playwright.yaml
+++ b/catalog/plugins/chendefine-dsh-web-fetch-playwright.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: chendefine-dsh-web-fetch-playwright
+name: dsh-web-fetch-playwright
+description:
+  en: "Playwright/CDP web-fetch provider for DeepSeek Harness: renders pages in a real browser, denoises them (Readability + DOMPurify), and returns markdown."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - playwright
+  - cdp
+  - web-fetch
+  - fetch-provider
+  - markdown
+  - bundle
+source:
+  repository: https://github.com/chendefine/dsh-web-fetch-playwright
+  repositoryNodeId: R_kgDOT_jnYg
+  subpath: null
+  commit: 18c30007dce9463c1972aeff304a37363204a74c
+creator:
+  github: chendefine
+package:
+  ecosystem: npm
+  name: dsh-web-fetch-playwright
+  version: 0.2.4
+  integrity: sha512-EDi8dzlXCrDoCG1AIrWzr7bqkJU8j9I3MNswujt48BaKK4tLkQyWvNCtvRgbOP3JLMTe7lhBXIwWhO0AGZNBTQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:16.078Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chendefine-dsh-web-fetch-playwright`
- Submission type: community curation
- Created by `chendefine` — https://github.com/chendefine
- Original source repository: https://github.com/chendefine/dsh-web-fetch-playwright
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.