### PR TITLE
catalog: add guoliyuan97-png-dsh-game-hud (community curation, created by @guoliyuan97-png)

### DIFF
--- a/catalog/plugins/guoliyuan97-png-dsh-game-hud.yaml
+++ b/catalog/plugins/guoliyuan97-png-dsh-game-hud.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: guoliyuan97-png-dsh-game-hud
+name: dsh-game-hud
+description:
+  en: cordis.patch.yml 示例：
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - hud
+  - game
+  - balance
+  - context
+  - peak-valley
+  - compaction
+  - deepseek-harness
+source:
+  repository: https://github.com/guoliyuan97-png/dsh-game-hud
+  repositoryNodeId: R_kgDOT9GMyg
+  subpath: null
+  commit: d828732117e1df07cb159388eac507b50caf66cb
+creator:
+  github: guoliyuan97-png
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:23.369Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `guoliyuan97-png-dsh-game-hud`
- Submission type: community curation
- Created by `guoliyuan97-png` — https://github.com/guoliyuan97-png
- Original source repository: https://github.com/guoliyuan97-png/dsh-game-hud
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.