### PR TITLE
catalog: add cloga-dsh-dev-tools (community curation, created by @cloga)

### DIFF
--- a/catalog/plugins/cloga-dsh-dev-tools.yaml
+++ b/catalog/plugins/cloga-dsh-dev-tools.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: cloga-dsh-dev-tools
+name: dsh-dev-tools
+description:
+  en: "DSH agent-native development tools: dsh status / dsh patch / dsh build / dsh upgrade. Lets the agent inspect the source tree, manage local patches, build a staging runtime, and check for new upstream versions - without leaving the session."
+  evidencePath: tools/dsh-dev-tools/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dev-tools
+  - upgrade
+  - patch
+  - dsh
+source:
+  repository: https://github.com/cloga/dsh-windows-ops
+  repositoryNodeId: R_kgDOUBA_Jg
+  subpath: tools/dsh-dev-tools
+  commit: 2a79f99e656b740cc4916e826aa365c549d56088
+creator:
+  github: cloga
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: tools/dsh-dev-tools/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:21.263Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cloga-dsh-dev-tools`
- Submission type: community curation
- Created by `cloga` — https://github.com/cloga
- Original source repository: https://github.com/cloga/dsh-windows-ops
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.