### PR TITLE
catalog: add gengdapeng-dsh-agent-message (community curation, created by @GengDaPeng)

### DIFF
--- a/catalog/plugins/gengdapeng-dsh-agent-message.yaml
+++ b/catalog/plugins/gengdapeng-dsh-agent-message.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: gengdapeng-dsh-agent-message
+name: dsh-agent-message
+description:
+  en: "A cross-session Agent communication plugin for DeepSeek Harness: it lets different Agent sessions running in the same process send and receive messages to each other, just like messaging."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - agent
+  - multi-agent
+  - messaging
+  - dsh
+source:
+  repository: https://github.com/GengDaPeng/dsh-agent-message
+  repositoryNodeId: R_kgDOT3pNXA
+  subpath: null
+  commit: 88c19c4492287a2220b396153d67a1637c887ae9
+creator:
+  github: GengDaPeng
+package:
+  ecosystem: npm
+  name: dsh-agent-message
+  version: 1.5.1
+  integrity: sha512-7dLo58i/QyqpKf2h6HRFF9DMDcfX3fcnqCGvbO0AU8pxkynQluZQuhXcehFNF2QwXZTgh10PNyqLEdixqRjPIQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:42.152Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gengdapeng-dsh-agent-message`
- Submission type: community curation
- Created by `GengDaPeng` — https://github.com/GengDaPeng
- Original source repository: https://github.com/GengDaPeng/dsh-agent-message
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.