### PR TITLE
catalog: add johnxu22786-dsh-context-triage (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-context-triage.yaml
+++ b/catalog/plugins/johnxu22786-dsh-context-triage.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: johnxu22786-dsh-context-triage
+name: dsh-context-triage
+description:
+  en: "A session context triage plugin for DeepSeek Harness (dsh) that automatically manages context volume during long sessions: it identifies and handles stale, duplicate, failed, oversized, and low-value message content to save token budget and curb context bloat."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - context
+  - token
+  - pruning
+  - triage
+source:
+  repository: https://github.com/JohnXu22786/context-pruner
+  repositoryNodeId: R_kgDOT59MQw
+  subpath: null
+  commit: 9fcef3da179f024f90add697e2883439e69a8415
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: npm
+  name: dsh-context-triage
+  version: 0.1.0
+  integrity: sha512-5JTg9qjjVanmRgZJH5afEaZh+6mfD7Q0tJiMWB0hJefK3taS49avj8DQLf7BvcFJNn4brl4md6cuu7Lo0oJPdQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:04.931Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-context-triage`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/context-pruner
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.