### PR TITLE
catalog: add ilharp-dsh-tool-approval (community curation, created by @ilharp)

### DIFF
--- a/catalog/plugins/ilharp-dsh-tool-approval.yaml
+++ b/catalog/plugins/ilharp-dsh-tool-approval.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ilharp-dsh-tool-approval
+name: dsh-tool-approval
+description:
+  en: Manual approval for Deepseek Harness (aka "Manual Mode"/"Ask Mode")
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - manual
+  - approval
+  - mode
+  - dsh
+source:
+  repository: https://github.com/ilharp/dsh-tool-approval
+  repositoryNodeId: R_kgDOT04FDw
+  subpath: null
+  commit: c01801a7e39c36515d8445747abff6a6388c1278
+creator:
+  github: ilharp
+package:
+  ecosystem: npm
+  name: dsh-tool-approval
+  version: 0.1.0
+  integrity: sha512-kxFq+PQy1Xkrrbh0UV7iPBE5r1uQuPipa3Kd1d/794hbgLUBeUVCix8UN3UF9RFrmWbd+sUM6kB3YhkN1YPXGw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:32.225Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ilharp-dsh-tool-approval`
- Submission type: community curation
- Created by `ilharp` — https://github.com/ilharp
- Original source repository: https://github.com/ilharp/dsh-tool-approval
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.