### PR TITLE
catalog: add kober-basket-dsh-cachescope (community curation, created by @kober-basket)

### DIFF
--- a/catalog/plugins/kober-basket-dsh-cachescope.yaml
+++ b/catalog/plugins/kober-basket-dsh-cachescope.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: kober-basket-dsh-cachescope
+name: "@kober-basket/dsh-cachescope"
+description:
+  en: Prompt-cache observability and logical-input diagnostics for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - prompt-cache
+  - prefill
+  - observability
+  - llm
+source:
+  repository: https://github.com/kober-basket/dsh-cachescope
+  repositoryNodeId: R_kgDOUEupCw
+  subpath: null
+  commit: 211f97b9dc5dddd5b6d0e4392b3baa2d511ca1e4
+creator:
+  github: kober-basket
+package:
+  ecosystem: npm
+  name: "@kober-basket/dsh-cachescope"
+  version: 0.1.1
+  integrity: sha512-+GmYu6W1IIBTt2tmDWqmMq4mrOhie/DWkufU3c84JSGsYCoOEWA3frtgcMMayE22XGoCY/E5tqqaXM8fn9/tRw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:24.696Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kober-basket-dsh-cachescope`
- Submission type: community curation
- Created by `kober-basket` — https://github.com/kober-basket
- Original source repository: https://github.com/kober-basket/dsh-cachescope
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.