### PR TITLE
catalog: add luxueliu-luxueliu-usage-command (community curation, created by @luxueliu)

### DIFF
--- a/catalog/plugins/luxueliu-luxueliu-usage-command.yaml
+++ b/catalog/plugins/luxueliu-luxueliu-usage-command.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: luxueliu-luxueliu-usage-command
+name: luxueliu-usage-command
+description:
+  en: "Luxueliu /usage command for DeepSeek Harness: per-day API spend card (by model × hour) from the local LiteLLM gateway log. Covers 3 billable model classes — official APIs (CNY + Beijing peak pricing), relay/OpenRouter APIs (USD), and plan pools (Cline/Token Plan, token-only) — all freely extensible via cordis config (d"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - usage
+  - cost
+  - litellm
+  - token-usage
+  - luxueliu
+  - dsh
+source:
+  repository: https://github.com/luxueliu/luxueliu-usage-command
+  repositoryNodeId: R_kgDOT-dmZA
+  subpath: null
+  commit: 41fbc5e80b178697b7a1d4aa2b50cf647a665858
+creator:
+  github: luxueliu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:35.155Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luxueliu-luxueliu-usage-command`
- Submission type: community curation
- Created by `luxueliu` — https://github.com/luxueliu
- Original source repository: https://github.com/luxueliu/luxueliu-usage-command
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.