### PR TITLE
catalog: add jiel521125-dsh-tianshu-analyzer (community curation, created by @jiel521125)

### DIFF
--- a/catalog/plugins/jiel521125-dsh-tianshu-analyzer.yaml
+++ b/catalog/plugins/jiel521125-dsh-tianshu-analyzer.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jiel521125-dsh-tianshu-analyzer
+name: dsh-tianshu-analyzer
+description:
+  en: TianShu (天枢) — Failure root-cause analyzer for DeepSeek Harness. Detects why an agent session failed, suggests fork points, and produces shareable diagnostic reports.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent
+  - diagnostics
+  - root-cause-analysis
+source:
+  repository: https://github.com/jiel521125/dsh-anlayzer
+  repositoryNodeId: R_kgDOT7-rsw
+  subpath: null
+  commit: 776e740e352b4159666d3302bd98c654a3117b13
+creator:
+  github: jiel521125
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:49.154Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiel521125-dsh-tianshu-analyzer`
- Submission type: community curation
- Created by `jiel521125` — https://github.com/jiel521125
- Original source repository: https://github.com/jiel521125/dsh-anlayzer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.