### PR TITLE
catalog: add hyperion2144-dsh-desktop-tauriapp (community curation, created by @hyperion2144)

### DIFF
--- a/catalog/plugins/hyperion2144-dsh-desktop-tauriapp.yaml
+++ b/catalog/plugins/hyperion2144-dsh-desktop-tauriapp.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: hyperion2144-dsh-desktop-tauriapp
+name: dsh-desktop-tauriapp
+description:
+  en: bash cd desktop pnpm install pnpm tauri build macOS 出 .app/.dmg；Windows 出 .msi/.exe
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - desktop
+  - tauri
+  - skill
+  - china-mirror
+  - windows
+source:
+  repository: https://github.com/hyperion2144/dsh-desktop-tauriapp
+  repositoryNodeId: R_kgDOT8Xh9g
+  subpath: null
+  commit: d9afaaab62f765691515838bab378c5826e71b2c
+creator:
+  github: hyperion2144
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:45:25.999Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hyperion2144-dsh-desktop-tauriapp`
- Submission type: community curation
- Created by `hyperion2144` — https://github.com/hyperion2144
- Original source repository: https://github.com/hyperion2144/dsh-desktop-tauriapp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.