### PR TITLE
catalog: add kyzzsa-dsh-klip (community curation, created by @Kyzzsa)

### DIFF
--- a/catalog/plugins/kyzzsa-dsh-klip.yaml
+++ b/catalog/plugins/kyzzsa-dsh-klip.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: kyzzsa-dsh-klip
+name: dsh-klip
+description:
+  en: "DeepSeek Harness plugin: KInterval interval language and the /klip command that splits a conversation into new sessions."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - kinterval
+  - interval
+  - language
+  - klip
+  - command
+  - splits
+  - conversation
+  - sessions
+  - dsh
+source:
+  repository: https://github.com/Kyzzsa/dsh-klip
+  repositoryNodeId: R_kgDOT-uVEw
+  subpath: null
+  commit: d146f8688193fe085360dd61e72f1e29aad2a9c9
+creator:
+  github: Kyzzsa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:42.248Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kyzzsa-dsh-klip`
- Submission type: community curation
- Created by `Kyzzsa` — https://github.com/Kyzzsa
- Original source repository: https://github.com/Kyzzsa/dsh-klip
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.