### PR TITLE
catalog: add linkingoscar-dsh-billing-glass (community curation, created by @linkingoscar)

### DIFF
--- a/catalog/plugins/linkingoscar-dsh-billing-glass.yaml
+++ b/catalog/plugins/linkingoscar-dsh-billing-glass.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: linkingoscar-dsh-billing-glass
+name: dsh-billing-glass
+description:
+  en: "Liquid-glass billing overlay for the DeepSeek Harness Web GUI: provider balances, session cost, daily spend and token buckets. DeepSeek-first with an extensible provider registry."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - billing
+  - balance
+  - glassmorphism
+  - liquid-glass
+  - web
+source:
+  repository: https://github.com/linkingoscar/dsh-billing-glass
+  repositoryNodeId: R_kgDOT4X66w
+  subpath: null
+  commit: d495f2ab9f6ece3fed7a9c8eaca9a75da723e3c1
+creator:
+  github: linkingoscar
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:02.699Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `linkingoscar-dsh-billing-glass`
- Submission type: community curation
- Created by `linkingoscar` — https://github.com/linkingoscar
- Original source repository: https://github.com/linkingoscar/dsh-billing-glass
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.