### PR TITLE
catalog: add kendu76-dsh-music-player (community curation, created by @kendu76)

### DIFF
--- a/catalog/plugins/kendu76-dsh-music-player.yaml
+++ b/catalog/plugins/kendu76-dsh-music-player.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: kendu76-dsh-music-player
+name: dsh-music-player
+description:
+  en: sh dsh plugin --profile <profile add dsh-music-player
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - music
+  - player
+  - audio
+  - tts
+  - novel
+  - book
+source:
+  repository: https://github.com/kendu76/dsh-music-player
+  repositoryNodeId: R_kgDOT7QPvQ
+  subpath: null
+  commit: 90a302aa967ce159a1d44a90e70d60b4a46812eb
+creator:
+  github: kendu76
+package:
+  ecosystem: npm
+  name: dsh-music-player
+  version: 0.6.6
+  integrity: sha512-n9auPt9Ebdtvj+7wh00yaJ4FtLHJ0f2ecsGsaMMGHnjybEuwoJbAb3ZQsjjgr/OQiah0G9/67RCNAG7Gcso5QQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:31.655Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kendu76-dsh-music-player`
- Submission type: community curation
- Created by `kendu76` — https://github.com/kendu76
- Original source repository: https://github.com/kendu76/dsh-music-player
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.