### PR TITLE
catalog: add hanxuanliang-dsh-chaos (community curation, created by @hanxuanliang)

### DIFF
--- a/catalog/plugins/hanxuanliang-dsh-chaos.yaml
+++ b/catalog/plugins/hanxuanliang-dsh-chaos.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: hanxuanliang-dsh-chaos
+name: "@hanxuanliang/dsh-chaos"
+description:
+  en: Peer multi-Agent collaboration for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - multi-agent
+  - collaboration
+  - dsh
+source:
+  repository: https://github.com/hanxuanliang/dsh-chaos
+  repositoryNodeId: R_kgDOT5HFvg
+  subpath: null
+  commit: d439bf9f47e2436c408e896ebb7fbad025faf791
+creator:
+  github: hanxuanliang
+package:
+  ecosystem: npm
+  name: "@hanxuanliang/dsh-chaos"
+  version: 0.1.2
+  integrity: sha512-rhad9mIImEfGGLIxZDP79Qwt/XzTyhr1JzSEiTBYNPv0rKO87OEnvYyiIEZdXqEa6oj6wERVU8alXV2QnHpFsw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:35.173Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hanxuanliang-dsh-chaos`
- Submission type: community curation
- Created by `hanxuanliang` — https://github.com/hanxuanliang
- Original source repository: https://github.com/hanxuanliang/dsh-chaos
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.