### PR TITLE
catalog: add jnrobin139-dsh-taskswarm (community curation, created by @jnrobin139)

### DIFF
--- a/catalog/plugins/jnrobin139-dsh-taskswarm.yaml
+++ b/catalog/plugins/jnrobin139-dsh-taskswarm.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: jnrobin139-dsh-taskswarm
+name: dsh-taskswarm
+description:
+  en: "TaskSwarm (蜂群) — multi-agent task orchestration for DeepSeek Harness. Native port of TaskPlane (github.com/HenryLach/taskplane, MIT): waves/lanes parallel execution, git worktree isolation, PROMPT.md/STATUS.md task packets, file mailbox, cross-model review."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - orchestration
+  - multi-agent
+  - task-runner
+  - parallel
+  - taskswarm
+source:
+  repository: https://github.com/february2015/dsh-taskswarm
+  repositoryNodeId: R_kgDOT4AuKA
+  subpath: null
+  commit: 032e2c9d228c20cab65fe0ea061d78a7c753ab8c
+creator:
+  github: jnrobin139
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:45.975Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jnrobin139-dsh-taskswarm`
- Submission type: community curation
- Created by `jnrobin139` — https://github.com/jnrobin139
- Original source repository: https://github.com/february2015/dsh-taskswarm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.