### PR TITLE
catalog: add kam74515-boop-dsh-show-me-how-much (community curation, created by @kam74515-boop)

### DIFF
--- a/catalog/plugins/kam74515-boop-dsh-show-me-how-much.yaml
+++ b/catalog/plugins/kam74515-boop-dsh-show-me-how-much.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: kam74515-boop-dsh-show-me-how-much
+name: dsh-show-me-how-much
+description:
+  en: DeepSeek Harness token usage and estimated cost dashboard
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - token-usage
+  - cost-tracking
+  - cache-hit
+  - dsh
+source:
+  repository: https://github.com/kam74515-boop/dsh-show-me-how-much
+  repositoryNodeId: R_kgDOT5VbdA
+  subpath: null
+  commit: 29edb9d36deeeda0a2ed2fada4eae2e3b5d4bf64
+creator:
+  github: kam74515-boop
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:09.035Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kam74515-boop-dsh-show-me-how-much`
- Submission type: community curation
- Created by `kam74515-boop` — https://github.com/kam74515-boop
- Original source repository: https://github.com/kam74515-boop/dsh-show-me-how-much
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.