### PR TITLE
catalog: add gpiox-dsh-api-balance-badge (community curation, created by @GPIOX)

### DIFF
--- a/catalog/plugins/gpiox-dsh-api-balance-badge.yaml
+++ b/catalog/plugins/gpiox-dsh-api-balance-badge.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: gpiox-dsh-api-balance-badge
+name: dsh-api-balance-badge
+description:
+  en: A floating badge for the DeepSeek Harness (DSH) Web GUI. Shows your LLM API account balance, drags anywhere, resizes, and switches text color to match whatever sits beneath it.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - balance
+  - api-balance
+  - badge
+source:
+  repository: https://github.com/GPIOX/dsh-api-balance
+  repositoryNodeId: R_kgDOT5JJ-A
+  subpath: null
+  commit: 38fe2bfa09f2060b501e10440a65eef11df48c9e
+creator:
+  github: GPIOX
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:17.722Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gpiox-dsh-api-balance-badge`
- Submission type: community curation
- Created by `GPIOX` — https://github.com/GPIOX
- Original source repository: https://github.com/GPIOX/dsh-api-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.