### PR TITLE
catalog: add fuqiangcraft-dsh-desktop-plugin (community curation, created by @FuqiangCraft)

### DIFF
--- a/catalog/plugins/fuqiangcraft-dsh-desktop-plugin.yaml
+++ b/catalog/plugins/fuqiangcraft-dsh-desktop-plugin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: fuqiangcraft-dsh-desktop-plugin
+name: "@mixian/dsh-desktop-plugin"
+description:
+  en: "Desktop-grade DeepSeek Harness plugin: native notifications for user questions/approvals, a floating attention HUD, a screen-capture tool, and a multi-agent tiling canvas."
+  evidencePath: packages/dsh-desktop-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis-plugin
+  - desktop
+  - notifications
+  - multi-agent
+source:
+  repository: https://github.com/FuqiangCraft/dsh-desktop
+  repositoryNodeId: R_kgDOUCL4iQ
+  subpath: packages/dsh-desktop-plugin
+  commit: 8cdc8f205535ada6abcf6afd81489e09260d38a6
+creator:
+  github: FuqiangCraft
+package:
+  ecosystem: npm
+  name: "@mixian/dsh-desktop-plugin"
+  version: 0.1.1
+  integrity: sha512-G8DpbEZDG8PutGmU7HPkc9zsy0DXfDfO9hNyWF7YKqc/iSUYAdF+yuZha9p+gP7/mUQStEVPFqBa/IEd3fwj3g==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-desktop-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:59.465Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fuqiangcraft-dsh-desktop-plugin`
- Submission type: community curation
- Created by `FuqiangCraft` — https://github.com/FuqiangCraft
- Original source repository: https://github.com/FuqiangCraft/dsh-desktop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.