### PR TITLE
catalog: add daboge-beach-gallery (community curation, created by @daboge-beach)

### DIFF
--- a/catalog/plugins/daboge-beach-gallery.yaml
+++ b/catalog/plugins/daboge-beach-gallery.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: daboge-beach-gallery
+name: "@dsh-skin-studio/gallery"
+description:
+  en: bash cd packages/gallery pnpm install pnpm dev http://localhost:5173
+  evidencePath: packages/gallery/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - skin
+  - gallery
+source:
+  repository: https://github.com/daboge-beach/dsh-skin-studio
+  repositoryNodeId: R_kgDOT5PBPw
+  subpath: packages/gallery
+  commit: f9f7e571c27dc20f28d806b69129bd2e81772b2e
+creator:
+  github: daboge-beach
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/gallery/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:24.220Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `daboge-beach-gallery`
- Submission type: community curation
- Created by `daboge-beach` — https://github.com/daboge-beach
- Original source repository: https://github.com/daboge-beach/dsh-skin-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.