### PR TITLE
catalog: add fancr-code-dsh-tray-launcher (community curation, created by @fancr-code)

### DIFF
--- a/catalog/plugins/fancr-code-dsh-tray-launcher.yaml
+++ b/catalog/plugins/fancr-code-dsh-tray-launcher.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: fancr-code-dsh-tray-launcher
+name: dsh-tray-launcher
+description:
+  en: <p align="center" <img src="https://img.shields.io/github/stars/fancr-code/dsh-tray-launcher?style=flat-square&cacheSeconds=300" alt="Stars" &nbsp; <img src="https://img.shields.io/npm/v/dsh-tray-launcher?style=flat-square" alt="npm" &nbsp; <img src="https://img.shields.io/npm/dm/dsh-tray-launcher?style=flat-square" al
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - windows
+  - system-tray
+  - launcher
+  - powershell
+source:
+  repository: https://github.com/fancr-code/dsh-tray-launcher
+  repositoryNodeId: R_kgDOT9IZ9g
+  subpath: null
+  commit: 02cca9e6e5368f3916ca2bfbc89b21203d6ca097
+creator:
+  github: fancr-code
+package:
+  ecosystem: npm
+  name: dsh-tray-launcher
+  version: 1.4.0
+  integrity: sha512-EO4rjTuWcldD3Ovl8+DBv006uWAL28KA46DzUwO5sh9KY/6VkfDusS3fBAsHNP1ZZcoMsHXsWc95muF5vlaKGQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:46.933Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fancr-code-dsh-tray-launcher`
- Submission type: community curation
- Created by `fancr-code` — https://github.com/fancr-code
- Original source repository: https://github.com/fancr-code/dsh-tray-launcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.