### PR TITLE
catalog: add dygin-dsh-recover-context (community curation, created by @dygin)

### DIFF
--- a/catalog/plugins/dygin-dsh-recover-context.yaml
+++ b/catalog/plugins/dygin-dsh-recover-context.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: dygin-dsh-recover-context
+name: dsh-recover-context
+description:
+  en: "DSH web plugin: roll back to before any of your questions, or edit the last one and resubmit, restoring the workspace files the discarded turns produced."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - rollback
+  - undo
+  - conversation
+  - checkpoint
+  - ui
+source:
+  repository: https://github.com/dygin/dsh-recover-context
+  repositoryNodeId: R_kgDOT96K8Q
+  subpath: null
+  commit: 42c64cd8a1a6462cdcd5003874e27b22abbbb669
+creator:
+  github: dygin
+package:
+  ecosystem: npm
+  name: dsh-recover-context
+  version: 1.0.5
+  integrity: sha512-Hk6mMjb+HDNLdLE5sysjG1jVgQL/fe40kevtZGfAQ+Y4kVH5xRFwM6gn3EcvGN3C1g/YDy6n5siWJTSyZAtdGQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:55.728Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dygin-dsh-recover-context`
- Submission type: community curation
- Created by `dygin` — https://github.com/dygin
- Original source repository: https://github.com/dygin/dsh-recover-context
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.