### PR TITLE
catalog: add izz-blue-dsh-devtools (community curation, created by @izz-BLUE)

### DIFF
--- a/catalog/plugins/izz-blue-dsh-devtools.yaml
+++ b/catalog/plugins/izz-blue-dsh-devtools.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: izz-blue-dsh-devtools
+name: dsh-devtools
+description:
+  en: "DevTools for DeepSeek Harness web: read-only Agent Runtime Trace — turn/step execution timeline, model latency (TTFT/decode), tool-call durations, retries, hook and turn end reasons. Metadata-first, durable events only, zero behavior modification."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - devtools
+  - read
+  - only
+  - agent
+  - runtime
+  - trace
+  - turn
+  - step
+  - execution
+  - timeline
+  - model
+  - latency
+  - ttft
+  - decode
+  - tool
+  - call
+source:
+  repository: https://github.com/izz-BLUE/dsh-devtools
+  repositoryNodeId: R_kgDOT5Edgg
+  subpath: null
+  commit: a5353db21bfd24a05ba5fc433722e38fe0e1cde6
+creator:
+  github: izz-BLUE
+package:
+  ecosystem: npm
+  name: dsh-devtools
+  version: 0.1.1
+  integrity: sha512-U2+DkuC72/WH22yq6R3MfjLe6zSDejyjeodV39dXjHIzcXr24yWsLI0aGq4aW6tSXEA1EnMfDPp3kdLNZNmW4w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:57.831Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `izz-blue-dsh-devtools`
- Submission type: community curation
- Created by `izz-BLUE` — https://github.com/izz-BLUE
- Original source repository: https://github.com/izz-BLUE/dsh-devtools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.