### PR TITLE
catalog: add jfwaskin-dsh-git-nexus (community curation, created by @JFWaskin)

### DIFF
--- a/catalog/plugins/jfwaskin-dsh-git-nexus.yaml
+++ b/catalog/plugins/jfwaskin-dsh-git-nexus.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jfwaskin-dsh-git-nexus
+name: dsh-git-nexus
+description:
+  en: "DSH web plugin: unified Git + GitHub + workflow + files panel (branch, stage/unstage, diff, commit, push/pull/sync, log, files, GitHub OAuth full access, workflow board)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - git
+  - oauth
+  - workflow
+source:
+  repository: https://github.com/JFWaskin/dsh-git-nexus
+  repositoryNodeId: R_kgDOT5uqtA
+  subpath: null
+  commit: 65b63233a905c70cb4152f70153917e11fded4c6
+creator:
+  github: JFWaskin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:48.107Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jfwaskin-dsh-git-nexus`
- Submission type: community curation
- Created by `JFWaskin` — https://github.com/JFWaskin
- Original source repository: https://github.com/JFWaskin/dsh-git-nexus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.