### PR TITLE
catalog: add kanchengw-dsh-mindseye (community curation, created by @kanchengw)

### DIFF
--- a/catalog/plugins/kanchengw-dsh-mindseye.yaml
+++ b/catalog/plugins/kanchengw-dsh-mindseye.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: kanchengw-dsh-mindseye
+name: dsh-mindseye
+description:
+  en: "MindsEye: model-driven vision tools, structured evidence, and exact cache for DeepSeek Harness"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - multimodal
+  - agent
+  - dsh
+source:
+  repository: https://github.com/kanchengw/dsh-mindseye
+  repositoryNodeId: R_kgDOT6I4rw
+  subpath: null
+  commit: 4e19e3c5e56787b09c7763e03441bf3f4503d438
+creator:
+  github: kanchengw
+package:
+  ecosystem: npm
+  name: dsh-mindseye
+  version: 0.2.7
+  integrity: sha512-ToI6saA28dU0jlMXA3DJ1f7FzoeBpG+3lKJ3V6FDjKJLZ+vmeHKpAYovDFu0Fjt4og3xNChb7HWmPvUnt2AS0g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:23.654Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kanchengw-dsh-mindseye`
- Submission type: community curation
- Created by `kanchengw` — https://github.com/kanchengw
- Original source repository: https://github.com/kanchengw/dsh-mindseye
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.