### PR TITLE
catalog: add huxint-dsh-team (community curation, created by @huxint)

### DIFF
--- a/catalog/plugins/huxint-dsh-team.yaml
+++ b/catalog/plugins/huxint-dsh-team.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: huxint-dsh-team
+name: dsh-team
+description:
+  en: "Agent teams for DeepSeek Harness: named long-lived teammates over ctx.subagents, a shared task list, a member-to-member mailbox, virtual workspaces, and a live team room in the conversation view"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - agent
+  - teams
+  - named
+  - long
+  - lived
+  - teammates
+  - over
+  - subagents
+  - shared
+  - task
+  - list
+  - member
+  - mailbox
+  - virtual
+  - workspaces
+  - live
+source:
+  repository: https://github.com/huxint/dsh-team
+  repositoryNodeId: R_kgDOT6G57w
+  subpath: null
+  commit: 8deb66dbf2262a4360455cc49a7bc35035ebdff2
+creator:
+  github: huxint
+package:
+  ecosystem: npm
+  name: dsh-team
+  version: 0.2.7
+  integrity: sha512-WsEXCJxSU9g2lWDf512MEG6UYkOZGJpF660WIig7HaB1ZWzZSp8AZbsfvaiATE0L8YMkMSekuZAAzIl0XddfjQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:40:55.479Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huxint-dsh-team`
- Submission type: community curation
- Created by `huxint` — https://github.com/huxint
- Original source repository: https://github.com/huxint/dsh-team
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.