### PR TITLE
catalog: add ch4acko3-dsh-patchouli-native-context-service (community curation, created by @CH4ACKO3)

### DIFF
--- a/catalog/plugins/ch4acko3-dsh-patchouli-native-context-service.yaml
+++ b/catalog/plugins/ch4acko3-dsh-patchouli-native-context-service.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ch4acko3-dsh-patchouli-native-context-service
+name: dsh-patchouli-native-context-service
+description:
+  en: Native local context indexing and retrieval for Patchouli
+  evidencePath: packages/native-context-service/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - native
+  - local
+  - context
+  - indexing
+  - retrieval
+  - patchouli
+  - dsh
+source:
+  repository: https://github.com/memorax-ai/dsh-patchouli
+  repositoryNodeId: R_kgDOT3_3gQ
+  subpath: packages/native-context-service
+  commit: f23c5989d2dabe3ccbc49ec97286bbc21060a95d
+creator:
+  github: CH4ACKO3
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/native-context-service/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:40.684Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ch4acko3-dsh-patchouli-native-context-service`
- Submission type: community curation
- Created by `CH4ACKO3` — https://github.com/CH4ACKO3
- Original source repository: https://github.com/memorax-ai/dsh-patchouli
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.