### PR TITLE
catalog: add chidaic-dsh-agent-notify (community curation, created by @chidaic)

### DIFF
--- a/catalog/plugins/chidaic-dsh-agent-notify.yaml
+++ b/catalog/plugins/chidaic-dsh-agent-notify.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: chidaic-dsh-agent-notify
+name: dsh-agent-notify
+description:
+  en: sh dsh plugin --profile web add dsh-agent-notify
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - notification
+  - notify
+  - windows
+  - toast
+  - web
+source:
+  repository: https://github.com/chidaic/dsh-agent-notify
+  repositoryNodeId: R_kgDOUAeX2Q
+  subpath: null
+  commit: a41c11bda2e13cd094d4db856b93d7a2569c7747
+creator:
+  github: chidaic
+package:
+  ecosystem: npm
+  name: dsh-agent-notify
+  version: 1.0.0
+  integrity: sha512-xiAEKQku+msf3gKwM57VJj2CmJQwo4Nfp8UTSA4Cw5uGfR3WQyOj+ecO1GxdNCF5JAPKS2AoBIIKixwW3nH6SQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:42.854Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chidaic-dsh-agent-notify`
- Submission type: community curation
- Created by `chidaic` — https://github.com/chidaic
- Original source repository: https://github.com/chidaic/dsh-agent-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.