### PR TITLE
catalog: add haoranwang0921-dsh-session-cleaner (community curation, created by @haoranwang0921)

### DIFF
--- a/catalog/plugins/haoranwang0921-dsh-session-cleaner.yaml
+++ b/catalog/plugins/haoranwang0921-dsh-session-cleaner.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: haoranwang0921-dsh-session-cleaner
+name: "@haoranwang0921/dsh-session-cleaner"
+description:
+  en: "dsh web GUI plugin: manage and delete conversation records (whole sessions or individual messages, cascade delete) from the settings page. Dual-face: node half serves /api/session-cleaner routes, browser half registers the settings-page view."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - manage
+  - delete
+  - conversation
+  - records
+  - whole
+  - sessions
+  - individual
+  - messages
+  - cascade
+  - settings
+  - page
+  - dual
+  - face
+  - node
+  - half
+  - serves
+source:
+  repository: https://github.com/haoranwang0921/dsh-session-cleaner
+  repositoryNodeId: R_kgDOT4oO9g
+  subpath: null
+  commit: 7471c4375e999d9f3bd49f2f5daad3275d8517a0
+creator:
+  github: haoranwang0921
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:27.399Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haoranwang0921-dsh-session-cleaner`
- Submission type: community curation
- Created by `haoranwang0921` — https://github.com/haoranwang0921
- Original source repository: https://github.com/haoranwang0921/dsh-session-cleaner
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.