### PR TITLE
catalog: add liuwenji007-dsh-muyu (community curation, created by @liuwenji007)

### DIFF
--- a/catalog/plugins/liuwenji007-dsh-muyu.yaml
+++ b/catalog/plugins/liuwenji007-dsh-muyu.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: liuwenji007-dsh-muyu
+name: dsh-muyu
+description:
+  en: "DeepSeek Harness Web overlay: knockable wooden-fish sprite and per-session merit plaque"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - wooden-fish
+  - muyu
+source:
+  repository: https://github.com/liuwenji007/dsh-muyu
+  repositoryNodeId: R_kgDOT9BLnw
+  subpath: null
+  commit: cff92d35db6a308e94fabddacdd382b042c38dd0
+creator:
+  github: liuwenji007
+package:
+  ecosystem: npm
+  name: dsh-muyu
+  version: 0.1.4
+  integrity: sha512-ILeYZG5f2zSNDmh/wPV7TtTFuSvQZ7hT4ZdZ1aAlGSt2eMa1USo12et8isqppOwZrC2LTsp2a4Am4ScmYmRQhA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:17.062Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liuwenji007-dsh-muyu`
- Submission type: community curation
- Created by `liuwenji007` — https://github.com/liuwenji007
- Original source repository: https://github.com/liuwenji007/dsh-muyu
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.