### PR TITLE
catalog: add hongyue0721-dsh-kimicode-swarm (community curation, created by @hongyue0721)

### DIFF
--- a/catalog/plugins/hongyue0721-dsh-kimicode-swarm.yaml
+++ b/catalog/plugins/hongyue0721-dsh-kimicode-swarm.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: hongyue0721-dsh-kimicode-swarm
+name: dsh-kimicode-swarm
+description:
+  en: bash dsh plugin --profile web add dsh-kimicode-swarm pnpm add dsh-kimicode-swarm
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - bash
+  - profile
+  - kimicode
+  - swarm
+  - pnpm
+  - dsh
+source:
+  repository: https://github.com/hongyue0721/dsh-kimicode-swarm
+  repositoryNodeId: R_kgDOT5PYew
+  subpath: null
+  commit: 1c09744ba438d8a685722a5817044afd1b391fd4
+creator:
+  github: hongyue0721
+package:
+  ecosystem: npm
+  name: dsh-kimicode-swarm
+  version: 0.1.0
+  integrity: sha512-HDQddaxfPExpr2/Xfl89n9wmmSrv7I6k77G/XtsFjjCe3gvWCgybmUsR/UOc2P+WLgZRo521HkjaPfgzWrVGkw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:46.976Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hongyue0721-dsh-kimicode-swarm`
- Submission type: community curation
- Created by `hongyue0721` — https://github.com/hongyue0721
- Original source repository: https://github.com/hongyue0721/dsh-kimicode-swarm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.