### PR TITLE
catalog: add iaaing-dsh-quiet-light (community curation, created by @iaaiNG)

### DIFF
--- a/catalog/plugins/iaaing-dsh-quiet-light.yaml
+++ b/catalog/plugins/iaaing-dsh-quiet-light.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: iaaing-dsh-quiet-light
+name: "@iaaing/dsh-quiet-light"
+description:
+  en: A VS Code Quiet Light theme for the DeepSeek Harness web GUI — registers the official quiet-light palette into the theme system and adds a Quiet Light cube to the Appearance settings.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - quiet-light
+  - theme
+  - dsh-plugin
+source:
+  repository: https://github.com/iaaiNG/quiet-light-dsh
+  repositoryNodeId: R_kgDOT6tjnQ
+  subpath: null
+  commit: f5dbc57d2770d2827580e18bde1cb778b7e64ef0
+creator:
+  github: iaaiNG
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:45:32.556Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `iaaing-dsh-quiet-light`
- Submission type: community curation
- Created by `iaaiNG` — https://github.com/iaaiNG
- Original source repository: https://github.com/iaaiNG/quiet-light-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.