### PR TITLE
catalog: add linxiushen-dsh-workflow-isolate (community curation, created by @Linxiushen)

### DIFF
--- a/catalog/plugins/linxiushen-dsh-workflow-isolate.yaml
+++ b/catalog/plugins/linxiushen-dsh-workflow-isolate.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: linxiushen-dsh-workflow-isolate
+name: dsh-workflow-isolate
+description:
+  en: QuickJS/WASM-isolated WorkflowEngine for running model-written DeepSeek Harness orchestration with bounded resource controls.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - workflow-engine
+  - quickjs
+  - wasm
+  - sandbox
+  - agentic
+source:
+  repository: https://github.com/Linxiushen/dsh-workflow-isolate
+  repositoryNodeId: R_kgDOT7gPog
+  subpath: null
+  commit: 0928d2b5cec465a4b69f2425d53fc63324c7e043
+creator:
+  github: Linxiushen
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:45.889Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `linxiushen-dsh-workflow-isolate`
- Submission type: community curation
- Created by `Linxiushen` — https://github.com/Linxiushen
- Original source repository: https://github.com/Linxiushen/dsh-workflow-isolate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.