### PR TITLE
catalog: add laplace-bit-dsh-bell-notify (community curation, created by @Laplace-bit)

### DIFF
--- a/catalog/plugins/laplace-bit-dsh-bell-notify.yaml
+++ b/catalog/plugins/laplace-bit-dsh-bell-notify.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: laplace-bit-dsh-bell-notify
+name: dsh-bell-notify
+description:
+  en: Configurable, unobtrusive Agent lifecycle sound cues for DeepSeek Harness (dsh), synthesized with Web Audio.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - cordis
+  - notification
+  - sound
+  - web-audio
+source:
+  repository: https://github.com/Laplace-bit/dsh-bell-notify
+  repositoryNodeId: R_kgDOT51-Mw
+  subpath: null
+  commit: 1ac15b288b964b2769f3ed9c8a7b80dfbcff8965
+creator:
+  github: Laplace-bit
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:04.900Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `laplace-bit-dsh-bell-notify`
- Submission type: community curation
- Created by `Laplace-bit` — https://github.com/Laplace-bit
- Original source repository: https://github.com/Laplace-bit/dsh-bell-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.