### PR TITLE
catalog: add heiheiha798-dsh-plugin-subagent-delete (community curation, created by @heiheiha798)

### DIFF
--- a/catalog/plugins/heiheiha798-dsh-plugin-subagent-delete.yaml
+++ b/catalog/plugins/heiheiha798-dsh-plugin-subagent-delete.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: heiheiha798-dsh-plugin-subagent-delete
+name: dsh-plugin-subagent-delete
+description:
+  en: "DeepSeek Harness plugin: ownership-checked delete subagent / release subagent / list subagents tools and host routes that permanently remove subagent sessions from the web UI list."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - subagent
+  - delete-subagent
+  - cleanup
+  - session-management
+  - dsh
+source:
+  repository: https://github.com/heiheiha798/dsh-plugin-subagent-delete
+  repositoryNodeId: R_kgDOT_U-Rw
+  subpath: null
+  commit: 44b44286d646aabc850cf6af8fff69749373a22a
+creator:
+  github: heiheiha798
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:43:30.839Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `heiheiha798-dsh-plugin-subagent-delete`
- Submission type: community curation
- Created by `heiheiha798` — https://github.com/heiheiha798
- Original source repository: https://github.com/heiheiha798/dsh-plugin-subagent-delete
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.