### PR TITLE
catalog: add garrisonz-dsh-chat-widener (community curation, created by @garrisonz)

### DIFF
--- a/catalog/plugins/garrisonz-dsh-chat-widener.yaml
+++ b/catalog/plugins/garrisonz-dsh-chat-widener.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: garrisonz-dsh-chat-widener
+name: dsh-chat-widener
+description:
+  en: Widen the DeepSeek Harness Web UI conversation content area (shipped default 748px) by overriding the chat-width CSS variables; configurable via the plugin row config.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - chat
+  - width
+  - ui
+source:
+  repository: https://github.com/garrisonz/dsh-chat-widener
+  repositoryNodeId: R_kgDOT7Slmg
+  subpath: null
+  commit: 9d404e09fc5316fb7f25056efc858a129e728a93
+creator:
+  github: garrisonz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:00:05.630Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `garrisonz-dsh-chat-widener`
- Submission type: community curation
- Created by `garrisonz` — https://github.com/garrisonz
- Original source repository: https://github.com/garrisonz/dsh-chat-widener
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.