### PR TITLE
catalog: add linconz-agentduel-dsh (community curation, created by @linconz)

### DIFF
--- a/catalog/plugins/linconz-agentduel-dsh.yaml
+++ b/catalog/plugins/linconz-agentduel-dsh.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: linconz-agentduel-dsh
+name: "@agentduel/agentduel-dsh"
+description:
+  en: AgentDuel plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - agentduel
+  - dsh
+source:
+  repository: https://github.com/linconz/agentduel-dsh
+  repositoryNodeId: R_kgDOT88vfA
+  subpath: null
+  commit: 636833692239589cb8b6ea40a7cb5191232b53a4
+creator:
+  github: linconz
+package:
+  ecosystem: npm
+  name: "@agentduel/agentduel-dsh"
+  version: 0.1.4
+  integrity: sha512-sak/NCENqnpx41hMZvnzak7E6QojyLna9dcuVNy0wQyOsnOH3jPtI8/V6pVBFgWoIkJ7UDh/tLI/2uy9E+c2AQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:44.082Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `linconz-agentduel-dsh`
- Submission type: community curation
- Created by `linconz` — https://github.com/linconz
- Original source repository: https://github.com/linconz/agentduel-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.