### PR TITLE
catalog: add heiheiha798-dsh-plugin-response-window (community curation, created by @heiheiha798)

### DIFF
--- a/catalog/plugins/heiheiha798-dsh-plugin-response-window.yaml
+++ b/catalog/plugins/heiheiha798-dsh-plugin-response-window.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: heiheiha798-dsh-plugin-response-window
+name: dsh-plugin-response-window
+description:
+  en: "DeepSeek Harness (DSH) web plugin: per-turn response window. Each turn's tool calls collapse into ONE always-expanded bounded slide (configurable N-line window, inner scroll, nothing hidden), and long assistant markdown gets a bounded scroll window too — Grok-build style, keeps every intermediate response visible insid"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - response-window
+  - tool-call
+  - slide
+  - web-ui
+source:
+  repository: https://github.com/heiheiha798/dsh-plugin-response-window
+  repositoryNodeId: R_kgDOUCRHzg
+  subpath: null
+  commit: 913283e245f1e534ec9a589ca6921f6d2b1ddb3e
+creator:
+  github: heiheiha798
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:45:12.275Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `heiheiha798-dsh-plugin-response-window`
- Submission type: community curation
- Created by `heiheiha798` — https://github.com/heiheiha798
- Original source repository: https://github.com/heiheiha798/dsh-plugin-response-window
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.