### PR TITLE
catalog: add domparent-dsh-oled-care (community curation, created by @domparent)

### DIFF
--- a/catalog/plugins/domparent-dsh-oled-care.yaml
+++ b/catalog/plugins/domparent-dsh-oled-care.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: domparent-dsh-oled-care
+name: dsh-oled-care
+description:
+  en: "OLED burn-in care for the DeepSeek Harness Web GUI: true-black nap screensaver, pure-black surfaces, gamma-aware text dimming with an idle/focus ladder, and slow accent-hue rotation."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - oled
+  - burn-in
+  - screensaver
+source:
+  repository: https://github.com/domparent/OLEDCare
+  repositoryNodeId: R_kgDOT-D_-A
+  subpath: null
+  commit: ed4bbf8dab015a6ba7961503656288a0ccadaae7
+creator:
+  github: domparent
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:20.350Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `domparent-dsh-oled-care`
- Submission type: community curation
- Created by `domparent` — https://github.com/domparent
- Original source repository: https://github.com/domparent/OLEDCare
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.