### PR TITLE
catalog: add jiayan-xu-dsh-memoria (community curation, created by @jiayan-xu)

### DIFF
--- a/catalog/plugins/jiayan-xu-dsh-memoria.yaml
+++ b/catalog/plugins/jiayan-xu-dsh-memoria.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: jiayan-xu-dsh-memoria
+name: "@jhp830901/dsh-memoria"
+description:
+  en: "memoria memory backend for dsh: registers memoria observe / memoria remember / memoria search / memoria recall so the dsh agent can persist to and recall from a vector+graph memory layer (memoria, default http://127.0.0.1:9003). Includes auto-write: turn-end observation and positive-feedback - importance-5 remember."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - memoria
+  - memory
+  - backend
+  - registers
+  - observe
+  - remember
+  - search
+  - recall
+  - agent
+  - persist
+  - vector
+  - graph
+  - layer
+  - default
+  - "9003"
+  - includes
+source:
+  repository: https://github.com/jiayan-xu/dsh-memoria
+  repositoryNodeId: R_kgDOT37tFA
+  subpath: null
+  commit: 436a55a823f77f063cfe8bec301790326115f447
+creator:
+  github: jiayan-xu
+package:
+  ecosystem: npm
+  name: "@jhp830901/dsh-memoria"
+  version: 0.2.1
+  integrity: sha512-aCqs0V9zD0EY7oIL35+Pf7P1IQAKoH2TSZy9vCc0C+QBYC+d0mBB3lYaS8CHM/jWvCWvVbm0sNplweJ0SkIJwA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:28.038Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiayan-xu-dsh-memoria`
- Submission type: community curation
- Created by `jiayan-xu` — https://github.com/jiayan-xu
- Original source repository: https://github.com/jiayan-xu/dsh-memoria
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.