### PR TITLE
catalog: add gdgfd22-dsh-lab-ssh (community curation, created by @gdgfd22)

### DIFF
--- a/catalog/plugins/gdgfd22-dsh-lab-ssh.yaml
+++ b/catalog/plugins/gdgfd22-dsh-lab-ssh.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: gdgfd22-dsh-lab-ssh
+name: dsh-lab-ssh
+description:
+  en: Safety-gated SSH tools for DeepSeek Harness and Codex laboratory operations
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - dsh-plugin
+  - codex
+  - mcp
+  - ssh
+  - offline-server
+  - gpu
+  - ai-ops
+  - dsh
+source:
+  repository: https://github.com/gdgfd22/deepseek-harness-ssh
+  repositoryNodeId: R_kgDOT9K6bQ
+  subpath: null
+  commit: 08858724285effdf19a021b461f934163a165ec9
+creator:
+  github: gdgfd22
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:40.641Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gdgfd22-dsh-lab-ssh`
- Submission type: community curation
- Created by `gdgfd22` — https://github.com/gdgfd22
- Original source repository: https://github.com/gdgfd22/deepseek-harness-ssh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.