### PR TITLE
catalog: add huabai-flowerwhite-dsh-plugin-design (community curation, created by @huabai-flowerwhite)

### DIFF
--- a/catalog/plugins/huabai-flowerwhite-dsh-plugin-design.yaml
+++ b/catalog/plugins/huabai-flowerwhite-dsh-plugin-design.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: huabai-flowerwhite-dsh-plugin-design
+name: dsh-plugin-design
+description:
+  en: text dsh-plugin-design/ ├── install.ps1 / install.sh 一键安装（node modules 链接 + cordis.patch.yml insert） ├── package.json npm 包：exports + dsh.client + dsh.bundle + scripts.test ├── dsh.plugin.yaml DH-TP-SDK manifest ├── cordis.patch.yml 挂载参考：host composition insert row ├── README.md / design.md / LICENSE / .gitignore ├── l
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - text
+  - design
+  - install
+  - node
+  - modules
+  - cordis
+  - patch
+  - insert
+  - package
+  - json
+  - exports
+  - client
+  - bundle
+  - scripts
+  - test
+  - yaml
+source:
+  repository: https://github.com/huabai-flowerwhite/dsh-plugin-design
+  repositoryNodeId: R_kgDOT_G2YA
+  subpath: null
+  commit: 8bd6ca54c1879f2074a3cb193eb419f4b18b2fc7
+creator:
+  github: huabai-flowerwhite
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:13.092Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huabai-flowerwhite-dsh-plugin-design`
- Submission type: community curation
- Created by `huabai-flowerwhite` — https://github.com/huabai-flowerwhite
- Original source repository: https://github.com/huabai-flowerwhite/dsh-plugin-design
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.