### PR TITLE
catalog: add johnxu22786-dsh-headless-json (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-headless-json.yaml
+++ b/catalog/plugins/johnxu22786-dsh-headless-json.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: johnxu22786-dsh-headless-json
+name: dsh-headless-json
+description:
+  en: "Structured, machine-readable CI output for DeepSeek Harness (dsh): session event capture with JSON/NDJSON reports, JUnit XML, semantic exit codes, artifact collection and privacy redaction. Ships as a dsh profile bundle and a standalone CLI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - ci
+  - headless
+  - junit
+  - ndjson
+  - bundle
+source:
+  repository: https://github.com/JohnXu22786/headless-json
+  repositoryNodeId: R_kgDOT-SnaQ
+  subpath: null
+  commit: 592adc096957e90a035f1c975d5c9f9b990b2c9c
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:13.335Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-headless-json`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/headless-json
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.