### PR TITLE
catalog: add junnanlys-dsh-bench-runner (community curation, created by @JunNanLYS)

### DIFF
--- a/catalog/plugins/junnanlys-dsh-bench-runner.yaml
+++ b/catalog/plugins/junnanlys-dsh-bench-runner.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: junnanlys-dsh-bench-runner
+name: dsh-bench-runner
+description:
+  en: "A layered distillation memory plugin for DeepSeek Harness: conversations are processed in the background through L0 capture → L1 atomic memories → L2 scene consolidation → L3 persona distillation, and relevant memories are automatically injected into context before every model step — neither the user nor the model need"
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - layered
+  - distillation
+  - memory
+  - conversations
+  - processed
+  - background
+  - through
+  - capture
+  - atomic
+  - memories
+  - scene
+  - consolidation
+  - persona
+  - relevant
+  - automatically
+  - injected
+source:
+  repository: https://github.com/JunNanLYS/dsh-layered-memory
+  repositoryNodeId: R_kgDOT521jg
+  subpath: bench/harness/dsh-bench-runner
+  commit: 0b2ffc6a08f1380c6771d0cb0430b6d2c5736bac
+creator:
+  github: JunNanLYS
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: bench/harness/dsh-bench-runner/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:27:29.149Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `junnanlys-dsh-bench-runner`
- Submission type: community curation
- Created by `JunNanLYS` — https://github.com/JunNanLYS
- Original source repository: https://github.com/JunNanLYS/dsh-layered-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.