### PR TITLE
catalog: add lin-1259-dsh-desktop-linux-updater (community curation, created by @lin-1259)

### DIFF
--- a/catalog/plugins/lin-1259-dsh-desktop-linux-updater.yaml
+++ b/catalog/plugins/lin-1259-dsh-desktop-linux-updater.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: lin-1259-dsh-desktop-linux-updater
+name: dsh-desktop-linux-updater
+description:
+  en: "One-click update for self-built Linux dsh-desktop: checks the fork's GitHub releases, downloads the deb, swaps the app dir and restarts. 桌面端 Linux 自建版一键更新。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - dsh-desktop
+  - linux
+  - updater
+source:
+  repository: https://github.com/lin-1259/dsh-desktop-linux-updater
+  repositoryNodeId: R_kgDOUA0HGg
+  subpath: null
+  commit: 66791e8aeb5060e5f3f71d6dd3b2da21b4e73ac7
+creator:
+  github: lin-1259
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:17.430Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lin-1259-dsh-desktop-linux-updater`
- Submission type: community curation
- Created by `lin-1259` — https://github.com/lin-1259
- Original source repository: https://github.com/lin-1259/dsh-desktop-linux-updater
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.