### PR TITLE
catalog: add harzva-dsh-obsidian (community curation, created by @Harzva)

### DIFF
--- a/catalog/plugins/harzva-dsh-obsidian.yaml
+++ b/catalog/plugins/harzva-dsh-obsidian.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: harzva-dsh-obsidian
+name: "@harness-flow/dsh-obsidian"
+description:
+  en: "DSH-native Obsidian bridge: index local projects into a vault and build a wiki-link knowledge graph"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - obsidian
+  - knowledge-graph
+  - vault
+  - local-first
+source:
+  repository: https://github.com/Harzva/dsh-obsidian
+  repositoryNodeId: R_kgDOT9ebPQ
+  subpath: null
+  commit: c1ecb59f3de64c2fab60a43fc2c792fca17a83f6
+creator:
+  github: Harzva
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:45:04.433Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `harzva-dsh-obsidian`
- Submission type: community curation
- Created by `Harzva` — https://github.com/Harzva
- Original source repository: https://github.com/Harzva/dsh-obsidian
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.