### PR TITLE
catalog: add han-1413141-dsh-ui-hub (community curation, created by @Han-1413141)

### DIFF
--- a/catalog/plugins/han-1413141-dsh-ui-hub.yaml
+++ b/catalog/plugins/han-1413141-dsh-ui-hub.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: han-1413141-dsh-ui-hub
+name: dsh-ui-hub
+description:
+  en: "A DSH web client plugin: UI Hub . It enumerates every UI contribution from every plugin — panels, buttons, icons, charts, fields — and lets you toggle each one, position each one, avoid floating collisions, and auto-arrange them into a tidy column ."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - client-plugin
+  - ui
+  - layout
+  - widget
+  - collision
+  - toggle
+  - position
+source:
+  repository: https://github.com/Han-1413141/dsh-ui-hub
+  repositoryNodeId: R_kgDOT5JHaQ
+  subpath: null
+  commit: d1ecaffed06a03696ebd77f40c4c61d1cb558f8f
+creator:
+  github: Han-1413141
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:00.644Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `han-1413141-dsh-ui-hub`
- Submission type: community curation
- Created by `Han-1413141` — https://github.com/Han-1413141
- Original source repository: https://github.com/Han-1413141/dsh-ui-hub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.