### PR TITLE
catalog: add qinpanwan-dsh-sky-skin (community curation, created by @QinpanWan)

### DIFF
--- a/catalog/plugins/qinpanwan-dsh-sky-skin.yaml
+++ b/catalog/plugins/qinpanwan-dsh-sky-skin.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: qinpanwan-dsh-sky-skin
+name: dsh-sky-skin
+description:
+  en: "A Sky: Children of the Light themed skin for the DeepSeek Harness web UI — three Light Children standing on a glowing constellation board, candlelight gold and a deep-blue starry night. The light theme shows two silhouettes against the setting sun."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - skin
+  - theme
+  - sky
+  - cotl
+  - harmonyos
+source:
+  repository: https://github.com/QinpanWan/dsh-sky-skin
+  repositoryNodeId: R_kgDOUDaXKw
+  subpath: null
+  commit: 107538f90757073b3d5ccce9e0300be0cafaa5e3
+creator:
+  github: QinpanWan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: CC-BY-SA-4.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T03:58:26.495Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qinpanwan-dsh-sky-skin`
- Submission type: community curation
- Created by `QinpanWan` — https://github.com/QinpanWan
- Original source repository: https://github.com/QinpanWan/dsh-sky-skin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.