### PR TITLE
catalog: add limitinfinitude-dsh-right-sidebar (community curation, created by @Limitinfinitude)

### DIFF
--- a/catalog/plugins/limitinfinitude-dsh-right-sidebar.yaml
+++ b/catalog/plugins/limitinfinitude-dsh-right-sidebar.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: limitinfinitude-dsh-right-sidebar
+name: dsh-right-sidebar
+description:
+  en: Codex-style right sidebar for DSH Web with automatic output collection, responsive previews, and session-aware tabs
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - codex
+  - style
+  - right
+  - sidebar
+  - automatic
+  - output
+  - collection
+  - responsive
+  - previews
+  - session
+  - aware
+  - tabs
+  - dsh
+source:
+  repository: https://github.com/Limitinfinitude/DSH-Right-Sidebar
+  repositoryNodeId: R_kgDOT5SWFw
+  subpath: null
+  commit: 80385b35f9ee6a3e0eb21ff81f708839e2fd3b81
+creator:
+  github: Limitinfinitude
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:32.383Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `limitinfinitude-dsh-right-sidebar`
- Submission type: community curation
- Created by `Limitinfinitude` — https://github.com/Limitinfinitude
- Original source repository: https://github.com/Limitinfinitude/DSH-Right-Sidebar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.