### PR TITLE
catalog: add johnxu22786-review-gate (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-review-gate.yaml
+++ b/catalog/plugins/johnxu22786-review-gate.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: johnxu22786-review-gate
+name: review-gate
+description:
+  en: "A DeepSeek Harness (dsh) bundle that turns code review into a hard gate: deterministic severity rules, LLM-assisted findings, team approval quorum and a compliance audit trail."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - bundle
+  - code-review
+  - gate
+  - approval
+  - compliance
+  - cordis
+source:
+  repository: https://github.com/JohnXu22786/review-gate
+  repositoryNodeId: R_kgDOT-Q4zA
+  subpath: null
+  commit: c673a3aebe667ddef152531f549a8fba445c5892
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:18.137Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-review-gate`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/review-gate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.