### PR TITLE
catalog: add hxy91819-dsh-auth (community curation, created by @hxy91819)

### DIFF
--- a/catalog/plugins/hxy91819-dsh-auth.yaml
+++ b/catalog/plugins/hxy91819-dsh-auth.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: hxy91819-dsh-auth
+name: dsh-auth
+description:
+  en: Caddy-fronted administrator authentication bundle for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-auth
+  - dsh-security
+  - cordis
+  - caddy
+  - authentication
+  - argon2id
+  - forward-auth
+source:
+  repository: https://github.com/hxy91819/dsh-auth
+  repositoryNodeId: R_kgDOT4aSmA
+  subpath: null
+  commit: 2463a595239b8ad289f39ecf7d59dd1fb94225ff
+creator:
+  github: hxy91819
+package:
+  ecosystem: npm
+  name: dsh-auth
+  version: 0.2.3
+  integrity: sha512-1g9k+Jex/Z2Er+ZthbMcstW0Nyf3prLR8lPNxcckQczKhmn4CdkEP26T5ch3MtCh3gt5qZAIxpAf9MNQ/0GuNw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:49.023Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hxy91819-dsh-auth`
- Submission type: community curation
- Created by `hxy91819` — https://github.com/hxy91819
- Original source repository: https://github.com/hxy91819/dsh-auth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.