### PR TITLE
catalog: add ffyuuu-dsh-llm-longcat (community curation, created by @ffyuuu)

### DIFF
--- a/catalog/plugins/ffyuuu-dsh-llm-longcat.yaml
+++ b/catalog/plugins/ffyuuu-dsh-llm-longcat.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: ffyuuu-dsh-llm-longcat
+name: dsh-llm-longcat
+description:
+  en: LongCat (LongCat-2.0) adapter for the DeepSeek Harness LLM seam — 1M context, thinking mode, tool calling
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - longcat
+  - llm-provider
+  - dsh
+source:
+  repository: https://github.com/ffyuuu/dsh-llm-longcat
+  repositoryNodeId: R_kgDOT-IKug
+  subpath: null
+  commit: b07900eea661cd65465e8f529a8495697152879d
+creator:
+  github: ffyuuu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:23.277Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ffyuuu-dsh-llm-longcat`
- Submission type: community curation
- Created by `ffyuuu` — https://github.com/ffyuuu
- Original source repository: https://github.com/ffyuuu/dsh-llm-longcat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.