### PR TITLE
catalog: add lolancier-dsh-pet (community curation, created by @Lolancier)

### DIFF
--- a/catalog/plugins/lolancier-dsh-pet.yaml
+++ b/catalog/plugins/lolancier-dsh-pet.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: lolancier-dsh-pet
+name: "@v-manager/dsh-pet"
+description:
+  en: "A Live2D pet companion for the DeepSeek Harness web UI: the Vivi (芊芊) character with petting/feeding, a daily-treat bond economy and mood-driven expressions."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - live2d
+  - companion
+  - vivi
+  - character
+  - petting
+  - feeding
+  - daily
+  - treat
+  - bond
+  - economy
+  - mood
+  - driven
+  - expressions
+  - dsh
+source:
+  repository: https://github.com/Lolancier/v-manager-dsh-pet
+  repositoryNodeId: R_kgDOUCZFpA
+  subpath: null
+  commit: 2cab8f14a7fed677826355e730b80f395f63dd76
+creator:
+  github: Lolancier
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:58.775Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lolancier-dsh-pet`
- Submission type: community curation
- Created by `Lolancier` — https://github.com/Lolancier
- Original source repository: https://github.com/Lolancier/v-manager-dsh-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.