### PR TITLE
catalog: add lengzhanbao-dsh-taffy-theme (community curation, created by @lengzhanbao)

### DIFF
--- a/catalog/plugins/lengzhanbao-dsh-taffy-theme.yaml
+++ b/catalog/plugins/lengzhanbao-dsh-taffy-theme.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: lengzhanbao-dsh-taffy-theme
+name: "@dsh-external/dsh-taffy-theme"
+description:
+  en: "Taffy Live Atelier / 塔菲直播工房 — candy acrylic DSH Web theme: light conservatory & dark stage art, gold-pink chat frame, Taffy overlays, optional agent preset."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - theme
+  - ui
+  - ui-theme
+  - webui
+  - taffy
+  - acrylic
+  - light-dark
+source:
+  repository: https://github.com/lengzhanbao/dsh-taffy-theme
+  repositoryNodeId: R_kgDOT_YHTg
+  subpath: null
+  commit: 25850a121727930e36a40418b80c693055ade276
+creator:
+  github: lengzhanbao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:34.487Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lengzhanbao-dsh-taffy-theme`
- Submission type: community curation
- Created by `lengzhanbao` — https://github.com/lengzhanbao
- Original source repository: https://github.com/lengzhanbao/dsh-taffy-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.