### PR TITLE
catalog: add luke-yong-dsh-plugin-project-management (community curation, created by @Luke-Yong)

### DIFF
--- a/catalog/plugins/luke-yong-dsh-plugin-project-management.yaml
+++ b/catalog/plugins/luke-yong-dsh-plugin-project-management.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: luke-yong-dsh-plugin-project-management
+name: dsh-plugin-project-management
+description:
+  en: Interview users, then generate and export project timelines / Gantt charts (Word + Excel) in DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - interview
+  - users
+  - generate
+  - export
+  - timelines
+  - gantt
+  - charts
+  - word
+  - excel
+  - dsh
+source:
+  repository: https://github.com/Luke-Yong/dsh-plugin-project-management
+  repositoryNodeId: R_kgDOT6o9Mw
+  subpath: null
+  commit: b10c38fa50b4d195971f649444e1326d0900febf
+creator:
+  github: Luke-Yong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:35.153Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luke-yong-dsh-plugin-project-management`
- Submission type: community curation
- Created by `Luke-Yong` — https://github.com/Luke-Yong
- Original source repository: https://github.com/Luke-Yong/dsh-plugin-project-management
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.