### PR TITLE
catalog: add jo32-dsh-hackernews-reader (community curation, created by @jo32)

### DIFF
--- a/catalog/plugins/jo32-dsh-hackernews-reader.yaml
+++ b/catalog/plugins/jo32-dsh-hackernews-reader.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: jo32-dsh-hackernews-reader
+name: "@deepdeck/dsh-hackernews-reader"
+description:
+  en: A standalone Hacker News reader with app-scoped AI conversations for DeepDeck
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - deepdeck
+  - cordis-plugin
+  - hacker-news
+  - reader
+  - dsh
+source:
+  repository: https://github.com/jo32/dsh-hackernews-reader
+  repositoryNodeId: R_kgDOUBpmSQ
+  subpath: null
+  commit: 369a3331d27d0697cd31861bbaf6b426f4759012
+creator:
+  github: jo32
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:48:24.788Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jo32-dsh-hackernews-reader`
- Submission type: community curation
- Created by `jo32` — https://github.com/jo32
- Original source repository: https://github.com/jo32/dsh-hackernews-reader
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.