### PR TITLE
catalog: add ivanhby930-cmd-dsh-plugin-retitle (community curation, created by @ivanhby930-cmd)

### DIFF
--- a/catalog/plugins/ivanhby930-cmd-dsh-plugin-retitle.yaml
+++ b/catalog/plugins/ivanhby930-cmd-dsh-plugin-retitle.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: ivanhby930-cmd-dsh-plugin-retitle
+name: dsh-plugin-retitle
+description:
+  en: bash dsh plugin --profile web add ./dsh-plugin-retitle
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - bash
+  - profile
+  - retitle
+  - dsh
+source:
+  repository: https://github.com/ivanhby930-cmd/dsh-plugin-retitle
+  repositoryNodeId: R_kgDOT8Ianw
+  subpath: null
+  commit: 63959028831bf97af3cf9719b062e15870c3b7ed
+creator:
+  github: ivanhby930-cmd
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:22.259Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ivanhby930-cmd-dsh-plugin-retitle`
- Submission type: community curation
- Created by `ivanhby930-cmd` — https://github.com/ivanhby930-cmd
- Original source repository: https://github.com/ivanhby930-cmd/dsh-plugin-retitle
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.