### PR TITLE
catalog: add lanbaolu-dsh-wechat-bridge (community curation, created by @lanbaolu)

### DIFF
--- a/catalog/plugins/lanbaolu-dsh-wechat-bridge.yaml
+++ b/catalog/plugins/lanbaolu-dsh-wechat-bridge.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: lanbaolu-dsh-wechat-bridge
+name: "@lanbaolu/dsh-wechat-bridge"
+description:
+  en: 微信 App ←→ iLink Bot API ←→ bridge daemon (Node.js) │ HTTP + SSE (127.0.0.1, token 鉴权) ▼ DSH Host Plugin │ ctx.agents.create/resume + followup ▼ DSH Agent (本机 LLM + 工具)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - wechat
+  - wechat-bridge
+  - ilink
+  - im-bridge
+  - chatbot
+  - notify
+  - remote
+source:
+  repository: https://github.com/lanbaolu/dsh-wechat-bridge
+  repositoryNodeId: R_kgDOT8Dl8Q
+  subpath: null
+  commit: fefec097295a55a65e430169972af507900e8627
+creator:
+  github: lanbaolu
+package:
+  ecosystem: npm
+  name: "@lanbaolu/dsh-wechat-bridge"
+  version: 0.6.0
+  integrity: sha512-v3Ft46nGp1ccjD5FR7XH9BxVDitwxA47MO+sgRVaG8xl4LfAl3TRJ2ZwFsyQO6Kr+BZM6hBAubkzfCVtg+k/+A==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:03.275Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lanbaolu-dsh-wechat-bridge`
- Submission type: community curation
- Created by `lanbaolu` — https://github.com/lanbaolu
- Original source repository: https://github.com/lanbaolu/dsh-wechat-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.