### PR TITLE
catalog: add frog755-dsh-hybrid-memory (community curation, created by @Frog755)

### DIFF
--- a/catalog/plugins/frog755-dsh-hybrid-memory.yaml
+++ b/catalog/plugins/frog755-dsh-hybrid-memory.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: frog755-dsh-hybrid-memory
+name: "@frog755/dsh-hybrid-memory"
+description:
+  en: "Hybrid memory plugin for DeepSeek Harness: L1 frozen-snapshot memory (MEMORY.md/USER.md, prefix-cache friendly) + L2 searchable knowledge base (one-fact-per-file, FTS5) + L3 multi-tool import. Data lives on D drive, never C."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - memory
+  - knowledge-base
+  - hybrid-memory
+source:
+  repository: https://github.com/Frog755/dsh-hybrid-memory
+  repositoryNodeId: R_kgDOUCP9xg
+  subpath: null
+  commit: b13d0fc69924f13b59ebd4720fba83e580039bba
+creator:
+  github: Frog755
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:06.407Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `frog755-dsh-hybrid-memory`
- Submission type: community curation
- Created by `Frog755` — https://github.com/Frog755
- Original source repository: https://github.com/Frog755/dsh-hybrid-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.