### PR TITLE
catalog: add dff652-dsh-agentmemory (community curation, created by @dff652)

### DIFF
--- a/catalog/plugins/dff652-dsh-agentmemory.yaml
+++ b/catalog/plugins/dff652-dsh-agentmemory.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: dff652-dsh-agentmemory
+name: "@dff652/dsh-agentmemory"
+description:
+  en: Configuration-only DeepSeek Harness bundle for an existing AgentMemory MCP stdio adapter
+  evidencePath: packages/dsh-agentmemory/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - mcp
+  - agentmemory
+  - dsh
+source:
+  repository: https://github.com/dff652/deepseek-harness-community-plugins
+  repositoryNodeId: R_kgDOT8C-WA
+  subpath: packages/dsh-agentmemory
+  commit: a846540ba57d1ca8c67eedc7b8b15e6202a25b27
+creator:
+  github: dff652
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh-agentmemory/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:33.114Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dff652-dsh-agentmemory`
- Submission type: community curation
- Created by `dff652` — https://github.com/dff652
- Original source repository: https://github.com/dff652/deepseek-harness-community-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.