### PR TITLE
catalog: add kuanfu0430-dsh-sidebar-branch-chat (community curation, created by @kuanfu0430)

### DIFF
--- a/catalog/plugins/kuanfu0430-dsh-sidebar-branch-chat.yaml
+++ b/catalog/plugins/kuanfu0430-dsh-sidebar-branch-chat.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: kuanfu0430-dsh-sidebar-branch-chat
+name: "@kuanfu0430/dsh-sidebar-branch-chat"
+description:
+  en: Adds a Branch Chat tab to dsh-better-sidebar that opens independent archived sessions with a head/middle/tail context digest and the same tools as the main agent.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - sidebar
+  - branch-chat
+  - dsh
+source:
+  repository: https://github.com/kuanfu0430/dsh-sidebar-branch-chat
+  repositoryNodeId: R_kgDOUCvq3Q
+  subpath: null
+  commit: 77ada5cda99f4fbf9b913cf7a9656e254a5be817
+creator:
+  github: kuanfu0430
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:26.874Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kuanfu0430-dsh-sidebar-branch-chat`
- Submission type: community curation
- Created by `kuanfu0430` — https://github.com/kuanfu0430
- Original source repository: https://github.com/kuanfu0430/dsh-sidebar-branch-chat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.