### PR TITLE
catalog: add kelaohu-dsh-lowtide (community curation, created by @KelaoHu)

### DIFF
--- a/catalog/plugins/kelaohu-dsh-lowtide.yaml
+++ b/catalog/plugins/kelaohu-dsh-lowtide.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: kelaohu-dsh-lowtide
+name: dsh-lowtide
+description:
+  en: "lowtide: human-adjudicated off-peak batch task pipeline for dsh (peak/valley pricing aware)"
+  evidencePath: packages/dsh/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - off-peak
+  - batch-tasks
+  - pricing
+  - scheduler
+  - productivity
+  - dsh
+source:
+  repository: https://github.com/KelaoHu/dsh-lowtide
+  repositoryNodeId: R_kgDOUBhZdA
+  subpath: packages/dsh
+  commit: 49caefc2d6a33148cb36b8dbca413d725161668f
+creator:
+  github: KelaoHu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:11.829Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kelaohu-dsh-lowtide`
- Submission type: community curation
- Created by `KelaoHu` — https://github.com/KelaoHu
- Original source repository: https://github.com/KelaoHu/dsh-lowtide
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.