### PR TITLE
catalog: add leechen298-code2skill (community curation, created by @leechen298)

### DIFF
--- a/catalog/plugins/leechen298-code2skill.yaml
+++ b/catalog/plugins/leechen298-code2skill.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: leechen298-code2skill
+name: "@leechen298/code2skill"
+description:
+  en: Generate and review portable Function, MCP, and Agent Skill packages from existing code.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - agent-skills
+  - code2skill
+  - deepseek-harness
+  - dsh-plugin
+  - mcp
+  - dsh
+source:
+  repository: https://github.com/leechen298/Code2Skill
+  repositoryNodeId: R_kgDOTbv2eg
+  subpath: null
+  commit: 85fc86a6155b237aa23fda9f02068166a90b590c
+creator:
+  github: leechen298
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:48:57.151Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leechen298-code2skill`
- Submission type: community curation
- Created by `leechen298` — https://github.com/leechen298
- Original source repository: https://github.com/leechen298/Code2Skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.