### PR TITLE
catalog: add kxsenlin-dsh-whale-font (community curation, created by @kxSenlin)

### DIFF
--- a/catalog/plugins/kxsenlin-dsh-whale-font.yaml
+++ b/catalog/plugins/kxsenlin-dsh-whale-font.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: kxsenlin-dsh-whale-font
+name: dsh-whale-font
+description:
+  en: bash dsh plugin --profile web add github:kxSenlin/dsh-whale-font
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - whale
+  - font
+  - pronoun
+  - accessibility
+source:
+  repository: https://github.com/kxSenlin/dsh-whale-font
+  repositoryNodeId: R_kgDOT4pGhA
+  subpath: null
+  commit: b35bf1e7d678019e5ca7df8eb428de13be35f797
+creator:
+  github: kxSenlin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:27:59.645Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kxsenlin-dsh-whale-font`
- Submission type: community curation
- Created by `kxSenlin` — https://github.com/kxSenlin
- Original source repository: https://github.com/kxSenlin/dsh-whale-font
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.