### PR TITLE
catalog: add hefulalala-dsh-remote-workspace (community curation, created by @Hefulalala)

### DIFF
--- a/catalog/plugins/hefulalala-dsh-remote-workspace.yaml
+++ b/catalog/plugins/hefulalala-dsh-remote-workspace.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: hefulalala-dsh-remote-workspace
+name: "@dsh-external/dsh-remote-workspace"
+description:
+  en: A plugin for DSH that brings SSH/SFTP remote workspaces into the workspace sidebar — alongside your local directories.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - brings
+  - sftp
+  - remote
+  - workspaces
+  - workspace
+  - sidebar
+  - alongside
+  - local
+  - directories
+  - dsh
+source:
+  repository: https://github.com/Hefulalala/dsh-remote-workspace
+  repositoryNodeId: R_kgDOT6r3tA
+  subpath: null
+  commit: ae07df0bea8989914ce70e997d182d3fae3be953
+creator:
+  github: Hefulalala
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:43:28.020Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hefulalala-dsh-remote-workspace`
- Submission type: community curation
- Created by `Hefulalala` — https://github.com/Hefulalala
- Original source repository: https://github.com/Hefulalala/dsh-remote-workspace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.