### PR TITLE
catalog: add chidaic-dsh-light-memory (community curation, created by @chidaic)

### DIFF
--- a/catalog/plugins/chidaic-dsh-light-memory.yaml
+++ b/catalog/plugins/chidaic-dsh-light-memory.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: chidaic-dsh-light-memory
+name: dsh-light-memory
+description:
+  en: sh dsh plugin --profile web add dsh-light-memory
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - memory
+  - markdown
+  - worklog
+  - lightweight
+  - prompt-cache
+  - agent
+source:
+  repository: https://github.com/chidaic/dsh-light-memory
+  repositoryNodeId: R_kgDOUBcNgg
+  subpath: null
+  commit: cf1966b04f389f521ac2c92040ba56dc2e0f9958
+creator:
+  github: chidaic
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:23.030Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chidaic-dsh-light-memory`
- Submission type: community curation
- Created by `chidaic` — https://github.com/chidaic
- Original source repository: https://github.com/chidaic/dsh-light-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.