### PR TITLE
catalog: add lemcae-dsh-balance (community curation, created by @LemCAE)

### DIFF
--- a/catalog/plugins/lemcae-dsh-balance.yaml
+++ b/catalog/plugins/lemcae-dsh-balance.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: lemcae-dsh-balance
+name: "@lemcae/dsh-balance"
+description:
+  en: DeepSeek Open Platform balance and session consumption readout (host + web client)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - open
+  - platform
+  - balance
+  - session
+  - consumption
+  - readout
+  - host
+  - client
+  - dsh
+source:
+  repository: https://github.com/LemCAE/dsh-balance
+  repositoryNodeId: R_kgDOT4gTPw
+  subpath: null
+  commit: 04686d592ad52762f235eb129518869bea7c55cc
+creator:
+  github: LemCAE
+package:
+  ecosystem: npm
+  name: "@lemcae/dsh-balance"
+  version: 0.1.7
+  integrity: sha512-Dn/npZJIDpLGvupRIokjFyy+/AqvYVQON0XhtayHrM3Vkd2Kb8uBsQZyRRFbFsf90Wy+5wITOifHMNOfcKuVyw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:19.548Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lemcae-dsh-balance`
- Submission type: community curation
- Created by `LemCAE` — https://github.com/LemCAE
- Original source repository: https://github.com/LemCAE/dsh-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.