### PR TITLE
catalog: add ibka512-dsh-ibka-balance (community curation, created by @ibka512)

### DIFF
--- a/catalog/plugins/ibka512-dsh-ibka-balance.yaml
+++ b/catalog/plugins/ibka512-dsh-ibka-balance.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ibka512-dsh-ibka-balance
+name: dsh-ibka-balance
+description:
+  en: "yaml - insert: - id: ibka-balance name: 'dsh-ibka-balance'"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - yaml
+  - insert
+  - ibka
+  - balance
+  - name
+  - dsh
+source:
+  repository: https://github.com/ibka512/dsh-ibka-balance
+  repositoryNodeId: R_kgDOT4qGOA
+  subpath: null
+  commit: 3975f965c83df66ee48dbe9e98578f58c85e48ab
+creator:
+  github: ibka512
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:23.791Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ibka512-dsh-ibka-balance`
- Submission type: community curation
- Created by `ibka512` — https://github.com/ibka512
- Original source repository: https://github.com/ibka512/dsh-ibka-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.