### PR TITLE
catalog: add ganfabo123-cmyk-dsh-explorer-agent (community curation, created by @ganfabo123-cmyk)

### DIFF
--- a/catalog/plugins/ganfabo123-cmyk-dsh-explorer-agent.yaml
+++ b/catalog/plugins/ganfabo123-cmyk-dsh-explorer-agent.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ganfabo123-cmyk-dsh-explorer-agent
+name: dsh-explorer-agent
+description:
+  en: Reusable read-only directory exploration agent for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - subagent
+  - repository-exploration
+  - read-only-agent
+  - dsh
+source:
+  repository: https://github.com/ganfabo123-cmyk/dsh-explorer-agent
+  repositoryNodeId: R_kgDOUEb_Cg
+  subpath: null
+  commit: 1d56b1c4c312087bb211ba2897f44d8a671e330f
+creator:
+  github: ganfabo123-cmyk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:00:04.180Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ganfabo123-cmyk-dsh-explorer-agent`
- Submission type: community curation
- Created by `ganfabo123-cmyk` — https://github.com/ganfabo123-cmyk
- Original source repository: https://github.com/ganfabo123-cmyk/dsh-explorer-agent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.