### PR TITLE
catalog: add karloflaw-dsh-goal-mode (community curation, created by @KarlOfLaw)

### DIFF
--- a/catalog/plugins/karloflaw-dsh-goal-mode.yaml
+++ b/catalog/plugins/karloflaw-dsh-goal-mode.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: karloflaw-dsh-goal-mode
+name: dsh-goal-mode
+description:
+  en: "Enhanced goal surface for the DeepSeek Harness web UI: full lifecycle dock above the composer (create / multiline edit / pause / resume / complete / clear with live round progress), a composer tool-row entry with phase dot, a collapsible chip, and a General-settings switch to hide the entry."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - enhanced
+  - goal
+  - surface
+  - full
+  - lifecycle
+  - dock
+  - above
+  - composer
+  - create
+  - multiline
+  - edit
+  - pause
+  - resume
+  - complete
+  - clear
+  - live
+source:
+  repository: https://github.com/KarlOfLaw/dsh-goal-mode-enhance
+  repositoryNodeId: R_kgDOT3dzQA
+  subpath: null
+  commit: f351daf586ebfc9606e4e5bfb1b141e318e59dab
+creator:
+  github: KarlOfLaw
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:26.819Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `karloflaw-dsh-goal-mode`
- Submission type: community curation
- Created by `KarlOfLaw` — https://github.com/KarlOfLaw
- Original source repository: https://github.com/KarlOfLaw/dsh-goal-mode-enhance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.