### PR TITLE
catalog: add linhx1999-dsh-writing-pad (community curation, created by @linhx1999)

### DIFF
--- a/catalog/plugins/linhx1999-dsh-writing-pad.yaml
+++ b/catalog/plugins/linhx1999-dsh-writing-pad.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: linhx1999-dsh-writing-pad
+name: dsh-writing-pad
+description:
+  en: Session-backed writing pad for the DeepSeek Harness web GUI with Markdown preview, complete-draft XML requests, human-readable transcript projections, and focused AI writing tools.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - session
+  - backed
+  - writing
+  - markdown
+  - preview
+  - complete
+  - draft
+  - requests
+  - human
+  - readable
+  - transcript
+  - projections
+  - focused
+  - tools
+  - dsh
+source:
+  repository: https://github.com/linhx1999/dsh-writing-pad
+  repositoryNodeId: R_kgDOT4EXJw
+  subpath: null
+  commit: b70b77310d21a46878dbfd9e6e3b4dfd208c8b43
+creator:
+  github: linhx1999
+package:
+  ecosystem: npm
+  name: dsh-writing-pad
+  version: 1.1.3
+  integrity: sha512-A3jf+Lqq/nO/c36DU4istSSRPKcFte8BaX91WmTvnwCh6VScKYeViL6SYoLROxceQ9FyynEAEUyGxgSuoj1tjA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:49:55.090Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `linhx1999-dsh-writing-pad`
- Submission type: community curation
- Created by `linhx1999` — https://github.com/linhx1999
- Original source repository: https://github.com/linhx1999/dsh-writing-pad
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.