### PR TITLE
catalog: add pyguy2-dsh-conversation-navigator (community curation, created by @PyGuy2)

### DIFF
--- a/catalog/plugins/pyguy2-dsh-conversation-navigator.yaml
+++ b/catalog/plugins/pyguy2-dsh-conversation-navigator.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: pyguy2-dsh-conversation-navigator
+name: dsh-conversation-navigator
+description:
+  en: 'A DeepSeek Harness (DSH) Web conversation navigator panel : a turn-folded outline floating on the right side of the conversation page. Click any node to smooth-jump, watch the current reading position highlight as you scroll, with step badges colored to match the built-in "Trajectory" view.'
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - cordis-plugin
+  - conversation
+  - navigator
+  - outline
+  - session
+source:
+  repository: https://github.com/gjj-star/dsh-conversation-navigator
+  repositoryNodeId: R_kgDOT66AIQ
+  subpath: null
+  commit: b7804a9fa4a39993a8a21bd0d4259521e274b534
+creator:
+  github: PyGuy2
+package:
+  ecosystem: npm
+  name: dsh-conversation-navigator
+  version: 0.1.25
+  integrity: sha512-xPFcNnpj+QzAAD+ZKyD1AFInUFw3xK1xfmG6zEy5R4R347q8OF9Pnd/J+h+k+bIZo+vQDcEkqqrLU9jo5+NaxA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:57:35.926Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 16
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pyguy2-dsh-conversation-navigator`
- Submission type: community curation
- Created by `PyGuy2` — https://github.com/PyGuy2
- Original source repository: https://github.com/gjj-star/dsh-conversation-navigator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.