### PR TITLE
catalog: add guidaoilps2-coder-dsvu (community curation, created by @guidaoilps2-coder)

### DIFF
--- a/catalog/plugins/guidaoilps2-coder-dsvu.yaml
+++ b/catalog/plugins/guidaoilps2-coder-dsvu.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: guidaoilps2-coder-dsvu
+name: "@svenyu/dsvu"
+description:
+  en: bash npm install @svenyu/dsvu
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - video-understand
+  - avis
+  - video-understanding
+  - low-cost
+  - bilibili
+  - dsvu
+  - deepseek-vision
+source:
+  repository: https://github.com/ilps2/dsvu-videounderstanding
+  repositoryNodeId: R_kgDOUBEARw
+  subpath: null
+  commit: b294905a648ae5862a105bd620eb8cc243b49e71
+creator:
+  github: guidaoilps2-coder
+package:
+  ecosystem: npm
+  name: "@svenyu/dsvu"
+  version: 0.6.6
+  integrity: sha512-qOt3Y/4d+zKrH5LQJWbv7yPJ4bRFgcC2j5+RscOCPPTINqRW/48AUqmaFEPVaaK2b+PnRnnqonYhd9HCM+EPgA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:15.626Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `guidaoilps2-coder-dsvu`
- Submission type: community curation
- Created by `guidaoilps2-coder` — https://github.com/guidaoilps2-coder
- Original source repository: https://github.com/ilps2/dsvu-videounderstanding
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.