### PR TITLE
catalog: add chenzheshushi-commits-dsh-evolve (community curation, created by @chenzheshushi-commits)

### DIFF
--- a/catalog/plugins/chenzheshushi-commits-dsh-evolve.yaml
+++ b/catalog/plugins/chenzheshushi-commits-dsh-evolve.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: chenzheshushi-commits-dsh-evolve
+name: dsh-evolve
+description:
+  en: Self-evolving memory + skill lifecycle for DeepSeek Harness. Cross-session memory with zero-token deterministic recall (bigram-Jaccard fused with FTS5 BM25 via RRF), a tiered approval gate, and reinforcement that strengthens what you repeat. Procedural knowledge crystallizes into SKILL.md files that refine in place and
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - memory
+  - skills
+  - self-evolving
+  - long-term-memory
+  - agent
+source:
+  repository: https://github.com/chenzheshushi-commits/dsh-evolve
+  repositoryNodeId: R_kgDOUBCiwQ
+  subpath: null
+  commit: 79200b9873f5158fc421cf33c663368e0a80c41e
+creator:
+  github: chenzheshushi-commits
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:08.455Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chenzheshushi-commits-dsh-evolve`
- Submission type: community curation
- Created by `chenzheshushi-commits` — https://github.com/chenzheshushi-commits
- Original source repository: https://github.com/chenzheshushi-commits/dsh-evolve
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.