### PR TITLE
catalog: add lisniuse-dsh-modal-enhancer (community curation, created by @lisniuse)

### DIFF
--- a/catalog/plugins/lisniuse-dsh-modal-enhancer.yaml
+++ b/catalog/plugins/lisniuse-dsh-modal-enhancer.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lisniuse-dsh-modal-enhancer
+name: dsh-modal-enhancer
+description:
+  en: Add drag, eight-way resize, pin, maximize, backdrop controls, and persistent state to DeepSeek Harness web modals.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - modal
+  - dialog
+  - draggable
+  - resizable
+  - client
+source:
+  repository: https://github.com/lisniuse/dsh-modal-enhancer
+  repositoryNodeId: R_kgDOT5H4pA
+  subpath: null
+  commit: 360a63dcde137f1ad970323c21dad7bd4a10e262
+creator:
+  github: lisniuse
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:25.765Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lisniuse-dsh-modal-enhancer`
- Submission type: community curation
- Created by `lisniuse` — https://github.com/lisniuse
- Original source repository: https://github.com/lisniuse/dsh-modal-enhancer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.