### PR TITLE
catalog: add hellosky983-dsh-foundry (community curation, created by @hellosky983)

### DIFF
--- a/catalog/plugins/hellosky983-dsh-foundry.yaml
+++ b/catalog/plugins/hellosky983-dsh-foundry.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: hellosky983-dsh-foundry
+name: dsh-foundry
+description:
+  en: Plugin Foundry — a self-extending, everything-is-a-plugin compiler for DeepSeek Harness. Ships a blueprint registry (scaffold → validate → deploy) as a runtime Service, three model tools, and a blueprint-gallery settings page.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - meta-plugin
+  - plugin-compiler
+  - blueprint
+  - extensibility
+source:
+  repository: https://github.com/hellosky983/dsh-foundry
+  repositoryNodeId: R_kgDOT5LveQ
+  subpath: null
+  commit: cff65b961af7c8395c614a87b9b8fd864ca33666
+creator:
+  github: hellosky983
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:43.248Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hellosky983-dsh-foundry`
- Submission type: community curation
- Created by `hellosky983` — https://github.com/hellosky983
- Original source repository: https://github.com/hellosky983/dsh-foundry
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.