### PR TITLE
catalog: add jazzulu-find-dsh-plugins (community curation, created by @JazzuLu)

### DIFF
--- a/catalog/plugins/jazzulu-find-dsh-plugins.yaml
+++ b/catalog/plugins/jazzulu-find-dsh-plugins.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: jazzulu-find-dsh-plugins
+name: find-dsh-plugins
+description:
+  en: A conversational plugin finder for DeepSeek Harness — semantic search × four-source aggregation × security audit.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - conversational
+  - finder
+  - semantic
+  - search
+  - four
+  - source
+  - aggregation
+  - security
+  - audit
+  - dsh
+source:
+  repository: https://github.com/JazzuLu/find-dsh-plugins
+  repositoryNodeId: R_kgDOT5USsg
+  subpath: null
+  commit: d31b01fcb6fd0f1af80d0106c6aeed76c59e1a90
+creator:
+  github: JazzuLu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:35.344Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jazzulu-find-dsh-plugins`
- Submission type: community curation
- Created by `JazzuLu` — https://github.com/JazzuLu
- Original source repository: https://github.com/JazzuLu/find-dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.