### PR TITLE
catalog: add lsh2002-dsh-custom-fonts (community curation, created by @lsh2002)

### DIFF
--- a/catalog/plugins/lsh2002-dsh-custom-fonts.yaml
+++ b/catalog/plugins/lsh2002-dsh-custom-fonts.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lsh2002-dsh-custom-fonts
+name: dsh-custom-fonts
+description:
+  en: Customize the Chinese and English fonts, the code font , and the global font size of the DeepSeek Harness Web UI — right from a settings page, with a live preview.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - font
+  - fonts
+  - font-size
+  - code-font
+  - chinese
+  - english
+  - ui
+source:
+  repository: https://github.com/lsh2002/dsh-custom-fonts
+  repositoryNodeId: R_kgDOUCnn8w
+  subpath: null
+  commit: 648efa35ef90ebd1375e545598c4a2da86f22bed
+creator:
+  github: lsh2002
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:46.857Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lsh2002-dsh-custom-fonts`
- Submission type: community curation
- Created by `lsh2002` — https://github.com/lsh2002
- Original source repository: https://github.com/lsh2002/dsh-custom-fonts
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.