### PR TITLE
catalog: add junqingv587-dsh-ssh-hub (community curation, created by @JUNQINGV587)

### DIFF
--- a/catalog/plugins/junqingv587-dsh-ssh-hub.yaml
+++ b/catalog/plugins/junqingv587-dsh-ssh-hub.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: junqingv587-dsh-ssh-hub
+name: dsh-ssh-hub
+description:
+  en: Multi-server SSH terminal panel for DeepSeek Harness Web GUI — manage hosts and open multiple SSH terminals in a bottom panel
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - ssh
+  - terminal
+  - multi-server
+source:
+  repository: https://github.com/JUNQINGV587/dsh-ssh-hub
+  repositoryNodeId: R_kgDOT8AfiA
+  subpath: null
+  commit: eec43a1352c2bdfed68f04feb7e88e87abc7f6f6
+creator:
+  github: JUNQINGV587
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:59.952Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `junqingv587-dsh-ssh-hub`
- Submission type: community curation
- Created by `JUNQINGV587` — https://github.com/JUNQINGV587
- Original source repository: https://github.com/JUNQINGV587/dsh-ssh-hub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.