### PR TITLE
catalog: add curtainsmall-dsh-electro-lab (community curation, created by @curtainsmall)

### DIFF
--- a/catalog/plugins/curtainsmall-dsh-electro-lab.yaml
+++ b/catalog/plugins/curtainsmall-dsh-electro-lab.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: curtainsmall-dsh-electro-lab
+name: dsh-electro-lab
+description:
+  en: "DSH plugin: electrical & electronics workbench"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - electrical
+  - electronics
+  - workbench
+  - dsh
+source:
+  repository: https://github.com/curtainsmall/dsh-electro-lab
+  repositoryNodeId: R_kgDOUAlJow
+  subpath: null
+  commit: 951fcc9bf90392fca9168a6eded0050003ea5cfd
+creator:
+  github: curtainsmall
+package:
+  ecosystem: npm
+  name: dsh-electro-lab
+  version: 0.2.0
+  integrity: sha512-95BbM11yt3arAsYQRYA4RE7k7rgssunxbCHsws+ouBZapzJJhj9EykYUiOmFcWKNjzJcnuUmpYG4KPGGM6/nrQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:22.823Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `curtainsmall-dsh-electro-lab`
- Submission type: community curation
- Created by `curtainsmall` — https://github.com/curtainsmall
- Original source repository: https://github.com/curtainsmall/dsh-electro-lab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.