### PR TITLE
catalog: add liyuk-dsh-skin-feishu (community curation, created by @Liyuk)

### DIFF
--- a/catalog/plugins/liyuk-dsh-skin-feishu.yaml
+++ b/catalog/plugins/liyuk-dsh-skin-feishu.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: liyuk-dsh-skin-feishu
+name: "@liyuk/dsh-skin-feishu"
+description:
+  en: "Note : This project's primary documentation is the Chinese README. This English copy mirrors it — when editing, keep both in sync."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - note
+  - primary
+  - documentation
+  - chinese
+  - english
+  - copy
+  - mirrors
+  - editing
+  - keep
+  - both
+  - sync
+  - dsh
+source:
+  repository: https://github.com/Liyuk/dsh-skin-chatlab
+  repositoryNodeId: R_kgDOT59ITw
+  subpath: packages/skin-feishu
+  commit: 01d06cd38b940a49ecf89dc0447c81645fba2aa2
+creator:
+  github: Liyuk
+package:
+  ecosystem: npm
+  name: "@liyuk/dsh-skin-feishu"
+  version: 1.0.3
+  integrity: sha512-MpSfsMH8St/DU9BCpfvo9m34qLHiGZjwY4e5hD6PX4e3mZlMqNm0/SGdJRmcvWRigTqxfy2lqNfgSoElrzTK4w==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/skin-feishu/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:55.272Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liyuk-dsh-skin-feishu`
- Submission type: community curation
- Created by `Liyuk` — https://github.com/Liyuk
- Original source repository: https://github.com/Liyuk/dsh-skin-chatlab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.