### PR TITLE
catalog: add feilongrong-dsh-balance-widget (community curation, created by @FeilongRong)

### DIFF
--- a/catalog/plugins/feilongrong-dsh-balance-widget.yaml
+++ b/catalog/plugins/feilongrong-dsh-balance-widget.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: feilongrong-dsh-balance-widget
+name: "@feilongrong/dsh-balance-widget"
+description:
+  en: "Sidebar balance widget for the DeepSeek Harness Web GUI (dsh web). A \"余额\" button appears in the sidebar footer; clicking it opens a panel listing each provider's account balance:"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - balance
+  - sidebar
+source:
+  repository: https://github.com/FeilongRong/dsh-balance-widget
+  repositoryNodeId: R_kgDOT-7FIA
+  subpath: null
+  commit: 79cd46dd4a4106768af15c6d99ffa8d7566bd37e
+creator:
+  github: FeilongRong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:42:16.176Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `feilongrong-dsh-balance-widget`
- Submission type: community curation
- Created by `FeilongRong` — https://github.com/FeilongRong
- Original source repository: https://github.com/FeilongRong/dsh-balance-widget
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.