### PR TITLE
catalog: add chumingjun-dsh-ccpg-canvasui (community curation, created by @chumingjun)

### DIFF
--- a/catalog/plugins/chumingjun-dsh-ccpg-canvasui.yaml
+++ b/catalog/plugins/chumingjun-dsh-ccpg-canvasui.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: chumingjun-dsh-ccpg-canvasui
+name: dsh-ccpg-canvasui
+description:
+  en: Workflow One is a visual AI workflow orchestrator for DeepSeek Harness (dsh). Describe what you need in natural language and the AI will plan and create a DAG of real dsh agents, scripts, conditions, and HTTP nodes. Fine-tune it on the canvas when needed, then start the flow, inspect every node's input, output, and art
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - workflow
+  - visual
+  - orchestrator
+  - describe
+  - what
+  - need
+  - natural
+  - language
+  - plan
+  - create
+  - real
+  - agents
+  - scripts
+  - conditions
+  - nodes
+  - fine
+source:
+  repository: https://github.com/chumingjun/dsh-harness-one
+  repositoryNodeId: R_kgDOT-ev7w
+  subpath: dsh-plugins/dsh-ccpg-canvasui
+  commit: a067ae8d03b908c096c5424680686f78d4ddc22d
+creator:
+  github: chumingjun
+package:
+  ecosystem: npm
+  name: dsh-ccpg-canvasui
+  version: 0.3.2
+  integrity: sha512-QuqFsfkd52nyFCoWkDLC0jLf1Ezmy7XEL1OFkTl3GK4AiLzorI14S22T6o1iBc+DUDWiEjJE8Z3vl8gtu9tVEg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: dsh-plugins/dsh-ccpg-canvasui/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:32.259Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chumingjun-dsh-ccpg-canvasui`
- Submission type: community curation
- Created by `chumingjun` — https://github.com/chumingjun
- Original source repository: https://github.com/chumingjun/dsh-harness-one
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.