### PR TITLE
catalog: add hann428-dsh-usage-dashboard (community curation, created by @Hann428)

### DIFF
--- a/catalog/plugins/hann428-dsh-usage-dashboard.yaml
+++ b/catalog/plugins/hann428-dsh-usage-dashboard.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: hann428-dsh-usage-dashboard
+name: dsh-usage-dashboard
+description:
+  en: "DeepSeek usage and billing panel for DeepSeek Harness: balance, peak/off-peak pricing, and live countdown."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - usage
+  - billing
+  - dsh
+source:
+  repository: https://github.com/Hann428/dsh-usage-dashboard
+  repositoryNodeId: R_kgDOT8e4ww
+  subpath: null
+  commit: efc6c8572ef35a8a8c1e0d19ce55c9fa3fc6d9f9
+creator:
+  github: Hann428
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:50.456Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hann428-dsh-usage-dashboard`
- Submission type: community curation
- Created by `Hann428` — https://github.com/Hann428
- Original source repository: https://github.com/Hann428/dsh-usage-dashboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.