### PR TITLE
catalog: add haoyueqin-dsh-diff-stat (community curation, created by @HaoyueQin)

### DIFF
--- a/catalog/plugins/haoyueqin-dsh-diff-stat.yaml
+++ b/catalog/plugins/haoyueqin-dsh-diff-stat.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: haoyueqin-dsh-diff-stat
+name: dsh-diff-stat
+description:
+  en: Inline +N −M diff badges on edit/write tool rows and a per-turn file change summary card for DeepSeek Harness. PTC/code-dispatch fallback, no git required.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - diff
+  - code-review
+source:
+  repository: https://github.com/HaoyueQin/dsh-diff-stat
+  repositoryNodeId: R_kgDOUC4j3Q
+  subpath: null
+  commit: 3cebf9ac2c5de0d537b1d43bb89d3e92edd340ec
+creator:
+  github: HaoyueQin
+package:
+  ecosystem: npm
+  name: dsh-diff-stat
+  version: 0.1.2
+  integrity: sha512-w3sgi0mSif2ACPgp4aeY+K5WcRmoMNukww8eVX2dwyoUN2vtICtn6Q0Unv+NOpORQuEN3tVqRPq34pQs1TpNBA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:43:04.355Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haoyueqin-dsh-diff-stat`
- Submission type: community curation
- Created by `HaoyueQin` — https://github.com/HaoyueQin
- Original source repository: https://github.com/HaoyueQin/dsh-diff-stat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.