### PR TITLE
catalog: add leaveimagination-dsh-qwen-coordinator-tools (community curation, created by @leaveimagination)

### DIFF
--- a/catalog/plugins/leaveimagination-dsh-qwen-coordinator-tools.yaml
+++ b/catalog/plugins/leaveimagination-dsh-qwen-coordinator-tools.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: leaveimagination-dsh-qwen-coordinator-tools
+name: dsh-qwen-coordinator-tools
+description:
+  en: Registers Qwen's five project Session tools directly in DSH while enforcing a single human-approved Coordinator Session ID. Calls are forwarded only to the authenticated loopback Qwen Gateway endpoint and become ordinary Qwen Task Manager work, preserving completion notifications and cancellation.
+  evidencePath: tools/dsh-qwen-coordinator-tools/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - registers
+  - qwen
+  - five
+  - session
+  - tools
+  - directly
+  - while
+  - enforcing
+  - single
+  - human
+  - approved
+  - coordinator
+  - calls
+  - forwarded
+  - only
+  - authenticated
+source:
+  repository: https://github.com/leaveimagination/dsh-qwen-voice
+  repositoryNodeId: R_kgDOT4GTsQ
+  subpath: tools/dsh-qwen-coordinator-tools
+  commit: 9522d924691456ea09ad3edaf2454ea63b6c04fa
+creator:
+  github: leaveimagination
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: tools/dsh-qwen-coordinator-tools/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:28.219Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leaveimagination-dsh-qwen-coordinator-tools`
- Submission type: community curation
- Created by `leaveimagination` — https://github.com/leaveimagination
- Original source repository: https://github.com/leaveimagination/dsh-qwen-voice
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.