### PR TITLE
catalog: add jinguanghai-dsh-forge-tcm (community curation, created by @jinguanghai)

### DIFF
--- a/catalog/plugins/jinguanghai-dsh-forge-tcm.yaml
+++ b/catalog/plugins/jinguanghai-dsh-forge-tcm.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: jinguanghai-dsh-forge-tcm
+name: dsh-forge-tcm
+description:
+  en: TCM diagnosis & herb-pair search
+  evidencePath: plugins/forge-tcm/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - diagnosis
+  - herb
+  - pair
+  - search
+  - dsh
+source:
+  repository: https://github.com/jinguanghai/deepseek-harness-forge-plugins
+  repositoryNodeId: R_kgDOT4V3ww
+  subpath: plugins/forge-tcm
+  commit: ad4e2dd73be06dc72fc05e0e1775032270bc3a0d
+creator:
+  github: jinguanghai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: plugins/forge-tcm/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:44:34.588Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jinguanghai-dsh-forge-tcm`
- Submission type: community curation
- Created by `jinguanghai` — https://github.com/jinguanghai
- Original source repository: https://github.com/jinguanghai/deepseek-harness-forge-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.