### PR TITLE
catalog: add lemoncat7-dsh-ssh (community curation, created by @lemoncat7)

### DIFF
--- a/catalog/plugins/lemoncat7-dsh-ssh.yaml
+++ b/catalog/plugins/lemoncat7-dsh-ssh.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lemoncat7-dsh-ssh
+name: "@lemoncat7/dsh-ssh"
+description:
+  en: Secure SSH profiles, browser terminals, proxies, port forwarding, and session-scoped AI access for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ssh
+  - terminal
+  - port-forwarding
+  - socks5
+  - proxy
+source:
+  repository: https://github.com/lemoncat7/dsh-ssh
+  repositoryNodeId: R_kgDOUB4NGQ
+  subpath: null
+  commit: df7b4f365151559d6925fdcc61d7d33986d69e52
+creator:
+  github: lemoncat7
+package:
+  ecosystem: npm
+  name: "@lemoncat7/dsh-ssh"
+  version: 1.1.8
+  integrity: sha512-4G1CMayb5ibEeNx9bQJLMxtz4Y0JqctVIOPm2donzt8hAybcN7xZ5duvDmdHYF0GgjEx8qW2PI0WlS36Y/O1Hw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:45.902Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lemoncat7-dsh-ssh`
- Submission type: community curation
- Created by `lemoncat7` — https://github.com/lemoncat7
- Original source repository: https://github.com/lemoncat7/dsh-ssh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.