### PR TITLE
catalog: add goecho-dsh-generation (community curation, created by @goecho)

### DIFF
--- a/catalog/plugins/goecho-dsh-generation.yaml
+++ b/catalog/plugins/goecho-dsh-generation.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: goecho-dsh-generation
+name: dsh-generation
+description:
+  en: Fork agent presets and run tasks on the next generation. Make, not a compiler.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - generation
+  - preset
+source:
+  repository: https://github.com/goecho/dsh-generation
+  repositoryNodeId: R_kgDOT8-wyg
+  subpath: null
+  commit: 9ed70cd3151c7e27b18d38a1a22efd10113ee604
+creator:
+  github: goecho
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:13.848Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `goecho-dsh-generation`
- Submission type: community curation
- Created by `goecho` — https://github.com/goecho
- Original source repository: https://github.com/goecho/dsh-generation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.