### PR TITLE
catalog: add kingguuu8-svg-dsh-pi-compatible (community curation, created by @kingguuu8-svg)

### DIFF
--- a/catalog/plugins/kingguuu8-svg-dsh-pi-compatible.yaml
+++ b/catalog/plugins/kingguuu8-svg-dsh-pi-compatible.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: kingguuu8-svg-dsh-pi-compatible
+name: dsh-pi-compatible
+description:
+  en: Full Access-only DeepSeek Harness presets with a Pi coding-agent 0.84.2-compatible seven-tool core and an optional DSH-backed Plus catalog.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-preset
+  - pi-compatible
+  - coding-agent
+  - full-access
+source:
+  repository: https://github.com/kingguuu8-svg/dsh-pi-compatible
+  repositoryNodeId: R_kgDOT7Exuw
+  subpath: null
+  commit: 6a026456d6c5d742f5767a585236c6be441357a0
+creator:
+  github: kingguuu8-svg
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:34.772Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kingguuu8-svg-dsh-pi-compatible`
- Submission type: community curation
- Created by `kingguuu8-svg` — https://github.com/kingguuu8-svg
- Original source repository: https://github.com/kingguuu8-svg/dsh-pi-compatible
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.