### PR TITLE
catalog: add iwtown-dsh-llm-wiki (community curation, created by @iwtown)

### DIFF
--- a/catalog/plugins/iwtown-dsh-llm-wiki.yaml
+++ b/catalog/plugins/iwtown-dsh-llm-wiki.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: iwtown-dsh-llm-wiki
+name: dsh-llm-wiki
+description:
+  en: 组件 文件 部署位置 --- --- --- 生命周期插件 plugin/dsh-llm-wiki.mjs ~/.dsh/profiles/web/（cordis.patch.yml 挂载） 检索技能 skills/wiki-search/SKILL.md ~/.agents/skills/wiki-search/ 写入技能 skills/wiki-write/SKILL.md ~/.agents/skills/wiki-write/ 管线 scripts/llm-wiki-pipeline.mjs ~/bin/ 向量代理 scripts/embed-proxy.mjs ~/bin/ + systemd 服务 定时 systemd/
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - llm-wiki
+  - obsidian
+  - knowledge-management
+  - karpathy
+  - dsh
+source:
+  repository: https://github.com/iwtown/dsh-llm-wiki
+  repositoryNodeId: R_kgDOUEkmCg
+  subpath: null
+  commit: 90030d862e247f24678c5429374169ab7dffde99
+creator:
+  github: iwtown
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:37.388Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `iwtown-dsh-llm-wiki`
- Submission type: community curation
- Created by `iwtown` — https://github.com/iwtown
- Original source repository: https://github.com/iwtown/dsh-llm-wiki
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.