### PR TITLE
catalog: add li3nga-dhs-multi-agent (community curation, created by @Li3NGa)

### DIFF
--- a/catalog/plugins/li3nga-dhs-multi-agent.yaml
+++ b/catalog/plugins/li3nga-dhs-multi-agent.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: li3nga-dhs-multi-agent
+name: dhs-multi-agent
+description:
+  en: Native DeepSeek Harness multi-agent Cordis plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - native
+  - multi
+  - agent
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/Li3NGa/DHS-multi-agent-plugin
+  repositoryNodeId: R_kgDOT5PI8w
+  subpath: null
+  commit: 3deec06331e3ac74b59e639f8872cdf0a09190ff
+creator:
+  github: Li3NGa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:48.683Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `li3nga-dhs-multi-agent`
- Submission type: community curation
- Created by `Li3NGa` — https://github.com/Li3NGa
- Original source repository: https://github.com/Li3NGa/DHS-multi-agent-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.