### PR TITLE
catalog: add flyhigao-dsh-sticky-notes (community curation, created by @flyhigao)

### DIFF
--- a/catalog/plugins/flyhigao-dsh-sticky-notes.yaml
+++ b/catalog/plugins/flyhigao-dsh-sticky-notes.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: flyhigao-dsh-sticky-notes
+name: dsh-sticky-notes
+description:
+  en: "Workspace sticky notes for DSH: save multiple Markdown notes inside the current workspace."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - notes
+  - sticky-notes
+  - workspace
+source:
+  repository: https://github.com/flyhigao/dsh-sticky-notes
+  repositoryNodeId: R_kgDOT6TYHw
+  subpath: null
+  commit: 3ba72b9d5064df76a39afb30102769dc49b7acc7
+creator:
+  github: flyhigao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:02.092Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `flyhigao-dsh-sticky-notes`
- Submission type: community curation
- Created by `flyhigao` — https://github.com/flyhigao
- Original source repository: https://github.com/flyhigao/dsh-sticky-notes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.