### PR TITLE
catalog: add inmny-dsh-plugin-sandbox-escalation-fix (community curation, created by @inmny)

### DIFF
--- a/catalog/plugins/inmny-dsh-plugin-sandbox-escalation-fix.yaml
+++ b/catalog/plugins/inmny-dsh-plugin-sandbox-escalation-fix.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: inmny-dsh-plugin-sandbox-escalation-fix
+name: dsh-plugin-sandbox-escalation-fix
+description:
+  en: Normalize redundant sandbox requests and malformed justifications in DeepSeek Harness tools
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - sandbox
+  - approval
+source:
+  repository: https://github.com/inmny/dsh-sandbox-escalation-fix
+  repositoryNodeId: R_kgDOT4aNug
+  subpath: null
+  commit: a6fa9fa56302ea685d39e1e44ec1f7a15000b28c
+creator:
+  github: inmny
+package:
+  ecosystem: npm
+  name: dsh-plugin-sandbox-escalation-fix
+  version: 0.1.2
+  integrity: sha512-9lfDkz0olxhduPH4n0MCF45I3wTCc4i+dk48nIZOfSIYS+IZbnXbyvQvWAaJgoDM82C2SwYpZ9P8AkYkIYoPvA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:43:55.186Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `inmny-dsh-plugin-sandbox-escalation-fix`
- Submission type: community curation
- Created by `inmny` — https://github.com/inmny
- Original source repository: https://github.com/inmny/dsh-sandbox-escalation-fix
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.