### PR TITLE
catalog: add kiligzzz-dsh-session-archive (community curation, created by @kiligzzz)

### DIFF
--- a/catalog/plugins/kiligzzz-dsh-session-archive.yaml
+++ b/catalog/plugins/kiligzzz-dsh-session-archive.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: kiligzzz-dsh-session-archive
+name: "@kiligzzz/dsh-session-archive"
+description:
+  en: "A DeepSeek Harness Web-plugin that surfaces the registry-global archived-session set: list archived sessions in the sidebar and restore (unarchive) them."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - surfaces
+  - registry
+  - global
+  - archived
+  - session
+  - list
+  - sessions
+  - sidebar
+  - restore
+  - unarchive
+  - dsh
+source:
+  repository: https://github.com/kiligzzz/dsh-session-archive
+  repositoryNodeId: R_kgDOT9CGAQ
+  subpath: null
+  commit: 5a1cd4560c41ceff2242113f362e87ee1bd998a8
+creator:
+  github: kiligzzz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:36.894Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kiligzzz-dsh-session-archive`
- Submission type: community curation
- Created by `kiligzzz` — https://github.com/kiligzzz
- Original source repository: https://github.com/kiligzzz/dsh-session-archive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.