### PR TITLE
catalog: add liujunheng-dsh-archive-purge (community curation, created by @LiuJunheng)

### DIFF
--- a/catalog/plugins/liujunheng-dsh-archive-purge.yaml
+++ b/catalog/plugins/liujunheng-dsh-archive-purge.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: liujunheng-dsh-archive-purge
+name: dsh-archive-purge
+description:
+  en: python launcher.py --install-plugin plugins\dsh-archive-purge python launcher.py --start 或手动重启服务
+  evidencePath: plugins/dsh-archive-purge/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - python
+  - launcher
+  - install
+  - archive
+  - purge
+  - start
+  - dsh
+source:
+  repository: https://github.com/LiuJunheng/DeepSeekHarnessGreen
+  repositoryNodeId: R_kgDOT4acfA
+  subpath: plugins/dsh-archive-purge
+  commit: 68e28cbe4ba72c701ac38f7c67c6ffaf33128862
+creator:
+  github: LiuJunheng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-archive-purge/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:31.790Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liujunheng-dsh-archive-purge`
- Submission type: community curation
- Created by `LiuJunheng` — https://github.com/LiuJunheng
- Original source repository: https://github.com/LiuJunheng/DeepSeekHarnessGreen
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.