### PR TITLE
catalog: add jacujay-dsh-model-balance (community curation, created by @jacujay)

### DIFF
--- a/catalog/plugins/jacujay-dsh-model-balance.yaml
+++ b/catalog/plugins/jacujay-dsh-model-balance.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: jacujay-dsh-model-balance
+name: dsh-model-balance
+description:
+  en: Auto-detect the current model vendor and show its balance or quota in the composer input row, with a settings page for custom endpoints.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - balance
+  - quota
+  - usage
+source:
+  repository: https://github.com/jacujay/dsh-model-balance
+  repositoryNodeId: R_kgDOT8hm1Q
+  subpath: null
+  commit: db0c331a0d6d92ee9596cc55a31527e6052a935d
+creator:
+  github: jacujay
+package:
+  ecosystem: npm
+  name: dsh-model-balance
+  version: 0.1.2
+  integrity: sha512-pyW1Pyh15Ptkv0Rsl9RRbRe6NMU7hvOyX4TBVfk14i0Eb+xZjeGIsc0FhY/aGLiZHTTZpxVDnlRwWiE2lu1sCg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:41.670Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jacujay-dsh-model-balance`
- Submission type: community curation
- Created by `jacujay` — https://github.com/jacujay
- Original source repository: https://github.com/jacujay/dsh-model-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.