### PR TITLE
catalog: add gongyuancaiji-dsh-chinese-thinking (community curation, created by @GongYuanCaiJi)

### DIFF
--- a/catalog/plugins/gongyuancaiji-dsh-chinese-thinking.yaml
+++ b/catalog/plugins/gongyuancaiji-dsh-chinese-thinking.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: gongyuancaiji-dsh-chinese-thinking
+name: dsh-chinese-thinking
+description:
+  en: Makes your DeepSeek Harness agent think and answer in Chinese by default.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - chinese
+  - i18n
+  - system-prompt
+source:
+  repository: https://github.com/GongYuanCaiJi/dsh-chinese-thinking
+  repositoryNodeId: R_kgDOT4yczA
+  subpath: null
+  commit: 42affd4041ee29592132a00db98028158b33406f
+creator:
+  github: GongYuanCaiJi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:41.300Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gongyuancaiji-dsh-chinese-thinking`
- Submission type: community curation
- Created by `GongYuanCaiJi` — https://github.com/GongYuanCaiJi
- Original source repository: https://github.com/GongYuanCaiJi/dsh-chinese-thinking
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.