### PR TITLE
catalog: add liujunheng-dsh-file-browser (community curation, created by @LiuJunheng)

### DIFF
--- a/catalog/plugins/liujunheng-dsh-file-browser.yaml
+++ b/catalog/plugins/liujunheng-dsh-file-browser.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: liujunheng-dsh-file-browser
+name: dsh-file-browser
+description:
+  en: python launcher.py --install-plugin plugins\dsh-file-browser python launcher.py --start 或手动重启服务
+  evidencePath: plugins/dsh-file-browser/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - python
+  - launcher
+  - install
+  - file
+  - browser
+  - start
+  - dsh
+source:
+  repository: https://github.com/LiuJunheng/DeepSeekHarnessGreen
+  repositoryNodeId: R_kgDOT4acfA
+  subpath: plugins/dsh-file-browser
+  commit: 68e28cbe4ba72c701ac38f7c67c6ffaf33128862
+creator:
+  github: LiuJunheng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-file-browser/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:31.790Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liujunheng-dsh-file-browser`
- Submission type: community curation
- Created by `LiuJunheng` — https://github.com/LiuJunheng
- Original source repository: https://github.com/LiuJunheng/DeepSeekHarnessGreen
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.