### PR TITLE
catalog: add luaphes-dsh-web-attention-badge (community curation, created by @Luaphes)

### DIFF
--- a/catalog/plugins/luaphes-dsh-web-attention-badge.yaml
+++ b/catalog/plugins/luaphes-dsh-web-attention-badge.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: luaphes-dsh-web-attention-badge
+name: dsh-web-attention-badge
+description:
+  en: "Web attention badge: a top-left corner indicator counting sessions waiting for user input or finished-but-unopened, plus a browser tab title prefix"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - web
+  - attention
+  - badge
+  - notification
+  - sessions
+source:
+  repository: https://github.com/Luaphes/dsh-web-attention-badge
+  repositoryNodeId: R_kgDOT3rmAw
+  subpath: null
+  commit: 8b2ede6ccda65da20d57e5e1af995aa9e089dc04
+creator:
+  github: Luaphes
+package:
+  ecosystem: npm
+  name: dsh-web-attention-badge
+  version: 0.3.2
+  integrity: sha512-o8EoA7nLw2A7JWpLdg8KWazr57n2AJt526FG9AwrEi8KKoAYao4U/03Sq5gbn3EDUGt/yyAF1pblDbysco3bzw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:11.264Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luaphes-dsh-web-attention-badge`
- Submission type: community curation
- Created by `Luaphes` — https://github.com/Luaphes
- Original source repository: https://github.com/Luaphes/dsh-web-attention-badge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.