### PR TITLE
catalog: add lengquan88-dsh-dual-auto (community curation, created by @lengquan88)

### DIFF
--- a/catalog/plugins/lengquan88-dsh-dual-auto.yaml
+++ b/catalog/plugins/lengquan88-dsh-dual-auto.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lengquan88-dsh-dual-auto
+name: "@lengquan88/dsh-dual-auto"
+description:
+  en: Dual-model auto-routing plugin for the DeepSeek Harness (dsh).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dual
+  - model
+  - auto
+  - routing
+  - dsh
+source:
+  repository: https://github.com/lengquan88/dsh-dual-auto
+  repositoryNodeId: R_kgDOT_3eEA
+  subpath: null
+  commit: 79585271cc01621ec73d9b6c6d82e832c4b8b462
+creator:
+  github: lengquan88
+package:
+  ecosystem: npm
+  name: "@lengquan88/dsh-dual-auto"
+  version: 0.1.2
+  integrity: sha512-ENQM0DAYTBvR86njPrwq4iida7fqneoYZeYk+Y+9kowzXKGFrtF9yO3quYiw0yHXUyv2t9Bk4kwDlVsNzRNI2g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:15.721Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lengquan88-dsh-dual-auto`
- Submission type: community curation
- Created by `lengquan88` — https://github.com/lengquan88
- Original source repository: https://github.com/lengquan88/dsh-dual-auto
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.