### PR TITLE
catalog: add johnnycls-dsh-no-setup-mode (community curation, created by @johnnycls)

### DIFF
--- a/catalog/plugins/johnnycls-dsh-no-setup-mode.yaml
+++ b/catalog/plugins/johnnycls-dsh-no-setup-mode.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: johnnycls-dsh-no-setup-mode
+name: dsh-no-setup-mode
+description:
+  en: Welcome home, Master~ One command, and your no-setup maid handles everything from there.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - no-setup
+  - no-setup-mode
+source:
+  repository: https://github.com/johnnycls/dsh-no-setup-mode
+  repositoryNodeId: R_kgDOT45X0g
+  subpath: null
+  commit: 555f2e6ed266ca5590cc693c0067142322119d4a
+creator:
+  github: johnnycls
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:45:16.318Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnnycls-dsh-no-setup-mode`
- Submission type: community curation
- Created by `johnnycls` — https://github.com/johnnycls
- Original source repository: https://github.com/johnnycls/dsh-no-setup-mode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.