### PR TITLE
catalog: add luxueliu-luxueliu-dsh-story (community curation, created by @luxueliu)

### DIFF
--- a/catalog/plugins/luxueliu-luxueliu-dsh-story.yaml
+++ b/catalog/plugins/luxueliu-luxueliu-dsh-story.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: luxueliu-luxueliu-dsh-story
+name: luxueliu-dsh-story
+description:
+  en: powershell dsh plugin --profile web add luxueliu/luxueliu-dsh-story
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - continue
+  - novel
+  - writing
+  - lorebook
+  - cue
+  - prompt
+  - transcript
+  - gemini
+source:
+  repository: https://github.com/luxueliu/luxueliu-dsh-story
+  repositoryNodeId: R_kgDOUEaVRQ
+  subpath: null
+  commit: 568dce67f7af6fd05a9db9e709970e1a9b65aa0c
+creator:
+  github: luxueliu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:49:01.553Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luxueliu-luxueliu-dsh-story`
- Submission type: community curation
- Created by `luxueliu` — https://github.com/luxueliu
- Original source repository: https://github.com/luxueliu/luxueliu-dsh-story
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.