### PR TITLE
catalog: add diluka-dsh-agent-plugin-market (community curation, created by @Diluka)

### DIFF
--- a/catalog/plugins/diluka-dsh-agent-plugin-market.yaml
+++ b/catalog/plugins/diluka-dsh-agent-plugin-market.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: diluka-dsh-agent-plugin-market
+name: dsh-agent-plugin-market
+description:
+  en: bash dsh plugin --profile web add github:Diluka/dsh-agent-plugin-market
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh
+  - cordis
+  - market
+  - skills
+  - codex
+source:
+  repository: https://github.com/Diluka/dsh-agent-plugin-market
+  repositoryNodeId: R_kgDOT8CGyw
+  subpath: null
+  commit: 47ab89cf991e05574de2cd5345d61b553aa6ece7
+creator:
+  github: Diluka
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:38.865Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `diluka-dsh-agent-plugin-market`
- Submission type: community curation
- Created by `Diluka` — https://github.com/Diluka
- Original source repository: https://github.com/Diluka/dsh-agent-plugin-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.