### PR TITLE
catalog: add cuddly-guacamole-dsh-auto-approval-llm (community curation, created by @cuddly-guacamole)

### DIFF
--- a/catalog/plugins/cuddly-guacamole-dsh-auto-approval-llm.yaml
+++ b/catalog/plugins/cuddly-guacamole-dsh-auto-approval-llm.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: cuddly-guacamole-dsh-auto-approval-llm
+name: "@quill507/dsh-auto-approval-llm"
+description:
+  en: LLM-assisted auto approval with timeout fallback for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - assisted
+  - auto
+  - approval
+  - timeout
+  - fallback
+  - dsh
+source:
+  repository: https://github.com/cuddly-guacamole/dsh-auto-approval-llm
+  repositoryNodeId: R_kgDOT8vJuA
+  subpath: null
+  commit: 1866db21200c11ea3299dab80eb2acd3c0e37a24
+creator:
+  github: cuddly-guacamole
+package:
+  ecosystem: npm
+  name: "@quill507/dsh-auto-approval-llm"
+  version: 0.0.10
+  integrity: sha512-iEOmGKSZMefEDMqUYHYdC9enXQGVxLehtC2ETxRiIuNgamV7oUMUPN+2+Uj5QKvLuSSHqJIciQ/0R61ytzNnsg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:54.440Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cuddly-guacamole-dsh-auto-approval-llm`
- Submission type: community curation
- Created by `cuddly-guacamole` — https://github.com/cuddly-guacamole
- Original source repository: https://github.com/cuddly-guacamole/dsh-auto-approval-llm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.