### PR TITLE
catalog: add lmh-2026-dsh-periscope (community curation, created by @lmh-2026)

### DIFF
--- a/catalog/plugins/lmh-2026-dsh-periscope.yaml
+++ b/catalog/plugins/lmh-2026-dsh-periscope.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lmh-2026-dsh-periscope
+name: dsh-periscope
+description:
+  en: "DSH plugin: keep text-only models (deepseek-v4-flash / deepseek-v4-pro) as the session default and automatically route image-bearing requests to a configured vision model; also ships the generic file-attachment feature (drag/paste any file as a durable attachment the agent reads by path) as core patches (apply via scri"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - bundle
+  - vision
+  - image
+  - multimodal
+  - auto-switch
+  - periscope
+  - attachment
+  - file
+  - upload
+source:
+  repository: https://github.com/lmh-2026/dsh-periscope
+  repositoryNodeId: R_kgDOUBDAVQ
+  subpath: null
+  commit: 5b4798ba4cc58902ca73f3909cdd59a2c0610fc9
+creator:
+  github: lmh-2026
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:54:06.690Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lmh-2026-dsh-periscope`
- Submission type: community curation
- Created by `lmh-2026` — https://github.com/lmh-2026
- Original source repository: https://github.com/lmh-2026/dsh-periscope
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.