### PR TITLE
catalog: add jinhongxun-dsh-mcphub (community curation, created by @jinhongxun)

### DIFF
--- a/catalog/plugins/jinhongxun-dsh-mcphub.yaml
+++ b/catalog/plugins/jinhongxun-dsh-mcphub.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: jinhongxun-dsh-mcphub
+name: dsh-mcphub
+description:
+  en: "MCP management panel for DeepSeek Harness: connection status (green dot), pip/npx local-server upgrade detection & one-click upgrade, add-server form writing cordis.patch.yml, connectivity probe, and usage help."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - mcp
+  - model-context-protocol
+source:
+  repository: https://github.com/jinhongxun/dsh-mcphub
+  repositoryNodeId: R_kgDOT78qQQ
+  subpath: null
+  commit: e2c1ed1e83422a21a35e020b512d9b3cedd96124
+creator:
+  github: jinhongxun
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:12.079Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jinhongxun-dsh-mcphub`
- Submission type: community curation
- Created by `jinhongxun` — https://github.com/jinhongxun
- Original source repository: https://github.com/jinhongxun/dsh-mcphub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.