### PR TITLE
catalog: add ishuowang-dsh-rolehub-bridge (community curation, created by @ishuowang)

### DIFF
--- a/catalog/plugins/ishuowang-dsh-rolehub-bridge.yaml
+++ b/catalog/plugins/ishuowang-dsh-rolehub-bridge.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ishuowang-dsh-rolehub-bridge
+name: dsh-rolehub-bridge
+description:
+  en: Native RoleHub discovery, verified role Sessions, and Agent Team Room integration for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - rolehub
+  - agent-role
+  - multi-agent
+  - agent-orchestration
+  - native-ui
+  - cordis
+source:
+  repository: https://github.com/ishuowang/dsh-rolehub-bridge
+  repositoryNodeId: R_kgDOT5K5KA
+  subpath: null
+  commit: a0444e4effc017c3683894beddbacf2058d2e47d
+creator:
+  github: ishuowang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:51.317Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ishuowang-dsh-rolehub-bridge`
- Submission type: community curation
- Created by `ishuowang` — https://github.com/ishuowang
- Original source repository: https://github.com/ishuowang/dsh-rolehub-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.