### PR TITLE
catalog: add jesmonx-dsh-web-shell (community curation, created by @JesmonX)

### DIFF
--- a/catalog/plugins/jesmonx-dsh-web-shell.yaml
+++ b/catalog/plugins/jesmonx-dsh-web-shell.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: jesmonx-dsh-web-shell
+name: dsh-web-shell
+description:
+  en: "Collapsible web terminal for DeepSeek Harness: a right-docked xterm.js shell (bash/zsh) over a WebSocket PTY bridge."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - collapsible
+  - terminal
+  - right
+  - docked
+  - xterm
+  - shell
+  - bash
+  - over
+  - websocket
+  - bridge
+  - dsh
+source:
+  repository: https://github.com/JesmonX/dsh-web-shell
+  repositoryNodeId: R_kgDOT5BolA
+  subpath: null
+  commit: 97f9ce4dc3c4c836bab0b8c30afed10a1160b520
+creator:
+  github: JesmonX
+package:
+  ecosystem: npm
+  name: dsh-web-shell
+  version: 0.1.1
+  integrity: sha512-X+bvhuU+mCKX9hdv+JU7Vp04QB4sFeJUGgtRwk5g1j7AypZMrx3CWqqNu4g7JmbfoRyJPF93IhxG0KtnoUje3g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:07.710Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jesmonx-dsh-web-shell`
- Submission type: community curation
- Created by `JesmonX` — https://github.com/JesmonX
- Original source repository: https://github.com/JesmonX/dsh-web-shell
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.