### PR TITLE
catalog: add lfm097384-context-prism-dsh-plugin (community curation, created by @LFM097384)

### DIFF
--- a/catalog/plugins/lfm097384-context-prism-dsh-plugin.yaml
+++ b/catalog/plugins/lfm097384-context-prism-dsh-plugin.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lfm097384-context-prism-dsh-plugin
+name: context-prism-dsh-plugin
+description:
+  en: DSH plugin with an in-process JavaScript port of ContextPrism (Local Context Engine)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - process
+  - javascript
+  - port
+  - contextprism
+  - local
+  - context
+  - engine
+  - dsh
+source:
+  repository: https://github.com/LFM097384/Context-Prism
+  repositoryNodeId: R_kgDOT8o6Ww
+  subpath: null
+  commit: 4ecb4d85dd511d3b864762a9fb5e926d53c70810
+creator:
+  github: LFM097384
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:01.432Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lfm097384-context-prism-dsh-plugin`
- Submission type: community curation
- Created by `LFM097384` — https://github.com/LFM097384
- Original source repository: https://github.com/LFM097384/Context-Prism
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.