### PR TITLE
catalog: add huanyulv-dsh-balance-tide (community curation, created by @huanyuLv)

### DIFF
--- a/catalog/plugins/huanyulv-dsh-balance-tide.yaml
+++ b/catalog/plugins/huanyulv-dsh-balance-tide.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: huanyulv-dsh-balance-tide
+name: dsh-balance-tide
+description:
+  en: "DeepSeek Harness (DSH) Web plugin: account balance + peak/off-peak pricing tide indicator."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - balance
+  - pricing
+  - peak-off-peak
+  - cost
+source:
+  repository: https://github.com/huanyuLv/dsh-balance-tide
+  repositoryNodeId: R_kgDOT4SOQg
+  subpath: null
+  commit: 8805c80eeaae26d40156cea9162091a6ab01311e
+creator:
+  github: huanyuLv
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:40:38.168Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huanyulv-dsh-balance-tide`
- Submission type: community curation
- Created by `huanyuLv` — https://github.com/huanyuLv
- Original source repository: https://github.com/huanyuLv/dsh-balance-tide
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.