### PR TITLE
catalog: add leo-ayh-oday-dsh-bundle (community curation, created by @Leo-Ayh-Oday)

### DIFF
--- a/catalog/plugins/leo-ayh-oday-dsh-bundle.yaml
+++ b/catalog/plugins/leo-ayh-oday-dsh-bundle.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: leo-ayh-oday-dsh-bundle
+name: "@leooday/dsh-bundle"
+description:
+  en: Orcana runtime pack profile bundle for DeepSeek Harness (dsh.bundle.patch contract)
+  evidencePath: packages/dsh-bundle/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - orcana
+  - runtime
+  - pack
+  - profile
+  - bundle
+  - patch
+  - contract
+  - dsh
+source:
+  repository: https://github.com/Leo-Ayh-Oday/dsh-orcana
+  repositoryNodeId: R_kgDOT4Grfg
+  subpath: packages/dsh-bundle
+  commit: 93b44a5b0251546300b2810a1cfd3089ec33c1de
+creator:
+  github: Leo-Ayh-Oday
+package:
+  ecosystem: npm
+  name: "@leooday/dsh-bundle"
+  version: 0.1.1
+  integrity: sha512-eC0PVTsoHMPoViV521+QAZfO7hKTt2LOLK/DUnuKx5o/khkwXIZvf/6c5mobwsrDOxAK8vxkuIrzd13B88HS+Q==
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh-bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:53.355Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leo-ayh-oday-dsh-bundle`
- Submission type: community curation
- Created by `Leo-Ayh-Oday` — https://github.com/Leo-Ayh-Oday
- Original source repository: https://github.com/Leo-Ayh-Oday/dsh-orcana
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.