### PR TITLE
catalog: add lussey820-dsh-http-tools-ui (community curation, created by @lussey820)

### DIFF
--- a/catalog/plugins/lussey820-dsh-http-tools-ui.yaml
+++ b/catalog/plugins/lussey820-dsh-http-tools-ui.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lussey820-dsh-http-tools-ui
+name: dsh-http-tools-ui
+description:
+  en: "UI cards for dsh-http-tools: keyed toolview rows for http request / curl parse / request history"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ui
+  - tool
+source:
+  repository: https://github.com/lussey820/dsh-http-tools
+  repositoryNodeId: R_kgDOT50Qug
+  subpath: ui
+  commit: c5ed617fd50caf4655f8a54a93e4367c492d9bd2
+creator:
+  github: lussey820
+package:
+  ecosystem: npm
+  name: dsh-http-tools-ui
+  version: 0.2.0
+  integrity: sha512-MsLnrfoVPKARKZmKE8BaFM0ya/ZrTGURE7bFfRyvTLt/O9P3M3mPTDaalemUjhqIY4UcVBs0gPD6M3wPrd0TkQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: ui/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:48.790Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lussey820-dsh-http-tools-ui`
- Submission type: community curation
- Created by `lussey820` — https://github.com/lussey820
- Original source repository: https://github.com/lussey820/dsh-http-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.