### PR TITLE
catalog: add johnxu22786-dsh-market-watch (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-market-watch.yaml
+++ b/catalog/plugins/johnxu22786-dsh-market-watch.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: johnxu22786-dsh-market-watch
+name: dsh-market-watch
+description:
+  en: "Financial market monitor for DeepSeek Harness: real-time quotes, local watchlist, threshold alerts, periodic polling, and in-chat ASCII/mermaid charts for A-share (Shanghai/Shenzhen/Beijing) stocks, indices, and cryptocurrencies."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - financial
+  - market
+  - monitor
+  - real
+  - time
+  - quotes
+  - local
+  - watchlist
+  - threshold
+  - alerts
+  - periodic
+  - polling
+  - chat
+  - ascii
+  - mermaid
+  - charts
+source:
+  repository: https://github.com/JohnXu22786/market-watch
+  repositoryNodeId: R_kgDOT-Szug
+  subpath: null
+  commit: eb7d6d79b184f8f58b44c03b3f56f6c8840e20e5
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:16.449Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-market-watch`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/market-watch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.