### PR TITLE
catalog: add letter2025-dsh-tool-search (community curation, created by @Letter2025)

### DIFF
--- a/catalog/plugins/letter2025-dsh-tool-search.yaml
+++ b/catalog/plugins/letter2025-dsh-tool-search.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: letter2025-dsh-tool-search
+name: dsh-tool-search
+description:
+  en: "Tool search & slimming for DeepSeek Harness: Hermes-style progressive disclosure — search, describe, and call long-tail tools on demand while keeping core tools eager"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - tool-search
+  - tool-slimming
+  - hermes
+  - semantic-search
+  - rerank
+source:
+  repository: https://github.com/Letter2025/dsh-tool-search
+  repositoryNodeId: R_kgDOT4N6hA
+  subpath: null
+  commit: d7961581973fd6ee93e92d0bd6942c757b0e46f4
+creator:
+  github: Letter2025
+package:
+  ecosystem: npm
+  name: dsh-tool-search
+  version: 0.1.3
+  integrity: sha512-nPVD+pkMODVj5syvaS2dTeS6wC28YLMAVW0F01Ot770kNZ2HoSP0r72O4JzVpSXehYMNDq+TniOLQEOHG1cU9w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:03.932Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `letter2025-dsh-tool-search`
- Submission type: community curation
- Created by `Letter2025` — https://github.com/Letter2025
- Original source repository: https://github.com/Letter2025/dsh-tool-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.