### PR TITLE
catalog: add lancecheney-dsh-deepseek-balance (community curation, created by @lancecheney)

### DIFF
--- a/catalog/plugins/lancecheney-dsh-deepseek-balance.yaml
+++ b/catalog/plugins/lancecheney-dsh-deepseek-balance.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: lancecheney-dsh-deepseek-balance
+name: "@lancecheney/dsh-deepseek-balance"
+description:
+  en: Session-header DeepSeek API balance, per-conversation spend, and peak/off-peak pricing indicator
+  evidencePath: packages/dsh-deepseek-balance/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - session
+  - header
+  - balance
+  - conversation
+  - spend
+  - peak
+  - pricing
+  - indicator
+  - dsh
+source:
+  repository: https://github.com/lancecheney/dsh-plugins
+  repositoryNodeId: R_kgDOT49fiA
+  subpath: packages/dsh-deepseek-balance
+  commit: 5fc65bfbae221fed4da07fd304b1e6afe002e9e6
+creator:
+  github: lancecheney
+package:
+  ecosystem: npm
+  name: "@lancecheney/dsh-deepseek-balance"
+  version: 0.1.2
+  integrity: sha512-w45tgD4BAb6GPSmFG+iSWU5ilzQ6nq0mzfGW9U15AmJRnCYd5/FHu1Dl2d0bDTXVyUfk0XWB0J4jSWxw4hO4nQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-deepseek-balance/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:30:30.625Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lancecheney-dsh-deepseek-balance`
- Submission type: community curation
- Created by `lancecheney` — https://github.com/lancecheney
- Original source repository: https://github.com/lancecheney/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.