### PR TITLE
catalog: add harvey-will-dsh-vision-analysis (community curation, created by @Harvey-Will)

### DIFF
--- a/catalog/plugins/harvey-will-dsh-vision-analysis.yaml
+++ b/catalog/plugins/harvey-will-dsh-vision-analysis.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: harvey-will-dsh-vision-analysis
+name: dsh-vision-analysis
+description:
+  en: "Model-facing analyze image tool for the DeepSeek Harness: multi-modal image understanding via any OpenAI- or Anthropic-compatible vision API, with 8 analysis modes, local path / http(s) URL / data URL input, and a Web UI hint that guides image-incapable models to the reliable local-path route."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - image-analysis
+  - ocr
+  - multimodal
+source:
+  repository: https://github.com/Harvey-Will/dsh-vision-analysis
+  repositoryNodeId: R_kgDOT_0OrA
+  subpath: null
+  commit: 2fb3e84cfbff0532b7036cb42f594c5b0eb263be
+creator:
+  github: Harvey-Will
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:43:17.465Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `harvey-will-dsh-vision-analysis`
- Submission type: community curation
- Created by `Harvey-Will` — https://github.com/Harvey-Will
- Original source repository: https://github.com/Harvey-Will/dsh-vision-analysis
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.