### PR TITLE
catalog: add jsdvjx-agent (community curation, created by @jsdvjx)

### DIFF
--- a/catalog/plugins/jsdvjx-agent.yaml
+++ b/catalog/plugins/jsdvjx-agent.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jsdvjx-agent
+name: "@dshn/agent"
+description:
+  en: "Forward this machine's local DeepSeek Harness (dsh) web service to the public internet over ds.hn: an outbound WSS tunnel to the relay, plus the trust-fence integration that lets forwarded requests through."
+  evidencePath: packages/agent/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - tunnel
+  - forwarding
+  - ds-hn
+source:
+  repository: https://github.com/jsdvjx/dshn
+  repositoryNodeId: R_kgDOT9HEHA
+  subpath: packages/agent
+  commit: d489c440139bfd9ca03bf9f105e038fa4a3d8d26
+creator:
+  github: jsdvjx
+package:
+  ecosystem: npm
+  name: "@dshn/agent"
+  version: 0.3.5
+  integrity: sha512-koe5Kcpk5FBPJayDIog9G1EYGOPHMmYhXERcpI5lHjyN3LQg0xRFwQm/5J4ppSSUgNhaBMe4MoOwdIsDA4UMew==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/agent/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:58.157Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jsdvjx-agent`
- Submission type: community curation
- Created by `jsdvjx` — https://github.com/jsdvjx
- Original source repository: https://github.com/jsdvjx/dshn
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.