### PR TITLE
catalog: add lhl-dsh-model-deploy (community curation, created by @lhl)

### DIFF
--- a/catalog/plugins/lhl-dsh-model-deploy.yaml
+++ b/catalog/plugins/lhl-dsh-model-deploy.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: lhl-dsh-model-deploy
+name: dsh-model-deploy
+description:
+  en: "DeepSeek Harness plugin: LLM model selection & deployment analysis (deployability, VRAM, TTFT, latency, throughput, power for 38 models × 20 GPUs/NPUs)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - llm
+  - model-selection
+  - deployment
+  - capacity-planning
+  - gpu
+  - npu
+  - ascend
+source:
+  repository: https://github.com/lhwwxy/dsh-model-deploy
+  repositoryNodeId: R_kgDOT78nyQ
+  subpath: null
+  commit: f66be5534db621fd1e4ee930bfb17577be1c9e9b
+creator:
+  github: lhl
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:02.998Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lhl-dsh-model-deploy`
- Submission type: community curation
- Created by `lhl` — https://github.com/lhl
- Original source repository: https://github.com/lhwwxy/dsh-model-deploy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.