### PR TITLE
catalog: add icearia0219-dsh-memory-spaces (community curation, created by @icearia0219)

### DIFF
--- a/catalog/plugins/icearia0219-dsh-memory-spaces.yaml
+++ b/catalog/plugins/icearia0219-dsh-memory-spaces.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: icearia0219-dsh-memory-spaces
+name: dsh-memory-spaces
+description:
+  en: Explicitly governed shared memory spaces for DeepSeek Harness sessions
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-memory
+  - session-memory
+  - shared-memory
+  - dsh
+source:
+  repository: https://github.com/icearia0219/dsh-memory-spaces
+  repositoryNodeId: R_kgDOUDa3eA
+  subpath: null
+  commit: ac8b58d087ff5a50e9a32030bd56cffe61da069d
+creator:
+  github: icearia0219
+package:
+  ecosystem: npm
+  name: dsh-memory-spaces
+  version: 0.1.0
+  integrity: sha512-BFnfrVqM6KVekYXAhqgukBoW35pJ5vBqIh/Ti49d2omdX30oSIwHEVLS2mdcI+cFHN3DwLeO0K033sO8ih//iQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:13.593Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `icearia0219-dsh-memory-spaces`
- Submission type: community curation
- Created by `icearia0219` — https://github.com/icearia0219
- Original source repository: https://github.com/icearia0219/dsh-memory-spaces
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.