### PR TITLE
catalog: add chumingjun-dsh-ccpg-llm-guard (community curation, created by @chumingjun)

### DIFF
--- a/catalog/plugins/chumingjun-dsh-ccpg-llm-guard.yaml
+++ b/catalog/plugins/chumingjun-dsh-ccpg-llm-guard.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: chumingjun-dsh-ccpg-llm-guard
+name: dsh-ccpg-llm-guard
+description:
+  en: Reject malformed model tool calls before they can poison a dsh session
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - reject
+  - malformed
+  - model
+  - tool
+  - calls
+  - before
+  - they
+  - poison
+  - session
+  - dsh
+source:
+  repository: https://github.com/chumingjun/dsh-harness-one
+  repositoryNodeId: R_kgDOT-ev7w
+  subpath: dsh-plugins/dsh-ccpg-llm-guard
+  commit: a067ae8d03b908c096c5424680686f78d4ddc22d
+creator:
+  github: chumingjun
+package:
+  ecosystem: npm
+  name: dsh-ccpg-llm-guard
+  version: 0.3.2
+  integrity: sha512-oDH5+8cKMNQ0hsU2Etkzpo/yaxif18h11Y0aheylZScsQ8SUaNIiziytC16XZg2OVOz4ikQAZTHrq8tHJ5j73g==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: dsh-plugins/dsh-ccpg-llm-guard/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:41:32.259Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chumingjun-dsh-ccpg-llm-guard`
- Submission type: community curation
- Created by `chumingjun` — https://github.com/chumingjun
- Original source repository: https://github.com/chumingjun/dsh-harness-one
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.