### PR TITLE
catalog: add log-li-dsh-automode (community curation, created by @log-li)

### DIFF
--- a/catalog/plugins/log-li-dsh-automode.yaml
+++ b/catalog/plugins/log-li-dsh-automode.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: log-li-dsh-automode
+name: "@log.li/dsh-automode"
+description:
+  en: "CC-style auto mode for DeepSeek Harness: deterministic deny/allow rules + pre-execute gate + model-agnostic two-stage classifier. Two-state (allow/reject) classifier since 0.8.0. TypeScript rewrite merging dsh-auto-mode v0.4.1 with Nuo-cl/dsh-auto-mode native integration."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - auto-mode
+  - approval
+  - classifier
+  - permissions
+  - dsh
+source:
+  repository: https://github.com/log-li/dsh-automode
+  repositoryNodeId: R_kgDOT_0XCA
+  subpath: null
+  commit: 148650e9a43d30087b5764e34a4b59699d78938e
+creator:
+  github: log-li
+package:
+  ecosystem: npm
+  name: "@log.li/dsh-automode"
+  version: 0.8.0
+  integrity: sha512-wyD8r8UxLLF5DTjuBaBsTDyJZnBFjNc3tWf93SARt/6m/3PXLhhaKFyyeEWZHEtonQ7lxMR8Y4CVJqjpNhCv6g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:31.697Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `log-li-dsh-automode`
- Submission type: community curation
- Created by `log-li` — https://github.com/log-li
- Original source repository: https://github.com/log-li/dsh-automode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.