### PR TITLE
catalog: add etony-dsh-task-board (community curation, created by @etony)

### DIFF
--- a/catalog/plugins/etony-dsh-task-board.yaml
+++ b/catalog/plugins/etony-dsh-task-board.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: etony-dsh-task-board
+name: "@etony668/dsh-task-board"
+description:
+  en: "A port of the CodexFF project task board for DeepSeek Harness (DSH) : a new Chat → Trajectory → Task Board tab in the conversation view, canvas-style draggable panels, agent tools and a sync skill, with local JSON storage and no external services."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - port
+  - codexff
+  - task
+  - board
+  - chat
+  - trajectory
+  - conversation
+  - view
+  - canvas
+  - style
+  - draggable
+  - panels
+  - agent
+  - tools
+  - sync
+  - skill
+source:
+  repository: https://github.com/etony668/dsh-task-board
+  repositoryNodeId: R_kgDOUBDxtQ
+  subpath: null
+  commit: 4e7f97cdbbc765d0e351e0e6d066f6a40ef14a0e
+creator:
+  github: etony
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:31.346Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `etony-dsh-task-board`
- Submission type: community curation
- Created by `etony` — https://github.com/etony
- Original source repository: https://github.com/etony668/dsh-task-board
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.