### PR TITLE
catalog: add lesliewylie-agent-loop-workflow (community curation, created by @LeslieWylie)

### DIFF
--- a/catalog/plugins/lesliewylie-agent-loop-workflow.yaml
+++ b/catalog/plugins/lesliewylie-agent-loop-workflow.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: lesliewylie-agent-loop-workflow
+name: agent-loop-workflow
+description:
+  en: "A project-agnostic multi-agent collaboration protocol for the DeepSeek Harness: loop guards that stop runaway agent loops, a six-field handoff format, risk-tiered review routing, and a fixed verify-commit-push-review-close sequence."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - agent-loop
+  - workflow
+  - multi-agent
+  - agent-orchestration
+  - handoff
+source:
+  repository: https://github.com/LeslieWylie/agent-loop-workflow
+  repositoryNodeId: R_kgDOT4Sr0Q
+  subpath: null
+  commit: 4ea9be64e9ef3e2940d4719576866044430e8d2c
+creator:
+  github: LeslieWylie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:36.679Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lesliewylie-agent-loop-workflow`
- Submission type: community curation
- Created by `LeslieWylie` — https://github.com/LeslieWylie
- Original source repository: https://github.com/LeslieWylie/agent-loop-workflow
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.