### PR TITLE
catalog: add dat-lequoc-dsh-kiro (community curation, created by @dat-lequoc)

### DIFF
--- a/catalog/plugins/dat-lequoc-dsh-kiro.yaml
+++ b/catalog/plugins/dat-lequoc-dsh-kiro.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dat-lequoc-dsh-kiro
+name: dsh-kiro
+description:
+  en: Kiro provider for DeepSeek Harness with multi-method login, usage, model controls, and token/profile refresh
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - kiro
+  - kiro-cli
+  - kiro2api
+  - claude
+  - opus
+  - oauth
+  - reasoning
+source:
+  repository: https://github.com/dat-lequoc/dsh-kiro
+  repositoryNodeId: R_kgDOUCx-3A
+  subpath: null
+  commit: f4fdcd1bd7e609ca0183b0079bd5a0a2bfcee3e9
+creator:
+  github: dat-lequoc
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:15.797Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dat-lequoc-dsh-kiro`
- Submission type: community curation
- Created by `dat-lequoc` — https://github.com/dat-lequoc
- Original source repository: https://github.com/dat-lequoc/dsh-kiro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.