### PR TITLE
catalog: add faith1688-dsh-usage-meter-harness (community curation, created by @faith1688)

### DIFF
--- a/catalog/plugins/faith1688-dsh-usage-meter-harness.yaml
+++ b/catalog/plugins/faith1688-dsh-usage-meter-harness.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: faith1688-dsh-usage-meter-harness
+name: "@faith1688/dsh-usage-meter-harness"
+description:
+  en: A real-time usage / cost / balance meter plugin for DeepSeek Harness (DSH) . See tokens, spending and real wallet balance right next to the chat input — for the official DeepSeek models and any custom model registered in DSH.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - usage
+  - meter
+  - cost
+  - billing
+  - session-projection
+source:
+  repository: https://github.com/faith1688/dsh-usage-meter-harness
+  repositoryNodeId: R_kgDOT6-niw
+  subpath: null
+  commit: bd288701676a7163e9d51f209de0b128672eec4f
+creator:
+  github: faith1688
+package:
+  ecosystem: npm
+  name: "@faith1688/dsh-usage-meter-harness"
+  version: 1.0.30
+  integrity: sha512-mdUiwJaddKKY6OA9A/4cqcdjuRPINX/ktyRcJ4xjlgl46Hq649YfjhpRN3K1v45e9+yQStLdE6nEL08CObEAmQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:32.876Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `faith1688-dsh-usage-meter-harness`
- Submission type: community curation
- Created by `faith1688` — https://github.com/faith1688
- Original source repository: https://github.com/faith1688/dsh-usage-meter-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.