### PR TITLE
catalog: add grunmin-dsh-acp-enhanced (community curation, created by @grunmin)

### DIFF
--- a/catalog/plugins/grunmin-dsh-acp-enhanced.yaml
+++ b/catalog/plugins/grunmin-dsh-acp-enhanced.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: grunmin-dsh-acp-enhanced
+name: dsh-acp-enhanced
+description:
+  en: "Enhanced ACP server for DeepSeek Harness: block-level streaming, usage/stat telemetry (cache hit rate, token speed, input/output tokens, context length, turns, tool timing), model & reasoning-effort switching, and permission-preset control over the ACP wire (Zed-friendly)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - acp
+  - agent-client-protocol
+  - zed
+  - zed-editor
+  - ai-agent
+  - coding-assistant
+  - llm
+source:
+  repository: https://github.com/grunmin/dsh-acp-enhanced
+  repositoryNodeId: R_kgDOT33_uQ
+  subpath: null
+  commit: 0118f33fdc88b8c69a84a3d624bc15b5c099acfb
+creator:
+  github: grunmin
+package:
+  ecosystem: npm
+  name: dsh-acp-enhanced
+  version: 0.3.2
+  integrity: sha512-rOa+6GuDnDkqvh9U1z8hZUwkIIRJEy8O3dy+BToYV/Io6AwK85as/wM3s3Ao68i4SzWqdVcH4NvKWbL3iUO5CQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:29.744Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `grunmin-dsh-acp-enhanced`
- Submission type: community curation
- Created by `grunmin` — https://github.com/grunmin
- Original source repository: https://github.com/grunmin/dsh-acp-enhanced
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.