### PR TITLE
catalog: add lcthe-dsh-timeline-rail (community curation, created by @lcthe)

### DIFF
--- a/catalog/plugins/lcthe-dsh-timeline-rail.yaml
+++ b/catalog/plugins/lcthe-dsh-timeline-rail.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: lcthe-dsh-timeline-rail
+name: "@lcthe/dsh-timeline-rail"
+description:
+  en: "A message timeline rail for the DeepSeek Harness web chat: evenly spaced tick marks for every user message along the right edge of the conversation, click to jump, hover to preview."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - timeline
+  - chat
+  - navigate
+source:
+  repository: https://github.com/lcthe/dsh-timeline-rail
+  repositoryNodeId: R_kgDOT624fA
+  subpath: null
+  commit: 661d4a859f80d8c6f445d844ee0fb081c30cbc66
+creator:
+  github: lcthe
+package:
+  ecosystem: npm
+  name: "@lcthe/dsh-timeline-rail"
+  version: 0.2.11
+  integrity: sha512-l9tJu9wuhoz8PQiP9/d6OEnghxVlWvu36eOMluSpCsiOmL0D2d11+MLYZXt2/zRfQVYnX82ukaBocl/PmrCD/w==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T06:28:52.560Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lcthe-dsh-timeline-rail`
- Submission type: community curation
- Created by `lcthe` — https://github.com/lcthe
- Original source repository: https://github.com/lcthe/dsh-timeline-rail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.