### PR TITLE
catalog: add lheyang-orca-dsh-launcher (community curation, created by @Lheyang)

### DIFF
--- a/catalog/plugins/lheyang-orca-dsh-launcher.yaml
+++ b/catalog/plugins/lheyang-orca-dsh-launcher.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: lheyang-orca-dsh-launcher
+name: orca-dsh-launcher
+description:
+  en: A Cordis plugin + native desktop app for DeepSeek Harness (DSH) that provides update checking, server start/stop, a system tray icon, a graphical console, and one-click installation.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - orca
+  - launcher
+  - tray
+  - update
+  - checker
+  - csharp
+  - dotnet
+  - wpf
+source:
+  repository: https://github.com/Lheyang/orca-dsh-launcher
+  repositoryNodeId: R_kgDOT6H9cA
+  subpath: null
+  commit: 518087f593f3eb7bf70af7a215e3e97bced9f05d
+creator:
+  github: Lheyang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:45.215Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lheyang-orca-dsh-launcher`
- Submission type: community curation
- Created by `Lheyang` — https://github.com/Lheyang
- Original source repository: https://github.com/Lheyang/orca-dsh-launcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.