### PR TITLE
catalog: add johnxu22786-hooks-adapter (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-hooks-adapter.yaml
+++ b/catalog/plugins/johnxu22786-hooks-adapter.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: johnxu22786-hooks-adapter
+name: hooks-adapter
+description:
+  en: "A universal hooks compatibility layer: run hooks declared in Claude Code / Codex / opencode / native configs on the DeepSeek Harness, with shell, webhook, oracle and proxy handlers."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - hooks
+source:
+  repository: https://github.com/JohnXu22786/hooks-adapter
+  repositoryNodeId: R_kgDOT59T5Q
+  subpath: null
+  commit: 32bf75a262956a23ca308e3c62fee6708ef43f4d
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:12.041Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-hooks-adapter`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/hooks-adapter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.