### PR TITLE
catalog: add lk251066-dsh-tui (community curation, created by @lk251066)

### DIFF
--- a/catalog/plugins/lk251066-dsh-tui.yaml
+++ b/catalog/plugins/lk251066-dsh-tui.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: lk251066-dsh-tui
+name: "@lk251066/dsh-tui"
+description:
+  en: Multi-session terminal workbench plugin for DeepSeek Harness
+  evidencePath: packages/dsh-tui/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - ai-agent
+  - cli
+  - coding-agent
+  - deepseek-harness
+  - developer-tools
+  - dsh
+  - dsh-plugin
+  - terminal
+  - tui
+  - typescript
+source:
+  repository: https://github.com/lk251066/dsh-tui-pro
+  repositoryNodeId: R_kgDOT5L99w
+  subpath: packages/dsh-tui
+  commit: 74287021abb6681706b1b79e8d35c947a4e3631f
+creator:
+  github: lk251066
+package:
+  ecosystem: npm
+  name: "@lk251066/dsh-tui"
+  version: 1.8.3
+  integrity: sha512-XduZzzvbe5TdvVrJGzPhwYsm6HmOXPcmIoT7buY3teCw7OkVg/NYoio00xLMF3DrdmYg/Y1VfTNfwpxwocTjdQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh-tui/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:54:00.525Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lk251066-dsh-tui`
- Submission type: community curation
- Created by `lk251066` — https://github.com/lk251066
- Original source repository: https://github.com/lk251066/dsh-tui-pro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.