### PR TITLE
catalog: add hades03-dsh-model-quota-usage (community curation, created by @Hades03)

### DIFF
--- a/catalog/plugins/hades03-dsh-model-quota-usage.yaml
+++ b/catalog/plugins/hades03-dsh-model-quota-usage.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: hades03-dsh-model-quota-usage
+name: dsh-model-quota-usage
+description:
+  en: powershell dsh plugin --profile web add "github:Hades03/dsh-model-quota-usage"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - client-plugin
+  - token
+  - model-usage
+  - quota
+  - cost
+  - usage
+  - billing
+  - budget
+  - i18n
+  - bilingual
+  - zh
+  - en
+  - language
+source:
+  repository: https://github.com/Hades03/dsh-model-quota-usage
+  repositoryNodeId: R_kgDOUApiAg
+  subpath: null
+  commit: 21b6b35ee5fdd03a71a6d2557bc933c3fdd1c05e
+creator:
+  github: Hades03
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:47.703Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hades03-dsh-model-quota-usage`
- Submission type: community curation
- Created by `Hades03` — https://github.com/Hades03
- Original source repository: https://github.com/Hades03/dsh-model-quota-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.