### PR TITLE
catalog: add geekcmore-blue (community curation, created by @GeekCmore)

### DIFF
--- a/catalog/plugins/geekcmore-blue.yaml
+++ b/catalog/plugins/geekcmore-blue.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: geekcmore-blue
+name: "@dsh-blue/blue"
+description:
+  en: "The dsh Blue bundle: the interactive terminal UI profile over dsh-base"
+  evidencePath: packages/bundle/blue/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - blue
+  - bundle
+  - interactive
+  - terminal
+  - profile
+  - over
+  - base
+  - dsh
+source:
+  repository: https://github.com/dsh-blue/blue
+  repositoryNodeId: R_kgDOT8oLVA
+  subpath: packages/bundle/blue
+  commit: 721f2c512bb76964e78a6eda591c243adaa65550
+creator:
+  github: GeekCmore
+package:
+  ecosystem: npm
+  name: "@dsh-blue/blue"
+  version: 0.1.0-rc.8
+  integrity: sha512-xEnksstVrXG8VULmdyi2jTiYQdYlyotjMA/OmrfbBzfMyLCE4L7BhY+gfYBk2HH6lxEFn06D+Fr984yT8ISnQA==
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/bundle/blue/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:42.652Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `geekcmore-blue`
- Submission type: community curation
- Created by `GeekCmore` — https://github.com/GeekCmore
- Original source repository: https://github.com/dsh-blue/blue
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.