### PR TITLE
catalog: add haoyueqin-dsh-deepseek-monitor (community curation, created by @HaoyueQin)

### DIFF
--- a/catalog/plugins/haoyueqin-dsh-deepseek-monitor.yaml
+++ b/catalog/plugins/haoyueqin-dsh-deepseek-monitor.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: haoyueqin-dsh-deepseek-monitor
+name: dsh-deepseek-monitor
+description:
+  en: "DSH web plugin: DeepSeek balance & platform usage monitoring, integrated into the Models settings provider row and the composer tool row (left of the model name). Replicates the DeepSeekMonitorWindows backend."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - balance
+  - platform
+  - usage
+  - monitoring
+  - integrated
+  - models
+  - settings
+  - provider
+  - composer
+  - tool
+  - left
+  - model
+  - name
+  - replicates
+  - deepseekmonitorwindows
+  - backend
+source:
+  repository: https://github.com/HaoyueQin/dsh-deepseek-monitor
+  repositoryNodeId: R_kgDOUApXzg
+  subpath: null
+  commit: 6799ab7ce14aae098300df73035932b8f40b7bec
+creator:
+  github: HaoyueQin
+package:
+  ecosystem: npm
+  name: dsh-deepseek-monitor
+  version: 0.1.2
+  integrity: sha512-r5/Fw5ejSIMqDfE6cl+KiPRBFf8L9TWqwDV6olTgrl7KFa4cFaJ8fgvtSg6d2YwiaQTAaeUAVEnreXO6bo1n7w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:43:07.144Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haoyueqin-dsh-deepseek-monitor`
- Submission type: community curation
- Created by `HaoyueQin` — https://github.com/HaoyueQin
- Original source repository: https://github.com/HaoyueQin/dsh-deepseek-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.