### PR TITLE
catalog: add guo6x-dsh-shipcheck (community curation, created by @guo6x)

### DIFF
--- a/catalog/plugins/guo6x-dsh-shipcheck.yaml
+++ b/catalog/plugins/guo6x-dsh-shipcheck.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: guo6x-dsh-shipcheck
+name: dsh-shipcheck
+description:
+  en: "Evidence-first frontend release checks for DSH: real browser inspection, user flows, visual baselines, and reproducible reports."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - frontend
+  - qa
+  - visual-regression
+  - release
+source:
+  repository: https://github.com/guo6x/dsh-shipcheck
+  repositoryNodeId: R_kgDOUD5U_Q
+  subpath: null
+  commit: 17fd57f0921d142c25e48ebace5203083fb5b550
+creator:
+  github: guo6x
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:53.127Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `guo6x-dsh-shipcheck`
- Submission type: community curation
- Created by `guo6x` — https://github.com/guo6x
- Original source repository: https://github.com/guo6x/dsh-shipcheck
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.