### PR TITLE
catalog: add hherosoul-dsh-smart-charts (community curation, created by @hherosoul)

### DIFF
--- a/catalog/plugins/hherosoul-dsh-smart-charts.yaml
+++ b/catalog/plugins/hherosoul-dsh-smart-charts.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: hherosoul-dsh-smart-charts
+name: dsh-smart-charts
+description:
+  en: Smart Charts skill for DeepSeek Harness — generates interactive ECharts visualizations from CSV/Excel/JSON data.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - skill
+  - echarts
+  - charts
+  - visualization
+  - dsh
+source:
+  repository: https://github.com/hherosoul/dsh-smart-charts
+  repositoryNodeId: R_kgDOT9fm0g
+  subpath: null
+  commit: 225bac88e6356aba51c3379ae960f9f9ec999c13
+creator:
+  github: hherosoul
+package:
+  ecosystem: npm
+  name: dsh-smart-charts
+  version: 6.0.1
+  integrity: sha512-hAIKag1NG20P/BXDYNLx09FXnOlznzTLTmYO2hqhT1teWqgshwJWv1se4fZUaQ77lgjBVJzTY8iDwmRoCQPRYA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:43:38.867Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hherosoul-dsh-smart-charts`
- Submission type: community curation
- Created by `hherosoul` — https://github.com/hherosoul
- Original source repository: https://github.com/hherosoul/dsh-smart-charts
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.