### PR TITLE
catalog: add ltspace-anysearch-dsh (community curation, created by @ltspace)

### DIFF
--- a/catalog/plugins/ltspace-anysearch-dsh.yaml
+++ b/catalog/plugins/ltspace-anysearch-dsh.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ltspace-anysearch-dsh
+name: "@anysearch/anysearch-dsh"
+description:
+  en: AnySearch web search and fetch providers plus advanced tools for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - anysearch
+  - deepseek-harness
+  - dsh-plugin
+  - web-search
+  - web-fetch
+  - dsh
+source:
+  repository: https://github.com/anysearch-team/anysearch-dsh
+  repositoryNodeId: R_kgDOT3e9Mg
+  subpath: null
+  commit: 3ccdef05e2b502509415b023e206a4c9f6afb038
+creator:
+  github: ltspace
+package:
+  ecosystem: npm
+  name: "@anysearch/anysearch-dsh"
+  version: 0.1.4
+  integrity: sha512-v7jb1oTrMcfq+DxMoRvwDZQ8xVCvU/Pf4MJKnGXAKt35GUzsLFfJW8eKgSg837/kzEVZTGg64lM94UwgiNMUuQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:37:57.272Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 332
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ltspace-anysearch-dsh`
- Submission type: community curation
- Created by `ltspace` — https://github.com/ltspace
- Original source repository: https://github.com/anysearch-team/anysearch-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.