### PR TITLE
catalog: add happyren-dsh-agent-messaging (community curation, created by @happyren)

### DIFF
--- a/catalog/plugins/happyren-dsh-agent-messaging.yaml
+++ b/catalog/plugins/happyren-dsh-agent-messaging.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: happyren-dsh-agent-messaging
+name: dsh-agent-messaging
+description:
+  en: "Cross-session agent-to-agent messaging for DeepSeek Harness: claims, verification and a decision ledger, so two agent sessions don't repeat, contradict or deadlock each other."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - agent
+  - agents
+  - multi-agent
+  - agent-to-agent
+  - messaging
+  - cross-session
+  - coordination
+  - a2a
+source:
+  repository: https://github.com/happyren/dsh-agent-messaging
+  repositoryNodeId: R_kgDOT3ehzQ
+  subpath: null
+  commit: cd295a5daa13b301e4e2f5a6164ff28bddd6acf2
+creator:
+  github: happyren
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:06.302Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `happyren-dsh-agent-messaging`
- Submission type: community curation
- Created by `happyren` — https://github.com/happyren
- Original source repository: https://github.com/happyren/dsh-agent-messaging
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.