### PR TITLE
catalog: add iiiweiii-dsh-guardwall (community curation, created by @iiiweiii)

### DIFF
--- a/catalog/plugins/iiiweiii-dsh-guardwall.yaml
+++ b/catalog/plugins/iiiweiii-dsh-guardwall.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: iiiweiii-dsh-guardwall
+name: dsh-guardwall
+description:
+  en: "Security for DeepSeek Harness in two layers: source-backed pre-install vetting plus fail-closed runtime guardrails and HMAC-chained audit logs. Zero runtime dependencies."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - security
+  - guardrail
+  - audit
+  - tamper-evident
+  - ssrf
+  - secret-detection
+  - plugin-vetting
+  - trust-score
+  - dsh
+source:
+  repository: https://github.com/iiiweiii/dsh-guardwall
+  repositoryNodeId: R_kgDOT_Pdvg
+  subpath: null
+  commit: 162ff316eacde260e810d55c67a5c7513e044937
+creator:
+  github: iiiweiii
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:30.039Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `iiiweiii-dsh-guardwall`
- Submission type: community curation
- Created by `iiiweiii` — https://github.com/iiiweiii
- Original source repository: https://github.com/iiiweiii/dsh-guardwall
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.