### PR TITLE
catalog: add future007s-dsh-peak-indicator (community curation, created by @future007s)

### DIFF
--- a/catalog/plugins/future007s-dsh-peak-indicator.yaml
+++ b/catalog/plugins/future007s-dsh-peak-indicator.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: future007s-dsh-peak-indicator
+name: dsh-peak-indicator
+description:
+  en: "yaml - insert: - id: peak-indicator name: 'dsh-peak-indicator'"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - peak
+  - off-peak
+  - pricing
+  - cost
+source:
+  repository: https://github.com/future007s/dsh-peak-indicator
+  repositoryNodeId: R_kgDOT6Jx-w
+  subpath: null
+  commit: 8f8c2c3ed2c2fcd51ded523ddcfa963ec0fa35ca
+creator:
+  github: future007s
+package:
+  ecosystem: npm
+  name: dsh-peak-indicator
+  version: 0.1.25
+  integrity: sha512-s8OUw3f23N1ESt/c8e8yA6y4jRf5rfQzaDyl2fBCjAdTjHGC0PJ9R264wHkLcNh0Po9eJUcqMzLs6YglOgWuFA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:40.273Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `future007s-dsh-peak-indicator`
- Submission type: community curation
- Created by `future007s` — https://github.com/future007s
- Original source repository: https://github.com/future007s/dsh-peak-indicator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.