### PR TITLE
catalog: add halosb-dsh-workmate (community curation, created by @halosb)

### DIFF
--- a/catalog/plugins/halosb-dsh-workmate.yaml
+++ b/catalog/plugins/halosb-dsh-workmate.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: halosb-dsh-workmate
+name: dsh-workmate
+description:
+  en: powershell dsh plugin --profile web add github:halosb/dsh-workmate
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - notification
+  - knowledge-base
+  - rag
+  - cordis
+source:
+  repository: https://github.com/halosb/dsh-workmate
+  repositoryNodeId: R_kgDOT4wzIA
+  subpath: null
+  commit: c38acb8fd29bf35548ddc09d7fbf63acddd46d2c
+creator:
+  github: halosb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:40:49.897Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `halosb-dsh-workmate`
- Submission type: community curation
- Created by `halosb` — https://github.com/halosb
- Original source repository: https://github.com/halosb/dsh-workmate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.