### PR TITLE
catalog: add ktdhhc-dsh-custom-subagents (community curation, created by @ktdhhc)

### DIFF
--- a/catalog/plugins/ktdhhc-dsh-custom-subagents.yaml
+++ b/catalog/plugins/ktdhhc-dsh-custom-subagents.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ktdhhc-dsh-custom-subagents
+name: dsh-custom-subagents
+description:
+  en: Custom reusable Subagent Definitions with a Settings page and one delegate agent tool for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - subagent
+  - delegation
+source:
+  repository: https://github.com/ktdhhc/dsh-custom-subagents
+  repositoryNodeId: R_kgDOT_NEew
+  subpath: null
+  commit: 8725328797247a262f2b59c4e57370a7f74b424b
+creator:
+  github: ktdhhc
+package:
+  ecosystem: npm
+  name: dsh-custom-subagents
+  version: 0.1.5
+  integrity: sha512-Q+CgG3o5p4PIxIR3da0ctXSuTBOpLQpobuzKS4rlSqbCmxmSRm2o7692Oh2+bHv/YTkIR/7Q4h5g5hfSwjIGSQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:40.014Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ktdhhc-dsh-custom-subagents`
- Submission type: community curation
- Created by `ktdhhc` — https://github.com/ktdhhc
- Original source repository: https://github.com/ktdhhc/dsh-custom-subagents
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.