### PR TITLE
catalog: add gearvoid-dsh-taskify (community curation, created by @GearVoid)

### DIFF
--- a/catalog/plugins/gearvoid-dsh-taskify.yaml
+++ b/catalog/plugins/gearvoid-dsh-taskify.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: gearvoid-dsh-taskify
+name: dsh-taskify
+description:
+  en: "Intent Anchor plugin for DeepSeek Harness Web: extract reviewable, provenance-backed constraints without rewriting the user's draft."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - intent-anchor
+  - constraint-extraction
+  - dsh-plugin
+source:
+  repository: https://github.com/GearVoid/dsh-taskify
+  repositoryNodeId: R_kgDOT6Q3tw
+  subpath: null
+  commit: 70ed6a8d81a908da6836c25f86ae1a12b798590e
+creator:
+  github: GearVoid
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:12.117Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gearvoid-dsh-taskify`
- Submission type: community curation
- Created by `GearVoid` — https://github.com/GearVoid
- Original source repository: https://github.com/GearVoid/dsh-taskify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.