### PR TITLE
catalog: add klrsl-dsh-packer (community curation, created by @KLRSL)

### DIFF
--- a/catalog/plugins/klrsl-dsh-packer.yaml
+++ b/catalog/plugins/klrsl-dsh-packer.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: klrsl-dsh-packer
+name: dsh-packer
+description:
+  en: "dsh-packer is a configuration packer plugin for DeepSeek Harness (DSH) . It packs your local Agent assets into zip archives, module by module, for two purposes:"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - packer
+  - configuration
+  - packs
+  - local
+  - agent
+  - assets
+  - archives
+  - module
+  - purposes
+  - dsh
+source:
+  repository: https://github.com/KLRSL/dsh-packer
+  repositoryNodeId: R_kgDOT51Ozg
+  subpath: null
+  commit: a4e0e97d5e74808b3f6e513b975ee66b5840bd1a
+creator:
+  github: KLRSL
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:46.521Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `klrsl-dsh-packer`
- Submission type: community curation
- Created by `KLRSL` — https://github.com/KLRSL
- Original source repository: https://github.com/KLRSL/dsh-packer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.