### PR TITLE
catalog: add fro2en12-dsh-download-progress (community curation, created by @Fro2en12)

### DIFF
--- a/catalog/plugins/fro2en12-dsh-download-progress.yaml
+++ b/catalog/plugins/fro2en12-dsh-download-progress.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: fro2en12-dsh-download-progress
+name: dsh-download-progress
+description:
+  en: 'English: A DeepSeek Harness (DSH) web plugin that surfaces a draggable download-progress panel in the bottom-right corner of the web GUI. It tracks panel-started URL downloads, agent shell/SSH transfers, and any "black-box" file growth inside registered workspaces — with live bytes, speed, percentage and ETA.'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - download
+  - progress
+  - transfer
+source:
+  repository: https://github.com/Fro2en12/dsh-download-progress
+  repositoryNodeId: R_kgDOT4zy9g
+  subpath: null
+  commit: d5b3816e36c0806a544499b166460bce948d4faf
+creator:
+  github: Fro2en12
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:06.572Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fro2en12-dsh-download-progress`
- Submission type: community curation
- Created by `Fro2en12` — https://github.com/Fro2en12
- Original source repository: https://github.com/Fro2en12/dsh-download-progress
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.