### PR TITLE
catalog: add chumingjun-dsh-ccpg-document-preview (community curation, created by @chumingjun)

### DIFF
--- a/catalog/plugins/chumingjun-dsh-ccpg-document-preview.yaml
+++ b/catalog/plugins/chumingjun-dsh-ccpg-document-preview.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: chumingjun-dsh-ccpg-document-preview
+name: dsh-ccpg-document-preview
+description:
+  en: Shared full-screen document preview for dsh and React applications
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - shared
+  - full
+  - screen
+  - document
+  - preview
+  - react
+  - applications
+  - dsh
+source:
+  repository: https://github.com/chumingjun/dsh-harness-one
+  repositoryNodeId: R_kgDOT-ev7w
+  subpath: dsh-plugins/dsh-ccpg-document-preview
+  commit: a067ae8d03b908c096c5424680686f78d4ddc22d
+creator:
+  github: chumingjun
+package:
+  ecosystem: npm
+  name: dsh-ccpg-document-preview
+  version: 0.3.2
+  integrity: sha512-Bfkmigd7YQMJuQfQTEEkxo/q6A9G+V2VyvAc5PnQBXzYgeluVQG5EKHyNUZOYYDjJVCTwLSRzaMlMjsadDHb3g==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: dsh-plugins/dsh-ccpg-document-preview/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:32.259Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chumingjun-dsh-ccpg-document-preview`
- Submission type: community curation
- Created by `chumingjun` — https://github.com/chumingjun
- Original source repository: https://github.com/chumingjun/dsh-harness-one
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.