### PR TITLE
catalog: add geekricardo-dsh-cordis-mcp (community curation, created by @GeekRicardo)

### DIFF
--- a/catalog/plugins/geekricardo-dsh-cordis-mcp.yaml
+++ b/catalog/plugins/geekricardo-dsh-cordis-mcp.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: geekricardo-dsh-cordis-mcp
+name: dsh-cordis-mcp
+description:
+  en: ┌─────────────┐ MCP (Streamable HTTP, loopback) ┌───────────────────────────┐ │ Claude Code │ ────── http://127.0.0.1:8090/mcp ──▶ │ DSH host (本插件) │ │ (claude) │ ────── JSON-RPC 2.0 ───────────────▶ │ dynamicCordisRunner │ └─────────────┘ │ cordisInspect │ │ agents (会话解析) │ └───────────────────────────┘
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - streamable
+  - loopback
+  - claude
+  - code
+  - "8090"
+  - host
+  - json
+  - dynamiccordisrunner
+  - cordisinspect
+  - agents
+  - dsh
+source:
+  repository: https://github.com/GeekRicardo/dsh-cordis-mcp
+  repositoryNodeId: R_kgDOT9DW0A
+  subpath: null
+  commit: a36a23751279a398da9923b7a198a3d2a44143fb
+creator:
+  github: GeekRicardo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:14.980Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `geekricardo-dsh-cordis-mcp`
- Submission type: community curation
- Created by `GeekRicardo` — https://github.com/GeekRicardo
- Original source repository: https://github.com/GeekRicardo/dsh-cordis-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.