### PR TITLE
catalog: add i1j-context-assembler-dsh (community curation, created by @i1j)

### DIFF
--- a/catalog/plugins/i1j-context-assembler-dsh.yaml
+++ b/catalog/plugins/i1j-context-assembler-dsh.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: i1j-context-assembler-dsh
+name: context-assembler-dsh
+description:
+  en: "Context Assembler DSH V0.99 — Context Assembler plugin for DeepSeek Harness (dsh): context compaction, cache-friendly topic-block management, water-pressure topic splitting, tool trace/rewrite, handoff planning and reality recall injection."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - context-assembly
+  - context-compression
+  - context-compaction
+  - topic-management
+  - handoff
+  - memory
+  - reality-injection
+  - tool-trace
+  - dsh
+source:
+  repository: https://github.com/i1j/context-assembler-DSH
+  repositoryNodeId: R_kgDOT7sZwQ
+  subpath: null
+  commit: 6807b032f771975ceaa9b66ce38fcf048b7438b5
+creator:
+  github: i1j
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:44:32.180Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `i1j-context-assembler-dsh`
- Submission type: community curation
- Created by `i1j` — https://github.com/i1j
- Original source repository: https://github.com/i1j/context-assembler-DSH
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.