### PR TITLE
catalog: add drscrewdriver-dsh-switch-search (community curation, created by @drscrewdriver)

### DIFF
--- a/catalog/plugins/drscrewdriver-dsh-switch-search.yaml
+++ b/catalog/plugins/drscrewdriver-dsh-switch-search.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: drscrewdriver-dsh-switch-search
+name: dsh-switch-search
+description:
+  en: <p align="center" <strong Session content search for the DeepSeek Harness sidebar — one-click toggle between title and content, with user / reply / tool filters</strong </p <p align="center" <a href="README.md" 中文</a · <strong English</strong </p <p align="center" <a href="LICENSE" <img alt="MIT License" src="https://i
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - align
+  - center
+  - strong
+  - session
+  - content
+  - search
+  - sidebar
+  - click
+  - toggle
+  - between
+  - title
+  - user
+  - reply
+  - tool
+  - filters
+  - href
+source:
+  repository: https://github.com/drscrewdriver/dsh-session-search-toggle
+  repositoryNodeId: R_kgDOT-BJSA
+  subpath: null
+  commit: 5b2b2d9f00019f8bda8fbce852a2365dfb44c640
+creator:
+  github: drscrewdriver
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:23.249Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `drscrewdriver-dsh-switch-search`
- Submission type: community curation
- Created by `drscrewdriver` — https://github.com/drscrewdriver
- Original source repository: https://github.com/drscrewdriver/dsh-session-search-toggle
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.