### PR TITLE
catalog: add codex-dsh-skills-marketplace (community curation, created by @codex)

### DIFF
--- a/catalog/plugins/codex-dsh-skills-marketplace.yaml
+++ b/catalog/plugins/codex-dsh-skills-marketplace.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: codex-dsh-skills-marketplace
+name: dsh-skills-marketplace
+description:
+  en: A DSH-native marketplace that organizes any Codex or Claude skill repository by plugin.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - native
+  - marketplace
+  - organizes
+  - codex
+  - claude
+  - skill
+  - repository
+  - dsh
+source:
+  repository: https://github.com/cxdyun/dsh-skills-marketplace
+  repositoryNodeId: R_kgDOT-k95w
+  subpath: null
+  commit: 3e26404afdcbe993f6abc07a221c7e3deb25f34b
+creator:
+  github: codex
+package:
+  ecosystem: npm
+  name: dsh-skills-marketplace
+  version: 1.1.0
+  integrity: sha512-23PsySR5v8Lnie+AY7mqpiwA0oa6Eu8m6PGGB2gRSig5MqJwMELA7N2xaZgvU7JzYiF5kHmDZgHy5MINk2XU5Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:12.384Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `codex-dsh-skills-marketplace`
- Submission type: community curation
- Created by `codex` — https://github.com/codex
- Original source repository: https://github.com/cxdyun/dsh-skills-marketplace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.