### PR TITLE
catalog: add loeanxi-dsh-cursor-acp (community curation, created by @loeanxi)

### DIFF
--- a/catalog/plugins/loeanxi-dsh-cursor-acp.yaml
+++ b/catalog/plugins/loeanxi-dsh-cursor-acp.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: loeanxi-dsh-cursor-acp
+name: dsh-cursor-acp
+description:
+  en: Hand a standalone job to the Cursor CLI already signed in on this machine.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cursor
+  - acp
+  - dsh
+source:
+  repository: https://github.com/loeanxi/dsh-cursor-acp
+  repositoryNodeId: R_kgDOT6BNXg
+  subpath: null
+  commit: 5170de77ffadeb170e3a460e558e7d35830fc585
+creator:
+  github: loeanxi
+package:
+  ecosystem: npm
+  name: dsh-cursor-acp
+  version: 0.2.0
+  integrity: sha512-lw2AiIwt5a8qtVUkcyGRBPX4G5vOMrzULQdeBbXM2w/N8Tz5VSfirHGfmtChGEI2oGX4k4widxaJA8ouzCIrvw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:31.702Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `loeanxi-dsh-cursor-acp`
- Submission type: community curation
- Created by `loeanxi` — https://github.com/loeanxi
- Original source repository: https://github.com/loeanxi/dsh-cursor-acp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.