### PR TITLE
catalog: add jeremy9682-dsh-llm-cursor-acp (community curation, created by @jeremy9682)

### DIFF
--- a/catalog/plugins/jeremy9682-dsh-llm-cursor-acp.yaml
+++ b/catalog/plugins/jeremy9682-dsh-llm-cursor-acp.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jeremy9682-dsh-llm-cursor-acp
+name: "@jeremy9682/dsh-llm-cursor-acp"
+description:
+  en: Cursor ACP native model provider for DeepSeek Harness
+  evidencePath: cursor-provider/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - cursor
+  - acp
+  - llm-provider
+  - model-provider
+  - dsh
+source:
+  repository: https://github.com/jeremy9682/dsh-cursor-codex
+  repositoryNodeId: R_kgDOT4yoLw
+  subpath: cursor-provider
+  commit: 81def5abbc01bd5b461710ed11a595bb4355f5f7
+creator:
+  github: jeremy9682
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cursor-provider/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:37.577Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jeremy9682-dsh-llm-cursor-acp`
- Submission type: community curation
- Created by `jeremy9682` — https://github.com/jeremy9682
- Original source repository: https://github.com/jeremy9682/dsh-cursor-codex
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.