### PR TITLE
catalog: add lifeopsgo-dsh-capability-toggle-plugin (community curation, created by @lifeopsgo)

### DIFF
--- a/catalog/plugins/lifeopsgo-dsh-capability-toggle-plugin.yaml
+++ b/catalog/plugins/lifeopsgo-dsh-capability-toggle-plugin.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: lifeopsgo-dsh-capability-toggle-plugin
+name: dsh-capability-toggle-plugin
+description:
+  en: DSH WebUI capability controls for skills, MCP servers, tools, prompt injections, approvals, and safety guards at session, project, and global levels.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - capability
+  - security
+source:
+  repository: https://github.com/lifeopsgo/dsh-capability-toggle-plugin
+  repositoryNodeId: R_kgDOUAQt5g
+  subpath: null
+  commit: 0d9fd8e5f54b53fb8409fbd94caee6451c23c9d7
+creator:
+  github: lifeopsgo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:42.491Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lifeopsgo-dsh-capability-toggle-plugin`
- Submission type: community curation
- Created by `lifeopsgo` — https://github.com/lifeopsgo
- Original source repository: https://github.com/lifeopsgo/dsh-capability-toggle-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.