### PR TITLE
catalog: add yinalger-dsh-tier-router (community curation, created by @yinalger)

### DIFF
--- a/catalog/plugins/yinalger-dsh-tier-router.yaml
+++ b/catalog/plugins/yinalger-dsh-tier-router.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yinalger-dsh-tier-router
+name: dsh-tier-router
+description:
+  en: "Tiered model routing for DeepSeek Harness (+ fallback chains + task-intensity effort): a strong tier for planning/architecture/review, a cheap tier for implementation, with plan-mode-aware auto routing, per-tier model fallback chains, task-intensity reasoning effort selection, advisor/review consultations, a high-impac"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - model-routing
+  - tiered-routing
+  - advisor
+source:
+  repository: https://github.com/BruceLanLan/dsh-tier-router
+  repositoryNodeId: R_kgDOT44CRA
+  subpath: null
+  commit: 2b021218420c2156eebda837a26a3f4a120197c5
+creator:
+  github: yinalger
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T02:38:04.781Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yinalger-dsh-tier-router`
- Submission type: community curation
- Created by `yinalger` — https://github.com/yinalger
- Original source repository: https://github.com/BruceLanLan/dsh-tier-router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.