### PR TITLE
catalog: add chunfenxiazhi-dsh-stability-audit (community curation, created by @chunfenxiazhi)

### DIFF
--- a/catalog/plugins/chunfenxiazhi-dsh-stability-audit.yaml
+++ b/catalog/plugins/chunfenxiazhi-dsh-stability-audit.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: chunfenxiazhi-dsh-stability-audit
+name: dsh-stability-audit
+description:
+  en: Scan installed DeepSeek Harness (dsh) plugins and get a stability risk grade + fix suggestion before they break your harness — static analysis, optional isolated install verification, and machine-readable output for any agent to surface problems and remedies fast.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - stability
+  - audit
+  - plugin-health
+source:
+  repository: https://github.com/chunfenxiazhi-collab/dsh-stability-audit
+  repositoryNodeId: R_kgDOUDDpUw
+  subpath: null
+  commit: a16e1cff7893e7d065ab77bb1c39916f969f7f70
+creator:
+  github: chunfenxiazhi
+package:
+  ecosystem: npm
+  name: dsh-stability-audit
+  version: 0.13.0
+  integrity: sha512-RweHd8msDyOkRR2244fuHiNXm0tDbVvqpHttuEKRPyRaPBBmLCYKVxHR/bgWEuSrUgCOe3TDssiIv7nhmuMtBw==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:44.501Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chunfenxiazhi-dsh-stability-audit`
- Submission type: community curation
- Created by `chunfenxiazhi` — https://github.com/chunfenxiazhi
- Original source repository: https://github.com/chunfenxiazhi-collab/dsh-stability-audit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.