### PR TITLE
catalog: add kaiji-z-dsh-plugin-lookatstudy (community curation, created by @Kaiji-Z)

### DIFF
--- a/catalog/plugins/kaiji-z-dsh-plugin-lookatstudy.yaml
+++ b/catalog/plugins/kaiji-z-dsh-plugin-lookatstudy.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: kaiji-z-dsh-plugin-lookatstudy
+name: dsh-plugin-lookatstudy
+description:
+  en: "Turn any markdown, local folder, or GitHub learning repo into a guided course inside DeepSeek Harness: gated skill-tree progression, BKT mastery tracking, SM-2 spaced repetition."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - learning
+  - tutor
+  - spaced-repetition
+  - dsh
+source:
+  repository: https://github.com/Kaiji-Z/dsh-plugin-lookatstudy
+  repositoryNodeId: R_kgDOT5Sl2w
+  subpath: null
+  commit: cdb26dd45257e03e4c515ac683169c779d2b4f42
+creator:
+  github: Kaiji-Z
+package:
+  ecosystem: npm
+  name: dsh-plugin-lookatstudy
+  version: 0.11.1
+  integrity: sha512-8vN7WLhMyWqrb8q1ZRyKOI39/JXBfQ3D+PAOMJvW7E2RDhj58TU5AthTEbYaFxZ1/VLrt3njDrrHX6Y6ovNkFA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:22.118Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kaiji-z-dsh-plugin-lookatstudy`
- Submission type: community curation
- Created by `Kaiji-Z` — https://github.com/Kaiji-Z
- Original source repository: https://github.com/Kaiji-Z/dsh-plugin-lookatstudy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.