### PR TITLE
catalog: add kelearns-dsh-token-usage (community curation, created by @KeLearns)

### DIFF
--- a/catalog/plugins/kelearns-dsh-token-usage.yaml
+++ b/catalog/plugins/kelearns-dsh-token-usage.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: kelearns-dsh-token-usage
+name: "@kelearns/dsh-token-usage"
+description:
+  en: "Token usage heatmap for the dsh web GUI: GitHub-style daily / weekly / cumulative token statistics with hover details, mounted via the official plugin mechanism (dsh plugin add) — no dsh source changes."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - token
+  - usage
+  - heatmap
+  - statistics
+source:
+  repository: https://github.com/KeLearns/dsh-token-usage
+  repositoryNodeId: R_kgDOT4b8PA
+  subpath: null
+  commit: b1c83721a8bc8c553ee73925733c961f16b12ec9
+creator:
+  github: KeLearns
+package:
+  ecosystem: npm
+  name: "@kelearns/dsh-token-usage"
+  version: 0.1.1
+  integrity: sha512-OmdArn2rxTJMxVyMWVbTO5J5FqI0+j4BXsZJOZHXvoNZEfhm/Ss1vLLuFoawxfNHLr73bOetZfsy3t0mih0Xpg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:29.964Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kelearns-dsh-token-usage`
- Submission type: community curation
- Created by `KeLearns` — https://github.com/KeLearns
- Original source repository: https://github.com/KeLearns/dsh-token-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.