### PR TITLE
catalog: add huang-zhishi-dsh-plugin-call-trace (community curation, created by @Huang-zhishi)

### DIFF
--- a/catalog/plugins/huang-zhishi-dsh-plugin-call-trace.yaml
+++ b/catalog/plugins/huang-zhishi-dsh-plugin-call-trace.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: huang-zhishi-dsh-plugin-call-trace
+name: dsh-plugin-call-trace
+description:
+  en: Persistent host-side LLM tool-call trace recorder for DeepSeek Harness. Writes every completed model tool call (name, args, status, result, duration, turn/step) to a JSONL file that survives restarts, with size rotation. Exposes a structured call trace model tool and a callTraceHistory service for a UI add-on. Optional
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - bundle
+  - trace
+  - observability
+  - tool-call
+source:
+  repository: https://github.com/Huang-zhishi/dsh-plugin-call-trace
+  repositoryNodeId: R_kgDOT43U4Q
+  subpath: null
+  commit: 66e467535cc11bf97a8112ed8d8beece8d00e83f
+creator:
+  github: Huang-zhishi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:17.828Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huang-zhishi-dsh-plugin-call-trace`
- Submission type: community curation
- Created by `Huang-zhishi` — https://github.com/Huang-zhishi
- Original source repository: https://github.com/Huang-zhishi/dsh-plugin-call-trace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.