### PR TITLE
catalog: add jimmyzwang-cloud-dsh-inkscreen-theme (community curation, created by @Jimmyzwang-cloud)

### DIFF
--- a/catalog/plugins/jimmyzwang-cloud-dsh-inkscreen-theme.yaml
+++ b/catalog/plugins/jimmyzwang-cloud-dsh-inkscreen-theme.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: jimmyzwang-cloud-dsh-inkscreen-theme
+name: dsh-inkscreen-theme
+description:
+  en: "DSH web plugin: an ink-and-paper Apple-glass theme with editorial typography, conversation status tabs, a Conversation/Trace switch, and a handwritten jimmy brand."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - theme
+  - deepseek-harness
+source:
+  repository: https://github.com/Jimmyzwang-cloud/dsh-inkscreen-theme
+  repositoryNodeId: R_kgDOUAx47g
+  subpath: null
+  commit: 12f1320b1fe0d7d88d10e4b9bec195397024168f
+creator:
+  github: Jimmyzwang-cloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:56.702Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jimmyzwang-cloud-dsh-inkscreen-theme`
- Submission type: community curation
- Created by `Jimmyzwang-cloud` — https://github.com/Jimmyzwang-cloud
- Original source repository: https://github.com/Jimmyzwang-cloud/dsh-inkscreen-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.