### PR TITLE
catalog: add izz-blue-dsh-deepseek-usage-dashboard (community curation, created by @izz-BLUE)

### DIFF
--- a/catalog/plugins/izz-blue-dsh-deepseek-usage-dashboard.yaml
+++ b/catalog/plugins/izz-blue-dsh-deepseek-usage-dashboard.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: izz-blue-dsh-deepseek-usage-dashboard
+name: "@linxin666/dsh-deepseek-usage-dashboard"
+description:
+  en: Daily DeepSeek token usage dashboard and balance watch for DSH Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - daily
+  - token
+  - usage
+  - dashboard
+  - balance
+  - watch
+  - dsh
+source:
+  repository: https://github.com/izz-BLUE/dsh-deepseek-usage-dashboard
+  repositoryNodeId: R_kgDOT4HhnA
+  subpath: null
+  commit: dd648b720dc528fb44486d518d3192509ca8a7f5
+creator:
+  github: izz-BLUE
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:19.368Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `izz-blue-dsh-deepseek-usage-dashboard`
- Submission type: community curation
- Created by `izz-BLUE` — https://github.com/izz-BLUE
- Original source repository: https://github.com/izz-BLUE/dsh-deepseek-usage-dashboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.