### PR TITLE
catalog: add lucasli2018-totoro-pet (community curation, created by @Lucasli2018)

### DIFF
--- a/catalog/plugins/lucasli2018-totoro-pet.yaml
+++ b/catalog/plugins/lucasli2018-totoro-pet.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lucasli2018-totoro-pet
+name: totoro-pet
+description:
+  en: powershell dsh plugin --profile web add totoro-pet
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - pet
+  - totoro
+source:
+  repository: https://github.com/Lucasli2018/totoro-pet
+  repositoryNodeId: R_kgDOUC6T0w
+  subpath: null
+  commit: 51b7fa853e4872c5ea704b8edb92b827dc4b7091
+creator:
+  github: Lucasli2018
+package:
+  ecosystem: npm
+  name: totoro-pet
+  version: 0.1.4
+  integrity: sha512-Fi+fqaO0GUqijzOqLdT8BHyk3+sUfPXm41lZpGMhUQITyS0wMv+fqE8b9rlVzk7TcyoMgmRY3XO0v4gmrgSWEg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:47.188Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lucasli2018-totoro-pet`
- Submission type: community curation
- Created by `Lucasli2018` — https://github.com/Lucasli2018
- Original source repository: https://github.com/Lucasli2018/totoro-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.