### PR TITLE
catalog: add frog755-dsh-prompt-vault (community curation, created by @Frog755)

### DIFF
--- a/catalog/plugins/frog755-dsh-prompt-vault.yaml
+++ b/catalog/plugins/frog755-dsh-prompt-vault.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: frog755-dsh-prompt-vault
+name: "@frog755/dsh-prompt-vault"
+description:
+  en: sh npx -y --package @deepseek-ai/dsh dsh plugin --profile web add @frog755/dsh-prompt-vault
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - prompt
+  - prompt-vault
+source:
+  repository: https://github.com/Frog755/dsh-prompt-vault
+  repositoryNodeId: R_kgDOUAoACA
+  subpath: null
+  commit: 714e9939617270a0f7b3a33b5c4aadcd1a6e8ac3
+creator:
+  github: Frog755
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:07.785Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `frog755-dsh-prompt-vault`
- Submission type: community curation
- Created by `Frog755` — https://github.com/Frog755
- Original source repository: https://github.com/Frog755/dsh-prompt-vault
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.