### PR TITLE
catalog: add loonai321-dsh-humanized-deepseek-maid (community curation, created by @loonai321)

### DIFF
--- a/catalog/plugins/loonai321-dsh-humanized-deepseek-maid.yaml
+++ b/catalog/plugins/loonai321-dsh-humanized-deepseek-maid.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: loonai321-dsh-humanized-deepseek-maid
+name: dsh-humanized-deepseek-maid
+description:
+  en: Gives the DeepSeek Harness agent a configurable humanized whale-girl maid persona (address, self-name, speaking mode), an immersive no-plugin-meta rule, and a lightweight layered memory with query-triggered recall.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - persona
+  - roleplay
+  - maid
+  - whale-girl
+  - memory
+  - dsh
+source:
+  repository: https://github.com/loonai321/dsh-humanized-deepseek-maid
+  repositoryNodeId: R_kgDOT5zndg
+  subpath: null
+  commit: c13281456456a6b4018288396eef14c3c97628c8
+creator:
+  github: loonai321
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:19.306Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `loonai321-dsh-humanized-deepseek-maid`
- Submission type: community curation
- Created by `loonai321` — https://github.com/loonai321
- Original source repository: https://github.com/loonai321/dsh-humanized-deepseek-maid
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.