### PR TITLE
catalog: add codingayice-dsh-interview (community curation, created by @codingayice)

### DIFF
--- a/catalog/plugins/codingayice-dsh-interview.yaml
+++ b/catalog/plugins/codingayice-dsh-interview.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: codingayice-dsh-interview
+name: dsh-interview
+description:
+  en: powershell dsh plugin --profile web add dsh-interview
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - interview
+  - interview-practice
+source:
+  repository: https://github.com/codingayice/dsh-interview
+  repositoryNodeId: R_kgDOT-T96g
+  subpath: null
+  commit: 5e9ba1bcea0feda5e47d0545d674e523631f712a
+creator:
+  github: codingayice
+package:
+  ecosystem: npm
+  name: dsh-interview
+  version: 0.5.1
+  integrity: sha512-1YGUDN/G/Ikx8RU0mlHw67eHsAk6aiyj/Gn9EAAmn1iKBbJHZ5kB3Okt5M/CFTDSmGeFCj5SgvTdgalC2JjmNA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:52.945Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `codingayice-dsh-interview`
- Submission type: community curation
- Created by `codingayice` — https://github.com/codingayice
- Original source repository: https://github.com/codingayice/dsh-interview
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.