### PR TITLE
catalog: add keepermttl-dsh-archive-viewer (community curation, created by @keepermttl)

### DIFF
--- a/catalog/plugins/keepermttl-dsh-archive-viewer.yaml
+++ b/catalog/plugins/keepermttl-dsh-archive-viewer.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: keepermttl-dsh-archive-viewer
+name: "@dsh-external/dsh-archive-viewer"
+description:
+  en: "Archived-session manager for the DeepSeek Harness (DSH) Web GUI : browse, read, and restore archived sessions , plus a one-click shutdown button in the header."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - archived
+  - session
+  - manager
+  - browse
+  - read
+  - restore
+  - sessions
+  - plus
+  - click
+  - shutdown
+  - button
+  - header
+  - dsh
+source:
+  repository: https://github.com/keepermttl/dsh-archive-viewer
+  repositoryNodeId: R_kgDOT3lPIA
+  subpath: null
+  commit: 715f33ad09425c0efcd4db1b405e0ca7b0e2d2de
+creator:
+  github: keepermttl
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:27:46.851Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `keepermttl-dsh-archive-viewer`
- Submission type: community curation
- Created by `keepermttl` — https://github.com/keepermttl
- Original source repository: https://github.com/keepermttl/dsh-archive-viewer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.