### PR TITLE
catalog: add hoyyang-dsh-mall (community curation, created by @hoyyang)

### DIFF
--- a/catalog/plugins/hoyyang-dsh-mall.yaml
+++ b/catalog/plugins/hoyyang-dsh-mall.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: hoyyang-dsh-mall
+name: dsh-mall
+description:
+  en: "Every dsh-plugin repo on GitHub, in one mall: browse, search, compare scores, install in one click. Not sure about a plugin? Let AI read its code first."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - marketplace
+  - market
+source:
+  repository: https://github.com/hoyyang/dsh-mall
+  repositoryNodeId: R_kgDOUDec8g
+  subpath: null
+  commit: 909955940ab3361f446e7a4951bf93fae9ea0f4c
+creator:
+  github: hoyyang
+package:
+  ecosystem: npm
+  name: dsh-mall
+  version: 1.7.90
+  integrity: sha512-9lX2Ree5jYf1CoIude5+66iOVmszRovqjo5tyfmiP8PTJ/xdJFCC8FRnh+glCR2AmA777UbDK+LfPJnocYHEeg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:40:53.169Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hoyyang-dsh-mall`
- Submission type: community curation
- Created by `hoyyang` — https://github.com/hoyyang
- Original source repository: https://github.com/hoyyang/dsh-mall
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.