### PR TITLE
catalog: add joeemp-dsh-plugin-desktop-pet (community curation, created by @JoeEmp)

### DIFF
--- a/catalog/plugins/joeemp-dsh-plugin-desktop-pet.yaml
+++ b/catalog/plugins/joeemp-dsh-plugin-desktop-pet.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: joeemp-dsh-plugin-desktop-pet
+name: dsh-plugin-desktop-pet
+description:
+  en: bash cd ~/.dsh/profiles/web pnpm add link:{project path}/desktop-pet
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - bash
+  - profiles
+  - pnpm
+  - link
+  - path
+  - desktop
+  - dsh
+source:
+  repository: https://github.com/JoeEmp/dsh-kamen-rider-pet
+  repositoryNodeId: R_kgDOT7XTeg
+  subpath: null
+  commit: 16f2be556f4dd4f3d2fc5f59da3d06a0b228ed68
+creator:
+  github: JoeEmp
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:48:26.436Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `joeemp-dsh-plugin-desktop-pet`
- Submission type: community curation
- Created by `JoeEmp` — https://github.com/JoeEmp
- Original source repository: https://github.com/JoeEmp/dsh-kamen-rider-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.