### PR TITLE
catalog: add jackcontrols-dsh-telegram-control (community curation, created by @jackControls)

### DIFF
--- a/catalog/plugins/jackcontrols-dsh-telegram-control.yaml
+++ b/catalog/plugins/jackcontrols-dsh-telegram-control.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jackcontrols-dsh-telegram-control
+name: dsh-telegram-control
+description:
+  en: "Remote-control plugin for DeepSeek Harness (dsh): drive agents, jobs and status from a Telegram bot"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - telegram
+  - remote-control
+source:
+  repository: https://github.com/jackControls/dsh-telegram-control
+  repositoryNodeId: R_kgDOT9AGfg
+  subpath: null
+  commit: 2430ffb80c7526d8a86184ea5107ae0f2ff4e431
+creator:
+  github: jackControls
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:39.752Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jackcontrols-dsh-telegram-control`
- Submission type: community curation
- Created by `jackControls` — https://github.com/jackControls
- Original source repository: https://github.com/jackControls/dsh-telegram-control
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.