### PR TITLE
catalog: add kanchengw-dsh-assembly-resume (community curation, created by @kanchengw)

### DIFF
--- a/catalog/plugins/kanchengw-dsh-assembly-resume.yaml
+++ b/catalog/plugins/kanchengw-dsh-assembly-resume.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: kanchengw-dsh-assembly-resume
+name: dsh-assembly.resume
+description:
+  en: Import local Codex and Claude Code sessions into DSH Agent conversations
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - codex
+  - claude-code
+  - claude-desktop
+  - ai-agent
+  - session-handoff
+  - session-import
+  - conversation-migration
+source:
+  repository: https://github.com/kanchengw/dsh-assembly.resume
+  repositoryNodeId: R_kgDOUDr7Zg
+  subpath: null
+  commit: 95bc54f53487894641c9e3c8058bd901c2afdf60
+creator:
+  github: kanchengw
+package:
+  ecosystem: npm
+  name: dsh-assembly.resume
+  version: 0.1.3
+  integrity: sha512-T1YYtigXfhitqfKc4lB7+7YpjB0GFMU0hKR3kWhgCfP2NSCaT1Iu1h4//tO0Qo09GPSHAX6u61rS+IQYZD05Mw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:28.287Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kanchengw-dsh-assembly-resume`
- Submission type: community curation
- Created by `kanchengw` — https://github.com/kanchengw
- Original source repository: https://github.com/kanchengw/dsh-assembly.resume
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.