### PR TITLE
catalog: add luckvd-dsh-pin-color (community curation, created by @LuckVd)

### DIFF
--- a/catalog/plugins/luckvd-dsh-pin-color.yaml
+++ b/catalog/plugins/luckvd-dsh-pin-color.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: luckvd-dsh-pin-color
+name: dsh-pin-color
+description:
+  en: "DeepSeek Harness (DSH) Web GUI plugin: pin sidebar sessions to the top (within the session group or globally across the workspace) and give each session a tab color plus an emoji shown before its name. Dual-face (host + browser), persisted by the host, no DSH source changes."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - session
+  - pin
+  - color
+  - emoji
+  - sidebar
+source:
+  repository: https://github.com/LuckVd/dsh-pin-color
+  repositoryNodeId: R_kgDOUAxpQg
+  subpath: null
+  commit: 4baa9ca0cb03760ca1bd5cf482e9a2f522bc2220
+creator:
+  github: LuckVd
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:59.324Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luckvd-dsh-pin-color`
- Submission type: community curation
- Created by `LuckVd` — https://github.com/LuckVd
- Original source repository: https://github.com/LuckVd/dsh-pin-color
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.