### PR TITLE
catalog: add lninghaha-dsh-coding-remote-kit (community curation, created by @lninghaha)

### DIFF
--- a/catalog/plugins/lninghaha-dsh-coding-remote-kit.yaml
+++ b/catalog/plugins/lninghaha-dsh-coding-remote-kit.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: lninghaha-dsh-coding-remote-kit
+name: dsh-coding-remote-kit
+description:
+  en: "DeepSeek Harness mobile pairing remote plugin: E2EE companion over a dual-plane allowlisted RPC (LAN / Tailscale / optional Cloudflare Quick Tunnel or self-hosted rendezvous)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - remote
+  - mobile
+  - pairing
+  - e2ee
+  - companion
+  - dsh-coding-remote-kit
+  - dsh
+source:
+  repository: https://github.com/lninghaha/dsh-coding-remote-kit
+  repositoryNodeId: R_kgDOT9ZA_g
+  subpath: null
+  commit: 8bbbd17e17e52506210f1d23518f4a1a3eb30d6f
+creator:
+  github: lninghaha
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:36.573Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lninghaha-dsh-coding-remote-kit`
- Submission type: community curation
- Created by `lninghaha` — https://github.com/lninghaha
- Original source repository: https://github.com/lninghaha/dsh-coding-remote-kit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.