### PR TITLE
catalog: add initial-d-dsh-plugin-mlquant-benchmark (community curation, created by @initial-d)

### DIFF
--- a/catalog/plugins/initial-d-dsh-plugin-mlquant-benchmark.yaml
+++ b/catalog/plugins/initial-d-dsh-plugin-mlquant-benchmark.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: initial-d-dsh-plugin-mlquant-benchmark
+name: dsh-plugin-mlquant-benchmark
+description:
+  en: DeepSeek Harness tools for reproducing the ml-quant-trading protocol v1 benchmark.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - quantitative-finance
+  - benchmark
+  - reproducibility
+  - pytorch
+  - mlquant
+  - dsh
+source:
+  repository: https://github.com/initial-d/dsh-plugin-mlquant-benchmark
+  repositoryNodeId: R_kgDOT-ZtCQ
+  subpath: null
+  commit: 3468ab731c561c1fad8344e4981a0d3b3addff1e
+creator:
+  github: initial-d
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:49.448Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `initial-d-dsh-plugin-mlquant-benchmark`
- Submission type: community curation
- Created by `initial-d` — https://github.com/initial-d
- Original source repository: https://github.com/initial-d/dsh-plugin-mlquant-benchmark
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.