### PR TITLE
catalog: add eugenevl-dsh-session-folders (community curation, created by @EugeneVl)

### DIFF
--- a/catalog/plugins/eugenevl-dsh-session-folders.yaml
+++ b/catalog/plugins/eugenevl-dsh-session-folders.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: eugenevl-dsh-session-folders
+name: dsh-session-folders
+description:
+  en: "Session folders for the DSH web sidebar: one-level named folders per workspace to group sessions, drag-and-drop or context menu to move them, server-side persistence. Status badges mirror the built-in session browser."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - folders
+  - sessions
+  - sidebar
+source:
+  repository: https://github.com/EugeneVl/dsh_session_folders
+  repositoryNodeId: R_kgDOT9Qvxw
+  subpath: null
+  commit: cea208f9830915812844770052e2224850fa43ba
+creator:
+  github: EugeneVl
+package:
+  ecosystem: npm
+  name: dsh-session-folders
+  version: 0.4.3
+  integrity: sha512-yICdrrodHmE0+oMRrOqaevzEv0KQkWQAHy6TGM3E6Z9c3yU7fbBjXnVhMaRm2IqquLJtK0qm+2JAQ9rSyjE+7w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:45.210Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `eugenevl-dsh-session-folders`
- Submission type: community curation
- Created by `EugeneVl` — https://github.com/EugeneVl
- Original source repository: https://github.com/EugeneVl/dsh_session_folders
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.