### PR TITLE
catalog: add oil-oil-dsh-oil-creator (community curation, created by @oil-oil)

### DIFF
--- a/catalog/plugins/oil-oil-dsh-oil-creator.yaml
+++ b/catalog/plugins/oil-oil-dsh-oil-creator.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: oil-oil-dsh-oil-creator
+name: dsh-oil-creator
+description:
+  en: "Jacky Creator: a local-first content and operations cockpit for DeepSeek Harness"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - jacky-creator
+  - creator
+  - content-workflow
+  - creator-operations
+  - video
+  - dsh
+source:
+  repository: https://github.com/Jackywxsz/DSH-Creator
+  repositoryNodeId: R_kgDOUDT8fw
+  subpath: null
+  commit: 8bba9e52e1cabfdd2b9455e80db54369d773389f
+creator:
+  github: oil-oil
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T05:46:31.549Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 39
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `oil-oil-dsh-oil-creator`
- Submission type: community curation
- Created by `oil-oil` — https://github.com/oil-oil
- Original source repository: https://github.com/Jackywxsz/DSH-Creator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.