### PR TITLE
catalog: add findshan-dsh-evolving-memory (community curation, created by @findshan)

### DIFF
--- a/catalog/plugins/findshan-dsh-evolving-memory.yaml
+++ b/catalog/plugins/findshan-dsh-evolving-memory.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: findshan-dsh-evolving-memory
+name: dsh-evolving-memory
+description:
+  en: sh dsh plugin --profile web add dsh-evolving-memory dsh --profile web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - self-evolving
+  - personalization
+  - dream
+  - cordis
+source:
+  repository: https://github.com/findshan/dsh-agent-memory
+  repositoryNodeId: R_kgDOT5YiQA
+  subpath: null
+  commit: f75da396b59cd43933527d3c1fce17c29c3cd06b
+creator:
+  github: findshan
+package:
+  ecosystem: npm
+  name: dsh-evolving-memory
+  version: 0.2.1
+  integrity: sha512-UXjgkZULiCxCUc1+ZEe3c5C2/DmUZKj8NewlBEYTUcWc5np+Ykn5/P7fCilESLAc9ZC2wmitCTWkgiEA5zDKMw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:39:24.970Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `findshan-dsh-evolving-memory`
- Submission type: community curation
- Created by `findshan` — https://github.com/findshan
- Original source repository: https://github.com/findshan/dsh-agent-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.