### PR TITLE
catalog: add jerryjiao-dsh-wewrite (community curation, created by @jerryjiao)

### DIFF
--- a/catalog/plugins/jerryjiao-dsh-wewrite.yaml
+++ b/catalog/plugins/jerryjiao-dsh-wewrite.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jerryjiao-dsh-wewrite
+name: dsh-wewrite
+description:
+  en: WeChat official account AI writing pipeline as a DeepSeek Harness (DSH) plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - wechat
+  - official
+  - account
+  - writing
+  - pipeline
+  - dsh
+source:
+  repository: https://github.com/jerryjiao/dsh-wewrite
+  repositoryNodeId: R_kgDOT8i7sA
+  subpath: null
+  commit: 6d55f15ea20634f3f1f904b32bdb12e6eb17b963
+creator:
+  github: jerryjiao
+package:
+  ecosystem: npm
+  name: dsh-wewrite
+  version: 0.5.3
+  integrity: sha512-Yzd2OhZH7+vCfgOrkBY8BGhkLriXrD/DTRP37POSMCix0i5irIGHzC7DklgAdiErD0Tgs/9dr5DasQCwwi0mlw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:05.994Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jerryjiao-dsh-wewrite`
- Submission type: community curation
- Created by `jerryjiao` — https://github.com/jerryjiao
- Original source repository: https://github.com/jerryjiao/dsh-wewrite
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.