### PR TITLE
catalog: add j0ss077-dsh-always-require-tools-approval (community curation, created by @J0ss077)

### DIFF
--- a/catalog/plugins/j0ss077-dsh-always-require-tools-approval.yaml
+++ b/catalog/plugins/j0ss077-dsh-always-require-tools-approval.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: j0ss077-dsh-always-require-tools-approval
+name: "@j0ss077/dsh-always-require-tools-approval"
+description:
+  en: Require a one-shot user approval before configured tools execute
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - require
+  - shot
+  - user
+  - approval
+  - before
+  - configured
+  - tools
+  - execute
+  - dsh
+source:
+  repository: https://github.com/J0ss077/dsh-always-require-tools-approval
+  repositoryNodeId: R_kgDOUCQAiw
+  subpath: null
+  commit: 7291e28b87444890bd9c82e848f6861b72b21246
+creator:
+  github: J0ss077
+package:
+  ecosystem: npm
+  name: "@j0ss077/dsh-always-require-tools-approval"
+  version: 1.1.0
+  integrity: sha512-+PGnxz4ONW5i/fOWvmpBehUXXKgro/T26h21pzDwHTe3u/waQcgXe5/e15IJXx2K4edsV+i6yMRpF5ZrGzFMqw==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:59.737Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `j0ss077-dsh-always-require-tools-approval`
- Submission type: community curation
- Created by `J0ss077` — https://github.com/J0ss077
- Original source repository: https://github.com/J0ss077/dsh-always-require-tools-approval
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.