### PR TITLE
catalog: add luckvd-dsh-btw (community curation, created by @LuckVd)

### DIFF
--- a/catalog/plugins/luckvd-dsh-btw.yaml
+++ b/catalog/plugins/luckvd-dsh-btw.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: luckvd-dsh-btw
+name: dsh-btw
+description:
+  en: "BTW side-ask panel for the DSH web GUI: answer from the current conversation (per-message anchors) in independent, history-preserving side sessions without writing to the main conversation."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-client
+  - btw
+  - side-ask
+source:
+  repository: https://github.com/LuckVd/dsh-btw
+  repositoryNodeId: R_kgDOT_LqoQ
+  subpath: null
+  commit: 01266d7e20765d9406624ebd9be803bca95125f2
+creator:
+  github: LuckVd
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:48.793Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luckvd-dsh-btw`
- Submission type: community curation
- Created by `LuckVd` — https://github.com/LuckVd
- Original source repository: https://github.com/LuckVd/dsh-btw
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.