### PR TITLE
catalog: add guo6x-dsh-housekeeper (community curation, created by @guo6x)

### DIFF
--- a/catalog/plugins/guo6x-dsh-housekeeper.yaml
+++ b/catalog/plugins/guo6x-dsh-housekeeper.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: guo6x-dsh-housekeeper
+name: dsh-housekeeper
+description:
+  en: "Environment housekeeper for DeepSeek Harness: toolchain inventory, agent scratch/cache scan with safe one-click cleanup, and the machine rules file (AGENTS.md) view/edit - all in the Web GUI settings. Zero runtime dependencies."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - housekeeping
+  - cache
+  - cleanup
+  - toolchain
+source:
+  repository: https://github.com/guo6x/dsh-housekeeper
+  repositoryNodeId: R_kgDOT5RqMA
+  subpath: null
+  commit: 9d4c3be7d01d9c86e96cbe8d5a7088c1e6f4548c
+creator:
+  github: guo6x
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:40:58.196Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `guo6x-dsh-housekeeper`
- Submission type: community curation
- Created by `guo6x` — https://github.com/guo6x
- Original source repository: https://github.com/guo6x/dsh-housekeeper
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.