### PR TITLE
catalog: add johnxu22786-web-bridge-mcp (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-web-bridge-mcp.yaml
+++ b/catalog/plugins/johnxu22786-web-bridge-mcp.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: johnxu22786-web-bridge-mcp
+name: web-bridge-mcp
+description:
+  en: "Web Bridge is an automation MCP server that uses a real browser . It gives agents a browser's eyes and hands: open web pages, read page structure, click, fill forms, take screenshots, and execute scripts. Its core mechanism is the accessibility-tree snapshot — rendering the page into a structured text tree with numbere"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - mcp
+  - browser
+  - playwright
+  - automation
+  - dsh
+source:
+  repository: https://github.com/JohnXu22786/browser-automation
+  repositoryNodeId: R_kgDOT59N3Q
+  subpath: null
+  commit: 4fdafaec821b2010e413f656f1431819477f0ce4
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:07.958Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-web-bridge-mcp`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/browser-automation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.