### PR TITLE
catalog: add johnxu22786-dsh-barricade (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-barricade.yaml
+++ b/catalog/plugins/johnxu22786-dsh-barricade.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: johnxu22786-dsh-barricade
+name: dsh-barricade
+description:
+  en: "A destructive-command interception gate for coding agents: it parses command semantics and judges risk before rm -rf , git reset --hard , git push --force and similar commands actually land, then requires human confirmation."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - safety
+  - guard
+source:
+  repository: https://github.com/JohnXu22786/safety-net
+  repositoryNodeId: R_kgDOT59NiQ
+  subpath: null
+  commit: 789ff47c8a1b8f397380e42280d621ef6b85da5f
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:13.839Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-barricade`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/safety-net
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.