### PR TITLE
catalog: add cnctem-dsh-acp (community curation, created by @cnctem)

### DIFF
--- a/catalog/plugins/cnctem-dsh-acp.yaml
+++ b/catalog/plugins/cnctem-dsh-acp.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: cnctem-dsh-acp
+name: dsh-acp
+description:
+  en: Agent Client Protocol (ACP) JSON-RPC stdio server for DeepSeek Harness — bridges Zed and other IDEs to dsh agents
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - agent
+  - client
+  - protocol
+  - json
+  - stdio
+  - server
+  - bridges
+  - other
+  - ides
+  - agents
+  - dsh
+source:
+  repository: https://github.com/cnctem/dsh-acp
+  repositoryNodeId: R_kgDOT48KUQ
+  subpath: null
+  commit: 2d9bbf7b0eba08065f0d068776ca6d07d7a7e0ff
+creator:
+  github: cnctem
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:51.519Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cnctem-dsh-acp`
- Submission type: community curation
- Created by `cnctem` — https://github.com/cnctem
- Original source repository: https://github.com/cnctem/dsh-acp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.