### PR TITLE
catalog: add jo32-dsh-app-conversations (community curation, created by @jo32)

### DIFF
--- a/catalog/plugins/jo32-dsh-app-conversations.yaml
+++ b/catalog/plugins/jo32-dsh-app-conversations.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: jo32-dsh-app-conversations
+name: "@deepdeck/dsh-app-conversations"
+description:
+  en: App-scoped workspaces and canonical conversation routing for DeepDeck
+  evidencePath: plugins/app-conversations/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - scoped
+  - workspaces
+  - canonical
+  - conversation
+  - routing
+  - deepdeck
+  - dsh
+source:
+  repository: https://github.com/jo32/DeepDeck
+  repositoryNodeId: R_kgDOT6sjUA
+  subpath: plugins/app-conversations
+  commit: d3fe239d7412ec905ee77f8979597b9a386eb1f5
+creator:
+  github: jo32
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/app-conversations/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:47:31.265Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jo32-dsh-app-conversations`
- Submission type: community curation
- Created by `jo32` — https://github.com/jo32
- Original source repository: https://github.com/jo32/DeepDeck
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.