### PR TITLE
catalog: add kes1ke-dsh-exit (community curation, created by @KeS1Ke)

### DIFF
--- a/catalog/plugins/kes1ke-dsh-exit.yaml
+++ b/catalog/plugins/kes1ke-dsh-exit.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: kes1ke-dsh-exit
+name: "@kesike/dsh-exit"
+description:
+  en: A focused exit control for the DeepSeek Harness web interface.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web
+  - exit
+source:
+  repository: https://github.com/KeS1Ke/dsh-start-and-exit
+  repositoryNodeId: R_kgDOUCfyNw
+  subpath: null
+  commit: 87b14de1e8fcf2bc845797c334a34836f312d06e
+creator:
+  github: KeS1Ke
+package:
+  ecosystem: npm
+  name: "@kesike/dsh-exit"
+  version: 0.2.5
+  integrity: sha512-PH5WWSFwmfrGOqFnKPehkkeEvbrrzKIzvGX0Czx9uxd0vXafLhP2nUKOAbFKJ5Z0v79KmRdt6H6zW/qippxRLA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:14.171Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kes1ke-dsh-exit`
- Submission type: community curation
- Created by `KeS1Ke` — https://github.com/KeS1Ke
- Original source repository: https://github.com/KeS1Ke/dsh-start-and-exit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.