### PR TITLE
catalog: add lchysh-keyringseam (community curation, created by @lchysh)

### DIFF
--- a/catalog/plugins/lchysh-keyringseam.yaml
+++ b/catalog/plugins/lchysh-keyringseam.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: lchysh-keyringseam
+name: keyringseam
+description:
+  en: A macOS Keychain-backed CredentialProvider for agent harnesses, initially compatible with DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - macos
+  - keychain
+  - backed
+  - credentialprovider
+  - agent
+  - harnesses
+  - initially
+  - compatible
+  - dsh
+source:
+  repository: https://github.com/fieldnote-ops/keyringseam
+  repositoryNodeId: R_kgDOT4h80A
+  subpath: null
+  commit: 22fdc53f882d55cb865511247622af51d2344796
+creator:
+  github: lchysh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:47.483Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lchysh-keyringseam`
- Submission type: community curation
- Created by `lchysh` — https://github.com/lchysh
- Original source repository: https://github.com/fieldnote-ops/keyringseam
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.