### PR TITLE
catalog: add hua1qing-dsh-hindsight-local (community curation, created by @Hua1Qing)

### DIFF
--- a/catalog/plugins/hua1qing-dsh-hindsight-local.yaml
+++ b/catalog/plugins/hua1qing-dsh-hindsight-local.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: hua1qing-dsh-hindsight-local
+name: dsh-hindsight-local
+description:
+  en: "DSH web client plugin: a sidebar toggle to start/stop the local Hindsight memory daemon (hindsight-embed) for the DeepSeek Harness desktop app."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - client
+  - sidebar
+  - toggle
+  - start
+  - stop
+  - local
+  - hindsight
+  - memory
+  - daemon
+  - embed
+  - desktop
+  - dsh
+source:
+  repository: https://github.com/Hua1Q1nG/dsh-hindsight-local-optimize
+  repositoryNodeId: R_kgDOT7cbBw
+  subpath: null
+  commit: 27c45d5fd4e214b58749707dc604ee760ac7e419
+creator:
+  github: Hua1Qing
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:42:31.186Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hua1qing-dsh-hindsight-local`
- Submission type: community curation
- Created by `Hua1Qing` — https://github.com/Hua1Qing
- Original source repository: https://github.com/Hua1Q1nG/dsh-hindsight-local-optimize
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.