### PR TITLE
catalog: add jiangli07-dsh-deepseek-quota-bar (community curation, created by @jiangli07)

### DIFF
--- a/catalog/plugins/jiangli07-dsh-deepseek-quota-bar.yaml
+++ b/catalog/plugins/jiangli07-dsh-deepseek-quota-bar.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: jiangli07-dsh-deepseek-quota-bar
+name: dsh-deepseek-quota-bar
+description:
+  en: "DeepSeek API quota widget for the dsh web GUI: floating bottom-right card with a blood-bar of remaining balance vs month-opening balance, plus today/month spend and current conversation cost (fork of dsh-deepseek-quota)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - quota
+  - balance
+  - usage
+  - cost
+  - web
+source:
+  repository: https://github.com/jiangli07/dsh-deepseek-quota-bar
+  repositoryNodeId: R_kgDOT5Bnng
+  subpath: null
+  commit: 67556ca89abb5c1465244771801292e8469675d0
+creator:
+  github: jiangli07
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:08.975Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiangli07-dsh-deepseek-quota-bar`
- Submission type: community curation
- Created by `jiangli07` — https://github.com/jiangli07
- Original source repository: https://github.com/jiangli07/dsh-deepseek-quota-bar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.