### PR TITLE
catalog: add johnxu22786-gavel-review (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-gavel-review.yaml
+++ b/catalog/plugins/johnxu22786-gavel-review.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: johnxu22786-gavel-review
+name: gavel-review
+description:
+  en: An adversarial, multi-perspective code review plugin. Multiple independent review perspectives (lenses) attack a code change in parallel — each perspective cares only about its own category of problems and does not interfere with the others; an arbitration layer then merges cross-lens findings, deduplicates them, grade
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - code-review
+  - adversarial-review
+  - llm
+  - agent
+source:
+  repository: https://github.com/JohnXu22786/adversarial-review
+  repositoryNodeId: R_kgDOT59Rfg
+  subpath: null
+  commit: 2d2e5cbc234650c60250b932204d1e5e7f662ac0
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: npm
+  name: gavel-review
+  version: 0.1.0
+  integrity: sha512-xSc+iw0j+u4PyrJmaBQpTIR3XaOx2eQuH2N7xqIAvF26PYJpKgNTzFOHmPyh9iwHBCDgpSyP9RCIgbuqx/vT1Q==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:02.940Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-gavel-review`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/adversarial-review
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.