### PR TITLE
catalog: add huitianyi-dsh-whale-desktop-launcher (community curation, created by @HUITianYi)

### DIFF
--- a/catalog/plugins/huitianyi-dsh-whale-desktop-launcher.yaml
+++ b/catalog/plugins/huitianyi-dsh-whale-desktop-launcher.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: huitianyi-dsh-whale-desktop-launcher
+name: dsh-whale-desktop-launcher
+description:
+  en: Windows desktop launcher for DeepSeek Harness with a whale-girl icon and a clean Chromium app-mode window.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - windows
+  - desktop-launcher
+source:
+  repository: https://github.com/HUITianYi/dsh-whale-desktop-launcher
+  repositoryNodeId: R_kgDOT65xoQ
+  subpath: null
+  commit: 326075f04a5b22d9b6e1d9a85f2ba418333460c4
+creator:
+  github: HUITianYi
+package:
+  ecosystem: npm
+  name: dsh-whale-desktop-launcher
+  version: 0.1.0
+  integrity: sha512-68A05WNQ+Lu7XGbLAdHN2eoynsFsu7SO/OHHCSCh2M9HfeVmKLE047e2MA58sVQbtIqofRd+GPiEZXA8RriJUQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:40:45.373Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huitianyi-dsh-whale-desktop-launcher`
- Submission type: community curation
- Created by `HUITianYi` — https://github.com/HUITianYi
- Original source repository: https://github.com/HUITianYi/dsh-whale-desktop-launcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.