### PR TITLE
catalog: add kenerlee-dsh-moments-aieo (community curation, created by @Kenerlee)

### DIFF
--- a/catalog/plugins/kenerlee-dsh-moments-aieo.yaml
+++ b/catalog/plugins/kenerlee-dsh-moments-aieo.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: kenerlee-dsh-moments-aieo
+name: dsh-moments-aieo
+description:
+  en: AIEO (GEO/AEO) diagnosis → positioning → content → monitoring skill bundle for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis-plugin
+  - skills
+  - aieo
+  - geo
+  - aeo
+source:
+  repository: https://github.com/Kenerlee/dsh-moments-aieo
+  repositoryNodeId: R_kgDOT-AF7Q
+  subpath: null
+  commit: bd7d25514f91fa8c8f8a7a7d319c60bea8e01503
+creator:
+  github: Kenerlee
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:33.203Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kenerlee-dsh-moments-aieo`
- Submission type: community curation
- Created by `Kenerlee` — https://github.com/Kenerlee
- Original source repository: https://github.com/Kenerlee/dsh-moments-aieo
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.