### PR TITLE
catalog: add flycat43-liang-harness-plugin (community curation, created by @Flycat43)

### DIFF
--- a/catalog/plugins/flycat43-liang-harness-plugin.yaml
+++ b/catalog/plugins/flycat43-liang-harness-plugin.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: flycat43-liang-harness-plugin
+name: liang-harness-plugin
+description:
+  en: An unofficial Liang character companion plugin for the DeepSeek Harness web profile.
+  evidencePath: plugins/liang-harness-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - cordis
+  - desktop-pet
+  - dsh
+source:
+  repository: https://github.com/Flycat43/liang-desktop-pet
+  repositoryNodeId: R_kgDOUBFsKQ
+  subpath: plugins/liang-harness-plugin
+  commit: 36e367799357a16ee2d4c2de79eacca879deef0f
+creator:
+  github: Flycat43
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/liang-harness-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:52.960Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `flycat43-liang-harness-plugin`
- Submission type: community curation
- Created by `Flycat43` — https://github.com/Flycat43
- Original source repository: https://github.com/Flycat43/liang-desktop-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.