### PR TITLE
catalog: add liwuzhan-dsh-integration (community curation, created by @liwuzhan)

### DIFF
--- a/catalog/plugins/liwuzhan-dsh-integration.yaml
+++ b/catalog/plugins/liwuzhan-dsh-integration.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: liwuzhan-dsh-integration
+name: "@agent-trade/dsh-integration"
+description:
+  en: DeepSeek Harness bundle for agent-native catalog, contact, deal, receipt, settlement, and human-task workflows
+  evidencePath: packages/dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - bundle
+  - agent
+  - native
+  - catalog
+  - contact
+  - deal
+  - receipt
+  - settlement
+  - human
+  - task
+  - workflows
+  - dsh
+source:
+  repository: https://github.com/liwuzhan/agent-native-trade
+  repositoryNodeId: R_kgDOUAzMDA
+  subpath: packages/dsh-plugin
+  commit: 74837208eb1b9c6b5b0e1d3055ebc31c93074fd8
+creator:
+  github: liwuzhan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:52:50.000Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liwuzhan-dsh-integration`
- Submission type: community curation
- Created by `liwuzhan` — https://github.com/liwuzhan
- Original source repository: https://github.com/liwuzhan/agent-native-trade
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.