### PR TITLE
catalog: add johnxu22786-dsh-bookkeeping (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-bookkeeping.yaml
+++ b/catalog/plugins/johnxu22786-dsh-bookkeeping.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: johnxu22786-dsh-bookkeeping
+name: dsh-bookkeeping
+description:
+  en: "Conversational bookkeeping plugin for DeepSeek Harness: record expenses/income by chat, query the ledger, run reports, export CSV/HTML, and track monthly budgets."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - dsh
+  - bookkeeping
+  - ledger
+  - accounting
+  - expense
+  - budget
+  - deepseek-harness
+source:
+  repository: https://github.com/JohnXu22786/bookkeeping
+  repositoryNodeId: R_kgDOT7VytA
+  subpath: null
+  commit: ee9c43bc0bb455ddc016afae8bc2bb72c2227832
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: npm
+  name: dsh-bookkeeping
+  version: 1.0.0
+  integrity: sha512-3ywr2LApVoqqpQun0WxWtcb5WXsL1jXvwduejfVxagCvNEMX8OYVEWcb6tEQ9dUr7ZGFX5Pd/TffgtpNVcJf3g==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:01.366Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-bookkeeping`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/bookkeeping
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.