### PR TITLE
catalog: add itr-del-dsh-cue-bank (community curation, created by @itr-del)

### DIFF
--- a/catalog/plugins/itr-del-dsh-cue-bank.yaml
+++ b/catalog/plugins/itr-del-dsh-cue-bank.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: itr-del-dsh-cue-bank
+name: dsh-cue-bank
+description:
+  en: "Cross-session memory cue bank for DeepSeek Harness: builds a persistent event-cue library (keywords, user language idiosyncrasies) and re-activates remembered event details on topic switches, mirroring human episodic recall."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - memory
+  - cue-bank
+  - cross-session
+  - context
+source:
+  repository: https://github.com/itr-del/dsh-cue-bank
+  repositoryNodeId: R_kgDOT5M9Cg
+  subpath: null
+  commit: 490ab615e6a486fbe8498335ed27d1210a57ab9d
+creator:
+  github: itr-del
+package:
+  ecosystem: npm
+  name: dsh-cue-bank
+  version: 0.1.0
+  integrity: sha512-/kD5InYp9bCi8IkBd6/eEPGG0lDgiqC0oOBLvcyqUee2FfqoelvRwFnq4/KG56XyGr7RJcvbnAVEwR9Px+3OSg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:56.107Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `itr-del-dsh-cue-bank`
- Submission type: community curation
- Created by `itr-del` — https://github.com/itr-del
- Original source repository: https://github.com/itr-del/dsh-cue-bank
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.