### PR TITLE
catalog: add jarvisluk-dsh-projectless-session (community curation, created by @jarvisluk)

### DIFF
--- a/catalog/plugins/jarvisluk-dsh-projectless-session.yaml
+++ b/catalog/plugins/jarvisluk-dsh-projectless-session.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: jarvisluk-dsh-projectless-session
+name: dsh-projectless-session
+description:
+  en: DeepSeek Harness Web plugin for date-organized projectless sessions under Documents/DSH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - projectless-session
+source:
+  repository: https://github.com/jarvisluk/dsh-projectless-session
+  repositoryNodeId: R_kgDOT8H6vw
+  subpath: null
+  commit: 8d1798dd213ce5aec193b76a316a2d3c08df2a73
+creator:
+  github: jarvisluk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:46.226Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jarvisluk-dsh-projectless-session`
- Submission type: community curation
- Created by `jarvisluk` — https://github.com/jarvisluk
- Original source repository: https://github.com/jarvisluk/dsh-projectless-session
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.