### PR TITLE
catalog: add hou-dl-dsh-token-heatmap (community curation, created by @Hou-DL)

### DIFF
--- a/catalog/plugins/hou-dl-dsh-token-heatmap.yaml
+++ b/catalog/plugins/hou-dl-dsh-token-heatmap.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: hou-dl-dsh-token-heatmap
+name: dsh-token-heatmap
+description:
+  en: A local Token usage heatmap plugin for DSH Web — GitHub-style calendar views, built into the Settings pane.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - local
+  - token
+  - usage
+  - heatmap
+  - style
+  - calendar
+  - views
+  - built
+  - settings
+  - pane
+  - dsh
+source:
+  repository: https://github.com/Hou-DL/dsh-token-pulse
+  repositoryNodeId: R_kgDOUCGDUw
+  subpath: null
+  commit: 7bd8ac690eead05c70092d74de70dc5a0c2fdb45
+creator:
+  github: Hou-DL
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:13.694Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hou-dl-dsh-token-heatmap`
- Submission type: community curation
- Created by `Hou-DL` — https://github.com/Hou-DL
- Original source repository: https://github.com/Hou-DL/dsh-token-pulse
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.