### PR TITLE
catalog: add linhut-dsh-client-ui-skin-stock (community curation, created by @linhut)

### DIFF
--- a/catalog/plugins/linhut-dsh-client-ui-skin-stock.yaml
+++ b/catalog/plugins/linhut-dsh-client-ui-skin-stock.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: linhut-dsh-client-ui-skin-stock
+name: "@linxin666/dsh-client-ui-skin-stock"
+description:
+  en: sh dsh plugin --profile web add github:linhut/dsh-stock-terminal
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - web-ui
+  - skin
+  - stock
+  - trading
+  - ticker
+  - watchlist
+  - positions
+source:
+  repository: https://github.com/linhut/dsh-stock-terminal
+  repositoryNodeId: R_kgDOT7TDVg
+  subpath: null
+  commit: 24d0bb96c58aba995fe755943519ff667b9a6e65
+creator:
+  github: linhut
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:01.498Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `linhut-dsh-client-ui-skin-stock`
- Submission type: community curation
- Created by `linhut` — https://github.com/linhut
- Original source repository: https://github.com/linhut/dsh-stock-terminal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.