### PR TITLE
catalog: add geekricardo-dsh-convmap (community curation, created by @GeekRicardo)

### DIFF
--- a/catalog/plugins/geekricardo-dsh-convmap.yaml
+++ b/catalog/plugins/geekricardo-dsh-convmap.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: geekricardo-dsh-convmap
+name: dsh-convmap
+description:
+  en: bash curl -fsSL https://raw.githubusercontent.com/GeekRicardo/dsh-convmap/main/install.sh bash
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - bash
+  - curl
+  - fssl
+  - githubusercontent
+  - geekricardo
+  - convmap
+  - main
+  - install
+  - dsh
+source:
+  repository: https://github.com/GeekRicardo/dsh-convmap
+  repositoryNodeId: R_kgDOT-M-zA
+  subpath: null
+  commit: 0ed3184e521b93c23aa898467ebc24eecb73e075
+creator:
+  github: GeekRicardo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:13.495Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `geekricardo-dsh-convmap`
- Submission type: community curation
- Created by `GeekRicardo` — https://github.com/GeekRicardo
- Original source repository: https://github.com/GeekRicardo/dsh-convmap
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.