### PR TITLE
catalog: add fjzzwxp-dsh-mnemosyne-memory (community curation, created by @fjzzwxp)

### DIFF
--- a/catalog/plugins/fjzzwxp-dsh-mnemosyne-memory.yaml
+++ b/catalog/plugins/fjzzwxp-dsh-mnemosyne-memory.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: fjzzwxp-dsh-mnemosyne-memory
+name: dsh-mnemosyne-memory
+description:
+  en: Choice -- 🌐 免费 Gemini API G PATH Choice -- 💻 完全离线 Ollama O PATH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - mnemosyne
+  - memory
+  - dsh
+  - hindsight
+  - long-term-memory
+  - vector-search
+  - llm-reflection
+source:
+  repository: https://github.com/fjzzwxp/dsh-mnemosyne-memory
+  repositoryNodeId: R_kgDOUC-5IA
+  subpath: null
+  commit: e98a92bac39831d07ddb53deb46b7a2786fbc6f9
+creator:
+  github: fjzzwxp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:03.357Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fjzzwxp-dsh-mnemosyne-memory`
- Submission type: community curation
- Created by `fjzzwxp` — https://github.com/fjzzwxp
- Original source repository: https://github.com/fjzzwxp/dsh-mnemosyne-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.