### PR TITLE
catalog: add lihang-lh-dsh-mood-light (community curation, created by @lihang-lh)

### DIFF
--- a/catalog/plugins/lihang-lh-dsh-mood-light.yaml
+++ b/catalog/plugins/lihang-lh-dsh-mood-light.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: lihang-lh-dsh-mood-light
+name: dsh-mood-light
+description:
+  en: A mood-light ring around the DSH web UI edge. It reads the current session state and automatically switches the light color and rhythm. The default effect is soft glow (diffuse) — borderless, a multi-layer inward-diffusing scattered light with a subtle organic irregularity. Marquee (rotating band) and linear gradient (
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - mood
+  - light
+  - ring
+  - around
+  - edge
+  - reads
+  - current
+  - session
+  - state
+  - automatically
+  - switches
+  - color
+  - rhythm
+  - default
+  - effect
+  - soft
+source:
+  repository: https://github.com/lihang-lh/dsh-moon-light
+  repositoryNodeId: R_kgDOT8P36g
+  subpath: null
+  commit: 1fcae743b10c38a9a39506237272959ba1e175de
+creator:
+  github: lihang-lh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:11.658Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lihang-lh-dsh-mood-light`
- Submission type: community curation
- Created by `lihang-lh` — https://github.com/lihang-lh
- Original source repository: https://github.com/lihang-lh/dsh-moon-light
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.