### PR TITLE
catalog: add kongchengzhi-dsh-cli-anything-aseprite (community curation, created by @KongChengZhi)

### DIFF
--- a/catalog/plugins/kongchengzhi-dsh-cli-anything-aseprite.yaml
+++ b/catalog/plugins/kongchengzhi-dsh-cli-anything-aseprite.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: kongchengzhi-dsh-cli-anything-aseprite
+name: dsh-cli-anything-aseprite
+description:
+  en: "Aseprite pixel-art studio for DeepSeek Harness: an agent-usable CLI harness (CLI-Anything methodology) + DSH plugin tools that let AI draw pixel art like a human, stroke by stroke, live-visible in the terminal."
+  evidencePath: dsh-cli-anything-aseprite/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - aseprite
+  - pixel-art
+  - cli-anything
+  - pixel-art-ai
+  - sprite
+source:
+  repository: https://github.com/KongChengZhi/dsh-pixel-studio
+  repositoryNodeId: R_kgDOT5Iggg
+  subpath: dsh-cli-anything-aseprite
+  commit: 52acee7d33ea1a787e878642f856efe05b6f4230
+creator:
+  github: KongChengZhi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: dsh-cli-anything-aseprite/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:22.749Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kongchengzhi-dsh-cli-anything-aseprite`
- Submission type: community curation
- Created by `KongChengZhi` — https://github.com/KongChengZhi
- Original source repository: https://github.com/KongChengZhi/dsh-pixel-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.