### PR TITLE
catalog: add lencx-minke-harness-overlay (community curation, created by @lencx)

### DIFF
--- a/catalog/plugins/lencx-minke-harness-overlay.yaml
+++ b/catalog/plugins/lencx-minke-harness-overlay.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: lencx-minke-harness-overlay
+name: "@lencx/minke-harness-overlay"
+description:
+  en: Minke-owned DeepSeek Harness product extensions
+  evidencePath: packages/harness-overlay/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - minke
+  - owned
+  - product
+  - extensions
+  - dsh
+source:
+  repository: https://github.com/lencx/Minke
+  repositoryNodeId: R_kgDOT44fxw
+  subpath: packages/harness-overlay
+  commit: c156b73e1e663a46de4e741da03ff0affb0c5476
+creator:
+  github: lencx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/harness-overlay/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:50.617Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lencx-minke-harness-overlay`
- Submission type: community curation
- Created by `lencx` — https://github.com/lencx
- Original source repository: https://github.com/lencx/Minke
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.