### PR TITLE
catalog: add liyuk-dsh-skin-slack (community curation, created by @Liyuk)

### DIFF
--- a/catalog/plugins/liyuk-dsh-skin-slack.yaml
+++ b/catalog/plugins/liyuk-dsh-skin-slack.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: liyuk-dsh-skin-slack
+name: "@liyuk/dsh-skin-slack"
+description:
+  en: Slack-inspired unofficial visual skin for DeepSeek Harness ChatLab.
+  evidencePath: packages/skin-slack/README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - slack
+  - inspired
+  - unofficial
+  - visual
+  - skin
+  - chatlab
+  - dsh
+source:
+  repository: https://github.com/Liyuk/dsh-skin-chatlab
+  repositoryNodeId: R_kgDOT59ITw
+  subpath: packages/skin-slack
+  commit: 01d06cd38b940a49ecf89dc0447c81645fba2aa2
+creator:
+  github: Liyuk
+package:
+  ecosystem: npm
+  name: "@liyuk/dsh-skin-slack"
+  version: 1.0.1
+  integrity: sha512-vTlLZ/aGClGjtLTWN3Lv5qTRKXIV9zT2nznrJqkFaQ8XHKvLxDCrbvlaILsh4x6/ozWcuTN/Wa2dO//RmZzyKw==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/skin-slack/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:50:55.272Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liyuk-dsh-skin-slack`
- Submission type: community curation
- Created by `Liyuk` — https://github.com/Liyuk
- Original source repository: https://github.com/Liyuk/dsh-skin-chatlab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.