### PR TITLE
catalog: add lxp731-dsh-service-control (community curation, created by @lxp731)

### DIFF
--- a/catalog/plugins/lxp731-dsh-service-control.yaml
+++ b/catalog/plugins/lxp731-dsh-service-control.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: lxp731-dsh-service-control
+name: dsh-service-control
+description:
+  en: "Wings for the dsh command: manage the service's systemd lifecycle, persisted config and runtime diagnostics through dsh --profile ctl . No separate CLI (the legacy dshctl is gone)."
+  evidencePath: dsh-service-control/README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - service
+  - control
+  - systemd
+  - daemon
+  - completion
+source:
+  repository: https://github.com/lxp731/agents-plugins
+  repositoryNodeId: R_kgDOTsoS1A
+  subpath: dsh-service-control
+  commit: 1111322693088c94443d9b217a010816c31cc891
+creator:
+  github: lxp731
+package:
+  ecosystem: npm
+  name: dsh-service-control
+  version: 0.2.5
+  integrity: sha512-Xt3MfTXmLMYiVe8oGmchOKYeWfUntuZtpElPBEALZoJmqrrpUL3ezUhItTaoCSK6PDgwhWR7i18guUkSLxP2LQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-service-control/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:49:01.592Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lxp731-dsh-service-control`
- Submission type: community curation
- Created by `lxp731` — https://github.com/lxp731
- Original source repository: https://github.com/lxp731/agents-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.