### PR TITLE
catalog: add huaxiren6-dsh-email-reader (community curation, created by @huaxiren6)

### DIFF
--- a/catalog/plugins/huaxiren6-dsh-email-reader.yaml
+++ b/catalog/plugins/huaxiren6-dsh-email-reader.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: huaxiren6-dsh-email-reader
+name: dsh-email-reader
+description:
+  en: "OAuth2-capable IMAP email reader for DeepSeek Harness: list/read/search mail for accounts where password auth is disabled (Outlook post-2024), with automatic token refresh, app-password Gmail via optional proxy, and ol email tools that coexist with the market dsh-email plugin."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - email
+  - imap
+  - oauth2
+  - xoauth2
+  - outlook
+  - gmail
+  - otp
+source:
+  repository: https://github.com/huaxiren6/DSH-EmailReader
+  repositoryNodeId: R_kgDOT-8d-Q
+  subpath: null
+  commit: da5fbd1c971e7ab8308bfd93aa1aae4db3a390c7
+creator:
+  github: huaxiren6
+package:
+  ecosystem: npm
+  name: dsh-email-reader
+  version: 0.1.2
+  integrity: sha512-FhCv9W33lcAec6Hs0pxa+Cqu0ETUzXI0pN9/A+IFiUcJRAWdHsOKv3KwT/CHhnxC0G03/BLcRokPrzy8ICqOHw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:22.604Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huaxiren6-dsh-email-reader`
- Submission type: community curation
- Created by `huaxiren6` — https://github.com/huaxiren6
- Original source repository: https://github.com/huaxiren6/DSH-EmailReader
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.