### PR TITLE
catalog: add francesco502-dsh-quota (community curation, created by @Francesco502)

### DIFF
--- a/catalog/plugins/francesco502-dsh-quota.yaml
+++ b/catalog/plugins/francesco502-dsh-quota.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: francesco502-dsh-quota
+name: "@francescoli/dsh-quota"
+description:
+  en: AI Quota and Token Usage Monitor for DeepSeek Harness (Codex, Cursor, Antigravity, OpenCode-Go)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - quota
+  - token-meter
+  - cursor
+  - codex
+  - openai
+  - antigravity
+  - opencode-go
+source:
+  repository: https://github.com/Francesco502/dsh-quota
+  repositoryNodeId: R_kgDOUEp04g
+  subpath: null
+  commit: 741329f5a2ce3658c6dc8e3ed51628041f8e1942
+creator:
+  github: Francesco502
+package:
+  ecosystem: npm
+  name: "@francescoli/dsh-quota"
+  version: 0.1.0
+  integrity: sha512-WfY5AE+bjvBFo0JgKQSfNNToJQPmqPnPxJziU8kRTHAMglmVRon0rcGOToeFd2uipBPGboY31/ouWWFEZ3W8lQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:56.047Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `francesco502-dsh-quota`
- Submission type: community curation
- Created by `Francesco502` — https://github.com/Francesco502
- Original source repository: https://github.com/Francesco502/dsh-quota
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.