### PR TITLE
catalog: add lmmzss-jk-dsh-plugin-balance (community curation, created by @lmmzss-jk)

### DIFF
--- a/catalog/plugins/lmmzss-jk-dsh-plugin-balance.yaml
+++ b/catalog/plugins/lmmzss-jk-dsh-plugin-balance.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lmmzss-jk-dsh-plugin-balance
+name: "@lmmzss/dsh-plugin-balance"
+description:
+  en: "DeepSeek Harness web plugin: header balance button (left of the native Session log), dropdown with account balance, live per-session model + token usage and official-rate cost estimates; auto-hides on the settings page"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - balance
+  - token-usage
+source:
+  repository: https://github.com/lmmzss-jk/dsh-plugin-balance
+  repositoryNodeId: R_kgDOT4gfKA
+  subpath: null
+  commit: a53522f818c32ad23d32c7dc4968a1fa1fddc100
+creator:
+  github: lmmzss-jk
+package:
+  ecosystem: npm
+  name: "@lmmzss/dsh-plugin-balance"
+  version: 0.1.1
+  integrity: sha512-wRAE2a9IV8F6z4AVI2VKCmA+hsqiAZBa4FNN9wxyf/L3tpoMM2KtUFEK81odLO9gHLSBrYdfF1Wl8AW/jXe7KA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:04.494Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lmmzss-jk-dsh-plugin-balance`
- Submission type: community curation
- Created by `lmmzss-jk` — https://github.com/lmmzss-jk
- Original source repository: https://github.com/lmmzss-jk/dsh-plugin-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.