### PR TITLE
catalog: add lucas-ward-dsh-ci-context (community curation, created by @lucas-ward)

### DIFF
--- a/catalog/plugins/lucas-ward-dsh-ci-context.yaml
+++ b/catalog/plugins/lucas-ward-dsh-ci-context.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: lucas-ward-dsh-ci-context
+name: dsh-ci-context
+description:
+  en: Privacy-focused CI execution context for DeepSeek Harness agents
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - ci
+  - github-actions
+  - gitlab-ci
+  - dsh
+source:
+  repository: https://github.com/lucas-ward/dsh-ci-context
+  repositoryNodeId: R_kgDOT4hYRg
+  subpath: null
+  commit: 7d814e3def47e257de0aa4b12e2d57572eb63d6a
+creator:
+  github: lucas-ward
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:47.224Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lucas-ward-dsh-ci-context`
- Submission type: community curation
- Created by `lucas-ward` — https://github.com/lucas-ward
- Original source repository: https://github.com/lucas-ward/dsh-ci-context
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.