### PR TITLE
catalog: add isheng-eqi-dsh-niulai-sound (community curation, created by @isheng-eqi)

### DIFF
--- a/catalog/plugins/isheng-eqi-dsh-niulai-sound.yaml
+++ b/catalog/plugins/isheng-eqi-dsh-niulai-sound.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: isheng-eqi-dsh-niulai-sound
+name: dsh-niulai-sound
+description:
+  en: sh dsh plugin --profile web add github:isheng-eqi/dsh-niulai-sound
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - niulai
+  - approval
+  - sound
+  - audio
+  - cordis
+source:
+  repository: https://github.com/isheng-eqi/dsh-niulai-sound
+  repositoryNodeId: R_kgDOT7XNOQ
+  subpath: null
+  commit: ab48ef06568561400c1a09ec265d3488562b48a3
+creator:
+  github: isheng-eqi
+package:
+  ecosystem: npm
+  name: dsh-niulai-sound
+  version: 1.0.0
+  integrity: sha512-wdhc9/BtTGLAOGcog3gVBZkEe95jQxYePsCpBs0p4LbkvjX+/1bsROJ78gYO7yR5gVE047/gwuBSazz9zK6liQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:15.182Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `isheng-eqi-dsh-niulai-sound`
- Submission type: community curation
- Created by `isheng-eqi` — https://github.com/isheng-eqi
- Original source repository: https://github.com/isheng-eqi/dsh-niulai-sound
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.