### PR TITLE
catalog: add leamonac0823-dsh-cornell-classic-theme (community curation, created by @leamonac0823)

### DIFF
--- a/catalog/plugins/leamonac0823-dsh-cornell-classic-theme.yaml
+++ b/catalog/plugins/leamonac0823-dsh-cornell-classic-theme.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: leamonac0823-dsh-cornell-classic-theme
+name: dsh-cornell-classic-theme
+description:
+  en: A Cornell notebook workspace and task brief for DeepSeek Harness Web UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - cornell
+  - notebook
+  - workspace
+  - task
+  - brief
+  - dsh
+source:
+  repository: https://github.com/leamonac0823/dsh-cornell-classic-theme
+  repositoryNodeId: R_kgDOT_Y8gA
+  subpath: null
+  commit: 0bcd3b5083ab8a9a0c3e68bd55c9c76dcb982a3b
+creator:
+  github: leamonac0823
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:13.870Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leamonac0823-dsh-cornell-classic-theme`
- Submission type: community curation
- Created by `leamonac0823` — https://github.com/leamonac0823
- Original source repository: https://github.com/leamonac0823/dsh-cornell-classic-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.