### PR TITLE
catalog: add github-cjx-dsh-tool-imagegen (community curation, created by @Github-CJX)

### DIFF
--- a/catalog/plugins/github-cjx-dsh-tool-imagegen.yaml
+++ b/catalog/plugins/github-cjx-dsh-tool-imagegen.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: github-cjx-dsh-tool-imagegen
+name: "@local/dsh-tool-imagegen"
+description:
+  en: bash cp -r dsh-tool-imagegen C:/Users/CJX/.dsh/plugins/
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - image-generation
+  - image-to-image
+  - openai-compatible
+  - dsh-plugin
+source:
+  repository: https://github.com/Github-CJX/dsh-tool-imagegen
+  repositoryNodeId: R_kgDOT6_OPQ
+  subpath: null
+  commit: 8544125fc0a69c399802b3c8c49eb10ed27976aa
+creator:
+  github: Github-CJX
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:18.304Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `github-cjx-dsh-tool-imagegen`
- Submission type: community curation
- Created by `Github-CJX` — https://github.com/Github-CJX
- Original source repository: https://github.com/Github-CJX/dsh-tool-imagegen
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.