### PR TITLE
catalog: add lussey820-dsh-http-tools (community curation, created by @lussey820)

### DIFF
--- a/catalog/plugins/lussey820-dsh-http-tools.yaml
+++ b/catalog/plugins/lussey820-dsh-http-tools.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lussey820-dsh-http-tools
+name: dsh-http-tools
+description:
+  en: "HTTP/API debugging toolset for DeepSeek Harness: http request, curl parse, request history"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - api
+  - curl
+  - rest
+  - agent
+  - tool
+source:
+  repository: https://github.com/lussey820/dsh-http-tools
+  repositoryNodeId: R_kgDOT50Qug
+  subpath: null
+  commit: c5ed617fd50caf4655f8a54a93e4367c492d9bd2
+creator:
+  github: lussey820
+package:
+  ecosystem: npm
+  name: dsh-http-tools
+  version: 0.1.5
+  integrity: sha512-+65vtdWJx2vQo+siEuNe3zL5nkl7tQ+yi/utMrtngKnB/5WBcKqSH3yP5t8EEo17SALzJX5EUSQUMxdnD1mrqg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:48.790Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lussey820-dsh-http-tools`
- Submission type: community curation
- Created by `lussey820` — https://github.com/lussey820
- Original source repository: https://github.com/lussey820/dsh-http-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.