### PR TITLE
catalog: add kestiny18-dsh-redact (community curation, created by @kestiny18)

### DIFF
--- a/catalog/plugins/kestiny18-dsh-redact.yaml
+++ b/catalog/plugins/kestiny18-dsh-redact.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: kestiny18-dsh-redact
+name: dsh-redact
+description:
+  en: Fail-closed canonical tool-output tokenization for DeepSeek Harness
+  evidencePath: dsh-redact/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - redaction
+  - secrets
+  - llm-security
+  - dsh
+source:
+  repository: https://github.com/kestiny18/dsh-plugins
+  repositoryNodeId: R_kgDOT4WKWQ
+  subpath: dsh-redact
+  commit: 9ed3d60d9dd93c21b48211034304686ebcf9c027
+creator:
+  github: kestiny18
+package:
+  ecosystem: npm
+  name: dsh-redact
+  version: 0.1.0
+  integrity: sha512-rHLns1vLqzk6WQrBP0t7xAPUiU/D94I1RmHzsZhicWeZmv8M5S8Cobe2LNkgy7JSrKSf8lEcxB621CBLe9pdZw==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-redact/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:16.190Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kestiny18-dsh-redact`
- Submission type: community curation
- Created by `kestiny18` — https://github.com/kestiny18
- Original source repository: https://github.com/kestiny18/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.