### PR TITLE
catalog: add deepseekbluefish-dsh-screenshot-plugin (community curation, created by @deepseekbluefish)

### DIFF
--- a/catalog/plugins/deepseekbluefish-dsh-screenshot-plugin.yaml
+++ b/catalog/plugins/deepseekbluefish-dsh-screenshot-plugin.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: deepseekbluefish-dsh-screenshot-plugin
+name: dsh-screenshot-plugin
+description:
+  en: "WeChat-style in-app screenshot button for DeepSeek Harness: drag to capture a screen region, PNG saved with auto-numbering, marker [Shot N HH:mm] written into the composer."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - screenshot
+  - capture
+  - screen
+source:
+  repository: https://github.com/deepseekbluefish/dsh-screenshot-plugin
+  repositoryNodeId: R_kgDOT_VrYQ
+  subpath: null
+  commit: 48f1be36e725e7a7199961896d836128515ef971
+creator:
+  github: deepseekbluefish
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:30.118Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `deepseekbluefish-dsh-screenshot-plugin`
- Submission type: community curation
- Created by `deepseekbluefish` — https://github.com/deepseekbluefish
- Original source repository: https://github.com/deepseekbluefish/dsh-screenshot-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.