### PR TITLE
catalog: add jmxsxwyzjdwl-dsh-mmroute (community curation, created by @jmxsxwyzjdwl)

### DIFF
--- a/catalog/plugins/jmxsxwyzjdwl-dsh-mmroute.yaml
+++ b/catalog/plugins/jmxsxwyzjdwl-dsh-mmroute.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jmxsxwyzjdwl-dsh-mmroute
+name: dsh-mmroute
+description:
+  en: "English summary — Multimodal router for DeepSeek Harness (DSH). Text-only models (e.g. DeepSeek, GLM) can still handle visual tasks: every image in every step of the agent stream — user uploads, read image results, MCP tool renders (Figma screenshots, …) — is transcribed into detailed text (verbatim OCR, chart data, vi"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - multimodal
+  - vision
+  - router
+source:
+  repository: https://github.com/jmxsxwyzjdwl/dsh-mmroute
+  repositoryNodeId: R_kgDOT_QIcg
+  subpath: null
+  commit: de9d11dc8df847025052d02aa25168de6d5cf5f2
+creator:
+  github: jmxsxwyzjdwl
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:01.244Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jmxsxwyzjdwl-dsh-mmroute`
- Submission type: community curation
- Created by `jmxsxwyzjdwl` — https://github.com/jmxsxwyzjdwl
- Original source repository: https://github.com/jmxsxwyzjdwl/dsh-mmroute
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.