### PR TITLE
catalog: add lucasx001-dsh-skin-claude-code (community curation, created by @lucasx001)

### DIFF
--- a/catalog/plugins/lucasx001-dsh-skin-claude-code.yaml
+++ b/catalog/plugins/lucasx001-dsh-skin-claude-code.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lucasx001-dsh-skin-claude-code
+name: dsh-skin-claude-code
+description:
+  en: "A Claude Code-inspired skin for the DeepSeek Harness web GUI: warm charcoal/cream surfaces, terracotta accent, and monospace terminal typography."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - theme
+  - skin
+  - claude-code
+  - monospace
+source:
+  repository: https://github.com/lucasx001/dsh-skin-claude-code
+  repositoryNodeId: R_kgDOT4Do6A
+  subpath: null
+  commit: 0226de0f52c18e40bc246b3638df5ca8fc6d672b
+creator:
+  github: lucasx001
+package:
+  ecosystem: npm
+  name: dsh-skin-claude-code
+  version: 0.1.3
+  integrity: sha512-F47QhfVEoQ3ykvnUfT/zKu2HWYgj9vuV/dsRdzcUfBHAWBW3x1XW3j8jnnOMwDJjj0+YSx+7YPUxDjGCq09FHw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:24.594Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lucasx001-dsh-skin-claude-code`
- Submission type: community curation
- Created by `lucasx001` — https://github.com/lucasx001
- Original source repository: https://github.com/lucasx001/dsh-skin-claude-code
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.