### PR TITLE
catalog: add jinguanghai-dsh-evidence-first (community curation, created by @jinguanghai)

### DIFF
--- a/catalog/plugins/jinguanghai-dsh-evidence-first.yaml
+++ b/catalog/plugins/jinguanghai-dsh-evidence-first.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: jinguanghai-dsh-evidence-first
+name: dsh-evidence-first
+description:
+  en: "Evidence-first guard plugin for DeepSeek Harness: warns when the agent claims completion without tool-execution evidence. 证据铁律：声称完成必须有实际执行证据。"
+  evidencePath: plugins/evidence-first/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - evidence
+  - first
+  - guard
+  - warns
+  - agent
+  - claims
+  - completion
+  - without
+  - tool
+  - execution
+  - dsh
+source:
+  repository: https://github.com/jinguanghai/deepseek-harness-forge-plugins
+  repositoryNodeId: R_kgDOT4V3ww
+  subpath: plugins/evidence-first
+  commit: ad4e2dd73be06dc72fc05e0e1775032270bc3a0d
+creator:
+  github: jinguanghai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: plugins/evidence-first/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:34.588Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jinguanghai-dsh-evidence-first`
- Submission type: community curation
- Created by `jinguanghai` — https://github.com/jinguanghai
- Original source repository: https://github.com/jinguanghai/deepseek-harness-forge-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.