### PR TITLE
catalog: add liangmianya-dsh-synapse (community curation, created by @liangmianya)

### DIFF
--- a/catalog/plugins/liangmianya-dsh-synapse.yaml
+++ b/catalog/plugins/liangmianya-dsh-synapse.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: liangmianya-dsh-synapse
+name: dsh-synapse
+description:
+  en: A visual, non-linear conversation workspace plugin for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - visual
+  - linear
+  - conversation
+  - workspace
+  - dsh
+source:
+  repository: https://github.com/liangmianya/dsh-synapse
+  repositoryNodeId: R_kgDOT6U6IA
+  subpath: null
+  commit: 56935dc1862e7791b212f6eb2dd26404def5a575
+creator:
+  github: liangmianya
+package:
+  ecosystem: npm
+  name: dsh-synapse
+  version: 0.4.1
+  integrity: sha512-PkmCY5LaPcoLC7rxVIPk4cqcteYg0/+pwFg1NvjnEOr1GFrivfSFUUMmw3GdG3qxakTp4KTAhWkXrMOfMzBcwg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:48:48.392Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 249
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liangmianya-dsh-synapse`
- Submission type: community curation
- Created by `liangmianya` — https://github.com/liangmianya
- Original source repository: https://github.com/liangmianya/dsh-synapse
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.