### PR TITLE
catalog: add celineycn-dsh-trading-bundle (community curation, created by @celineycn)

### DIFF
--- a/catalog/plugins/celineycn-dsh-trading-bundle.yaml
+++ b/catalog/plugins/celineycn-dsh-trading-bundle.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: celineycn-dsh-trading-bundle
+name: "@dsh-trading/bundle"
+description:
+  en: DeepSeek Harness bundle wiring the dsh-trading research stack into a profile
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - trading
+  - market-data
+  - technical-analysis
+  - research
+source:
+  repository: https://github.com/maddogfinance/dsh-trading
+  repositoryNodeId: R_kgDOT7AWPw
+  subpath: bundle/trading
+  commit: f26dbca15beef1a0e139a5c7db5155d3734cfb7c
+creator:
+  github: celineycn
+package:
+  ecosystem: npm
+  name: "@dsh-trading/bundle"
+  version: 0.2.0
+  integrity: sha512-1KVpanjhv0PPJLDjbTSBQ7ftnEJwcsNA1xeinQAXvhX8mG+y9Hd7cgj3PN/WTnd7l9FHs/FCijwbVqxWOiJJ3A==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: bundle/trading/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:49:02.030Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `celineycn-dsh-trading-bundle`
- Submission type: community curation
- Created by `celineycn` — https://github.com/celineycn
- Original source repository: https://github.com/maddogfinance/dsh-trading
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.