### PR TITLE
catalog: add gongyuancaiji-dsh-extension-workbook (community curation, created by @GongYuanCaiJi)

### DIFF
--- a/catalog/plugins/gongyuancaiji-dsh-extension-workbook.yaml
+++ b/catalog/plugins/gongyuancaiji-dsh-extension-workbook.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: gongyuancaiji-dsh-extension-workbook
+name: dsh-extension-workbook
+description:
+  en: bash git clone https://github.com/GongYuanCaiJi/dsh-extension-workbook.git cd dsh-extension-workbook && npm install 触发 prepare，产出 dist/ dsh plugin --profile <profile add ../dsh-extension-workbook
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - extension
+  - skill
+  - excel
+  - xlsx
+  - xlsm
+  - ooxml
+source:
+  repository: https://github.com/GongYuanCaiJi/dsh-extension-workbook
+  repositoryNodeId: R_kgDOT40OJg
+  subpath: null
+  commit: c3f434d06c98cf5e2f183321c70d61d4c723002e
+creator:
+  github: GongYuanCaiJi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:45.010Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gongyuancaiji-dsh-extension-workbook`
- Submission type: community curation
- Created by `GongYuanCaiJi` — https://github.com/GongYuanCaiJi
- Original source repository: https://github.com/GongYuanCaiJi/dsh-extension-workbook
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.