### PR TITLE
catalog: add libinyam-dsh-vision-provider (community curation, created by @libinyam)

### DIFF
--- a/catalog/plugins/libinyam-dsh-vision-provider.yaml
+++ b/catalog/plugins/libinyam-dsh-vision-provider.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: libinyam-dsh-vision-provider
+name: dsh-vision-provider
+description:
+  en: DeepSeek Harness adapter that exposes each configured vision model as a selectable DeepSeek composite in Web UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - vision
+  - multimodal
+  - openai-compatible
+  - image-input
+  - profile-bundle
+  - composite-model
+  - vision-sidecar
+source:
+  repository: https://github.com/libinyam/dsh-vision-provider
+  repositoryNodeId: R_kgDOT3iaZw
+  subpath: null
+  commit: c4c76c2a2a69313b91728dcde2827e014aad7c72
+creator:
+  github: libinyam
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:52.411Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `libinyam-dsh-vision-provider`
- Submission type: community curation
- Created by `libinyam` — https://github.com/libinyam
- Original source repository: https://github.com/libinyam/dsh-vision-provider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.