### PR TITLE
catalog: add renoschubert-mattpocock-skills-dsh-zh (community curation, created by @renoschubert)

### DIFF
--- a/catalog/plugins/renoschubert-mattpocock-skills-dsh-zh.yaml
+++ b/catalog/plugins/renoschubert-mattpocock-skills-dsh-zh.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: renoschubert-mattpocock-skills-dsh-zh
+name: mattpocock-skills-dsh-zh
+description:
+  en: "Matt Pocock 技能中文版 for DeepSeek Harness: 25 个技能(grilling、writing-for-agents、wait-what、TDD、code-review 等)正文全部译为中文,适配 DSH 的 Cordis 插件架构。Chinese translation of the full promoted mattpocock/skills set (MIT, (c) Matt Pocock)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - skills
+  - mattpocock
+  - aihero
+  - chinese
+source:
+  repository: https://github.com/gongyijie85/mattpocock-skills-dsh-zh
+  repositoryNodeId: R_kgDOT51-Ng
+  subpath: null
+  commit: 663a1c20401406c2b75c7658aed7f8cc00bf3ee3
+creator:
+  github: renoschubert
+package:
+  ecosystem: npm
+  name: mattpocock-skills-dsh-zh
+  version: 0.1.1
+  integrity: sha512-K/RtIaY0rgvqyd5ReHtF0lFMk+w5cxJ5VYihhkClBwXZm3Cnj4gbcoTzuJJXHw4mvLS5cKnLrooB22vtWwX9Yg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:41:27.217Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `renoschubert-mattpocock-skills-dsh-zh`
- Submission type: community curation
- Created by `renoschubert` — https://github.com/renoschubert
- Original source repository: https://github.com/gongyijie85/mattpocock-skills-dsh-zh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.