### PR TITLE
catalog: add dcrzsy-dsh-enhance-tool (community curation, created by @dcrzsy)

### DIFF
--- a/catalog/plugins/dcrzsy-dsh-enhance-tool.yaml
+++ b/catalog/plugins/dcrzsy-dsh-enhance-tool.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: dcrzsy-dsh-enhance-tool
+name: dsh-enhance-tool
+description:
+  en: DeepSeek Harness (dsh) web UI enhancer — polish, prompt library, suggested replies, width/font settings, MCP & automation panels.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - enhancer
+  - polish
+  - prompt
+  - library
+  - suggested
+  - replies
+  - width
+  - font
+  - settings
+  - automation
+  - panels
+  - dsh
+source:
+  repository: https://github.com/dcrzsy/dsh-enhance-tool
+  repositoryNodeId: R_kgDOUAd88w
+  subpath: null
+  commit: cd3affab9f21dfe119203f8aa8f63ad294498729
+creator:
+  github: dcrzsy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:49.445Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dcrzsy-dsh-enhance-tool`
- Submission type: community curation
- Created by `dcrzsy` — https://github.com/dcrzsy
- Original source repository: https://github.com/dcrzsy/dsh-enhance-tool
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.