### PR TITLE
catalog: add cilis-dsh-tauri-launcher (community curation, created by @cilis)

### DIFF
--- a/catalog/plugins/cilis-dsh-tauri-launcher.yaml
+++ b/catalog/plugins/cilis-dsh-tauri-launcher.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: cilis-dsh-tauri-launcher
+name: "@lenorin/dsh-tauri-launcher"
+description:
+  en: Following DeepSeek Harness's "everything-is-a-plugin" architecture, this project abstracts desktop launch, exit confirmation, and desktop-shortcut management into a standard Web plugin. From Settings → Desktop Launcher you can bring up the Tauri desktop app in one click — enjoying both the deep integration of the plugi
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - following
+  - everything
+  - architecture
+  - abstracts
+  - desktop
+  - launch
+  - exit
+  - confirmation
+  - shortcut
+  - management
+  - standard
+  - settings
+  - launcher
+  - bring
+  - tauri
+  - click
+source:
+  repository: https://github.com/cilis/dsh-tauri-launcher
+  repositoryNodeId: R_kgDOT-h3yA
+  subpath: null
+  commit: c36e292659db672a1d85500947fd6d5db7d258ef
+creator:
+  github: cilis
+package:
+  ecosystem: npm
+  name: "@lenorin/dsh-tauri-launcher"
+  version: 1.0.4
+  integrity: sha512-z0J022H+KTAYS8zQteGAmSfSXJnpeKrEbdqa9DXUv5dHMJQqaJ1xHpHtC30QNaPL9RXM5AqYIU5fN0yHxqBaDQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:19.957Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cilis-dsh-tauri-launcher`
- Submission type: community curation
- Created by `cilis` — https://github.com/cilis
- Original source repository: https://github.com/cilis/dsh-tauri-launcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.