### PR TITLE
catalog: add jasen215-dsh-continual-harness (community curation, created by @jasen215)

### DIFF
--- a/catalog/plugins/jasen215-dsh-continual-harness.yaml
+++ b/catalog/plugins/jasen215-dsh-continual-harness.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: jasen215-dsh-continual-harness
+name: dsh-continual-harness
+description:
+  en: "Standalone DeepSeek Harness plugin: continual harness self-evolution. The agent persists and refines reusable prompt notes, memories, skill contracts, and subagent specs through small evidence-backed edits, with automatic refinement gates, rollback, and prompt injection."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - self-improvement
+  - continual-harness
+  - agent
+  - dsh
+source:
+  repository: https://github.com/jasen215/dsh-continual-harness
+  repositoryNodeId: R_kgDOT7LX-w
+  subpath: null
+  commit: 290cc0605fcbeed78cdb7f057c79078adfb8290f
+creator:
+  github: jasen215
+package:
+  ecosystem: npm
+  name: dsh-continual-harness
+  version: 0.2.1
+  integrity: sha512-eR4QAN/xiRYDFf7OQhwrgKyRiDbruPYAiCNv4cGqDdaaMhUQNVMBwOFnli+L37sx0FcIejhzFEYuPJ5H0PELaA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:43:50.576Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jasen215-dsh-continual-harness`
- Submission type: community curation
- Created by `jasen215` — https://github.com/jasen215
- Original source repository: https://github.com/jasen215/dsh-continual-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.