### PR TITLE
catalog: add freakz2z-dsh-catgirl-plugin (community curation, created by @Freakz2z)

### DIFF
--- a/catalog/plugins/freakz2z-dsh-catgirl-plugin.yaml
+++ b/catalog/plugins/freakz2z-dsh-catgirl-plugin.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: freakz2z-dsh-catgirl-plugin
+name: dsh-catgirl-plugin
+description:
+  en: Token-efficient catgirl persona runtime for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - persona
+  - catgirl
+  - token-optimization
+source:
+  repository: https://github.com/Freakz2z/dsh-catgirl-plugin
+  repositoryNodeId: R_kgDOT4jh_Q
+  subpath: null
+  commit: b1a7b4958edbc3458c2e3e8049b5fc8188a950c5
+creator:
+  github: Freakz2z
+package:
+  ecosystem: npm
+  name: dsh-catgirl-plugin
+  version: 0.1.1
+  integrity: sha512-8ip/ZcIlSHXzFLs871jIkpniTUyuaFdvrmala6Vbv78cvjK0ghzHeq7lAZTyHzOqXsLybO7eMF0I59sm+6VB5A==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:03.569Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `freakz2z-dsh-catgirl-plugin`
- Submission type: community curation
- Created by `Freakz2z` — https://github.com/Freakz2z
- Original source repository: https://github.com/Freakz2z/dsh-catgirl-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.