### PR TITLE
catalog: add greenlv-dsh-session-insights (community curation, created by @GreenLv)

### DIFF
--- a/catalog/plugins/greenlv-dsh-session-insights.yaml
+++ b/catalog/plugins/greenlv-dsh-session-insights.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: greenlv-dsh-session-insights
+name: dsh-session-insights
+description:
+  en: Local-first, evidence-backed session retrospectives for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - session-insights
+  - developer-tools
+source:
+  repository: https://github.com/GreenLv/dsh-session-insights
+  repositoryNodeId: R_kgDOT_REmg
+  subpath: null
+  commit: c6f1d0b9df3ab065b10eebed33622bd19247353a
+creator:
+  github: GreenLv
+package:
+  ecosystem: npm
+  name: dsh-session-insights
+  version: 0.3.0
+  integrity: sha512-/HWBPhiYUsA06b/6jHa8Z7DFaAWlG1RPctdTRKhSi0s7hUKGNu+v5zY3kcljC2redgsskkNnnip2/5Qoy62SEQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:43.416Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `greenlv-dsh-session-insights`
- Submission type: community curation
- Created by `GreenLv` — https://github.com/GreenLv
- Original source repository: https://github.com/GreenLv/dsh-session-insights
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.