### PR TITLE
catalog: add leeminjing-dsh-eyes (community curation, created by @Leeminjing)

### DIFF
--- a/catalog/plugins/leeminjing-dsh-eyes.yaml
+++ b/catalog/plugins/leeminjing-dsh-eyes.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: leeminjing-dsh-eyes
+name: dsh-eyes
+description:
+  en: "On-demand vision for text-only LLMs in DeepSeek Harness: keep pasted/attached images in the backend, and let the model call view image to look at them anytime via any OpenAI-compatible vision endpoint — as if the model were natively multimodal."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - vision
+  - multimodal
+  - ocr
+  - openai-compatible
+  - dsh
+source:
+  repository: https://github.com/Leeminjing/dsh-eyes
+  repositoryNodeId: R_kgDOT570Cg
+  subpath: null
+  commit: b645e41dd6afeba06c58414914a77a150d49fe1a
+creator:
+  github: Leeminjing
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:32.523Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leeminjing-dsh-eyes`
- Submission type: community curation
- Created by `Leeminjing` — https://github.com/Leeminjing
- Original source repository: https://github.com/Leeminjing/dsh-eyes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.