### PR TITLE
catalog: add itailang2333-dsh-skill-cockpit (community curation, created by @Itailang2333)

### DIFF
--- a/catalog/plugins/itailang2333-dsh-skill-cockpit.yaml
+++ b/catalog/plugins/itailang2333-dsh-skill-cockpit.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: itailang2333-dsh-skill-cockpit
+name: dsh-skill-cockpit
+description:
+  en: "DSH web plugin: Skill Cockpit panel in Settings. See all skills (system/project/pool) with Chinese notes, search, enable/disable/delete/import, local test-fire scoring, and per-skill usage stats to spot zombie skills."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skill
+  - skill-cockpit
+  - agent-skills
+  - cordis
+source:
+  repository: https://github.com/Itailang2333/dsh-skill-cockpit
+  repositoryNodeId: R_kgDOT7Iy6A
+  subpath: null
+  commit: 0c62324912df06ba3d31dc6c18f7bb3e72c57745
+creator:
+  github: Itailang2333
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:20.680Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `itailang2333-dsh-skill-cockpit`
- Submission type: community curation
- Created by `Itailang2333` — https://github.com/Itailang2333
- Original source repository: https://github.com/Itailang2333/dsh-skill-cockpit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.