### PR TITLE
catalog: add hellosky983-dsh-skillradar (community curation, created by @hellosky983)

### DIFF
--- a/catalog/plugins/hellosky983-dsh-skillradar.yaml
+++ b/catalog/plugins/hellosky983-dsh-skillradar.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: hellosky983-dsh-skillradar
+name: dsh-skillradar
+description:
+  en: "Skill Radar for DeepSeek Harness (dsh): scan the current session's visible skills, score their relevance against the recent conversation, and recommend which skill to load. Model tool + optional interactive panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - skill
+  - radar
+  - scan
+  - current
+  - session
+  - visible
+  - skills
+  - score
+  - relevance
+  - against
+  - recent
+  - conversation
+  - recommend
+  - load
+  - model
+  - tool
+source:
+  repository: https://github.com/hellosky983/dsh-skillradar
+  repositoryNodeId: R_kgDOT4AbTg
+  subpath: null
+  commit: bb96fce5457a3186322caa664e1daef7a04c4e2f
+creator:
+  github: hellosky983
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:45.137Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hellosky983-dsh-skillradar`
- Submission type: community curation
- Created by `hellosky983` — https://github.com/hellosky983
- Original source repository: https://github.com/hellosky983/dsh-skillradar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.