### PR TITLE
catalog: add hellosky983-dsh-fabric (community curation, created by @hellosky983)

### DIFF
--- a/catalog/plugins/hellosky983-dsh-fabric.yaml
+++ b/catalog/plugins/hellosky983-dsh-fabric.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: hellosky983-dsh-fabric
+name: dsh-fabric
+description:
+  en: Fabric — the everything-is-a-plugin primitive for DeepSeek Harness (dsh). Unifies every DSH extensibility seam (tool / skill / command / prompt section / context / variable / event listener / llm adapter / subagent provider / web route / settings namespace / projection / service) behind one declarative DSL, published a
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - fabric
+  - extensibility
+  - meta-plugin
+  - dsl
+source:
+  repository: https://github.com/hellosky983/dsh-fabric
+  repositoryNodeId: R_kgDOT5KiHg
+  subpath: null
+  commit: 683bc3a3dd750986a549c45a7ca696e96947d991
+creator:
+  github: hellosky983
+package:
+  ecosystem: npm
+  name: dsh-fabric
+  version: 0.1.0
+  integrity: sha512-SG+5BaixmTbb4D7iVFiz4hvLj5BNR92dJzgwnWO3hanOWu6h0lRrUk8s/ak1EzhcXOc5Ri5QxiiY8bAH0PWJuA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:40.970Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hellosky983-dsh-fabric`
- Submission type: community curation
- Created by `hellosky983` — https://github.com/hellosky983
- Original source repository: https://github.com/hellosky983/dsh-fabric
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.