### PR TITLE
catalog: add luxueliu-luxueliu-reasoning-efforts (community curation, created by @luxueliu)

### DIFF
--- a/catalog/plugins/luxueliu-luxueliu-reasoning-efforts.yaml
+++ b/catalog/plugins/luxueliu-luxueliu-reasoning-efforts.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: luxueliu-luxueliu-reasoning-efforts
+name: luxueliu-reasoning-efforts
+description:
+  en: "Reasoning-effort ladders for every non-ds model on a local LLM gateway route in DeepSeek Harness: declares selectable thinking levels (off/low/medium/high/xhigh/max) for hand-declared gateway models that would otherwise show no reasoning control at all, and re-applies them to the live profile settings after DSH upgrade"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - reasoning-efforts
+  - reasoning
+  - llm
+  - gateway
+  - litellm
+  - luxueliu
+  - dsh
+source:
+  repository: https://github.com/luxueliu/luxueliu-reasoning-efforts
+  repositoryNodeId: R_kgDOT_1JTw
+  subpath: null
+  commit: b0745d94718abeb1a6b24642cd606247ff65d450
+creator:
+  github: luxueliu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:49.039Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luxueliu-luxueliu-reasoning-efforts`
- Submission type: community curation
- Created by `luxueliu` — https://github.com/luxueliu
- Original source repository: https://github.com/luxueliu/luxueliu-reasoning-efforts
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.