### PR TITLE
catalog: add jilian-dsh-dsh-rules-manager (community curation, created by @jilian-dsh)

### DIFF
--- a/catalog/plugins/jilian-dsh-dsh-rules-manager.yaml
+++ b/catalog/plugins/jilian-dsh-dsh-rules-manager.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: jilian-dsh-dsh-rules-manager
+name: dsh-rules-manager
+description:
+  en: "DeepSeek Harness (dsh) rules, commands & skills manager: /rules slash command, settings panel with visual rule editing, command list, user-defined custom commands (with {input} argument support, disable/enable), skill management (view/disable/enable/delete-to-trash), and backup restore. Installable as an official dsh b"
+  evidencePath: dsh-rules-manager/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - rules
+  - commands
+  - agent
+source:
+  repository: https://github.com/jilian-dsh/dsh-rules-manager
+  repositoryNodeId: R_kgDOT4EKxg
+  subpath: dsh-rules-manager
+  commit: a2dba04eeae2aa04f4e7ac667c3758758fa7d1c4
+creator:
+  github: jilian-dsh
+package:
+  ecosystem: npm
+  name: dsh-rules-manager
+  version: 1.5.1
+  integrity: sha512-jJQ4asMJfqYkOSdyR4z0HfTNN+YdmNrxQRnw8BpTJ88zZUKkQlIbKTd5dg7lv9XWFffWOYx1W6f+3NLiSN21fQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-rules-manager/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:51.254Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jilian-dsh-dsh-rules-manager`
- Submission type: community curation
- Created by `jilian-dsh` — https://github.com/jilian-dsh
- Original source repository: https://github.com/jilian-dsh/dsh-rules-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.