### PR TITLE
catalog: add lucien-dsh-session-status (community curation, created by @Lucien)

### DIFF
--- a/catalog/plugins/lucien-dsh-session-status.yaml
+++ b/catalog/plugins/lucien-dsh-session-status.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: lucien-dsh-session-status
+name: dsh-session-status
+description:
+  en: bash dsh plugin --profile web add dsh-session-status
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session
+  - session-status
+  - label
+  - cordis
+source:
+  repository: https://github.com/LucienLL/dsh-session-status
+  repositoryNodeId: R_kgDOUEMeWg
+  subpath: null
+  commit: dc7138ff0024be3dd2a0b5d774da7c63b0c65e11
+creator:
+  github: Lucien
+package:
+  ecosystem: npm
+  name: dsh-session-status
+  version: 0.2.0
+  integrity: sha512-hKEJj9cWhYtIkJUrW6TVtijFZmTYtkPfpz4x6OCCXVoLmfE+uQymhDxKQBaByf8ecJTTuD8dYMlDvPJn1gfLog==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:58.779Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lucien-dsh-session-status`
- Submission type: community curation
- Created by `Lucien` — https://github.com/Lucien
- Original source repository: https://github.com/LucienLL/dsh-session-status
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.