### PR TITLE
catalog: add johnxu22786-dsh-computer-control (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-computer-control.yaml
+++ b/catalog/plugins/johnxu22786-dsh-computer-control.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: johnxu22786-dsh-computer-control
+name: dsh-computer-control
+description:
+  en: "dsh bundle for computer-control: desktop control (screen capture, pointer/keyboard injection, accessibility-tree semantic actions, safety guards) bridged to the harness over stdio JSON-RPC."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - bundle
+  - computer
+  - control
+  - desktop
+  - screen
+  - capture
+  - pointer
+  - keyboard
+  - injection
+  - accessibility
+  - tree
+  - semantic
+  - actions
+  - safety
+  - guards
+  - bridged
+source:
+  repository: https://github.com/JohnXu22786/computer-control
+  repositoryNodeId: R_kgDOT59Rmw
+  subpath: null
+  commit: c9244af2f012e1118c8ce42c2036d797ac663879
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: npm
+  name: dsh-computer-control
+  version: 0.1.0
+  integrity: sha512-sJ96S9g2yc8EDyTRqLXdnqHSAgmzsswJpB94Iq5+wzcHDnJ+FlP48oJk8LCnoHP4gxc5wkCSZ9U7ntfdTMb+DQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:10.213Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-computer-control`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/computer-control
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.