### PR TITLE
catalog: add johnxu22786-dsh-doc-index (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-doc-index.yaml
+++ b/catalog/plugins/johnxu22786-dsh-doc-index.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: johnxu22786-dsh-doc-index
+name: dsh-doc-index
+description:
+  en: "dsh bundle: local semantic index over workspace documents (MD/PDF/DOCX/TXT) with FTS5 BM25 + local embedding hybrid retrieval, hit citations with line numbers, and incremental updates."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - bundle
+  - local
+  - semantic
+  - index
+  - over
+  - workspace
+  - documents
+  - docx
+  - fts5
+  - bm25
+  - embedding
+  - hybrid
+  - retrieval
+  - citations
+  - line
+  - numbers
+source:
+  repository: https://github.com/JohnXu22786/docindex
+  repositoryNodeId: R_kgDOT-SN3g
+  subpath: null
+  commit: fa4a32389153e14ae4d3d8dbbef44b7a22c97adf
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:08.032Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-doc-index`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/docindex
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.