### PR TITLE
catalog: add dataizu-dsh-whale-aqua-theme (community curation, created by @dataizu)

### DIFF
--- a/catalog/plugins/dataizu-dsh-whale-aqua-theme.yaml
+++ b/catalog/plugins/dataizu-dsh-whale-aqua-theme.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: dataizu-dsh-whale-aqua-theme
+name: dsh-whale-aqua-theme
+description:
+  en: sh dsh plugin --profile web add https://github.com/dataizu/dsh-whale-aqua-theme
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+source:
+  repository: https://github.com/dataizu/dsh-whale-aqua-theme
+  repositoryNodeId: R_kgDOT4dKyw
+  subpath: null
+  commit: 8f4abbbde43710b26755e192e4b935cfba4fc37a
+creator:
+  github: dataizu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:17.458Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dataizu-dsh-whale-aqua-theme`
- Submission type: community curation
- Created by `dataizu` — https://github.com/dataizu
- Original source repository: https://github.com/dataizu/dsh-whale-aqua-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.