### PR TITLE
catalog: add jiangwangyang-dsh-theme-blackhole (community curation, created by @jiangwangyang)

### DIFF
--- a/catalog/plugins/jiangwangyang-dsh-theme-blackhole.yaml
+++ b/catalog/plugins/jiangwangyang-dsh-theme-blackhole.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: jiangwangyang-dsh-theme-blackhole
+name: dsh-theme-blackhole
+description:
+  en: "Black hole theme plugin for the DeepSeek Harness Web UI: WebGL Schwarzschild black hole background with deep-space glass panels, switchable from Settings General 主题-黑洞. Install into a web profile: dsh plugin --profile web add <path-to-this-package"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - black
+  - hole
+  - theme
+  - webgl
+  - schwarzschild
+  - background
+  - deep
+  - space
+  - glass
+  - panels
+  - switchable
+  - settings
+  - general
+  - install
+  - profile
+  - path
+source:
+  repository: https://github.com/jiangwangyang/dsh-theme-blackhole
+  repositoryNodeId: R_kgDOT-kGMA
+  subpath: null
+  commit: b32e855fce0f8bfd3ccfd1fcb897328a9f62bd8e
+creator:
+  github: jiangwangyang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:52.397Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiangwangyang-dsh-theme-blackhole`
- Submission type: community curation
- Created by `jiangwangyang` — https://github.com/jiangwangyang
- Original source repository: https://github.com/jiangwangyang/dsh-theme-blackhole
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.