### PR TITLE
catalog: add jinguanghai-deepseek-harness-forge-plugins (community curation, created by @jinguanghai)

### DIFF
--- a/catalog/plugins/jinguanghai-deepseek-harness-forge-plugins.yaml
+++ b/catalog/plugins/jinguanghai-deepseek-harness-forge-plugins.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: jinguanghai-deepseek-harness-forge-plugins
+name: deepseek-harness-forge-plugins
+description:
+  en: "Forge plugins for DeepSeek Harness: gate computing + TCM + memory (13 tools). Install via dsh plugin add github:jinguanghai/deepseek-harness-forge-plugins ."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - forge
+  - gate
+  - computing
+  - memory
+  - tools
+  - install
+  - jinguanghai
+  - dsh
+source:
+  repository: https://github.com/jinguanghai/deepseek-harness-forge-plugins
+  repositoryNodeId: R_kgDOT4V3ww
+  subpath: null
+  commit: ad4e2dd73be06dc72fc05e0e1775032270bc3a0d
+creator:
+  github: jinguanghai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:34.588Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jinguanghai-deepseek-harness-forge-plugins`
- Submission type: community curation
- Created by `jinguanghai` — https://github.com/jinguanghai
- Original source repository: https://github.com/jinguanghai/deepseek-harness-forge-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.