### PR TITLE
catalog: add garrisonz-dsh-sidebar-width (community curation, created by @garrisonz)

### DIFF
--- a/catalog/plugins/garrisonz-dsh-sidebar-width.yaml
+++ b/catalog/plugins/garrisonz-dsh-sidebar-width.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: garrisonz-dsh-sidebar-width
+name: dsh-sidebar-width
+description:
+  en: Control the DeepSeek Harness Web UI left sidebar width (min/max/default) by patching the installed ui-layout client bundle at dsh web startup.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - sidebar
+  - ui
+source:
+  repository: https://github.com/garrisonz/dsh-sidebar-width
+  repositoryNodeId: R_kgDOT5P-yQ
+  subpath: null
+  commit: ae5671c5f61582870e9234d043a41b2518f96fd5
+creator:
+  github: garrisonz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:09.256Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `garrisonz-dsh-sidebar-width`
- Submission type: community curation
- Created by `garrisonz` — https://github.com/garrisonz
- Original source repository: https://github.com/garrisonz/dsh-sidebar-width
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.