### PR TITLE
catalog: add tonite31-dsh-plugin-superself (community curation, created by @tonite31)

### DIFF
--- a/catalog/plugins/tonite31-dsh-plugin-superself.yaml
+++ b/catalog/plugins/tonite31-dsh-plugin-superself.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: tonite31-dsh-plugin-superself
+name: dsh-plugin-superself
+description:
+  en: "DeepSeek Harness plugin: Superself's self CLI as model-facing tools plus a /self command — cross-session, cross-project project state for agents."
+  evidencePath: apps/dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - cordis
+  - superself
+  - agents
+  - project-state
+  - workflow
+source:
+  repository: https://github.com/fxylabs/superself
+  repositoryNodeId: R_kgDOThIzlg
+  subpath: apps/dsh-plugin
+  commit: b94f3615e1f409339a6b3a728754bf3bd59d52f9
+creator:
+  github: tonite31
+package:
+  ecosystem: npm
+  name: dsh-plugin-superself
+  version: 0.1.0
+  integrity: sha512-wumrLv2GVHzJs54tKk7oUfAG5d90I9guCb+438wzbHECono7dekSvHKWiXwqp7ocyFI1qWGKyXQevvmblIU2BQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: apps/dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:00:01.007Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tonite31-dsh-plugin-superself`
- Submission type: community curation
- Created by `tonite31` — https://github.com/tonite31
- Original source repository: https://github.com/fxylabs/superself
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.