### PR TITLE
catalog: add leo-ayh-oday-dsh-orcana-linux-bundle (community curation, created by @Leo-Ayh-Oday)

### DIFF
--- a/catalog/plugins/leo-ayh-oday-dsh-orcana-linux-bundle.yaml
+++ b/catalog/plugins/leo-ayh-oday-dsh-orcana-linux-bundle.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: leo-ayh-oday-dsh-orcana-linux-bundle
+name: "@leooday/dsh-orcana-linux-bundle"
+description:
+  en: dsh-orcana Linux native-evidence profile bundle for DeepSeek Harness (dsh.bundle.patch contract)
+  evidencePath: packages/dsh-orcana-linux-bundle/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - orcana
+  - linux
+  - native
+  - evidence
+  - profile
+  - bundle
+  - patch
+  - contract
+  - dsh
+source:
+  repository: https://github.com/Leo-Ayh-Oday/dsh-orcana
+  repositoryNodeId: R_kgDOT4Grfg
+  subpath: packages/dsh-orcana-linux-bundle
+  commit: 93b44a5b0251546300b2810a1cfd3089ec33c1de
+creator:
+  github: Leo-Ayh-Oday
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh-orcana-linux-bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:53.355Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leo-ayh-oday-dsh-orcana-linux-bundle`
- Submission type: community curation
- Created by `Leo-Ayh-Oday` — https://github.com/Leo-Ayh-Oday
- Original source repository: https://github.com/Leo-Ayh-Oday/dsh-orcana
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.