### PR TITLE
catalog: add lifeodyssey-dsh-compressor (community curation, created by @lifeodyssey)

### DIFF
--- a/catalog/plugins/lifeodyssey-dsh-compressor.yaml
+++ b/catalog/plugins/lifeodyssey-dsh-compressor.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: lifeodyssey-dsh-compressor
+name: dsh-compressor
+description:
+  en: In-process DeepSeek Harness context compression bundle
+  evidencePath: plugins/dsh-compressor/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - context-compression
+  - dsh
+source:
+  repository: https://github.com/lifeodyssey/dsh-compressor
+  repositoryNodeId: R_kgDOS642mg
+  subpath: plugins/dsh-compressor
+  commit: 76b39ab7ff2f5c4c847ef93f793e3d2e7bb0a3ce
+creator:
+  github: lifeodyssey
+package:
+  ecosystem: npm
+  name: dsh-compressor
+  version: 0.1.0
+  integrity: sha512-oJT3Xy8/jpofp5elHmow6+4W2hPSJi35pYPMCHzoQqtSlhMVEmx5iyxTQ1jmPxJB9OsqUA7sTZcJD/MEH9609w==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-compressor/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:08.423Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lifeodyssey-dsh-compressor`
- Submission type: community curation
- Created by `lifeodyssey` — https://github.com/lifeodyssey
- Original source repository: https://github.com/lifeodyssey/dsh-compressor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.