### PR TITLE
catalog: add lesliewylie-review-workflow (community curation, created by @LeslieWylie)

### DIFF
--- a/catalog/plugins/lesliewylie-review-workflow.yaml
+++ b/catalog/plugins/lesliewylie-review-workflow.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: lesliewylie-review-workflow
+name: review-workflow
+description:
+  en: "A structured multi-panelist review workflow for the DeepSeek Harness: N panelists score in isolated subagents blind to each other, a chair reconciles disagreement, an independent critic audits the process."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - review
+  - workflow
+  - multi-panelist
+  - checkpoint
+source:
+  repository: https://github.com/LeslieWylie/review-workflow
+  repositoryNodeId: R_kgDOT4SsIQ
+  subpath: null
+  commit: f423c032ce55694916d5e1edf6520722b1cd809b
+creator:
+  github: LeslieWylie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:40.465Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lesliewylie-review-workflow`
- Submission type: community curation
- Created by `LeslieWylie` — https://github.com/LeslieWylie
- Original source repository: https://github.com/LeslieWylie/review-workflow
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.