### PR TITLE
catalog: add kannakuron-dsh-ptc-cordis-preset (community curation, created by @KannaKuron)

### DIFF
--- a/catalog/plugins/kannakuron-dsh-ptc-cordis-preset.yaml
+++ b/catalog/plugins/kannakuron-dsh-ptc-cordis-preset.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: kannakuron-dsh-ptc-cordis-preset
+name: dsh-ptc-cordis-preset
+description:
+  en: "DSH plugin: a Creation-mode preset built on top of PTC mode — every capability of PTC (Code Mode SDK tool presentation), plus the self-referential Cordis toolset, runtime inspection, dynamic-plugin experiments, and preset-authoring guidance. Materializes the 'ptc-cordis' agent preset into your user preset root at start"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - agent-preset
+  - ptc
+  - code-mode
+  - cordis
+  - dsh-plugin
+source:
+  repository: https://github.com/KannaKuron/dsh-ptc-cordis-preset
+  repositoryNodeId: R_kgDOT9XFGw
+  subpath: null
+  commit: 7554041f19fe55d1e2d19e9332afa2072fc7700b
+creator:
+  github: KannaKuron
+package:
+  ecosystem: npm
+  name: dsh-ptc-cordis-preset
+  version: 0.6.3
+  integrity: sha512-vyQ9s0pFx+alwWLI2tqRfdW3ZRKEiXQuHnBamJLIxTBN9e5cgOXvBohi5LKGKh+w48HvWMKBpbRjvM4RmIgcyw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:25.181Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kannakuron-dsh-ptc-cordis-preset`
- Submission type: community curation
- Created by `KannaKuron` — https://github.com/KannaKuron
- Original source repository: https://github.com/KannaKuron/dsh-ptc-cordis-preset
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.