### PR TITLE
catalog: add jason-skd-dsh-session-fork (community curation, created by @Jason-skd)

### DIFF
--- a/catalog/plugins/jason-skd-dsh-session-fork.yaml
+++ b/catalog/plugins/jason-skd-dsh-session-fork.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jason-skd-dsh-session-fork
+name: dsh-session-fork
+description:
+  en: "dsh plugin: git-like conversation forking (branch refs on sessions)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - conversation
+  - forking
+  - branch
+  - refs
+  - sessions
+  - dsh
+source:
+  repository: https://github.com/Jason-skd/dsh-session-fork
+  repositoryNodeId: R_kgDOT-tM3g
+  subpath: null
+  commit: 929d585689a8bff2809336b4f60e820dad87638c
+creator:
+  github: Jason-skd
+package:
+  ecosystem: npm
+  name: dsh-session-fork
+  version: 0.2.0
+  integrity: sha512-4hAiubTWZGCzUrgSAmw/Y5joHvHK0B4tBNkwHVz2cY+2mEYXZUc/CDE1Z/SjUeTub4Q7rHn4RWJpvC26WoX7Fg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:20.958Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jason-skd-dsh-session-fork`
- Submission type: community curation
- Created by `Jason-skd` — https://github.com/Jason-skd
- Original source repository: https://github.com/Jason-skd/dsh-session-fork
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.