### PR TITLE
catalog: add lhbsaa-dsh-visibridge (community curation, created by @lhbsaa)

### DIFF
--- a/catalog/plugins/lhbsaa-dsh-visibridge.yaml
+++ b/catalog/plugins/lhbsaa-dsh-visibridge.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lhbsaa-dsh-visibridge
+name: dsh-visibridge
+description:
+  en: "Host-level vision bridge for text-only models: analyze image tool (Ollama local / Xiaomi MiMo cloud / any OpenAI-compatible endpoint) returning structured evidence."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - vision
+  - ocr
+  - ollama
+  - xiaomi-mimo
+  - agent
+source:
+  repository: https://github.com/lhbsaa/dsh-visibridge
+  repositoryNodeId: R_kgDOT7KhdA
+  subpath: null
+  commit: cf2684830d51ad27cfce343cb131e30963c3141b
+creator:
+  github: lhbsaa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:17.701Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lhbsaa-dsh-visibridge`
- Submission type: community curation
- Created by `lhbsaa` — https://github.com/lhbsaa
- Original source repository: https://github.com/lhbsaa/dsh-visibridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.