### PR TITLE
catalog: add inkshadewoods-dsh-tool-visual-primitives (community curation, created by @InkshadeWoods)

### DIFF
--- a/catalog/plugins/inkshadewoods-dsh-tool-visual-primitives.yaml
+++ b/catalog/plugins/inkshadewoods-dsh-tool-visual-primitives.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: inkshadewoods-dsh-tool-visual-primitives
+name: dsh-tool-visual-primitives
+description:
+  en: powershell dsh plugin --profile web add dsh-tool-visual-primitives@latest
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - vision
+  - visual-primitives
+  - multimodal
+source:
+  repository: https://github.com/InkshadeWoods/dsh-tool-visual-primitives
+  repositoryNodeId: R_kgDOT5Zi0A
+  subpath: null
+  commit: e1ba75ad226059c8df374df5c3c607f874e4f3d5
+creator:
+  github: InkshadeWoods
+package:
+  ecosystem: npm
+  name: dsh-tool-visual-primitives
+  version: 1.3.0
+  integrity: sha512-eOLzWR4ekBD+HN6k2MbdnVmpXGFVrruBMy/Qhhif7+bxVdhaTyyccDCfEYw38xUH3IJ8u85bnlRwQzlR7XfpwA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:34.933Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `inkshadewoods-dsh-tool-visual-primitives`
- Submission type: community curation
- Created by `InkshadeWoods` — https://github.com/InkshadeWoods
- Original source repository: https://github.com/InkshadeWoods/dsh-tool-visual-primitives
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.