### PR TITLE
catalog: add chenjie1129-dsh-remotion-video-plugin (community curation, created by @chenjie1129)

### DIFF
--- a/catalog/plugins/chenjie1129-dsh-remotion-video-plugin.yaml
+++ b/catalog/plugins/chenjie1129-dsh-remotion-video-plugin.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: chenjie1129-dsh-remotion-video-plugin
+name: "@chenjie1129/dsh-remotion-video-plugin"
+description:
+  en: Remotion video creation and verified rendering plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - remotion
+  - video
+  - agent-skill
+  - dsh
+source:
+  repository: https://github.com/chenjie1129/remotion-video-plugin
+  repositoryNodeId: R_kgDOT_utMQ
+  subpath: null
+  commit: 6aaf7a490cabd13520a58ebc03bf5d4b80727723
+creator:
+  github: chenjie1129
+package:
+  ecosystem: npm
+  name: "@chenjie1129/dsh-remotion-video-plugin"
+  version: 0.4.0
+  integrity: sha512-Me+1QtSsCHPESdVADZy/J62FIhqRP0MDiG/R/ZgpMy0PyGDER8lGu+rZ0Rx7Q6fP+182tEHym1l3c46F+SppTw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:39.950Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chenjie1129-dsh-remotion-video-plugin`
- Submission type: community curation
- Created by `chenjie1129` — https://github.com/chenjie1129
- Original source repository: https://github.com/chenjie1129/remotion-video-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.