### PR TITLE
catalog: add haoyueqin-dsh-usage-statistics-panel (community curation, created by @HaoyueQin)

### DIFF
--- a/catalog/plugins/haoyueqin-dsh-usage-statistics-panel.yaml
+++ b/catalog/plugins/haoyueqin-dsh-usage-statistics-panel.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: haoyueqin-dsh-usage-statistics-panel
+name: dsh-usage-statistics-panel
+description:
+  en: "DSH web plugin: a usage statistics panel with per-day token trend, GitHub-style activity heatmap, cache hit-rate curve and per-model breakdown, replicating the reasonix usage stats feature."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - usage-statistics
+  - token
+  - stats
+  - heatmap
+source:
+  repository: https://github.com/HaoyueQin/dsh-usage-statistics-panel
+  repositoryNodeId: R_kgDOT90YGw
+  subpath: null
+  commit: df62adea7a161dd5963af021124963bed5950676
+creator:
+  github: HaoyueQin
+package:
+  ecosystem: npm
+  name: dsh-usage-statistics-panel
+  version: 0.1.6
+  integrity: sha512-VvskPb+M/5mlwl0lRb92OEcDl305ggbx6fubb8PwOa7aJ9wPr8Nds6Hq2Mu7eBKGZUnlggkx+5nbK1HEXxqBKA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:37.579Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haoyueqin-dsh-usage-statistics-panel`
- Submission type: community curation
- Created by `HaoyueQin` — https://github.com/HaoyueQin
- Original source repository: https://github.com/HaoyueQin/dsh-usage-statistics-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.