### PR TITLE
catalog: add loyalchiiina-dsh-chat-image-lightbox (community curation, created by @loyalchiiina)

### DIFF
--- a/catalog/plugins/loyalchiiina-dsh-chat-image-lightbox.yaml
+++ b/catalog/plugins/loyalchiiina-dsh-chat-image-lightbox.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: loyalchiiina-dsh-chat-image-lightbox
+name: "@loyalchiiina/dsh-chat-image-lightbox"
+description:
+  en: "DSH plugin: display images inline in chat with lightbox zoom, download (save-as), and prev/next navigation"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - image
+  - lightbox
+  - gallery
+  - download
+  - dsh
+source:
+  repository: https://github.com/loyalchiiina/dsh-chat-image-lightbox
+  repositoryNodeId: R_kgDOUBDmsw
+  subpath: null
+  commit: 81d4d95a12e7b9d43ce61978aec8e36d5f5389c3
+creator:
+  github: loyalchiiina
+package:
+  ecosystem: npm
+  name: "@loyalchiiina/dsh-chat-image-lightbox"
+  version: 1.1.0
+  integrity: sha512-wsgbVXMH7YE/D1/ULHjnnYqLxzdxqcN5ENvj0aBnI7cqGLdjhaIVGs/CXzoWMq7wPH7Zl4zHHvf6iMM8GZUhmQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:46.328Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `loyalchiiina-dsh-chat-image-lightbox`
- Submission type: community curation
- Created by `loyalchiiina` — https://github.com/loyalchiiina
- Original source repository: https://github.com/loyalchiiina/dsh-chat-image-lightbox
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.