### PR TITLE
catalog: add kkbsgg-dsh-balance (community curation, created by @kkbsgg)

### DIFF
--- a/catalog/plugins/kkbsgg-dsh-balance.yaml
+++ b/catalog/plugins/kkbsgg-dsh-balance.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: kkbsgg-dsh-balance
+name: "@kkbsgg/dsh-balance"
+description:
+  en: Shows the selected model provider's account balance next to the composer model seat once a model and reasoning effort are selected.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - balance
+  - deepseek-harness
+source:
+  repository: https://github.com/kkbsgg/dsh-balance
+  repositoryNodeId: R_kgDOT9LtjQ
+  subpath: null
+  commit: e65ea1b0f2900f992dd3fe58eb46f0c9dd280e9d
+creator:
+  github: kkbsgg
+package:
+  ecosystem: npm
+  name: "@kkbsgg/dsh-balance"
+  version: 0.2.0
+  integrity: sha512-X6A7Iznf6jIBQ43JN6muLBSoqSCCWpc4WmiwQS8CSxwy84T3hLLTZi4ctrsIe6ad4M5H1rsIq0PrmWEr9H/KiA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:43.288Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kkbsgg-dsh-balance`
- Submission type: community curation
- Created by `kkbsgg` — https://github.com/kkbsgg
- Original source repository: https://github.com/kkbsgg/dsh-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.