### PR TITLE
catalog: add listenj-axiom-dre-dsh (community curation, created by @ListenJ)

### DIFF
--- a/catalog/plugins/listenj-axiom-dre-dsh.yaml
+++ b/catalog/plugins/listenj-axiom-dre-dsh.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: listenj-axiom-dre-dsh
+name: axiom-dre-dsh
+description:
+  en: "Axiom Deterministic Reasoning Engine (DRE) as a DeepSeek Harness (dsh) plugin: bridges the DRE knowledge-verification / deterministic-cognition / constraint-solving / synapse-memory tools into dsh under the dre prefix to strengthen information certainty."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - dre
+  - deterministic-reasoning
+  - mcp
+source:
+  repository: https://github.com/ListenJ/axiom-dre-dsh
+  repositoryNodeId: R_kgDOT81NQg
+  subpath: null
+  commit: 5f83f1a4a6fe6ba49ec26dcb178ba396cb8e23a7
+creator:
+  github: ListenJ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:27.395Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `listenj-axiom-dre-dsh`
- Submission type: community curation
- Created by `ListenJ` — https://github.com/ListenJ
- Original source repository: https://github.com/ListenJ/axiom-dre-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.