### PR TITLE
catalog: add jeremy9682-dsh-tool-cursor (community curation, created by @jeremy9682)

### DIFF
--- a/catalog/plugins/jeremy9682-dsh-tool-cursor.yaml
+++ b/catalog/plugins/jeremy9682-dsh-tool-cursor.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: jeremy9682-dsh-tool-cursor
+name: dsh-tool-cursor
+description:
+  en: Delegate a task to Cursor's agent through the official cursor-agent CLI (headless), ported from the opencodex cursor.ts tool.
+  evidencePath: plugin-cursor/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - delegate
+  - task
+  - cursor
+  - agent
+  - through
+  - official
+  - headless
+  - ported
+  - opencodex
+  - tool
+  - dsh
+source:
+  repository: https://github.com/jeremy9682/dsh-observability
+  repositoryNodeId: R_kgDOT4ooUQ
+  subpath: plugin-cursor
+  commit: f5bdac556c0f4e6b61bd89201ec0e2401fb45c8e
+creator:
+  github: jeremy9682
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: plugin-cursor/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:03.406Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jeremy9682-dsh-tool-cursor`
- Submission type: community curation
- Created by `jeremy9682` — https://github.com/jeremy9682
- Original source repository: https://github.com/jeremy9682/dsh-observability
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.