### PR TITLE
catalog: add islibaodong-dsh-login (community curation, created by @islibaodong)

### DIFF
--- a/catalog/plugins/islibaodong-dsh-login.yaml
+++ b/catalog/plugins/islibaodong-dsh-login.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: islibaodong-dsh-login
+name: "@islibaodong/dsh-login"
+description:
+  en: Multi-user authentication gateway plugin for the DSH Web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - multi
+  - user
+  - authentication
+  - gateway
+  - dsh
+source:
+  repository: https://github.com/islibaodong/dsh-login
+  repositoryNodeId: R_kgDOT67wzA
+  subpath: null
+  commit: 3949b67ebc5297f489bc247c414f57cca2498f86
+creator:
+  github: islibaodong
+package:
+  ecosystem: npm
+  name: "@islibaodong/dsh-login"
+  version: 0.1.0
+  integrity: sha512-XJYSDQRC7TklKRJbeABifykg7xMVDHT7YOtyMsa9pGCu0Agp9/B7ZE2nmQSJTj9hNBN1O0oD/P3euqv/sE1ylg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:54.622Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `islibaodong-dsh-login`
- Submission type: community curation
- Created by `islibaodong` — https://github.com/islibaodong
- Original source repository: https://github.com/islibaodong/dsh-login
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.