### PR TITLE
catalog: add mateuszjuszczyk-oh-my-dsh (community curation, created by @MateuszJuszczyk)

### DIFF
--- a/catalog/plugins/mateuszjuszczyk-oh-my-dsh.yaml
+++ b/catalog/plugins/mateuszjuszczyk-oh-my-dsh.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: mateuszjuszczyk-oh-my-dsh
+name: oh-my-dsh
+description:
+  en: "Oh My DSH — tiered model routing for DeepSeek Harness: think/build tiers, an automatic vision tier for images, and image generation through an ordinary chat model (e.g. gpt-5.6-luna on opencode-go), all configured from an 'oh my dsh' settings tab. Works in the Web (Desktop) surface and in the terminal (TUI)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - model-routing
+  - tiered-routing
+  - llm
+  - coding-agent
+  - vision
+  - image-generation
+  - open-source
+source:
+  repository: https://github.com/llmpolska/oh-my-dsh
+  repositoryNodeId: R_kgDOT5q09w
+  subpath: null
+  commit: 38c826b30e1598dbd74a5f52a74ab3e7e9a7accd
+creator:
+  github: MateuszJuszczyk
+package:
+  ecosystem: npm
+  name: oh-my-dsh
+  version: 0.1.0
+  integrity: sha512-9CP+NZWIlSbuIoucRMRoj0SXKVHgzmNdgkosTG0aGCmJLXVPPK55sWaSaxkJJVU7tNnQ8ynExqtSknKGlAGrbg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:51:02.527Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mateuszjuszczyk-oh-my-dsh`
- Submission type: community curation
- Created by `MateuszJuszczyk` — https://github.com/MateuszJuszczyk
- Original source repository: https://github.com/llmpolska/oh-my-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.