### PR TITLE
catalog: add kyo615-dsh-browser-control (community curation, created by @kyo615)

### DIFF
--- a/catalog/plugins/kyo615-dsh-browser-control.yaml
+++ b/catalog/plugins/kyo615-dsh-browser-control.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: kyo615-dsh-browser-control
+name: dsh-browser-control
+description:
+  en: "A dynamic Cordis plugin for DeepSeek Harness: let an AI control a real, visible Chrome browser via Playwright MCP, with a live view of every action inside the GUI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - playwright
+  - mcp
+  - browser
+  - chrome
+  - ai-agent
+source:
+  repository: https://github.com/kyo615/dsh-browser-control
+  repositoryNodeId: R_kgDOT5AQuQ
+  subpath: null
+  commit: 9c10f2c42999947a2c8009443994f6297d472b8c
+creator:
+  github: kyo615
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:27:43.025Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kyo615-dsh-browser-control`
- Submission type: community curation
- Created by `kyo615` — https://github.com/kyo615
- Original source repository: https://github.com/kyo615/dsh-browser-control
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.