### PR TITLE
catalog: add jilian-dsh-dsh-rule-engine (community curation, created by @jilian-dsh)

### DIFF
--- a/catalog/plugins/jilian-dsh-dsh-rule-engine.yaml
+++ b/catalog/plugins/jilian-dsh-dsh-rule-engine.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: jilian-dsh-dsh-rule-engine
+name: dsh-rule-engine
+description:
+  en: bash dsh plugin --profile web add dsh-rule-engine
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - rules
+  - guard
+  - security
+  - agent
+source:
+  repository: https://github.com/jilian-dsh/dsh-rule-engine
+  repositoryNodeId: R_kgDOT5lVYw
+  subpath: null
+  commit: fd6997fffc1263957bb28c610d0747ac19cc2496
+creator:
+  github: jilian-dsh
+package:
+  ecosystem: npm
+  name: dsh-rule-engine
+  version: 0.5.8
+  integrity: sha512-JMle5uQ4cq2kLyAcrTOy00roezdNz+lG5fQgPOePSzsV3o4SmqYZZAaJdk1E3IklOPBWD2uWs1I2NrsCXfHBDw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:31.444Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jilian-dsh-dsh-rule-engine`
- Submission type: community curation
- Created by `jilian-dsh` — https://github.com/jilian-dsh
- Original source repository: https://github.com/jilian-dsh/dsh-rule-engine
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.