### PR TITLE
catalog: add classlu-dsh-telegram-bridge (community curation, created by @CLASSLU)

### DIFF
--- a/catalog/plugins/classlu-dsh-telegram-bridge.yaml
+++ b/catalog/plugins/classlu-dsh-telegram-bridge.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: classlu-dsh-telegram-bridge
+name: dsh-telegram-bridge
+description:
+  en: "Telegram bot bridge for DeepSeek Harness (dsh): chat with your DSH agent from Telegram, with access control, skills, and workspace browsing."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - telegram
+  - bot
+source:
+  repository: https://github.com/CLASSLU/dsh-telegram-bridge
+  repositoryNodeId: R_kgDOUCVvqw
+  subpath: null
+  commit: 2adaaafe173064074f835bfa0af8ab9bc08d670f
+creator:
+  github: CLASSLU
+package:
+  ecosystem: npm
+  name: dsh-telegram-bridge
+  version: 0.1.0
+  integrity: sha512-UKVgjdDctpbwsvEskJW/i1aYXGTzTtCEV3Kno6rdYx/NRe5SlVn53U3y0TeY4fkVNzEGIJnqEDCExy+GGi3E3Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:19.620Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `classlu-dsh-telegram-bridge`
- Submission type: community curation
- Created by `CLASSLU` — https://github.com/CLASSLU
- Original source repository: https://github.com/CLASSLU/dsh-telegram-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.