### PR TITLE
catalog: add happy2git-dsh-web-cross-session (community curation, created by @Happy2Git)

### DIFF
--- a/catalog/plugins/happy2git-dsh-web-cross-session.yaml
+++ b/catalog/plugins/happy2git-dsh-web-cross-session.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: happy2git-dsh-web-cross-session
+name: dsh-web-cross-session
+description:
+  en: "DSH web plugin: cross-session capability for the Web UI — sidebar content search, composer @-references to other sessions, message forwarding between live sessions, and the model-facing session-query tools (config-gated)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - cross
+  - session
+  - capability
+  - sidebar
+  - content
+  - search
+  - composer
+  - references
+  - other
+  - sessions
+  - message
+  - forwarding
+  - between
+  - live
+  - model
+  - facing
+source:
+  repository: https://github.com/Happy2Git/dsh-web-cross-session
+  repositoryNodeId: R_kgDOUAVVCQ
+  subpath: null
+  commit: 2deec0c989cddcf0fb3a27283a31d7be844e1231
+creator:
+  github: Happy2Git
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:58.597Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `happy2git-dsh-web-cross-session`
- Submission type: community curation
- Created by `Happy2Git` — https://github.com/Happy2Git
- Original source repository: https://github.com/Happy2Git/dsh-web-cross-session
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.