### PR TITLE
catalog: add guo-ziao-dsh-interrupt-button (community curation, created by @guo-ziao)

### DIFF
--- a/catalog/plugins/guo-ziao-dsh-interrupt-button.yaml
+++ b/catalog/plugins/guo-ziao-dsh-interrupt-button.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: guo-ziao-dsh-interrupt-button
+name: dsh-interrupt-button
+description:
+  en: "A green interrupt button beside the DeepSeek Harness send box: silently stops a running agent, which then summarizes its progress and asks for your new requirements; the interrupt prompt is customizable."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - interrupt
+  - stop
+  - web-ui
+  - productivity
+source:
+  repository: https://github.com/guo-ziao/dsh-interrupt-button
+  repositoryNodeId: R_kgDOT5SgSg
+  subpath: null
+  commit: f91c86b720075238b9420b10b2f19b833ebae0fd
+creator:
+  github: guo-ziao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:32.407Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `guo-ziao-dsh-interrupt-button`
- Submission type: community curation
- Created by `guo-ziao` — https://github.com/guo-ziao
- Original source repository: https://github.com/guo-ziao/dsh-interrupt-button
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.