### PR TITLE
catalog: add haoyu-qi-dsh-zentao (community curation, created by @haoyu-qi)

### DIFF
--- a/catalog/plugins/haoyu-qi-dsh-zentao.yaml
+++ b/catalog/plugins/haoyu-qi-dsh-zentao.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: haoyu-qi-dsh-zentao
+name: "@deepseek-ai/dsh-zentao"
+description:
+  en: Installable DSH Web customization and personal ZenTao floating work-center bundle
+  evidencePath: packages/bundle/zentao/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - installable
+  - customization
+  - personal
+  - zentao
+  - floating
+  - work
+  - center
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/haoyu-qi/dsh-zentao
+  repositoryNodeId: R_kgDOT49SZw
+  subpath: packages/bundle/zentao
+  commit: 4927171172a32863a986be654b23118ca76c908d
+creator:
+  github: haoyu-qi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/bundle/zentao/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:56.290Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haoyu-qi-dsh-zentao`
- Submission type: community curation
- Created by `haoyu-qi` — https://github.com/haoyu-qi
- Original source repository: https://github.com/haoyu-qi/dsh-zentao
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.