### PR TITLE
catalog: add godchen520-dsh-web-search-bing (community curation, created by @godchen520)

### DIFF
--- a/catalog/plugins/godchen520-dsh-web-search-bing.yaml
+++ b/catalog/plugins/godchen520-dsh-web-search-bing.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: godchen520-dsh-web-search-bing
+name: dsh-web-search-bing
+description:
+  en: Free Bing-backed web search provider for DeepSeek Harness (DSH). No API key needed, uses cn.bing.com for mainland China accessibility.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - search
+  - web-search
+  - bing
+  - free
+  - cn-bing
+source:
+  repository: https://github.com/godchen520/dsh-web-search-bing
+  repositoryNodeId: R_kgDOT86mpg
+  subpath: null
+  commit: 1c57c235170d6e94f0c9e706b632a2118908426d
+creator:
+  github: godchen520
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:38.914Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `godchen520-dsh-web-search-bing`
- Submission type: community curation
- Created by `godchen520` — https://github.com/godchen520
- Original source repository: https://github.com/godchen520/dsh-web-search-bing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.