### PR TITLE
catalog: add frog755-dsh-client-auto-retry (community curation, created by @Frog755)

### DIFF
--- a/catalog/plugins/frog755-dsh-client-auto-retry.yaml
+++ b/catalog/plugins/frog755-dsh-client-auto-retry.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: frog755-dsh-client-auto-retry
+name: "@frog755/dsh-client-auto-retry"
+description:
+  en: powershell pnpm add @frog755/dsh-client-auto-retry
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - retry
+  - auto-retry
+  - client
+source:
+  repository: https://github.com/Frog755/dsh-client-auto-retry
+  repositoryNodeId: R_kgDOT8jOhQ
+  subpath: null
+  commit: adffe5341ea25c15646fff6fb09b21e70cd23048
+creator:
+  github: Frog755
+package:
+  ecosystem: npm
+  name: "@frog755/dsh-client-auto-retry"
+  version: 0.3.1
+  integrity: sha512-zXPzWKPVtil5iGods+tk/Ay3/Pi+TRprrmKqS+w6UkNDef9R8kedPoHdGfldAloG0kwJTcw+JszywUsUFVbkyg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:07.908Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `frog755-dsh-client-auto-retry`
- Submission type: community curation
- Created by `Frog755` — https://github.com/Frog755
- Original source repository: https://github.com/Frog755/dsh-client-auto-retry
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.