### PR TITLE
catalog: add leaveimagination-dsh-qwen-voice (community curation, created by @leaveimagination)

### DIFF
--- a/catalog/plugins/leaveimagination-dsh-qwen-voice.yaml
+++ b/catalog/plugins/leaveimagination-dsh-qwen-voice.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: leaveimagination-dsh-qwen-voice
+name: dsh-qwen-voice
+description:
+  en: powershell git clone https://github.com/leaveimagination/dsh-qwen-voice.git cd dsh-qwen-voice .\scripts\install.cmd
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - powershell
+  - clone
+  - leaveimagination
+  - qwen
+  - voice
+  - scripts
+  - install
+  - dsh
+source:
+  repository: https://github.com/leaveimagination/dsh-qwen-voice
+  repositoryNodeId: R_kgDOT4GTsQ
+  subpath: null
+  commit: 9522d924691456ea09ad3edaf2454ea63b6c04fa
+creator:
+  github: leaveimagination
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:28.219Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leaveimagination-dsh-qwen-voice`
- Submission type: community curation
- Created by `leaveimagination` — https://github.com/leaveimagination
- Original source repository: https://github.com/leaveimagination/dsh-qwen-voice
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.