### PR TITLE
catalog: add lavapapa-dsh-composer-layout (community curation, created by @lavapapa)

### DIFF
--- a/catalog/plugins/lavapapa-dsh-composer-layout.yaml
+++ b/catalog/plugins/lavapapa-dsh-composer-layout.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lavapapa-dsh-composer-layout
+name: dsh-composer-layout
+description:
+  en: Keep long answers and detailed prompts side by side with a dockable DSH Composer.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - composer
+  - web-ui
+source:
+  repository: https://github.com/lavapapa/dsh-composer-layout
+  repositoryNodeId: R_kgDOT8-L4w
+  subpath: null
+  commit: 1779dc2d0d9abecf359618eef0c838bf4c218247
+creator:
+  github: lavapapa
+package:
+  ecosystem: npm
+  name: dsh-composer-layout
+  version: 0.1.8
+  integrity: sha512-mvU8T1bNNhy3DKeTxwDx7lY+UZdNSDeW+Q7YWAvVoiJv72MoTxj2FqRDnl6g+RixJjhym4JyEIeHbz/eC9wgLw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:06.612Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lavapapa-dsh-composer-layout`
- Submission type: community curation
- Created by `lavapapa` — https://github.com/lavapapa
- Original source repository: https://github.com/lavapapa/dsh-composer-layout
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.