### PR TITLE
catalog: add jw53222-faultseed-dsh (community curation, created by @JW53222)

### DIFF
--- a/catalog/plugins/jw53222-faultseed-dsh.yaml
+++ b/catalog/plugins/jw53222-faultseed-dsh.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jw53222-faultseed-dsh
+name: faultseed-dsh
+description:
+  en: "dsh (DeepSeek Harness) bundle: mounts the faultseed honesty-guardrail hooks over @deepseek-ai/dsh-hooks-claude-code, unmodified, via dispatch.py"
+  evidencePath: adapters/dsh/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - claude-code
+  - hooks
+  - guardrails
+  - honesty
+  - fault-seeding
+  - agent-safety
+source:
+  repository: https://github.com/JW53222/faultseed
+  repositoryNodeId: R_kgDOT4Yizg
+  subpath: adapters/dsh
+  commit: 263f0611765e746b36fe25d851694ef4ca156603
+creator:
+  github: JW53222
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: adapters/dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:04.529Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jw53222-faultseed-dsh`
- Submission type: community curation
- Created by `JW53222` — https://github.com/JW53222
- Original source repository: https://github.com/JW53222/faultseed
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.