### PR TITLE
catalog: add guo6x-dsh-palate (community curation, created by @guo6x)

### DIFF
--- a/catalog/plugins/guo6x-dsh-palate.yaml
+++ b/catalog/plugins/guo6x-dsh-palate.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: guo6x-dsh-palate
+name: dsh-palate
+description:
+  en: "An eye that grows: accumulated design taste for DSH agents. A taste corpus + codified principles that sharpen with every example you feed — review designs against learned judgment, not a fixed ruler."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - design
+  - taste
+  - aesthetic
+  - review
+  - critique
+source:
+  repository: https://github.com/guo6x/dsh-palate
+  repositoryNodeId: R_kgDOT8M4_A
+  subpath: null
+  commit: a155c1a1959185ba198256d9abe13cca6d0518f5
+creator:
+  github: guo6x
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:21.565Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `guo6x-dsh-palate`
- Submission type: community curation
- Created by `guo6x` — https://github.com/guo6x
- Original source repository: https://github.com/guo6x/dsh-palate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.