### PR TITLE
catalog: add lx2000wasd-dsh-web-plugin-manager (community curation, created by @LX2000WASD)

### DIFF
--- a/catalog/plugins/lx2000wasd-dsh-web-plugin-manager.yaml
+++ b/catalog/plugins/lx2000wasd-dsh-web-plugin-manager.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: lx2000wasd-dsh-web-plugin-manager
+name: dsh-web-plugin-manager
+description:
+  en: "Manage DeepSeek Harness (DSH) plugins from the Web UI: list, enable/disable, install/remove, environments, and a GitHub-awesome-driven marketplace."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - plugin-manager
+  - marketplace
+source:
+  repository: https://github.com/LX2000WASD/dsh-web-plugin-manager
+  repositoryNodeId: R_kgDOT3t3Tg
+  subpath: null
+  commit: 633d9fc2abd851a5a811d2ed06921a9711606c6f
+creator:
+  github: LX2000WASD
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:11.264Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 67
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lx2000wasd-dsh-web-plugin-manager`
- Submission type: community curation
- Created by `LX2000WASD` — https://github.com/LX2000WASD
- Original source repository: https://github.com/LX2000WASD/dsh-web-plugin-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.