### PR TITLE
catalog: add lsq64737-dsh-windows-notifications (community curation, created by @lsq64737)

### DIFF
--- a/catalog/plugins/lsq64737-dsh-windows-notifications.yaml
+++ b/catalog/plugins/lsq64737-dsh-windows-notifications.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lsq64737-dsh-windows-notifications
+name: "@lsq64737/dsh-windows-notifications"
+description:
+  en: Windows desktop notifications, sounds, and DSH-styled in-app notification cards for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - windows
+  - desktop
+  - notifications
+  - sounds
+  - styled
+  - notification
+  - cards
+  - dsh
+source:
+  repository: https://github.com/lsq-dsh-plugins/dsh-windows-notifications
+  repositoryNodeId: R_kgDOUBEe1w
+  subpath: null
+  commit: 9769f3fa1b4e4dd922ef449510eb3b258d9183ef
+creator:
+  github: lsq64737
+package:
+  ecosystem: npm
+  name: "@lsq64737/dsh-windows-notifications"
+  version: 0.1.1
+  integrity: sha512-AtnHzWqq8UmXwL0SZ511+87F8LIY3X15S8RXtUVwORNWPf74meQVgmm9VUwcUZ3gaG0OAnhhlxAS6ndD2eJsXA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:32.679Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lsq64737-dsh-windows-notifications`
- Submission type: community curation
- Created by `lsq64737` — https://github.com/lsq64737
- Original source repository: https://github.com/lsq-dsh-plugins/dsh-windows-notifications
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.