### PR TITLE
catalog: add renoschubert-mattpocock-skills-dsh (community curation, created by @renoschubert)

### DIFF
--- a/catalog/plugins/renoschubert-mattpocock-skills-dsh.yaml
+++ b/catalog/plugins/renoschubert-mattpocock-skills-dsh.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: renoschubert-mattpocock-skills-dsh
+name: mattpocock-skills-dsh
+description:
+  en: "Matt Pocock's skills for the DeepSeek Harness: grilling, writing-for-agents, wait-what and more — adapted from https://github.com/mattpocock/skills"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - skills
+  - mattpocock
+  - aihero
+source:
+  repository: https://github.com/gongyijie85/mattpocock-skills-dsh
+  repositoryNodeId: R_kgDOT5tF2g
+  subpath: null
+  commit: ab38276ab1073887b7204cc0c02e131adedf9ac9
+creator:
+  github: renoschubert
+package:
+  ecosystem: npm
+  name: mattpocock-skills-dsh
+  version: 0.1.3
+  integrity: sha512-S7HU6pWk/LD6vN76f4S0HdrhpbUD1Oo6meOWMTB1XxE1U2SYWUnPR62JLS7FyWFB2sMzEDKphGyfyEovXKgnLQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T04:40:47.393Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `renoschubert-mattpocock-skills-dsh`
- Submission type: community curation
- Created by `renoschubert` — https://github.com/renoschubert
- Original source repository: https://github.com/gongyijie85/mattpocock-skills-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.