### PR TITLE
catalog: add lak321-dsh-filetree (community curation, created by @lak321)

### DIFF
--- a/catalog/plugins/lak321-dsh-filetree.yaml
+++ b/catalog/plugins/lak321-dsh-filetree.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: lak321-dsh-filetree
+name: dsh-filetree
+description:
+  en: "DSH bundle: workspace file-tree sidebar — browse/edit project files via /api/filetree (host) + client UI"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - bundle
+  - workspace
+  - file
+  - tree
+  - sidebar
+  - browse
+  - edit
+  - files
+  - filetree
+  - host
+  - client
+  - dsh
+source:
+  repository: https://github.com/lak321/dsh-filetree
+  repositoryNodeId: R_kgDOT5ZjfQ
+  subpath: null
+  commit: 039700268865a86c1455820831e55892f8d7775c
+creator:
+  github: lak321
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:01.552Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lak321-dsh-filetree`
- Submission type: community curation
- Created by `lak321` — https://github.com/lak321
- Original source repository: https://github.com/lak321/dsh-filetree
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.