### PR TITLE
catalog: add lion-1209-dsh-plugin-lion-skills (community curation, created by @Lion-1209)

### DIFF
--- a/catalog/plugins/lion-1209-dsh-plugin-lion-skills.yaml
+++ b/catalog/plugins/lion-1209-dsh-plugin-lion-skills.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lion-1209-dsh-plugin-lion-skills
+name: dsh-plugin-lion-skills
+description:
+  en: "Lion-Skills — a developer-focused agent skill suite (in Chinese) as a DeepSeek Harness plugin: 11 workflow skills for code review, debugging, testing, naming, spec writing, and more."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-skills
+  - claude-code-skills
+  - dsh
+source:
+  repository: https://github.com/Lion-1209/dsh-plugin-lion-skills
+  repositoryNodeId: R_kgDOT63aqg
+  subpath: null
+  commit: f3bba5af021c3a1fd6157878f2faf2fde5395484
+creator:
+  github: Lion-1209
+package:
+  ecosystem: npm
+  name: dsh-plugin-lion-skills
+  version: 0.1.0
+  integrity: sha512-SyuCU581sY62S4W5TYj1X3s9XfjZ4kbRg9A92cFAc2WOZDsUsvhb2UVFGWRNhmvMvAM32kEpixXdGhHSVmH1Ng==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:22.819Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lion-1209-dsh-plugin-lion-skills`
- Submission type: community curation
- Created by `Lion-1209` — https://github.com/Lion-1209
- Original source repository: https://github.com/Lion-1209/dsh-plugin-lion-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.