### PR TITLE
catalog: add exoticknight-dsh-labnana (community curation, created by @exoticknight)

### DIFF
--- a/catalog/plugins/exoticknight-dsh-labnana.yaml
+++ b/catalog/plugins/exoticknight-dsh-labnana.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: exoticknight-dsh-labnana
+name: dsh-labnana
+description:
+  en: "Labnana image generation for DeepSeek Harness: text-to-image / image-to-image / precise editing with credits estimation, subscription balance and web settings UI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - labnana
+  - image-generation
+  - text-to-image
+  - image-to-image
+  - gemini
+  - nano-banana
+  - gpt-image
+  - wan2-7
+  - seedream
+source:
+  repository: https://github.com/exoticknight/dsh-labnana
+  repositoryNodeId: R_kgDOUAYMqw
+  subpath: null
+  commit: a2ca18fdebabdecf4e90894b58433f8c1bfc0156
+creator:
+  github: exoticknight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:58.976Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `exoticknight-dsh-labnana`
- Submission type: community curation
- Created by `exoticknight` — https://github.com/exoticknight
- Original source repository: https://github.com/exoticknight/dsh-labnana
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.