### PR TITLE
catalog: add dong3434-dsh-auto-maintenance (community curation, created by @dong3434)

### DIFF
--- a/catalog/plugins/dong3434-dsh-auto-maintenance.yaml
+++ b/catalog/plugins/dong3434-dsh-auto-maintenance.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: dong3434-dsh-auto-maintenance
+name: dsh-auto-maintenance
+description:
+  en: DSH Auto Maintenance System — startup diagnosis, auto-fix, scheduled backups, smart-start, config monitoring, and automatic plugin-change self-check with rollback, in one Cordis plugin.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - deepseek-harness
+  - maintenance
+  - auto-fix
+  - diagnosis
+  - backup
+  - monitor
+  - self-check
+  - rollback
+  - rescue
+  - auto-repair
+source:
+  repository: https://github.com/dong3434/dsh-auto-maintenance
+  repositoryNodeId: R_kgDOUCOKdA
+  subpath: null
+  commit: ee55afb14ac81aa190b15d7eb9caca829650f572
+creator:
+  github: dong3434
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:21.739Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dong3434-dsh-auto-maintenance`
- Submission type: community curation
- Created by `dong3434` — https://github.com/dong3434
- Original source repository: https://github.com/dong3434/dsh-auto-maintenance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.