### PR TITLE
catalog: add edge-sky-dsh-oauth-adapter (community curation, created by @edge-sky)

### DIFF
--- a/catalog/plugins/edge-sky-dsh-oauth-adapter.yaml
+++ b/catalog/plugins/edge-sky-dsh-oauth-adapter.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: edge-sky-dsh-oauth-adapter
+name: "@edge-sky/dsh-oauth-adapter"
+description:
+  en: Web OAuth account surface for official DSH authorization flows
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - oauth
+  - account
+  - surface
+  - official
+  - authorization
+  - flows
+  - dsh
+source:
+  repository: https://github.com/edge-sky/dsh-oauth-adapter
+  repositoryNodeId: R_kgDOUAuFtw
+  subpath: null
+  commit: 559a757351093b42b695c36f77d81f8cbfe05a03
+creator:
+  github: edge-sky
+package:
+  ecosystem: npm
+  name: "@edge-sky/dsh-oauth-adapter"
+  version: 0.1.1-rc.11
+  integrity: sha512-obQd/wZmGzqNJD88yxib8YIhxDHGz8MBMNSaJ/EjZGplrcoMzDfKRtulRXOGP8pJyp8qsk/gjvJ7uD9TDZM8ZQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:57.492Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `edge-sky-dsh-oauth-adapter`
- Submission type: community curation
- Created by `edge-sky` — https://github.com/edge-sky
- Original source repository: https://github.com/edge-sky/dsh-oauth-adapter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.