### PR TITLE
catalog: add loadingvx-deepseek-harness-ultra-slash (community curation, created by @loadingvx)

### DIFF
--- a/catalog/plugins/loadingvx-deepseek-harness-ultra-slash.yaml
+++ b/catalog/plugins/loadingvx-deepseek-harness-ultra-slash.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: loadingvx-deepseek-harness-ultra-slash
+name: deepseek-harness-ultra-slash
+description:
+  en: "Ultra Slash for DeepSeek Harness: a separate / menu group for this plugin's commands."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - ultra-slash
+  - steer
+  - slash-command
+source:
+  repository: https://github.com/loadingvx/deepseeh-harness-ultra-slash
+  repositoryNodeId: R_kgDOT7RHbA
+  subpath: null
+  commit: 9cb233b1e253a86d84e12e5ddcda529df6e25537
+creator:
+  github: loadingvx
+package:
+  ecosystem: npm
+  name: deepseek-harness-ultra-slash
+  version: 0.2.2
+  integrity: sha512-51HER0C7qeZ2IvulHNkQPkWK9HWqcexqDZyvqBs3DzbmOx976t3ZfN6wxOxX+3BmGXuo5RYEENk0scGNR07aqw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:31.032Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `loadingvx-deepseek-harness-ultra-slash`
- Submission type: community curation
- Created by `loadingvx` — https://github.com/loadingvx
- Original source repository: https://github.com/loadingvx/deepseeh-harness-ultra-slash
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.