### PR TITLE
catalog: add flyhigao-dsh-produced-file-paths (community curation, created by @flyhigao)

### DIFF
--- a/catalog/plugins/flyhigao-dsh-produced-file-paths.yaml
+++ b/catalog/plugins/flyhigao-dsh-produced-file-paths.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: flyhigao-dsh-produced-file-paths
+name: dsh-produced-file-paths
+description:
+  en: Show and copy absolute paths for files produced by DSH turns.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - file-paths
+  - clipboard
+source:
+  repository: https://github.com/flyhigao/dsh-produced-file-paths
+  repositoryNodeId: R_kgDOT-32JA
+  subpath: null
+  commit: ab469f82c0a7d8a38c6b9af178db0d4327654b1b
+creator:
+  github: flyhigao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:54.409Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `flyhigao-dsh-produced-file-paths`
- Submission type: community curation
- Created by `flyhigao` — https://github.com/flyhigao
- Original source repository: https://github.com/flyhigao/dsh-produced-file-paths
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.