### PR TITLE
catalog: add kfirsch-dsh-hebrew-rtl (community curation, created by @kfirsch)

### DIFF
--- a/catalog/plugins/kfirsch-dsh-hebrew-rtl.yaml
+++ b/catalog/plugins/kfirsch-dsh-hebrew-rtl.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: kfirsch-dsh-hebrew-rtl
+name: dsh-hebrew-rtl
+description:
+  en: "Correct Hebrew RTL rendering for the DeepSeek Harness web GUI: per-block direction by dominant script, bidi-safe input fields, and RTL-aware Cmd+Left/Right line navigation."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - hebrew
+  - rtl
+  - bidi
+  - i18n
+source:
+  repository: https://github.com/kfirsch/dsh-hebrew-rtl
+  repositoryNodeId: R_kgDOUC9E6A
+  subpath: null
+  commit: 6ff8346a0db7b892197154bca723d6f6fa70bc7c
+creator:
+  github: kfirsch
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:33.825Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kfirsch-dsh-hebrew-rtl`
- Submission type: community curation
- Created by `kfirsch` — https://github.com/kfirsch
- Original source repository: https://github.com/kfirsch/dsh-hebrew-rtl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.