### PR TITLE
catalog: add lcthe-dsh-usage-monitor (community curation, created by @lcthe)

### DIFF
--- a/catalog/plugins/lcthe-dsh-usage-monitor.yaml
+++ b/catalog/plugins/lcthe-dsh-usage-monitor.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: lcthe-dsh-usage-monitor
+name: "@lcthe/dsh-usage-monitor"
+description:
+  en: "DSH plugin: usage and credit balance monitor — auto-query provider balances from configured API keys."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - usage
+  - balance
+  - monitor
+source:
+  repository: https://github.com/lcthe/dsh-usage-monitor
+  repositoryNodeId: R_kgDOUATv9w
+  subpath: null
+  commit: 54022c6525cd25210a285c6ec5e3f428fc33ed00
+creator:
+  github: lcthe
+package:
+  ecosystem: npm
+  name: "@lcthe/dsh-usage-monitor"
+  version: 1.1.1
+  integrity: sha512-zrVV0Xh9ymGpFJQTW6eIourlfLcQvOp7FWgfO5DtaCLkylIB4KUlexR3/3K2y+FV60/8q/0hxXv4i3RCBhe0MQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:24.852Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lcthe-dsh-usage-monitor`
- Submission type: community curation
- Created by `lcthe` — https://github.com/lcthe
- Original source repository: https://github.com/lcthe/dsh-usage-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.