### PR TITLE
catalog: add kyomio-dsh-zen-remote (community curation, created by @KyoMio)

### DIFF
--- a/catalog/plugins/kyomio-dsh-zen-remote.yaml
+++ b/catalog/plugins/kyomio-dsh-zen-remote.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: kyomio-dsh-zen-remote
+name: dsh-zen-remote
+description:
+  en: sh dsh plugin add dsh-zen-remote
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - dsh-plugin-add
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - mobile
+  - mobile-ui
+  - phone
+  - pwa
+  - progressive-web-app
+  - remote-access
+  - pairing
+  - public
+  - reverse-proxy
+  - gateway
+  - service-worker
+source:
+  repository: https://github.com/KyoMio/dsh-zen-remote
+  repositoryNodeId: R_kgDOT7eP2g
+  subpath: null
+  commit: 398d14603a6d582739dac2f3521fbdf011e1acb8
+creator:
+  github: KyoMio
+package:
+  ecosystem: npm
+  name: dsh-zen-remote
+  version: 1.1.9
+  integrity: sha512-WT0wXH8nIPd5wpW0IVIR+F2pI2ONTWJXt4kpy5Av81kiy64bQrOlEqCnsvR6l1lK7HuPxe0PqDEXmCUcDiAyRg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:27:40.846Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kyomio-dsh-zen-remote`
- Submission type: community curation
- Created by `KyoMio` — https://github.com/KyoMio
- Original source repository: https://github.com/KyoMio/dsh-zen-remote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.