### PR TITLE
catalog: add kinmat-a-dsh-theme-switch (community curation, created by @kinmat-A)

### DIFF
--- a/catalog/plugins/kinmat-a-dsh-theme-switch.yaml
+++ b/catalog/plugins/kinmat-a-dsh-theme-switch.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: kinmat-a-dsh-theme-switch
+name: "@dsh-external/dsh-theme-switch"
+description:
+  en: "DSH theme switch: auto-detects installed skin/theme plugins and offers one-click, official-style switching under Settings → Plugins → Skins ."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+  - deepseek-harness
+source:
+  repository: https://github.com/kinmat-A/dsh-theme-switch
+  repositoryNodeId: R_kgDOT5fusA
+  subpath: null
+  commit: 320edb2601e4ff1d62ea8bb7bf14bb3a8d2c4d67
+creator:
+  github: kinmat-A
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:36.889Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kinmat-a-dsh-theme-switch`
- Submission type: community curation
- Created by `kinmat-A` — https://github.com/kinmat-A
- Original source repository: https://github.com/kinmat-A/dsh-theme-switch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.