### PR TITLE
catalog: add bbbdbbb-dsh-dejaview (community curation, created by @bbbdbbb)

### DIFF
--- a/catalog/plugins/bbbdbbb-dsh-dejaview.yaml
+++ b/catalog/plugins/bbbdbbb-dsh-dejaview.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: bbbdbbb-dsh-dejaview
+name: dsh-dejaview
+description:
+  en: A DeepSeek Harness tool that checks whether a similar dsh plugin already exists before you build one, by searching the awesome-dsh-plugin registry and the dsh-plugin GitHub topic.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dejaview
+  - novelty-check
+  - duplicate-detection
+  - dsh
+source:
+  repository: https://github.com/jiang4wqy/dsh-dejaview
+  repositoryNodeId: R_kgDOT8KAOA
+  subpath: null
+  commit: 0a64c03abcf672ec346950064a9a22b9fa3f315b
+creator:
+  github: bbbdbbb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:50.070Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bbbdbbb-dsh-dejaview`
- Submission type: community curation
- Created by `bbbdbbb` — https://github.com/bbbdbbb
- Original source repository: https://github.com/jiang4wqy/dsh-dejaview
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.