### PR TITLE
catalog: add lonelymoon87-dsh-guardian (community curation, created by @lonelymoon87)

### DIFF
--- a/catalog/plugins/lonelymoon87-dsh-guardian.yaml
+++ b/catalog/plugins/lonelymoon87-dsh-guardian.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: lonelymoon87-dsh-guardian
+name: dsh-guardian
+description:
+  en: Dangerous-operation policy, canonical output redaction, and security review for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - security
+  - redaction
+  - policy
+  - dsh
+source:
+  repository: https://github.com/lonelymoon87/dsh-guardian
+  repositoryNodeId: R_kgDOT3pMfQ
+  subpath: null
+  commit: 6091479072ea236249a858467d481708868678e8
+creator:
+  github: lonelymoon87
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:31.726Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lonelymoon87-dsh-guardian`
- Submission type: community curation
- Created by `lonelymoon87` — https://github.com/lonelymoon87
- Original source repository: https://github.com/lonelymoon87/dsh-guardian
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.