### PR TITLE
catalog: add horusjiang-dsh-map-tools (community curation, created by @HorusJiang)

### DIFF
--- a/catalog/plugins/horusjiang-dsh-map-tools.yaml
+++ b/catalog/plugins/horusjiang-dsh-map-tools.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: horusjiang-dsh-map-tools
+name: dsh-map-tools
+description:
+  en: "Map & routing tools for DeepSeek Harness: driving/transit/walking/bicycling route planning, geocoding, reverse geocoding and POI search via Amap (高德) or free OSM/OSRM."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - map
+  - routing
+  - path-planning
+  - geocoding
+  - amap
+  - gaode
+  - osm
+  - osrm
+source:
+  repository: https://github.com/HorusJiang/dsh-map-tools
+  repositoryNodeId: R_kgDOT8_0Cw
+  subpath: null
+  commit: ceb48cd0bca746c3b8cf221923c0da1e1d766cfd
+creator:
+  github: HorusJiang
+package:
+  ecosystem: npm
+  name: dsh-map-tools
+  version: 0.4.4
+  integrity: sha512-s75G0w1GSAtELKOOIxbjqv5og6qVGg+GXB/xAVbl2f8Q/g8V4uNVWyw+/lGQ2RRekctN+sfkl9GuE9E9o1AqoQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:05.173Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `horusjiang-dsh-map-tools`
- Submission type: community curation
- Created by `HorusJiang` — https://github.com/HorusJiang
- Original source repository: https://github.com/HorusJiang/dsh-map-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.