### PR TITLE
catalog: add ldchaowin-dsh-plugin-notify-sound (community curation, created by @ldchaowin)

### DIFF
--- a/catalog/plugins/ldchaowin-dsh-plugin-notify-sound.yaml
+++ b/catalog/plugins/ldchaowin-dsh-plugin-notify-sound.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: ldchaowin-dsh-plugin-notify-sound
+name: dsh-plugin-notify-sound
+description:
+  en: "DeepSeek Harness plugin: per-workspace task-completion ringtones plus attention sounds for approval / question / plan-review / goal-blocked / task-failure events (Web UI; built-in synth, voice (TTS), custom audio)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - notification
+  - sound
+  - ringtone
+  - tts
+  - voice
+source:
+  repository: https://github.com/ldchaowin/dsh-plugin-notify-sound
+  repositoryNodeId: R_kgDOT4PHXg
+  subpath: null
+  commit: d6a267dea612569fd97340e62fb9ff6c7873702b
+creator:
+  github: ldchaowin
+package:
+  ecosystem: npm
+  name: dsh-plugin-notify-sound
+  version: 1.0.0
+  integrity: sha512-++s1Jg4lBaPCD8uzbwgPbbCy4VKJDQNdVNzc+6XTFeswYASZSfcvOWUVoM5yPhDlVYHJ6I09sM2UXIIr1UM1qg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:16.378Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ldchaowin-dsh-plugin-notify-sound`
- Submission type: community curation
- Created by `ldchaowin` — https://github.com/ldchaowin
- Original source repository: https://github.com/ldchaowin/dsh-plugin-notify-sound
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.