### PR TITLE
catalog: add guard42-dsh-humanize (community curation, created by @Guard42)

### DIFF
--- a/catalog/plugins/guard42-dsh-humanize.yaml
+++ b/catalog/plugins/guard42-dsh-humanize.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: guard42-dsh-humanize
+name: dsh-humanize
+description:
+  en: Humanize Mode for DeepSeek Harness — the humanfia flow philosophy (draft → check → lock → review → run/resume, SHA-256 lock identity, HMAC review gate, event-sourced resumability) as an agent preset. Installing this bundle auto-installs the preset into the DSH preset root.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-preset
+  - humanize
+  - flow
+  - workflow-orchestration
+  - llm-agents
+source:
+  repository: https://github.com/Guard42/dsh-humanize
+  repositoryNodeId: R_kgDOUCZMBA
+  subpath: null
+  commit: 18adeaf0f25862c21a0943539fda16345504deed
+creator:
+  github: Guard42
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:19.716Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `guard42-dsh-humanize`
- Submission type: community curation
- Created by `Guard42` — https://github.com/Guard42
- Original source repository: https://github.com/Guard42/dsh-humanize
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.