### PR TITLE
catalog: add ishuowang-dsh-agent-team-room (community curation, created by @ishuowang)

### DIFF
--- a/catalog/plugins/ishuowang-dsh-agent-team-room.yaml
+++ b/catalog/plugins/ishuowang-dsh-agent-team-room.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: ishuowang-dsh-agent-team-room
+name: dsh-agent-team-room
+description:
+  en: Native DSH rooms for connecting independent sessions and provider-backed AI members without bundled roles or scenarios.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - multi-agent
+  - agent-orchestration
+  - agent-room
+  - session-room
+  - rolehub
+  - native-ui
+  - cordis
+source:
+  repository: https://github.com/ishuowang/dsh-agent-team-room
+  repositoryNodeId: R_kgDOT4n-AQ
+  subpath: null
+  commit: 1b420c760f5db78a19c87f1e439a5b85db61a843
+creator:
+  github: ishuowang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:43:57.104Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ishuowang-dsh-agent-team-room`
- Submission type: community curation
- Created by `ishuowang` — https://github.com/ishuowang
- Original source repository: https://github.com/ishuowang/dsh-agent-team-room
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.