### PR TITLE
catalog: add drscrewdriver-dsh-thinking-levels (community curation, created by @drscrewdriver)

### DIFF
--- a/catalog/plugins/drscrewdriver-dsh-thinking-levels.yaml
+++ b/catalog/plugins/drscrewdriver-dsh-thinking-levels.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: drscrewdriver-dsh-thinking-levels
+name: dsh-thinking-levels
+description:
+  en: "DSH host plugin: thinking-level (reasoning effort) control for dsh — auto-adjust per tool round, with optional manual lock and per-tool timing telemetry."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - host
+  - thinking
+  - level
+  - reasoning
+  - effort
+  - control
+  - auto
+  - adjust
+  - tool
+  - round
+  - optional
+  - manual
+  - lock
+  - timing
+  - telemetry
+  - dsh
+source:
+  repository: https://github.com/drscrewdriver/dsh-thinking-levels
+  repositoryNodeId: R_kgDOT8j97g
+  subpath: null
+  commit: 0ff856a77ca64e0715ffa259dd37569e283b18a1
+creator:
+  github: drscrewdriver
+package:
+  ecosystem: npm
+  name: dsh-thinking-levels
+  version: 0.4.1
+  integrity: sha512-j09BbmXq7Dd9SqMsBic0xMdBPXAhMd1WiEGG3ppNk338TmbT75yM2veRStV3oOzBcU+4IWw/7bRww5+0V1tf7A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:43.794Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `drscrewdriver-dsh-thinking-levels`
- Submission type: community curation
- Created by `drscrewdriver` — https://github.com/drscrewdriver
- Original source repository: https://github.com/drscrewdriver/dsh-thinking-levels
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.