### PR TITLE
catalog: add delef-dsh-free-web-search (community curation, created by @delef)

### DIFF
--- a/catalog/plugins/delef-dsh-free-web-search.yaml
+++ b/catalog/plugins/delef-dsh-free-web-search.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: delef-dsh-free-web-search
+name: dsh-free-web-search
+description:
+  en: "Free web search for DeepSeek Harness: Bing, DuckDuckGo, SearXNG, Exa, Tavily, Keenable — with automatic fallback, time filtering, and platform search"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - web-search
+  - bing
+  - duckduckgo
+  - searxng
+  - exa
+  - tavily
+source:
+  repository: https://github.com/delef/dsh-free-web-search
+  repositoryNodeId: R_kgDOT_qgag
+  subpath: null
+  commit: 94bd12880a8f4000374cd25629f5e97c9d5364fd
+creator:
+  github: delef
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:18.864Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `delef-dsh-free-web-search`
- Submission type: community curation
- Created by `delef` — https://github.com/delef
- Original source repository: https://github.com/delef/dsh-free-web-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.