### PR TITLE
catalog: add lispking-dsh-qq-skin (community curation, created by @lispking)

### DIFF
--- a/catalog/plugins/lispking-dsh-qq-skin.yaml
+++ b/catalog/plugins/lispking-dsh-qq-skin.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: lispking-dsh-qq-skin
+name: dsh-qq-skin
+description:
+  en: "QQ 风格皮肤插件 for DeepSeek Harness: overlays a Tencent QQ messenger look on the Web client through the official theme token layer (ctx.theme.overrideTokens)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skin
+  - theme
+  - qq
+source:
+  repository: https://github.com/lispking/dsh-qq-skin
+  repositoryNodeId: R_kgDOUApmRg
+  subpath: null
+  commit: 676d1706b77d193872682ff8a558313692351bdb
+creator:
+  github: lispking
+package:
+  ecosystem: npm
+  name: dsh-qq-skin
+  version: 0.1.2
+  integrity: sha512-HoSeuy/JE0BVApg2BM/zP91AAiitP7NwRuAlgzeGOtQ79Aeug0gYfHMR6hh1GrapPePRY4iAmHViy4hK4wDBoQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:27.981Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lispking-dsh-qq-skin`
- Submission type: community curation
- Created by `lispking` — https://github.com/lispking
- Original source repository: https://github.com/lispking/dsh-qq-skin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.