### PR TITLE
catalog: add diag5-dsh-better-input (community curation, created by @DIAG5)

### DIFF
--- a/catalog/plugins/diag5-dsh-better-input.yaml
+++ b/catalog/plugins/diag5-dsh-better-input.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: diag5-dsh-better-input
+name: dsh-better-input
+description:
+  en: "Better input experience for DeepSeek Harness: voice input, AI polishing, prompt optimization, and local file input / file-to-Markdown"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - voice
+  - speech-to-text
+  - input
+  - better-input
+source:
+  repository: https://github.com/DIAG5/dsh-better-input
+  repositoryNodeId: R_kgDOT-fuVQ
+  subpath: null
+  commit: 70eaa627e497bec0a96e2327178645df15675cf5
+creator:
+  github: DIAG5
+package:
+  ecosystem: npm
+  name: dsh-better-input
+  version: 0.1.6
+  integrity: sha512-Owon43j1U79M6MZufUNk6DyHJDM+nmvOmqxr4oufAY9wcR3B6/ouVG9TGpe/Eu4shlA5KmUbbY9yD7GOQOh5Pg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:32.780Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 18
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `diag5-dsh-better-input`
- Submission type: community curation
- Created by `DIAG5` — https://github.com/DIAG5
- Original source repository: https://github.com/DIAG5/dsh-better-input
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.