### PR TITLE
catalog: add fish121380-dsh-little-mouse-pointer (community curation, created by @Fish121380)

### DIFF
--- a/catalog/plugins/fish121380-dsh-little-mouse-pointer.yaml
+++ b/catalog/plugins/fish121380-dsh-little-mouse-pointer.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: fish121380-dsh-little-mouse-pointer
+name: dsh-little-mouse-pointer
+description:
+  en: DeepSeek Harness bundle for a Windows desktop UI context picker and MCP server for Codex, DeepSeek Harness, and AI agents
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - bundle
+  - windows
+  - desktop
+  - context
+  - picker
+  - server
+  - codex
+  - agents
+  - dsh
+source:
+  repository: https://github.com/Fish121380/auto-mouse
+  repositoryNodeId: R_kgDOT_VQFQ
+  subpath: null
+  commit: f6102369316ec3c15e87703c3abffe186d2e4383
+creator:
+  github: Fish121380
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:35.755Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fish121380-dsh-little-mouse-pointer`
- Submission type: community curation
- Created by `Fish121380` — https://github.com/Fish121380
- Original source repository: https://github.com/Fish121380/auto-mouse
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.