### PR TITLE
catalog: add ishuowang-dsh-sideband (community curation, created by @ishuowang)

### DIFF
--- a/catalog/plugins/ishuowang-dsh-sideband.yaml
+++ b/catalog/plugins/ishuowang-dsh-sideband.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ishuowang-dsh-sideband
+name: dsh-sideband
+description:
+  en: Asynchronous, LLM-summarized context handoff between DeepSeek Harness sessions and agent rooms.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - context-handoff
+  - agent-orchestration
+  - sideband
+  - multi-agent
+  - session-relay
+  - native-ui
+source:
+  repository: https://github.com/ishuowang/dsh-sideband
+  repositoryNodeId: R_kgDOT4q6-w
+  subpath: null
+  commit: 393acf603fbbfec89958f5c8735e26e7a5da477c
+creator:
+  github: ishuowang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:17.212Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ishuowang-dsh-sideband`
- Submission type: community curation
- Created by `ishuowang` — https://github.com/ishuowang
- Original source repository: https://github.com/ishuowang/dsh-sideband
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.