### PR TITLE
catalog: add hyp6666-dsh-open-file (community curation, created by @Hyp6666)

### DIFF
--- a/catalog/plugins/hyp6666-dsh-open-file.yaml
+++ b/catalog/plugins/hyp6666-dsh-open-file.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: hyp6666-dsh-open-file
+name: dsh-open-file
+description:
+  en: Workspace-bound arbitrary file upload, reading, OCR, and rendering for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - file-upload
+  - ocr
+source:
+  repository: https://github.com/hyper-dsh-plugins/dsh-open-file
+  repositoryNodeId: R_kgDOT7V7hg
+  subpath: null
+  commit: d788e38eee2feaf0c8ae54036bc335a567055118
+creator:
+  github: Hyp6666
+package:
+  ecosystem: npm
+  name: dsh-open-file
+  version: 0.1.1-rc.2
+  integrity: sha512-axKFJQUREvCAZFaY+KV5lUbpZQ+84+XwLFXvdNVyi2oWFh1KVQ2DHXn32rZpx0VmiHdbA0IIoFWPJsm04Er5UA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:51.969Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hyp6666-dsh-open-file`
- Submission type: community curation
- Created by `Hyp6666` — https://github.com/Hyp6666
- Original source repository: https://github.com/hyper-dsh-plugins/dsh-open-file
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.