### PR TITLE
catalog: add huantm-dshhub-market (community curation, created by @huantm)

### DIFF
--- a/catalog/plugins/huantm-dshhub-market.yaml
+++ b/catalog/plugins/huantm-dshhub-market.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: huantm-dshhub-market
+name: dshhub-market
+description:
+  en: The good stuff has a code. Enter it, get it.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - marketplace
+  - market
+  - plugin-manager
+source:
+  repository: https://github.com/dshhub-co/dshhub-market
+  repositoryNodeId: R_kgDOT_lQjw
+  subpath: null
+  commit: 92a41ed259a70610af574e99e785b903d24cabf7
+creator:
+  github: huantm
+package:
+  ecosystem: npm
+  name: dshhub-market
+  version: 0.8.32
+  integrity: sha512-sxRxwbxEjI06ZNCYCwgRnRbhVQgwDU70LluWPrP5YU5WROXmJJqO35e+9a9tIZfyBlfzJ+yzCBnsUdUOeY3rww==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:52.747Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huantm-dshhub-market`
- Submission type: community curation
- Created by `huantm` — https://github.com/huantm
- Original source repository: https://github.com/dshhub-co/dshhub-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.