### PR TITLE
catalog: add karamachia217-dsh-bundle-manager (community curation, created by @KaramachiA217)

### DIFF
--- a/catalog/plugins/karamachia217-dsh-bundle-manager.yaml
+++ b/catalog/plugins/karamachia217-dsh-bundle-manager.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: karamachia217-dsh-bundle-manager
+name: dsh-bundle-manager
+description:
+  en: "DSH web plugin: runtime mount manager for optional third-party plugin bundles — mount/unmount bundle rows in-process through the Loader API (instant, no restart, never touches the profile manifest), with named presets and self-healing failure fallback. v0.5 adds official coexistence (import/export between the official "
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - runtime
+  - mount
+  - manager
+  - optional
+  - third
+  - party
+  - bundles
+  - unmount
+  - bundle
+  - rows
+  - process
+  - through
+  - loader
+  - instant
+  - restart
+  - never
+source:
+  repository: https://github.com/KaramachiA217/dsh-bundle-manager
+  repositoryNodeId: R_kgDOT7NlqQ
+  subpath: null
+  commit: 45a6acd38c35f3c112a91f11523c6e95a1a2ed65
+creator:
+  github: KaramachiA217
+package:
+  ecosystem: npm
+  name: dsh-bundle-manager
+  version: 0.5.6
+  integrity: sha512-MIWl+H2XtGUAvmv4hs0UZUQLn8PRGUvUlRL9JzGUrkzLGQ5jc6WKqfU9Qp01lP4M90gdRB74G9vyIjEYdwYsGA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:30.071Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `karamachia217-dsh-bundle-manager`
- Submission type: community curation
- Created by `KaramachiA217` — https://github.com/KaramachiA217
- Original source repository: https://github.com/KaramachiA217/dsh-bundle-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.