### PR TITLE
catalog: add lcthe-dsh-skills-hub (community curation, created by @lcthe)

### DIFF
--- a/catalog/plugins/lcthe-dsh-skills-hub.yaml
+++ b/catalog/plugins/lcthe-dsh-skills-hub.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lcthe-dsh-skills-hub
+name: "@lcthe/dsh-skills-hub"
+description:
+  en: DSH plugin for browsing, searching, inspecting, importing, uploading, and safely deleting skills across global and registered workspace directories.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - skill
+  - manager
+source:
+  repository: https://github.com/lcthe/dsh-skills-hub
+  repositoryNodeId: R_kgDOT9NkmQ
+  subpath: null
+  commit: 2ad30b02003d9d426be67d9572cecd661227d70a
+creator:
+  github: lcthe
+package:
+  ecosystem: npm
+  name: "@lcthe/dsh-skills-hub"
+  version: 0.2.5
+  integrity: sha512-EJUlXt+oVNbwQOO4+ve7LAawawWN41ofXcpu4qdT0gScrdWrW+5hghuYro4N9oqeb+d13/ad4wGvubFPVHPe2A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:50.670Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lcthe-dsh-skills-hub`
- Submission type: community curation
- Created by `lcthe` — https://github.com/lcthe
- Original source repository: https://github.com/lcthe/dsh-skills-hub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.