### PR TITLE
catalog: add johnxu22786-dsh-praxis (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-praxis.yaml
+++ b/catalog/plugins/johnxu22786-dsh-praxis.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: johnxu22786-dsh-praxis
+name: dsh-praxis
+description:
+  en: Praxis — a bundled engineering-methodology skill library for DeepSeek Harness (dsh). Ships as a self-contained Cordis plugin that registers a skill provider on ctx.skills.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - skills
+  - agent-skills
+  - methodology
+  - tdd
+  - debugging
+  - planning
+  - code-review
+source:
+  repository: https://github.com/JohnXu22786/skill-framework
+  repositoryNodeId: R_kgDOT59MRQ
+  subpath: null
+  commit: 4b50d404566acf81e4cd0a6cfd818abd2e466f5f
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:15.431Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-praxis`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/skill-framework
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.