### PR TITLE
catalog: add lxj808624-dsh-tool-git (community curation, created by @lxj808624)

### DIFF
--- a/catalog/plugins/lxj808624-dsh-tool-git.yaml
+++ b/catalog/plugins/lxj808624-dsh-tool-git.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lxj808624-dsh-tool-git
+name: dsh-tool-git
+description:
+  en: "Structured, safe Git tool family for DeepSeek Harness: status/diff/log/branch/stage/commit/stash/show/fetch/pull/remote/checkout with a destructive-command guard."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - git
+  - tool
+source:
+  repository: https://github.com/lxj808624/dsh-tool-git
+  repositoryNodeId: R_kgDOT3mxSQ
+  subpath: null
+  commit: 09df9e9ad56a144d61647f465b54f84bbf90113c
+creator:
+  github: lxj808624
+package:
+  ecosystem: npm
+  name: dsh-tool-git
+  version: 0.1.3
+  integrity: sha512-iDDvA+bMc+5bxhUNHrDslqpNIomd057L3tWq/O3cyNyK7FGafXHyk7t+7KKnriqu9H0/atPODwIa9ZplISmkIA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:16.398Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lxj808624-dsh-tool-git`
- Submission type: community curation
- Created by `lxj808624` — https://github.com/lxj808624
- Original source repository: https://github.com/lxj808624/dsh-tool-git
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.