### PR TITLE
catalog: add lunaship-dsh-links (community curation, created by @lunaship)

### DIFF
--- a/catalog/plugins/lunaship-dsh-links.yaml
+++ b/catalog/plugins/lunaship-dsh-links.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lunaship-dsh-links
+name: dsh-links
+description:
+  en: <p align="center" <strong Beta</strong · <strong Android only</strong · <strong Trusted LAN</strong · <strong Relay 内测（需接入码）</strong · <strong Unofficial</strong </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - android
+  - lan
+  - mobile
+source:
+  repository: https://github.com/lunaship/dsh-links
+  repositoryNodeId: R_kgDOT8eE7A
+  subpath: null
+  commit: 558d6a175572772a3883fb4c6b4761f915dc4d32
+creator:
+  github: lunaship
+package:
+  ecosystem: npm
+  name: dsh-links
+  version: 0.1.0-beta.9
+  integrity: sha512-pkrrbPO2QuNBvV/OsyBD89NLqGRojo+j/k0ASUL9mLaVeQ8JUwedNhQrwnvcfG286bZyDJWrrmipZUN/fp0ysw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:24.690Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lunaship-dsh-links`
- Submission type: community curation
- Created by `lunaship` — https://github.com/lunaship
- Original source repository: https://github.com/lunaship/dsh-links
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.