### PR TITLE
catalog: add l3n3l-dsh-resume (community curation, created by @L3n3L)

### DIFF
--- a/catalog/plugins/l3n3l-dsh-resume.yaml
+++ b/catalog/plugins/l3n3l-dsh-resume.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: l3n3l-dsh-resume
+name: dsh-resume
+description:
+  en: "Markdown campus resume workbench: the agent edits resumes and CSS templates under jobhunt/, and the user previews and exports from the sidebar."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - resume
+  - campus
+  - jobhunt
+  - markdown
+source:
+  repository: https://github.com/L3n3L/dsh-resume
+  repositoryNodeId: R_kgDOT_yOzA
+  subpath: null
+  commit: 353f5766909bd8ee3095f569113c8ade0df7e29c
+creator:
+  github: L3n3L
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:43.587Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `l3n3l-dsh-resume`
- Submission type: community curation
- Created by `L3n3L` — https://github.com/L3n3L
- Original source repository: https://github.com/L3n3L/dsh-resume
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.