### PR TITLE
catalog: add lesliewylie-dsh-session-search-pro (community curation, created by @LeslieWylie)

### DIFF
--- a/catalog/plugins/lesliewylie-dsh-session-search-pro.yaml
+++ b/catalog/plugins/lesliewylie-dsh-session-search-pro.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: lesliewylie-dsh-session-search-pro
+name: dsh-session-search-pro
+description:
+  en: Indexed cross-session search for DeepSeek Harness — search, list, and read past and current DSH sessions through the built-in sessionQuery service. Zero runtime dependencies.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - session-search
+  - search
+  - agent-tools
+  - cordis
+source:
+  repository: https://github.com/LeslieWylie/dsh-session-search-pro
+  repositoryNodeId: R_kgDOT4UblA
+  subpath: null
+  commit: 82787487d75f6af3d0e1b219a19dec49b93213cb
+creator:
+  github: LeslieWylie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:38.703Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lesliewylie-dsh-session-search-pro`
- Submission type: community curation
- Created by `LeslieWylie` — https://github.com/LeslieWylie
- Original source repository: https://github.com/LeslieWylie/dsh-session-search-pro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.