### PR TITLE
catalog: add lonelymoon87-dsh-specflow (community curation, created by @lonelymoon87)

### DIFF
--- a/catalog/plugins/lonelymoon87-dsh-specflow.yaml
+++ b/catalog/plugins/lonelymoon87-dsh-specflow.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: lonelymoon87-dsh-specflow
+name: dsh-specflow
+description:
+  en: Specification-driven development workflows for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - spec-driven-development
+  - agent
+  - workflow
+  - dsh
+source:
+  repository: https://github.com/lonelymoon87/dsh-specflow
+  repositoryNodeId: R_kgDOT3pL4A
+  subpath: null
+  commit: 39acc6f785438f7b6a133e9147f9cb0c40c3ec15
+creator:
+  github: lonelymoon87
+package:
+  ecosystem: npm
+  name: dsh-specflow
+  version: 0.1.4
+  integrity: sha512-gV7TBm9Xf1eFaxvRj1UkWrGqh5Pj7sYDXbjhAs/VBEhx4wZP3/xhOnV1XK66Qbb66Se+pWYWl77TUgGSkxK2FQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:19.307Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lonelymoon87-dsh-specflow`
- Submission type: community curation
- Created by `lonelymoon87` — https://github.com/lonelymoon87
- Original source repository: https://github.com/lonelymoon87/dsh-specflow
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.