### PR TITLE
catalog: add kaixinbaba-dsh-complete-notify (community curation, created by @kaixinbaba)

### DIFF
--- a/catalog/plugins/kaixinbaba-dsh-complete-notify.yaml
+++ b/catalog/plugins/kaixinbaba-dsh-complete-notify.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: kaixinbaba-dsh-complete-notify
+name: dsh-complete-notify
+description:
+  en: sh dsh plugin --profile web add dsh-complete-notify dsh plugin --profile web add "github:kaixinbaba/dsh-complete-notify" launchctl kickstart -k gui/$(id -u)/com.dsh.dsh-web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - notification
+  - sound
+  - toast
+source:
+  repository: https://github.com/kaixinbaba/dsh-complete-notify
+  repositoryNodeId: R_kgDOT54iwQ
+  subpath: null
+  commit: da84f4284dd06bcf2fe7800169d3a89063db462e
+creator:
+  github: kaixinbaba
+package:
+  ecosystem: npm
+  name: dsh-complete-notify
+  version: 0.6.2
+  integrity: sha512-rmv0qqWG9OOAR2CY74k1a+HXyRLVWBIq2NMatc2pvzFYx5/yJQ4cI2SxVgSWIY6X+LJqlLnTYzvaqKWmRMhv+A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:27:53.857Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kaixinbaba-dsh-complete-notify`
- Submission type: community curation
- Created by `kaixinbaba` — https://github.com/kaixinbaba
- Original source repository: https://github.com/kaixinbaba/dsh-complete-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.