### PR TITLE
catalog: add fashionmascherine-svg-dsh-polymarket-knowhow (community curation, created by @fashionmascherine-svg)

### DIFF
--- a/catalog/plugins/fashionmascherine-svg-dsh-polymarket-knowhow.yaml
+++ b/catalog/plugins/fashionmascherine-svg-dsh-polymarket-knowhow.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: fashionmascherine-svg-dsh-polymarket-knowhow
+name: dsh-polymarket-knowhow
+description:
+  en: "DeepSeek Harness plugin: complete Polymarket API coverage — market data tools, authenticated trading tools, WebSocket stream service, and an embedded Polymarket knowhow skill"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - polymarket
+  - prediction-markets
+  - clob
+  - gamma-api
+  - trading
+  - cordis
+  - agent-tools
+  - dsh
+source:
+  repository: https://github.com/fashionmascherine-svg/dsh-polymarket-knowhow
+  repositoryNodeId: R_kgDOUAz0zg
+  subpath: null
+  commit: b7f8d8ee78c6a5a02682e4775c2c997b38b90fc4
+creator:
+  github: fashionmascherine-svg
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:00.422Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fashionmascherine-svg-dsh-polymarket-knowhow`
- Submission type: community curation
- Created by `fashionmascherine-svg` — https://github.com/fashionmascherine-svg
- Original source repository: https://github.com/fashionmascherine-svg/dsh-polymarket-knowhow
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.