### PR TITLE
catalog: add paimon1999-dsh-task-notify (community curation, created by @paimon1999)

### DIFF
--- a/catalog/plugins/paimon1999-dsh-task-notify.yaml
+++ b/catalog/plugins/paimon1999-dsh-task-notify.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: paimon1999-dsh-task-notify
+name: dsh-task-notify
+description:
+  en: Task-completion system notifications for DeepSeek Harness — macOS Notification Center, Windows Toast, and mobile push via Bark / ntfy / ServerChan / webhook
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - notification
+  - task-completion
+  - bark
+  - ntfy
+source:
+  repository: https://github.com/DeepseekHarnessPlugins/Notification
+  repositoryNodeId: R_kgDOUErG7w
+  subpath: null
+  commit: 5da12d12d31e260e22210efa2779b44d71db8891
+creator:
+  github: paimon1999
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:59:31.578Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `paimon1999-dsh-task-notify`
- Submission type: community curation
- Created by `paimon1999` — https://github.com/paimon1999
- Original source repository: https://github.com/DeepseekHarnessPlugins/Notification
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.