### PR TITLE
catalog: add lagran-cursor-harness-bridge (community curation, created by @lagran)

### DIFF
--- a/catalog/plugins/lagran-cursor-harness-bridge.yaml
+++ b/catalog/plugins/lagran-cursor-harness-bridge.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: lagran-cursor-harness-bridge
+name: cursor-harness-bridge
+description:
+  en: DeepSeek Harness Web UI backed by a local Cursor SDK agent
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - backed
+  - local
+  - cursor
+  - agent
+  - dsh
+source:
+  repository: https://github.com/lagran/cursor-harness-bridge
+  repositoryNodeId: R_kgDOT6rPpQ
+  subpath: null
+  commit: 8d96f86e97a436f0b40462eba0f47643ba17f26f
+creator:
+  github: lagran
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:29.040Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lagran-cursor-harness-bridge`
- Submission type: community curation
- Created by `lagran` — https://github.com/lagran
- Original source repository: https://github.com/lagran/cursor-harness-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.