### PR TITLE
catalog: add huaxiren6-dsh-remote-qr-button (community curation, created by @huaxiren6)

### DIFF
--- a/catalog/plugins/huaxiren6-dsh-remote-qr-button.yaml
+++ b/catalog/plugins/huaxiren6-dsh-remote-qr-button.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: huaxiren6-dsh-remote-qr-button
+name: dsh-remote-qr-button
+description:
+  en: "Floating phone-pairing QR button for the DSH WebUI. Companion UI for dsh-remote-link: opens its /qr pairing page in an in-app overlay."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ui
+  - remote
+  - qr
+  - phone
+  - pairing
+source:
+  repository: https://github.com/huaxiren6/DSH-QrPairing
+  repositoryNodeId: R_kgDOT9PCYQ
+  subpath: null
+  commit: 8427d4613a587bb947e8e7eb69fbdba1e435b402
+creator:
+  github: huaxiren6
+package:
+  ecosystem: npm
+  name: dsh-remote-qr-button
+  version: 0.2.7
+  integrity: sha512-T+MO+/FQPznegqsvGvqJ8YXPRTtPFDScijPGNM53jOrUNiknM9MG+pTzDJHjwMEVv7iumBYZdgQnEzux0WB/SQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:45:20.675Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huaxiren6-dsh-remote-qr-button`
- Submission type: community curation
- Created by `huaxiren6` — https://github.com/huaxiren6
- Original source repository: https://github.com/huaxiren6/DSH-QrPairing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.