### PR TITLE
catalog: add h2o-mero-dsh-git-sidebar (community curation, created by @H2O-MERO)

### DIFF
--- a/catalog/plugins/h2o-mero-dsh-git-sidebar.yaml
+++ b/catalog/plugins/h2o-mero-dsh-git-sidebar.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: h2o-mero-dsh-git-sidebar
+name: dsh-git-sidebar
+description:
+  en: "DSH plugin: VSCode-style uncommitted changes sidebar for the DeepSeek Harness web GUI — staged / unstaged / untracked files, per-file diffs and open-in-editor, docked to the right of the conversation page"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - vscode
+  - style
+  - uncommitted
+  - changes
+  - sidebar
+  - staged
+  - unstaged
+  - untracked
+  - files
+  - file
+  - diffs
+  - open
+  - editor
+  - docked
+  - right
+  - conversation
+source:
+  repository: https://github.com/H2O-MERO/dsh-git-sidebar
+  repositoryNodeId: R_kgDOT-ifzg
+  subpath: null
+  commit: 95235b7f0821c0bd76c8ddd2a8dea4b48918bb22
+creator:
+  github: H2O-MERO
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:45.502Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `h2o-mero-dsh-git-sidebar`
- Submission type: community curation
- Created by `H2O-MERO` — https://github.com/H2O-MERO
- Original source repository: https://github.com/H2O-MERO/dsh-git-sidebar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.