### PR TITLE
catalog: add icefall7-dsh-plugin-scout (community curation, created by @icefall7)

### DIFF
--- a/catalog/plugins/icefall7-dsh-plugin-scout.yaml
+++ b/catalog/plugins/icefall7-dsh-plugin-scout.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: icefall7-dsh-plugin-scout
+name: dsh-plugin-scout
+description:
+  en: "A DeepSeek Harness plugin + skill that scouts the DSH ecosystem: the core deepseek-harness repo and every dsh-plugin-tagged repository, discovers harnesses related to your goal, and judges whether each is worth trying."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - skill
+  - scouts
+  - ecosystem
+  - core
+  - repo
+  - every
+  - tagged
+  - repository
+  - discovers
+  - harnesses
+  - related
+  - goal
+  - judges
+  - whether
+  - each
+  - worth
+source:
+  repository: https://github.com/icefall7/dsh-plugin-scout
+  repositoryNodeId: R_kgDOT4xkUQ
+  subpath: null
+  commit: cccc690850c986570a2d51980818644716344df0
+creator:
+  github: icefall7
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:28.340Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `icefall7-dsh-plugin-scout`
- Submission type: community curation
- Created by `icefall7` — https://github.com/icefall7
- Original source repository: https://github.com/icefall7/dsh-plugin-scout
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.