### PR TITLE
catalog: add fendouai-dsh-humanizer (community curation, created by @fendouai)

### DIFF
--- a/catalog/plugins/fendouai-dsh-humanizer.yaml
+++ b/catalog/plugins/fendouai-dsh-humanizer.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: fendouai-dsh-humanizer
+name: dsh-humanizer
+description:
+  en: "Writing skill for DeepSeek Harness: de-AI humanizer plus personal voice clone. Scans AI-writing patterns, builds a style fingerprint from your samples, and returns rewrite briefs so the agent writes like you."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - writing
+  - humanizer
+  - voice-clone
+  - style-transfer
+  - de-ai
+source:
+  repository: https://github.com/lynote-ai/dsh-humanizer
+  repositoryNodeId: R_kgDOT-YUeA
+  subpath: null
+  commit: 9314b95d0b1ba663331f47f0a8ea006b6dc5f509
+creator:
+  github: fendouai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:16.391Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fendouai-dsh-humanizer`
- Submission type: community curation
- Created by `fendouai` — https://github.com/fendouai
- Original source repository: https://github.com/lynote-ai/dsh-humanizer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.