### PR TITLE
catalog: add chengshuyi-dsh-plugin (community curation, created by @chengshuyi)

### DIFF
--- a/catalog/plugins/chengshuyi-dsh-plugin.yaml
+++ b/catalog/plugins/chengshuyi-dsh-plugin.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: chengshuyi-dsh-plugin
+name: "@agentsight/dsh-plugin"
+description:
+  en: AgentSight observability plugin for DeepSeek Harness
+  evidencePath: src/agentsight/dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh-plugin
+  - agentsight
+  - observability
+  - dsh
+source:
+  repository: https://github.com/alibaba/anolisa
+  repositoryNodeId: R_kgDOR0eWAQ
+  subpath: src/agentsight/dsh-plugin
+  commit: 0b99b4fae5dc46b96a4a8c6203b2a1ed10143325
+creator:
+  github: chengshuyi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: src/agentsight/dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:10.929Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chengshuyi-dsh-plugin`
- Submission type: community curation
- Created by `chengshuyi` — https://github.com/chengshuyi
- Original source repository: https://github.com/alibaba/anolisa
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.