### PR TITLE
catalog: add noreply-dsh-marketplace (community curation, created by @noreply)

### DIFF
--- a/catalog/plugins/noreply-dsh-marketplace.yaml
+++ b/catalog/plugins/noreply-dsh-marketplace.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: noreply-dsh-marketplace
+name: dsh-marketplace
+description:
+  en: "Plugin marketplace for DeepSeek Harness: browse plugins collected by the dshregistry index, install/uninstall with hot reload via profile cordis.patch.yml, with security warning and risk explanation before every install."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - marketplace
+  - browse
+  - collected
+  - dshregistry
+  - index
+  - install
+  - uninstall
+  - reload
+  - profile
+  - cordis
+  - patch
+  - security
+  - warning
+  - risk
+  - explanation
+  - before
+source:
+  repository: https://github.com/lmy414/dshregistry
+  repositoryNodeId: R_kgDOT5nW0g
+  subpath: plugin
+  commit: 0e3d6ca541ef52c68f07dd898c13e493574d5d29
+creator:
+  github: noreply
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T07:54:09.347Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noreply-dsh-marketplace`
- Submission type: community curation
- Created by `noreply` — https://github.com/noreply
- Original source repository: https://github.com/lmy414/dshregistry
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.