### PR TITLE
catalog: add lsq64737-dsh-workbench-layout (community curation, created by @lsq64737)

### DIFF
--- a/catalog/plugins/lsq64737-dsh-workbench-layout.yaml
+++ b/catalog/plugins/lsq64737-dsh-workbench-layout.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: lsq64737-dsh-workbench-layout
+name: "@lsq64737/dsh-workbench-layout"
+description:
+  en: DSH-styled three-column workspace with file editing, Markdown preview, Git controls, terminals, and native conversation
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - styled
+  - three
+  - column
+  - workspace
+  - file
+  - editing
+  - markdown
+  - preview
+  - controls
+  - terminals
+  - native
+  - conversation
+  - dsh
+source:
+  repository: https://github.com/lsq-dsh-plugins/dsh-workbench-layout
+  repositoryNodeId: R_kgDOUBEgAQ
+  subpath: null
+  commit: e74b1a281e3e0a791cb2a934c966e4c5135f6e16
+creator:
+  github: lsq64737
+package:
+  ecosystem: npm
+  name: "@lsq64737/dsh-workbench-layout"
+  version: 0.1.5
+  integrity: sha512-9e3NdpaZLUeQfpyFP43tuUW91lhoy3lX2G5vQL3nM4VxvgAfZmAcnEoJSCJYExrIi47diG3HtpkpEkkVCFLH7Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:46.852Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lsq64737-dsh-workbench-layout`
- Submission type: community curation
- Created by `lsq64737` — https://github.com/lsq64737
- Original source repository: https://github.com/lsq-dsh-plugins/dsh-workbench-layout
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.