### PR TITLE
catalog: add lesliewylie-dsh-ops-kit (community curation, created by @LeslieWylie)

### DIFF
--- a/catalog/plugins/lesliewylie-dsh-ops-kit.yaml
+++ b/catalog/plugins/lesliewylie-dsh-ops-kit.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lesliewylie-dsh-ops-kit
+name: dsh-ops-kit
+description:
+  en: A reusable DeepSeek Harness bundle for evidence-driven memory, orchestration, benchmark operations, repository audits, and plugin release workflows.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - evidence-based
+  - agent-loop
+  - orchestration
+  - memory
+  - benchmark
+source:
+  repository: https://github.com/LeslieWylie/dsh-ops-kit
+  repositoryNodeId: R_kgDOT4PCrw
+  subpath: null
+  commit: d4db8b308fb507ce0c176c551b29c917d68ce751
+creator:
+  github: LeslieWylie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:37.289Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lesliewylie-dsh-ops-kit`
- Submission type: community curation
- Created by `LeslieWylie` — https://github.com/LeslieWylie
- Original source repository: https://github.com/LeslieWylie/dsh-ops-kit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.