### PR TITLE
catalog: add jimchen-g-dsh-frontier-repro (community curation, created by @JimChen-g)

### DIFF
--- a/catalog/plugins/jimchen-g-dsh-frontier-repro.yaml
+++ b/catalog/plugins/jimchen-g-dsh-frontier-repro.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: jimchen-g-dsh-frontier-repro
+name: dsh-frontier-repro
+description:
+  en: Evidence-first frontier AI radar and reproducibility gate for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - ai-research
+  - reproducibility
+  - arxiv
+  - dsh
+source:
+  repository: https://github.com/JimChen-g/dsh-frontier-repro
+  repositoryNodeId: R_kgDOT6PAvA
+  subpath: null
+  commit: 95ef63bef431ece1092201d6eae91ff3bf674e9d
+creator:
+  github: JimChen-g
+package:
+  ecosystem: npm
+  name: dsh-frontier-repro
+  version: 0.3.1
+  integrity: sha512-XN1mhehx36DWRGRfJVliACLOPPuyIqCFT70U020MnBjJm2BZkxi7gJVZqbLy0dgBMMhQN9rh7kwS7f/Msfk6gQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:54.259Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jimchen-g-dsh-frontier-repro`
- Submission type: community curation
- Created by `JimChen-g` — https://github.com/JimChen-g
- Original source repository: https://github.com/JimChen-g/dsh-frontier-repro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.