### PR TITLE
catalog: add lunw-shopline-ai-toolkit-dsh (community curation, created by @lunw)

### DIFF
--- a/catalog/plugins/lunw-shopline-ai-toolkit-dsh.yaml
+++ b/catalog/plugins/lunw-shopline-ai-toolkit-dsh.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lunw-shopline-ai-toolkit-dsh
+name: shopline-ai-toolkit-dsh
+description:
+  en: "SHOPLINE AI Toolkit for DeepSeek Harness (DSH): bridges the official SHOPLINE Developer MCP server and ships SHOPLINE agent skills, mirroring the Shopify AI Toolkit architecture. dsh-plugin."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - shopline
+  - ai-toolkit
+  - mcp
+  - model-context-protocol
+  - ecommerce
+  - openapi
+  - graphql
+  - sline
+source:
+  repository: https://github.com/lunw/shopline-ai-toolkit-dsh
+  repositoryNodeId: R_kgDOT3jK1A
+  subpath: null
+  commit: e2d47a6c9a0d75865ad8bb089118ce0dfee9b594
+creator:
+  github: lunw
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:16.431Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lunw-shopline-ai-toolkit-dsh`
- Submission type: community curation
- Created by `lunw` — https://github.com/lunw
- Original source repository: https://github.com/lunw/shopline-ai-toolkit-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.