### PR TITLE
catalog: add lorodn4x-dsh-russian-locale (community curation, created by @Lorodn4x)

### DIFF
--- a/catalog/plugins/lorodn4x-dsh-russian-locale.yaml
+++ b/catalog/plugins/lorodn4x-dsh-russian-locale.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: lorodn4x-dsh-russian-locale
+name: dsh-russian-locale
+description:
+  en: "Russian language pack for DeepSeek Harness web UI: adds Русский to the language picker"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - russian
+  - locale
+  - i18n
+  - dsh
+source:
+  repository: https://github.com/Lorodn4x/dsh-russian-locale
+  repositoryNodeId: R_kgDOUDGWvw
+  subpath: null
+  commit: 8c5e7c8964f031da6b7cf99ec1c4d1d9ceb62483
+creator:
+  github: Lorodn4x
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:58.777Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lorodn4x-dsh-russian-locale`
- Submission type: community curation
- Created by `Lorodn4x` — https://github.com/Lorodn4x
- Original source repository: https://github.com/Lorodn4x/dsh-russian-locale
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.