### PR TITLE
catalog: add liqiming-whu-dsh-environment-context (community curation, created by @liqiming-whu)

### DIFF
--- a/catalog/plugins/liqiming-whu-dsh-environment-context.yaml
+++ b/catalog/plugins/liqiming-whu-dsh-environment-context.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: liqiming-whu-dsh-environment-context
+name: dsh-environment-context
+description:
+  en: Real-time weather, location, battery, and system-device context for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - weather
+  - geolocation
+  - context
+source:
+  repository: https://github.com/liqiming-whu/dsh-environment-context
+  repositoryNodeId: R_kgDOT8eI8w
+  subpath: null
+  commit: 90e9f835e0ce58d76d5bc3a7deefe510a8a24980
+creator:
+  github: liqiming-whu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:24.016Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liqiming-whu-dsh-environment-context`
- Submission type: community curation
- Created by `liqiming-whu` — https://github.com/liqiming-whu
- Original source repository: https://github.com/liqiming-whu/dsh-environment-context
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.