### PR TITLE
catalog: add luzhengyangtx-dsh-telegram-duty (community curation, created by @luzhengyangtx)

### DIFF
--- a/catalog/plugins/luzhengyangtx-dsh-telegram-duty.yaml
+++ b/catalog/plugins/luzhengyangtx-dsh-telegram-duty.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: luzhengyangtx-dsh-telegram-duty
+name: "@luzhengyangtx/dsh-telegram-duty"
+description:
+  en: "Telegram duty gateway for DeepSeek Harness: long-poll Telegram into a dedicated duty session, global approval forwarding while on duty, and a local/duty watch toggle."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - telegram
+  - gateway
+  - bot
+  - agent
+  - approval
+source:
+  repository: https://github.com/luzhengyangtx/dsh-telegram-duty
+  repositoryNodeId: R_kgDOT4ronQ
+  subpath: null
+  commit: 30685d213a3e34b4a8000f36a7d90a3bf8318f37
+creator:
+  github: luzhengyangtx
+package:
+  ecosystem: npm
+  name: "@luzhengyangtx/dsh-telegram-duty"
+  version: 0.4.0
+  integrity: sha512-7fxHBBYKHG79RFEc8DSZfJpWfq/Oo38xfwYQ0FT0dBiXPqbYPx5z1JL/EJcaErfoFl8vjDOjfeoRSnG3hd3IiQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:11.274Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luzhengyangtx-dsh-telegram-duty`
- Submission type: community curation
- Created by `luzhengyangtx` — https://github.com/luzhengyangtx
- Original source repository: https://github.com/luzhengyangtx/dsh-telegram-duty
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.