### PR TITLE
catalog: add johnxu22786-dsh-rss-digest (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-rss-digest.yaml
+++ b/catalog/plugins/johnxu22786-dsh-rss-digest.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: johnxu22786-dsh-rss-digest
+name: dsh-rss-digest
+description:
+  en: RSS/Atom feed subscription, scheduled fetching, deduplication, LLM-powered summarization, and daily Markdown digests — as a dsh (DeepSeek Harness) bundle.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - rss
+  - atom
+  - digest
+  - news
+  - summary
+  - briefing
+source:
+  repository: https://github.com/JohnXu22786/rss-digest
+  repositoryNodeId: R_kgDOT-QRXQ
+  subpath: null
+  commit: 1cf3a6d547fde1584fc56bc8409a8c4e21784ec8
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: npm
+  name: dsh-rss-digest
+  version: 0.1.0
+  integrity: sha512-FbPvC756ezDze2J9MZOQpK8qoCk98iM0F7zLJE/XKAv3dJrBRe1wbE/Ro6ZdOS2Ahf9tUBd8Aebb+SBHQOFNTA==
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:19.723Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-rss-digest`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/rss-digest
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.