### PR TITLE
catalog: add dayi-z-memoripo (community curation, created by @Dayi-Z)

### DIFF
--- a/catalog/plugins/dayi-z-memoripo.yaml
+++ b/catalog/plugins/dayi-z-memoripo.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: dayi-z-memoripo
+name: memoripo
+description:
+  en: A living memory workbench for DeepSeek Harness — watch Hindsight memory grow, read and use it, in a persistent sidebar.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - hindsight
+  - knowledge
+  - ui
+  - dsh
+source:
+  repository: https://github.com/Dayi-Z/memoripo
+  repositoryNodeId: R_kgDOUFC_dg
+  subpath: null
+  commit: aface4b0c8dc62c846e2acf93c6e6ca386489fd7
+creator:
+  github: Dayi-Z
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:48.099Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dayi-z-memoripo`
- Submission type: community curation
- Created by `Dayi-Z` — https://github.com/Dayi-Z
- Original source repository: https://github.com/Dayi-Z/memoripo
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.