### PR TITLE
catalog: add jeremy9682-dsh-skill-pack (community curation, created by @jeremy9682)

### DIFF
--- a/catalog/plugins/jeremy9682-dsh-skill-pack.yaml
+++ b/catalog/plugins/jeremy9682-dsh-skill-pack.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jeremy9682-dsh-skill-pack
+name: "@jeremy9682/dsh-skill-pack"
+description:
+  en: A shareable set of 12 workflow skills for the DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skills
+  - workflow
+source:
+  repository: https://github.com/jeremy9682/dsh-skill-pack
+  repositoryNodeId: R_kgDOT40qkg
+  subpath: null
+  commit: 6e0bed1aa846ef00ee6fdd3d8bf9c63b46b014e2
+creator:
+  github: jeremy9682
+package:
+  ecosystem: npm
+  name: "@jeremy9682/dsh-skill-pack"
+  version: 0.2.0
+  integrity: sha512-/r0eaJagl092Xl/M5138B6DNeV9K7NXog5kR98DvdwvZV/h+gW3/bWACxwGxiDLJDziyC+5tZhuv4g1NSEfvdA==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:07.232Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jeremy9682-dsh-skill-pack`
- Submission type: community curation
- Created by `jeremy9682` — https://github.com/jeremy9682
- Original source repository: https://github.com/jeremy9682/dsh-skill-pack
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.