### PR TITLE
catalog: add imrascal-dsh-archive (community curation, created by @imrascal)

### DIFF
--- a/catalog/plugins/imrascal-dsh-archive.yaml
+++ b/catalog/plugins/imrascal-dsh-archive.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: imrascal-dsh-archive
+name: "@imrascal/dsh-archive"
+description:
+  en: A DeepSeek Harness (DSH) plugin that manages archived sessions and the trash from the settings panel.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - archive
+  - trash
+  - session
+source:
+  repository: https://github.com/imrascal/dsh-archive
+  repositoryNodeId: R_kgDOT7bdnQ
+  subpath: null
+  commit: 9ee5770a0640375519f3e7528db0e6efeedb1efc
+creator:
+  github: imrascal
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:13.452Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `imrascal-dsh-archive`
- Submission type: community curation
- Created by `imrascal` — https://github.com/imrascal
- Original source repository: https://github.com/imrascal/dsh-archive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.