### PR TITLE
catalog: add gitfangj-dsh-models-radar (community curation, created by @gitfangj)

### DIFF
--- a/catalog/plugins/gitfangj-dsh-models-radar.yaml
+++ b/catalog/plugins/gitfangj-dsh-models-radar.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: gitfangj-dsh-models-radar
+name: dsh-models-radar
+description:
+  en: "Model capability radar for the DeepSeek Harness web GUI: a Settings tab that charts codexradar crowd-benchmark scores per model tier — task-composition bars, 7-day IQ trend, efficiency badges"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - model
+  - capability
+  - radar
+  - settings
+  - charts
+  - codexradar
+  - crowd
+  - benchmark
+  - scores
+  - tier
+  - task
+  - composition
+  - bars
+  - trend
+  - efficiency
+  - badges
+source:
+  repository: https://github.com/hi-fangj/dsh-models-radar
+  repositoryNodeId: R_kgDOUExErA
+  subpath: null
+  commit: b07335a8aee1a06d82c127ab836c62ea67b2559c
+creator:
+  github: gitfangj
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:43:50.513Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gitfangj-dsh-models-radar`
- Submission type: community curation
- Created by `gitfangj` — https://github.com/gitfangj
- Original source repository: https://github.com/hi-fangj/dsh-models-radar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.