### PR TITLE
catalog: add fandc520-dsh-comfyui (community curation, created by @fandc520)

### DIFF
--- a/catalog/plugins/fandc520-dsh-comfyui.yaml
+++ b/catalog/plugins/fandc520-dsh-comfyui.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: fandc520-dsh-comfyui
+name: dsh-comfyui
+description:
+  en: "Drive ComfyUI from DeepSeek Harness: generate and process images and videos through agent tools, with a workflow/asset/queue panel, in-chat results and a settings page. / 让 DeepSeek Harness 的 Agent 直接驱动 ComfyUI 生成与处理图像、视频，带工作流/资产/队列面板。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - comfyui
+  - image-generation
+  - video-generation
+source:
+  repository: https://github.com/fandc520/dsh-comfyui
+  repositoryNodeId: R_kgDOT-zKcg
+  subpath: null
+  commit: 0843841c7fc526d7f995427d98c87ec757fdebb0
+creator:
+  github: fandc520
+package:
+  ecosystem: npm
+  name: dsh-comfyui
+  version: 0.3.0-beta.4
+  integrity: sha512-NB/VJ3Mmd/heoRfxJC/F285m2aK/mFx3qcPs4yqhQHw02gPlRZeI/FWMVnOg6HkdKwd4UBhSgPjU4/JITUVIog==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:31.003Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 32
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fandc520-dsh-comfyui`
- Submission type: community curation
- Created by `fandc520` — https://github.com/fandc520
- Original source repository: https://github.com/fandc520/dsh-comfyui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.