### PR TITLE
catalog: add keke050-dsh-wallpaper (community curation, created by @keke050)

### DIFF
--- a/catalog/plugins/keke050-dsh-wallpaper.yaml
+++ b/catalog/plugins/keke050-dsh-wallpaper.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: keke050-dsh-wallpaper
+name: dsh-wallpaper
+description:
+  en: Set a custom background wallpaper for the DeepSeek Harness desktop app — presets, image URL, upload, and an opacity slider
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - wallpaper
+  - background
+  - theme
+source:
+  repository: https://github.com/keke050/dsh-wallpaper
+  repositoryNodeId: R_kgDOT5KZow
+  subpath: null
+  commit: 226ccd76c75291681d58709319b8d8da3dd6f44e
+creator:
+  github: keke050
+package:
+  ecosystem: npm
+  name: dsh-wallpaper
+  version: 0.1.0
+  integrity: sha512-pq6h4ODQFAqcT52mndw3WbYF8lZegrSLbEuN9hhQvalDCA9LPXP5XSWh4Fxna4h1VzCzMxaleuZ/BWvYnMQErw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:28.401Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `keke050-dsh-wallpaper`
- Submission type: community curation
- Created by `keke050` — https://github.com/keke050
- Original source repository: https://github.com/keke050/dsh-wallpaper
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.