### PR TITLE
catalog: add liuliuhuhushui-dsh-quota-float (community curation, created by @liuliuhuhushui)

### DIFF
--- a/catalog/plugins/liuliuhuhushui-dsh-quota-float.yaml
+++ b/catalog/plugins/liuliuhuhushui-dsh-quota-float.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: liuliuhuhushui-dsh-quota-float
+name: "@liuliuhuhushui/dsh-quota-float"
+description:
+  en: Floating usage & balance widget for DeepSeek Harness — follows each conversation's selected model (Kimi / DeepSeek / Volc Ark / DashScope)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - quota
+  - usage
+  - balance
+  - kimi
+  - widget
+source:
+  repository: https://github.com/liuliuhuhushui/dsh-quota-float
+  repositoryNodeId: R_kgDOT5L5mQ
+  subpath: null
+  commit: 9a083d7e67e1657c2f6618272fcb4d71b8ff7b6a
+creator:
+  github: liuliuhuhushui
+package:
+  ecosystem: npm
+  name: "@liuliuhuhushui/dsh-quota-float"
+  version: 0.1.0
+  integrity: sha512-DTmHNUfeJSYEyUuCHc1LBD7MJa5okNdDnAQoxGZvw2s0uFqQaR5xAQDSl7XYjVo8dXinfExXqD51xKIDIgv9kA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:29.813Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liuliuhuhushui-dsh-quota-float`
- Submission type: community curation
- Created by `liuliuhuhushui` — https://github.com/liuliuhuhushui
- Original source repository: https://github.com/liuliuhuhushui/dsh-quota-float
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.