### PR TITLE
catalog: add lhy723-dsh-neu-theme (community curation, created by @Lhy723)

### DIFF
--- a/catalog/plugins/lhy723-dsh-neu-theme.yaml
+++ b/catalog/plugins/lhy723-dsh-neu-theme.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lhy723-dsh-neu-theme
+name: dsh-neu-theme
+description:
+  en: A Neumorphism (soft-UI) theme plugin for DeepSeek Harness web — gentle raised-and-recessed surfaces in a cream light palette and an ink-dark palette, complete with ambient lighting, material gloss, grain texture, glassmorphism and micro-interactions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+  - neumorphism
+  - soft-ui
+  - web-ui
+source:
+  repository: https://github.com/Lhy723/dsh-neu-theme
+  repositoryNodeId: R_kgDOT5uU_g
+  subpath: null
+  commit: 834bf7100d8b298e74921ae3605f7b2045bd25aa
+creator:
+  github: Lhy723
+package:
+  ecosystem: npm
+  name: dsh-neu-theme
+  version: 0.1.1
+  integrity: sha512-33Xtoo8CqEmjCVdxyVxTzAz/IOkrM29CyhBdeDUny6/8oBmAWIOlRwPPPNPouL+/w188XPCoqC+nBlFbNmOuyA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:06.710Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lhy723-dsh-neu-theme`
- Submission type: community curation
- Created by `Lhy723` — https://github.com/Lhy723
- Original source repository: https://github.com/Lhy723/dsh-neu-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.