### PR TITLE
catalog: add hanyi7867069-create-dsh-moonrise (community curation, created by @hanyi7867069-create)

### DIFF
--- a/catalog/plugins/hanyi7867069-create-dsh-moonrise.yaml
+++ b/catalog/plugins/hanyi7867069-create-dsh-moonrise.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: hanyi7867069-create-dsh-moonrise
+name: dsh-moonrise
+description:
+  en: 月升 Moonrise — a warm amber-on-midnight theme for the DeepSeek Harness Web UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - theme
+  - moonrise
+  - dsh
+source:
+  repository: https://github.com/hanyi7867069-create/dsh-moonrise
+  repositoryNodeId: R_kgDOT7A3jA
+  subpath: null
+  commit: 4e8029680754eafa5fa738fea3f03ac2c605c138
+creator:
+  github: hanyi7867069-create
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:59.263Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hanyi7867069-create-dsh-moonrise`
- Submission type: community curation
- Created by `hanyi7867069-create` — https://github.com/hanyi7867069-create
- Original source repository: https://github.com/hanyi7867069-create/dsh-moonrise
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.