### PR TITLE
catalog: add lee-coder-00-dsh-headroom (community curation, created by @Lee-coder-00)

### DIFF
--- a/catalog/plugins/lee-coder-00-dsh-headroom.yaml
+++ b/catalog/plugins/lee-coder-00-dsh-headroom.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: lee-coder-00-dsh-headroom
+name: dsh-headroom
+description:
+  en: "Headroom-inspired automatic context compression plugin for DeepSeek Harness (dsh): compresses tool outputs before they reach the model and keeps every lossy compression reversible via CCR retrieval tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - context-compression
+  - headroom
+  - llm
+  - agent
+source:
+  repository: https://github.com/giter00/dsh-headroom
+  repositoryNodeId: R_kgDOT6GHYA
+  subpath: null
+  commit: ca5de630fd9a4be1b0e0f900cc3260f52052019d
+creator:
+  github: Lee-coder-00
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:49.977Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lee-coder-00-dsh-headroom`
- Submission type: community curation
- Created by `Lee-coder-00` — https://github.com/Lee-coder-00
- Original source repository: https://github.com/giter00/dsh-headroom
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.