### PR TITLE
catalog: add hhheeewww-dsh-mcp-console (community curation, created by @HHHEEEWWW)

### DIFF
--- a/catalog/plugins/hhheeewww-dsh-mcp-console.yaml
+++ b/catalog/plugins/hhheeewww-dsh-mcp-console.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: hhheeewww-dsh-mcp-console
+name: dsh-mcp-console
+description:
+  en: "MCP management panel for DeepSeek Harness Web UI (Settings - MCP): view / add / edit / remove MCP servers (stdio & streamable-http), import MCP configs from GitHub, backed by the official @deepseek-ai/dsh-mcp-client bridge with hot add/remove (no restart)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - model-context-protocol
+  - mcp-manager
+source:
+  repository: https://github.com/HHHEEEWWW/dsh-mcp-console
+  repositoryNodeId: R_kgDOT4Fh8g
+  subpath: null
+  commit: 28f8f4ba0b151e2f66d6bbb79fb04267d2873c3d
+creator:
+  github: HHHEEEWWW
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:29.376Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hhheeewww-dsh-mcp-console`
- Submission type: community curation
- Created by `HHHEEEWWW` — https://github.com/HHHEEEWWW
- Original source repository: https://github.com/HHHEEEWWW/dsh-mcp-console
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.