### PR TITLE
catalog: add lion-1209-dsh-plugin-wiki-tools (community curation, created by @Lion-1209)

### DIFF
--- a/catalog/plugins/lion-1209-dsh-plugin-wiki-tools.yaml
+++ b/catalog/plugins/lion-1209-dsh-plugin-wiki-tools.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: lion-1209-dsh-plugin-wiki-tools
+name: dsh-plugin-wiki-tools
+description:
+  en: "Native DeepSeek Harness tools for an Obsidian wiki vault: wiki query, wiki write, and wiki lint implement the mechanical core (path routing, delta tracking, index/log bookkeeping, health checks) of the wiki skill suite."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - obsidian
+  - knowledge-base
+  - wiki
+  - dsh
+source:
+  repository: https://github.com/Lion-1209/dsh-plugin-wiki-tools
+  repositoryNodeId: R_kgDOT8Erxw
+  subpath: null
+  commit: 85de359ccd9af268fe2bd7aa3069d0aaef00259f
+creator:
+  github: Lion-1209
+package:
+  ecosystem: npm
+  name: dsh-plugin-wiki-tools
+  version: 0.14.0
+  integrity: sha512-dGAYn7iWK2JXM1TRdvSR7JJrUeFmnCZd2wv0mOwKkIu9KJz1W6J2Y2IHfHJzzr1GHvFgPedA66QvszRcavfUIQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:07.294Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lion-1209-dsh-plugin-wiki-tools`
- Submission type: community curation
- Created by `Lion-1209` — https://github.com/Lion-1209
- Original source repository: https://github.com/Lion-1209/dsh-plugin-wiki-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.