### PR TITLE
catalog: add hunter118-dsh-s7r (community curation, created by @hunter118)

### DIFF
--- a/catalog/plugins/hunter118-dsh-s7r.yaml
+++ b/catalog/plugins/hunter118-dsh-s7r.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: hunter118-dsh-s7r
+name: dsh-s7r
+description:
+  en: S7R System 7 Reimagined workstation plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - system-7
+  - retro-ui
+  - agent-workspace
+  - dsh
+source:
+  repository: https://github.com/hunter118/dsh-s7r
+  repositoryNodeId: R_kgDOT9mZ8g
+  subpath: null
+  commit: 5ce0d3b1d4f3ca76f6b2d90f1effcaa785bf0b2d
+creator:
+  github: hunter118
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:20.877Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hunter118-dsh-s7r`
- Submission type: community curation
- Created by `hunter118` — https://github.com/hunter118
- Original source repository: https://github.com/hunter118/dsh-s7r
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.