### PR TITLE
catalog: add jokasa7-dsh-product-subagent-console (community curation, created by @Jokasa7)

### DIFF
--- a/catalog/plugins/jokasa7-dsh-product-subagent-console.yaml
+++ b/catalog/plugins/jokasa7-dsh-product-subagent-console.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jokasa7-dsh-product-subagent-console
+name: dsh-product-subagent-console
+description:
+  en: Plan, run, and compare multi-Agent work inside DeepSeek Harness conversations
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - subagent
+  - codex
+  - claude-code
+  - multi-agent
+  - agent-planner
+  - workflow
+  - dsh
+source:
+  repository: https://github.com/Jokasa7/dsh-product-subagent-console
+  repositoryNodeId: R_kgDOUAO2jw
+  subpath: null
+  commit: 0d0e1dfcb4df1b2bd8c39f4763102bd3dd437359
+creator:
+  github: Jokasa7
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:25.085Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jokasa7-dsh-product-subagent-console`
- Submission type: community curation
- Created by `Jokasa7` — https://github.com/Jokasa7
- Original source repository: https://github.com/Jokasa7/dsh-product-subagent-console
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.