### PR TITLE
catalog: add jermaine123123-context-editor-deepseek-harness (community curation, created by @jermaine123123)

### DIFF
--- a/catalog/plugins/jermaine123123-context-editor-deepseek-harness.yaml
+++ b/catalog/plugins/jermaine123123-context-editor-deepseek-harness.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jermaine123123-context-editor-deepseek-harness
+name: context-editor-deepseek-harness
+description:
+  en: Context Editor view and native context projection for DeepSeek Harness
+  evidencePath: adapters/deepseek-harness/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - context
+  - editor
+  - view
+  - native
+  - projection
+  - dsh
+source:
+  repository: https://github.com/jermaine123123/agent-context-editor
+  repositoryNodeId: R_kgDOT7004g
+  subpath: adapters/deepseek-harness
+  commit: e7c6e83987bba198bca891a5307ccdde77bc0dfa
+creator:
+  github: jermaine123123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: adapters/deepseek-harness/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:47.036Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jermaine123123-context-editor-deepseek-harness`
- Submission type: community curation
- Created by `jermaine123123` — https://github.com/jermaine123123
- Original source repository: https://github.com/jermaine123123/agent-context-editor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.