### PR TITLE
catalog: add lovezi0-dsh-memory-palace (community curation, created by @lovezi0)

### DIFF
--- a/catalog/plugins/lovezi0-dsh-memory-palace.yaml
+++ b/catalog/plugins/lovezi0-dsh-memory-palace.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: lovezi0-dsh-memory-palace
+name: dsh-memory-palace
+description:
+  en: bash dsh plugin --profile web add github:lovezi0/dsh-memory-palace
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - bash
+  - profile
+  - lovezi0
+  - memory
+  - palace
+  - dsh
+source:
+  repository: https://github.com/lovezi0/dsh-memory-palace
+  repositoryNodeId: R_kgDOT50q5Q
+  subpath: null
+  commit: cca004c48bacf0d3d773684cec6ad5518fb16e75
+creator:
+  github: lovezi0
+package:
+  ecosystem: npm
+  name: dsh-memory-palace
+  version: 1.4.0
+  integrity: sha512-tG+oRJvNDqBc7BCcRaEB8vZCmgZrtq3W205UYGyw8utlsTCEzdwji+SU4u/Id9EoiDbYI5CV7U6j7U2RE0hEQA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:19.282Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lovezi0-dsh-memory-palace`
- Submission type: community curation
- Created by `lovezi0` — https://github.com/lovezi0
- Original source repository: https://github.com/lovezi0/dsh-memory-palace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.