### PR TITLE
catalog: add hanmiao33-bubble-explain (community curation, created by @Hanmiao33)

### DIFF
--- a/catalog/plugins/hanmiao33-bubble-explain.yaml
+++ b/catalog/plugins/hanmiao33-bubble-explain.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: hanmiao33-bubble-explain
+name: "@dsh-external/bubble-explain"
+description:
+  en: A DeepSeek Harness profile bundle that explains any selected text inside a conversation with a streaming Markdown bubble, with recursive follow-up questions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - profile
+  - bundle
+  - explains
+  - selected
+  - text
+  - inside
+  - conversation
+  - streaming
+  - markdown
+  - bubble
+  - recursive
+  - follow
+  - questions
+  - dsh
+source:
+  repository: https://github.com/Hanmiao33/dsh-bubble-explain
+  repositoryNodeId: R_kgDOUBR15Q
+  subpath: null
+  commit: 117e5da071bca9355a6f25f878810256573c2893
+creator:
+  github: Hanmiao33
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:53.807Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hanmiao33-bubble-explain`
- Submission type: community curation
- Created by `Hanmiao33` — https://github.com/Hanmiao33
- Original source repository: https://github.com/Hanmiao33/dsh-bubble-explain
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.