### PR TITLE
catalog: add hezhongtang-dsh-update-copilot (community curation, created by @hezhongtang)

### DIFF
--- a/catalog/plugins/hezhongtang-dsh-update-copilot.yaml
+++ b/catalog/plugins/hezhongtang-dsh-update-copilot.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: hezhongtang-dsh-update-copilot
+name: dsh-update-copilot
+description:
+  en: "Update copilot for DeepSeek Harness: tracks the DSH core, bundled packages, and every installed plugin across npm and git, merged package-centric over all profiles, with one-click updates — the update command is identical for every profile. · DSH 更新助手：追踪 dsh 本体、bundle 包和所有已装插件（npm 与 git 双通道，跨 profile 按包合并），一键更新——各 prof"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - update-checker
+  - plugin-manager
+  - dependency-updates
+  - version-radar
+  - semver
+  - changelog
+  - agent-tools
+  - cordis-plugin
+source:
+  repository: https://github.com/hezhongtang/dsh-update-copilot
+  repositoryNodeId: R_kgDOT43OUw
+  subpath: null
+  commit: ae749a6f64016206afa97018e4843f80f6953812
+creator:
+  github: hezhongtang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:43:43.915Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hezhongtang-dsh-update-copilot`
- Submission type: community curation
- Created by `hezhongtang` — https://github.com/hezhongtang
- Original source repository: https://github.com/hezhongtang/dsh-update-copilot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.