### PR TITLE
catalog: add hatsuyuki0103-dsh-at-any (community curation, created by @hatsuyuki0103)

### DIFF
--- a/catalog/plugins/hatsuyuki0103-dsh-at-any.yaml
+++ b/catalog/plugins/hatsuyuki0103-dsh-at-any.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: hatsuyuki0103-dsh-at-any
+name: dsh-at-any
+description:
+  en: "Codex-style @path references for the DeepSeek Harness web GUI: search workspace paths without injecting file content"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - at-file
+  - file-mention
+  - workspace
+  - ui
+  - dsh
+source:
+  repository: https://github.com/hatsuyuki0103/dsh-at-any
+  repositoryNodeId: R_kgDOT7PzoQ
+  subpath: null
+  commit: e9185dbd0bfa40e71cd467d72455f7e07b9f129c
+creator:
+  github: hatsuyuki0103
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:17.713Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hatsuyuki0103-dsh-at-any`
- Submission type: community curation
- Created by `hatsuyuki0103` — https://github.com/hatsuyuki0103
- Original source repository: https://github.com/hatsuyuki0103/dsh-at-any
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.