### PR TITLE
catalog: add kiligzzz-dsh-session-nav (community curation, created by @kiligzzz)

### DIFF
--- a/catalog/plugins/kiligzzz-dsh-session-nav.yaml
+++ b/catalog/plugins/kiligzzz-dsh-session-nav.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: kiligzzz-dsh-session-nav
+name: "@kiligzzz/dsh-session-nav"
+description:
+  en: "Piano-key style in-conversation navigation bar for the DeepSeek Harness web GUI: one key per user message, hover ladder animation, turn-preview tooltip, active-message highlight, click-to-jump. Official dual-face dsh plugin (host + client), no dsh source changes."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - navigation
+  - piano
+  - conversation
+source:
+  repository: https://github.com/kiligzzz/dsh-session-nav
+  repositoryNodeId: R_kgDOT-Ghlg
+  subpath: null
+  commit: 57d42eafae0f6e0db235eb930208e1d8aa084604
+creator:
+  github: kiligzzz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:27:48.396Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kiligzzz-dsh-session-nav`
- Submission type: community curation
- Created by `kiligzzz` — https://github.com/kiligzzz
- Original source repository: https://github.com/kiligzzz/dsh-session-nav
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.