### PR TITLE
catalog: add libiwolve-dsh-experience-library (community curation, created by @libiwolve)

### DIFF
--- a/catalog/plugins/libiwolve-dsh-experience-library.yaml
+++ b/catalog/plugins/libiwolve-dsh-experience-library.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: libiwolve-dsh-experience-library
+name: "@libiwolve/dsh-experience-library"
+description:
+  en: meow-memory makes your AI remember; this plugin makes your AI remember "the right way to do things".
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - meow
+  - memory
+  - remember
+  - right
+  - things
+  - dsh
+source:
+  repository: https://github.com/libiwolve/dsh-experience-library
+  repositoryNodeId: R_kgDOUCEE2A
+  subpath: null
+  commit: 153bb640467061ab3b768749d6f555ef39cf7cb4
+creator:
+  github: libiwolve
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:21.902Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `libiwolve-dsh-experience-library`
- Submission type: community curation
- Created by `libiwolve` — https://github.com/libiwolve
- Original source repository: https://github.com/libiwolve/dsh-experience-library
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.