### PR TITLE
catalog: add kirkchinese-dsh-citeciter (community curation, created by @kirkchinese)

### DIFF
--- a/catalog/plugins/kirkchinese-dsh-citeciter.yaml
+++ b/catalog/plugins/kirkchinese-dsh-citeciter.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: kirkchinese-dsh-citeciter
+name: "@kirkchinese/dsh-citeciter"
+description:
+  en: Verifiable, source-bound, read-only investigations for DeepSeek Harness responses
+  evidencePath: packages/citeciter/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - citation
+  - source-bound
+  - verification
+  - evidence
+  - investigation
+  - context-management
+  - read-only
+  - explanation
+  - observer
+  - topic
+source:
+  repository: https://github.com/kirkchinese/CiteCiter
+  repositoryNodeId: R_kgDOT7WsnQ
+  subpath: packages/citeciter
+  commit: 8f5f1dc1f12f29c50a981dae235784462928cc5f
+creator:
+  github: kirkchinese
+package:
+  ecosystem: npm
+  name: "@kirkchinese/dsh-citeciter"
+  version: 0.4.1
+  integrity: sha512-BVHm9TqH4OluyJJ7Rtu09vV6bcxwXoWCntTNRQjhU7ed7saqICKp4bqAawg1W38U4p2JQt6n1ps5ENCn2bYYaA==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/citeciter/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:21.081Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kirkchinese-dsh-citeciter`
- Submission type: community curation
- Created by `kirkchinese` — https://github.com/kirkchinese
- Original source repository: https://github.com/kirkchinese/CiteCiter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.