### PR TITLE
catalog: add free-corner-dsh-chat-tools (community curation, created by @Free-corner)

### DIFF
--- a/catalog/plugins/free-corner-dsh-chat-tools.yaml
+++ b/catalog/plugins/free-corner-dsh-chat-tools.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: free-corner-dsh-chat-tools
+name: dsh-chat-tools
+description:
+  en: "DSH Web client plugin: adjustable chat column width and alignment, a numbered question history with keyboard navigation and auto-load of older questions, plus markdown outline rails on both the conversation and the file preview."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - client
+  - adjustable
+  - chat
+  - column
+  - width
+  - alignment
+  - numbered
+  - question
+  - history
+  - keyboard
+  - navigation
+  - auto
+  - load
+  - older
+  - questions
+  - plus
+source:
+  repository: https://github.com/Free-corner/dsh-chat-tools
+  repositoryNodeId: R_kgDOT96N8w
+  subpath: null
+  commit: d903dbfb6f2f7b4481fe7abb35ded74994b74341
+creator:
+  github: Free-corner
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:04.982Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `free-corner-dsh-chat-tools`
- Submission type: community curation
- Created by `Free-corner` — https://github.com/Free-corner
- Original source repository: https://github.com/Free-corner/dsh-chat-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.