### PR TITLE
catalog: add johnxu22786-dsh-secret-guard (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-secret-guard.yaml
+++ b/catalog/plugins/johnxu22786-dsh-secret-guard.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: johnxu22786-dsh-secret-guard
+name: dsh-secret-guard
+description:
+  en: "A DeepSeek Harness (dsh) security plugin: blocks agents from reading or writing sensitive files (.env, credentials, key material), masks leaked secret-shaped values in tool results, keeps an audit journal, and exposes safe inspection tools that never print raw values."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - security
+  - secrets
+  - guard
+  - redaction
+  - env
+  - dsh
+source:
+  repository: https://github.com/JohnXu22786/secret-guard
+  repositoryNodeId: R_kgDOT59U-A
+  subpath: null
+  commit: 999d0009e68278cc7a196a55e4c6451176e1fe5d
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: npm
+  name: dsh-secret-guard
+  version: 0.1.0
+  integrity: sha512-iTjx32oKxs6cUjkMO3+yLXTumFnpxbJa/hoalPgl1SpqiYFs4XyKFg94P9cYBIF1V1eKN5cX/UmHdHWE6nBeiw==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:21.295Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-secret-guard`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/secret-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.