### PR TITLE
catalog: add kirkchinese-plugin (community curation, created by @kirkchinese)

### DIFF
--- a/catalog/plugins/kirkchinese-plugin.yaml
+++ b/catalog/plugins/kirkchinese-plugin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: kirkchinese-plugin
+name: "@claude2dsh/plugin"
+description:
+  en: Import Claude Code sessions and skills into DeepSeek Harness, and sync DSH sessions back to Claude Code
+  evidencePath: packages/plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - claude-code
+  - migration
+  - session
+  - skills
+source:
+  repository: https://github.com/kirkchinese/claude2dsh
+  repositoryNodeId: R_kgDOT5ydsA
+  subpath: packages/plugin
+  commit: 8499f7577dfb9645e8a932d767b408163f4ee99f
+creator:
+  github: kirkchinese
+package:
+  ecosystem: npm
+  name: "@claude2dsh/plugin"
+  version: 0.2.0-rc.5
+  integrity: sha512-Tg9cD9sc/i/LpS03XSScnKQiseK90q+k8inhofNJkr4de2kQvzrHU6fM38BAz3U9v2tmdjikLrCnJXJBjuSk9g==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:40.538Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kirkchinese-plugin`
- Submission type: community curation
- Created by `kirkchinese` — https://github.com/kirkchinese
- Original source repository: https://github.com/kirkchinese/claude2dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.