### PR TITLE
catalog: add darkings-dsh-agy-provider (community curation, created by @darkings)

### DIFF
--- a/catalog/plugins/darkings-dsh-agy-provider.yaml
+++ b/catalog/plugins/darkings-dsh-agy-provider.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: darkings-dsh-agy-provider
+name: dsh-agy-provider
+description:
+  en: Expose the locally authenticated AGY CLI as a DSH model provider.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - expose
+  - locally
+  - authenticated
+  - model
+  - provider
+  - dsh
+source:
+  repository: https://github.com/darkings/dsh-agy-provider
+  repositoryNodeId: R_kgDOT78aVg
+  subpath: null
+  commit: 44ada9fb96aee3d81045739c427460d7df4927cf
+creator:
+  github: darkings
+package:
+  ecosystem: npm
+  name: dsh-agy-provider
+  version: 0.10.0
+  integrity: sha512-8xu06oS9TnnYWoDEAd2WI40A3NKXRAHTAhduFw8jJuX3o+TCDMI09/Ys9Lh9+ax1vvoWk8hjia9dTprTskcq5Q==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:55.999Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `darkings-dsh-agy-provider`
- Submission type: community curation
- Created by `darkings` — https://github.com/darkings
- Original source repository: https://github.com/darkings/dsh-agy-provider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.