### PR TITLE
catalog: add gdy01-dsh-token-cost (community curation, created by @gdy01)

### DIFF
--- a/catalog/plugins/gdy01-dsh-token-cost.yaml
+++ b/catalog/plugins/gdy01-dsh-token-cost.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: gdy01-dsh-token-cost
+name: dsh-token-cost
+description:
+  en: "DSH plugin: per-project LLM token usage and RMB cost (input / cache-hit / output) based on model standard prices."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - token
+  - cost
+  - usage
+  - billing
+source:
+  repository: https://github.com/gdy01/dsh-token-cost
+  repositoryNodeId: R_kgDOT69VEA
+  subpath: null
+  commit: 637ea42376fe29c309d7484c2edaf65420f9aa13
+creator:
+  github: gdy01
+package:
+  ecosystem: npm
+  name: dsh-token-cost
+  version: 0.1.0
+  integrity: sha512-m0xWWbl4PJ9GMhXkKcAjFQWVjguUGn3ZRQhRO5w9ymrglh/EMvmTMx7AQs+5yUl/c06xK58pOmLGiimjVBdW+w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:10.683Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gdy01-dsh-token-cost`
- Submission type: community curation
- Created by `gdy01` — https://github.com/gdy01
- Original source repository: https://github.com/gdy01/dsh-token-cost
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.