### PR TITLE
catalog: add lijinhao315-dsh-client-ui-question-index (community curation, created by @lijinhao315)

### DIFF
--- a/catalog/plugins/lijinhao315-dsh-client-ui-question-index.yaml
+++ b/catalog/plugins/lijinhao315-dsh-client-ui-question-index.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: lijinhao315-dsh-client-ui-question-index
+name: "@deepseek-ai/dsh-client-ui-question-index"
+description:
+  en: "Question index surface: an ordered, collapsible list of the user's asked questions floating on the right side of the conversation, with click-to-jump into the flow"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - question-index
+  - chat-history
+  - ui
+source:
+  repository: https://github.com/lijinhao315/dsh-question-index
+  repositoryNodeId: R_kgDOUBj9Qw
+  subpath: null
+  commit: d6163f9f449e6306d2efab7b87b9cb0c6cf72597
+creator:
+  github: lijinhao315
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:14.812Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lijinhao315-dsh-client-ui-question-index`
- Submission type: community curation
- Created by `lijinhao315` — https://github.com/lijinhao315
- Original source repository: https://github.com/lijinhao315/dsh-question-index
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.