### PR TITLE
catalog: fix three entries whose creator was not the real GitHub account

### DIFF
--- a/catalog/plugins/0nt-one-dsh-neo-skin.yaml
+++ b/catalog/plugins/0nt-one-dsh-neo-skin.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-id: crazygummies-dsh-neo-skin
+id: 0nt-one-dsh-neo-skin
 name: dsh-neo-skin
 description:
   en: Neo-brutalism skin for DeepSeek Harness Web UI — stacks hard-border / high-contrast --dsw-alias- token overrides (DS-native blue + black-white + green + orange) on top of the built-in light/dark palettes.
@@ -20,7 +20,7 @@ source:
   subpath: null
   commit: fe5ef0e671fab5ab8c8700013f3966eb9642455f
 creator:
-  github: CrazyGummies
+  github: 0nt-one
 package:
   ecosystem: source
 dsh:

--- a/catalog/plugins/0nt-one-dsh-voice-input-web.yaml
+++ b/catalog/plugins/0nt-one-dsh-voice-input-web.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-id: crazygummies-dsh-voice-input-web
+id: 0nt-one-dsh-voice-input-web
 name: dsh-voice-input-web
 description:
   en: "Voice input for DeepSeek Harness Web UI: a mic button in the composer tool row that uses the browser's Web Speech API (Chrome/Edge) to transcribe speech directly into the message draft. Zero dependencies, no API keys."
@@ -23,7 +23,7 @@ source:
   subpath: null
   commit: c2fceee6a865a8466f3909d3896172f0f2fad2fa
 creator:
-  github: CrazyGummies
+  github: 0nt-one
 package:
   ecosystem: source
 dsh:

--- a/catalog/plugins/thewolfwalker-dsh-notifier.yaml
+++ b/catalog/plugins/thewolfwalker-dsh-notifier.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-id: invalid-email-address-dsh-notifier
+id: thewolfwalker-dsh-notifier
 name: dsh-notifier
 description:
   en: Unified notification push plugin for DeepSeek Harness (DSH) — one minimal notify() API in front, 27 channels behind.
@@ -30,7 +30,7 @@ source:
   subpath: null
   commit: cc4781e9939210b2d91b63f5448ccef40708a7c2
 creator:
-  github: invalid-email-address
+  github: THEWOLFWALKER
 package:
   ecosystem: npm
   name: dsh-notifier


### PR DESCRIPTION
Three entries credited a creator handle that GitHub cannot link to a person:

- `crazygummies-dsh-neo-skin`, `crazygummies-dsh-voice-input-web`: the account was renamed `CrazyGummies` → `0nt-one` (repository owner, id 317453732).
- `invalid-email-address-dsh-notifier`: the DSH marker commit had a malformed author email, so GitHub reported the placeholder account `invalid-email-address`; the plugin belongs to the repository owner `THEWOLFWALKER` (id 109017787).

The ids follow the creator-first derivation, so the files are renamed accordingly. Each commit carries the `Co-authored-by` trailer for the real creator.