### PR TITLE
catalog: add giiiiiithub-dsh-terminal (community curation, created by @giiiiiithub)

### DIFF
--- a/catalog/plugins/giiiiiithub-dsh-terminal.yaml
+++ b/catalog/plugins/giiiiiithub-dsh-terminal.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: giiiiiithub-dsh-terminal
+name: dsh-terminal
+description:
+  en: "Terminal panel for the DSH Web UI: a real PTY shell (cmd.exe by default on Windows) rendered in the browser with xterm.js. Host half spawns shells with node-pty; client half is a browser plugin."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - terminal
+  - pty
+  - xterm
+  - web-ui
+source:
+  repository: https://github.com/giiiiiithub/terminal
+  repositoryNodeId: R_kgDOT47ktg
+  subpath: null
+  commit: c6d0fbfc45f6fc5ccfb4a60c4a1d400ebd177e24
+creator:
+  github: giiiiiithub
+package:
+  ecosystem: npm
+  name: dsh-terminal
+  version: 0.1.1
+  integrity: sha512-by9Lif/brkyvcaWJbZTOD9YeOU/PCXToVxm/QVzNA/xc8nQ1uYYtVDft7Necc3H3SWfkZkncJYYK/kPU+K9U6Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:16.384Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `giiiiiithub-dsh-terminal`
- Submission type: community curation
- Created by `giiiiiithub` — https://github.com/giiiiiithub
- Original source repository: https://github.com/giiiiiithub/terminal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.