### PR TITLE
catalog: add jorinyang-dsh-doctor (community curation, created by @jorinyang)

### DIFF
--- a/catalog/plugins/jorinyang-dsh-doctor.yaml
+++ b/catalog/plugins/jorinyang-dsh-doctor.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: jorinyang-dsh-doctor
+name: "@jorinyang/dsh-doctor"
+description:
+  en: "DeepSeek Harness diagnostic, repair, and rollback plugin: dsh doctor (diagnose), dsh doctor fix (journaled repair), dsh doctor rollback (LIFO undo), plus a Cordis runtime service for dynamic self-healing."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - diagnostic
+  - doctor
+  - repair
+  - cli
+  - agent
+  - dsh-doctor
+source:
+  repository: https://github.com/jorinyang/dsh-doctor
+  repositoryNodeId: R_kgDOT3rLwQ
+  subpath: null
+  commit: 79418687575d499f9445b4ada7a6a01e18947e68
+creator:
+  github: jorinyang
+package:
+  ecosystem: npm
+  name: "@jorinyang/dsh-doctor"
+  version: 0.3.2
+  integrity: sha512-mJXZEHJ9trypj631Yex3B9IHbtft77FGioLqTpenBSNbPHKBp5v78eoZunFRC2VqzLT18yT7KpY/PX0tOmCu7w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:18.619Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jorinyang-dsh-doctor`
- Submission type: community curation
- Created by `jorinyang` — https://github.com/jorinyang
- Original source repository: https://github.com/jorinyang/dsh-doctor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.