### PR TITLE
catalog: add liyuk-dsh-skin-chatlab-core (community curation, created by @Liyuk)

### DIFF
--- a/catalog/plugins/liyuk-dsh-skin-chatlab-core.yaml
+++ b/catalog/plugins/liyuk-dsh-skin-chatlab-core.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: liyuk-dsh-skin-chatlab-core
+name: "@liyuk/dsh-skin-chatlab-core"
+description:
+  en: "Note : This project's primary documentation is the Chinese README. This English copy mirrors it — when editing, keep both in sync."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - note
+  - primary
+  - documentation
+  - chinese
+  - english
+  - copy
+  - mirrors
+  - editing
+  - keep
+  - both
+  - sync
+  - dsh
+source:
+  repository: https://github.com/Liyuk/dsh-skin-chatlab
+  repositoryNodeId: R_kgDOT59ITw
+  subpath: packages/core
+  commit: 01d06cd38b940a49ecf89dc0447c81645fba2aa2
+creator:
+  github: Liyuk
+package:
+  ecosystem: npm
+  name: "@liyuk/dsh-skin-chatlab-core"
+  version: 1.0.4
+  integrity: sha512-A/9/MfaQy3Ls/QJF2KR1ukw0SsxG0a26UbXj+IVS9MEkg8EuMyW0k4X+QQmPH6iz3BDynrnu1eelFkf7w6NImA==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/core/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:55.272Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liyuk-dsh-skin-chatlab-core`
- Submission type: community curation
- Created by `Liyuk` — https://github.com/Liyuk
- Original source repository: https://github.com/Liyuk/dsh-skin-chatlab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.