### PR TITLE
catalog: add linxuhao-dsh-plugin-aitelier (community curation, created by @linxuhao)

### DIFF
--- a/catalog/plugins/linxuhao-dsh-plugin-aitelier.yaml
+++ b/catalog/plugins/linxuhao-dsh-plugin-aitelier.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: linxuhao-dsh-plugin-aitelier
+name: dsh-plugin-aitelier
+description:
+  en: "Use AItelier as a subagent from DeepSeek Harness: generate, edit, run, export and import SkillFlow pipelines. Client only — requires a running AItelier backend (Docker; see README)."
+  evidencePath: integrations/dsh/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - aitelier
+  - dsh-plugin
+  - dsh-skill
+  - mcp
+  - skillflow
+  - dsh
+source:
+  repository: https://github.com/linxuhao/AItelier
+  repositoryNodeId: R_kgDOR5f9ig
+  subpath: integrations/dsh
+  commit: ee083e17d7086987cff0da9a9311dcc586688e88
+creator:
+  github: linxuhao
+package:
+  ecosystem: npm
+  name: dsh-plugin-aitelier
+  version: 0.1.5
+  integrity: sha512-xiCC+bLoBnxgE+8wL/ekYaZd2ZPmGe2AdJdMJZn2TERwjoqZ00nbeMFUUa1cXpOFw4n/Hqf+sGQACykEvez1kw==
+dsh:
+  profiles:
+    - headless
+  evidencePath: integrations/dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:19.804Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `linxuhao-dsh-plugin-aitelier`
- Submission type: community curation
- Created by `linxuhao` — https://github.com/linxuhao
- Original source repository: https://github.com/linxuhao/AItelier
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.