### PR TITLE
catalog: add icycreamdas-shidi-dsh-plugin (community curation, created by @IcyCreamDAS)

### DIFF
--- a/catalog/plugins/icycreamdas-shidi-dsh-plugin.yaml
+++ b/catalog/plugins/icycreamdas-shidi-dsh-plugin.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: icycreamdas-shidi-dsh-plugin
+name: shidi-dsh-plugin
+description:
+  en: "AI-for-Science research workflow skill bundle for DeepSeek Harness: multi-angle literature review with per-angle files, anchored experiment design with a caveat list, figures, paper reading; cross-verification briefs."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - skills
+  - research
+  - literature-review
+  - experiment-design
+  - ai4s
+  - ai-for-science
+  - research-agent
+  - academic-research
+  - science-agent
+source:
+  repository: https://github.com/IcyCreamDAS/shidi-skill
+  repositoryNodeId: R_kgDOTsRh8g
+  subpath: null
+  commit: 003509b684b59d8be1caa325db03c4626cf39b6e
+creator:
+  github: IcyCreamDAS
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:05.258Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `icycreamdas-shidi-dsh-plugin`
- Submission type: community curation
- Created by `IcyCreamDAS` — https://github.com/IcyCreamDAS
- Original source repository: https://github.com/IcyCreamDAS/shidi-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.