### PR TITLE
catalog: add lacquervii-dsh-smooth-cursor (community curation, created by @Lacquervii)

### DIFF
--- a/catalog/plugins/lacquervii-dsh-smooth-cursor.yaml
+++ b/catalog/plugins/lacquervii-dsh-smooth-cursor.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lacquervii-dsh-smooth-cursor
+name: dsh-smooth-cursor
+description:
+  en: Smooth comet-mode animated caret for the DSH chat composer — a standalone installable DSH plugin (ported from the Obsidian Animated Cursor plugin)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - cursor
+  - caret
+  - composer
+source:
+  repository: https://github.com/Lacquervii/smooth-cursor
+  repositoryNodeId: R_kgDOT-f16g
+  subpath: null
+  commit: 7f0caa930131aaf509b9fd19c244b3169c4f37c6
+creator:
+  github: Lacquervii
+package:
+  ecosystem: npm
+  name: dsh-smooth-cursor
+  version: 0.1.6
+  integrity: sha512-NvmRYZWw0T7ZJijyrj260xzJZ1X6aVQ0Ly3PlJ+XVAknK+bx83Lm8MdCUKjRzsD7nSTcowNBBWi+8JU6hwmZvw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:48.388Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lacquervii-dsh-smooth-cursor`
- Submission type: community curation
- Created by `Lacquervii` — https://github.com/Lacquervii
- Original source repository: https://github.com/Lacquervii/smooth-cursor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.