### PR TITLE
catalog: add lesliewylie-dsh-task-relay (community curation, created by @LeslieWylie)

### DIFF
--- a/catalog/plugins/lesliewylie-dsh-task-relay.yaml
+++ b/catalog/plugins/lesliewylie-dsh-task-relay.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: lesliewylie-dsh-task-relay
+name: dsh-task-relay
+description:
+  en: DSH cross-session task relay plugin — a persistent shared task queue with handoff notes for cross-session and subagent coordination.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - cross
+  - session
+  - task
+  - relay
+  - persistent
+  - shared
+  - queue
+  - handoff
+  - notes
+  - subagent
+  - coordination
+  - dsh
+source:
+  repository: https://github.com/LeslieWylie/dsh-task-relay
+  repositoryNodeId: R_kgDOT4TqFA
+  subpath: null
+  commit: de69deeee9071dd8fe7eb9e24deffe8adf668b20
+creator:
+  github: LeslieWylie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:39.775Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lesliewylie-dsh-task-relay`
- Submission type: community curation
- Created by `LeslieWylie` — https://github.com/LeslieWylie
- Original source repository: https://github.com/LeslieWylie/dsh-task-relay
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.