### PR TITLE
catalog: add laplace-bit-dsh-pianist (community curation, created by @Laplace-bit)

### DIFF
--- a/catalog/plugins/laplace-bit-dsh-pianist.yaml
+++ b/catalog/plugins/laplace-bit-dsh-pianist.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: laplace-bit-dsh-pianist
+name: dsh-pianist
+description:
+  en: "A deterministic piano performance plugin for DSH: shared musical timeline, piano audio engine, visual engine, and DSH-compatible host/browser boundary."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - piano
+  - music
+  - timeline
+  - audio
+  - webgl
+source:
+  repository: https://github.com/Laplace-bit/dsh-pianist
+  repositoryNodeId: R_kgDOT7ER8g
+  subpath: null
+  commit: 182e5aea7c4fa67b8d625ff4e9af0a4d312b01b9
+creator:
+  github: Laplace-bit
+package:
+  ecosystem: npm
+  name: dsh-pianist
+  version: 0.1.0
+  integrity: sha512-r3P+VeXClzehpsD+/ZS3WHUUksnekaUranFOhSrSZlZ9yXJ12o4krMuAym4UWfuOqvwIIt5A6aPxRoGj49tdqw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:29:49.691Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `laplace-bit-dsh-pianist`
- Submission type: community curation
- Created by `Laplace-bit` — https://github.com/Laplace-bit
- Original source repository: https://github.com/Laplace-bit/dsh-pianist
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.