### PR TITLE
catalog: add jonychan8394-dsh-llm-balance (community curation, created by @JonyChan8394)

### DIFF
--- a/catalog/plugins/jonychan8394-dsh-llm-balance.yaml
+++ b/catalog/plugins/jonychan8394-dsh-llm-balance.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jonychan8394-dsh-llm-balance
+name: dsh-llm-balance
+description:
+  en: LLM API balances below the chat input, driven by the providers configured in dsh; click a balance to open its recharge page.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - balance
+  - billing
+  - usage
+  - dsh
+source:
+  repository: https://github.com/JonyChan8394/dsh-llm-balance
+  repositoryNodeId: R_kgDOT6pllg
+  subpath: null
+  commit: 189050c72e758f4ca62190e13dcfde99d52bce86
+creator:
+  github: JonyChan8394
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:17.086Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jonychan8394-dsh-llm-balance`
- Submission type: community curation
- Created by `JonyChan8394` — https://github.com/JonyChan8394
- Original source repository: https://github.com/JonyChan8394/dsh-llm-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.