### PR TITLE
catalog: add jeremy9682-dsh-codex-observability (community curation, created by @jeremy9682)

### DIFF
--- a/catalog/plugins/jeremy9682-dsh-codex-observability.yaml
+++ b/catalog/plugins/jeremy9682-dsh-codex-observability.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: jeremy9682-dsh-codex-observability
+name: dsh-codex-observability
+description:
+  en: "Two small plugins for DeepSeek Harness that close the observability gap around external subagent runs. Background and upstream proposal: discussion 1493."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - small
+  - close
+  - observability
+  - around
+  - external
+  - subagent
+  - runs
+  - background
+  - upstream
+  - proposal
+  - discussion
+  - "1493"
+  - dsh
+source:
+  repository: https://github.com/jeremy9682/dsh-observability
+  repositoryNodeId: R_kgDOT4ooUQ
+  subpath: null
+  commit: f5bdac556c0f4e6b61bd89201ec0e2401fb45c8e
+creator:
+  github: jeremy9682
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:03.406Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jeremy9682-dsh-codex-observability`
- Submission type: community curation
- Created by `jeremy9682` — https://github.com/jeremy9682
- Original source repository: https://github.com/jeremy9682/dsh-observability
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.