### PR TITLE
catalog: add kanonouta-dsh-captain (community curation, created by @KanoNoUta)

### DIFF
--- a/catalog/plugins/kanonouta-dsh-captain.yaml
+++ b/catalog/plugins/kanonouta-dsh-captain.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: kanonouta-dsh-captain
+name: "@kanonouta/dsh-captain"
+description:
+  en: Captain GPT planner, DeepSeek worker, GPT reviewer orchestration plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - captain
+  - planner
+  - worker
+  - reviewer
+  - orchestration
+  - dsh
+source:
+  repository: https://github.com/KanoNoUta/dsh-captain
+  repositoryNodeId: R_kgDOT4np_g
+  subpath: null
+  commit: dac7c1cffa8e55494b5b87bdb603702adb7e3aba
+creator:
+  github: KanoNoUta
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:27:57.724Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kanonouta-dsh-captain`
- Submission type: community curation
- Created by `KanoNoUta` — https://github.com/KanoNoUta
- Original source repository: https://github.com/KanoNoUta/dsh-captain
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.