### PR TITLE
catalog: add klrsl-dsh-fuse (community curation, created by @KLRSL)

### DIFF
--- a/catalog/plugins/klrsl-dsh-fuse.yaml
+++ b/catalog/plugins/klrsl-dsh-fuse.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: klrsl-dsh-fuse
+name: dsh-fuse
+description:
+  en: bash dsh plugin --profile web add link:./dsh-fuse
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - bash
+  - profile
+  - link
+  - fuse
+  - dsh
+source:
+  repository: https://github.com/KLRSL/dsh-fuse
+  repositoryNodeId: R_kgDOT9pLrw
+  subpath: null
+  commit: 54a9f2e12acbf96712f52daba55fea4f27c253f7
+creator:
+  github: KLRSL
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:38.432Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `klrsl-dsh-fuse`
- Submission type: community curation
- Created by `KLRSL` — https://github.com/KLRSL
- Original source repository: https://github.com/KLRSL/dsh-fuse
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.