### PR TITLE
catalog: add lxp731-task-complete-notify-for-dsh (community curation, created by @lxp731)

### DIFF
--- a/catalog/plugins/lxp731-task-complete-notify-for-dsh.yaml
+++ b/catalog/plugins/lxp731-task-complete-notify-for-dsh.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lxp731-task-complete-notify-for-dsh
+name: task-complete-notify-for-dsh
+description:
+  en: "DSH (DeepSeek Harness) plugin: desktop notification + chime when a run finishes — completion, errors, and approval requests — with a configurable duration threshold."
+  evidencePath: task-complete-notify-for-dsh/README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - notification
+  - desktop-notification
+  - notify
+  - chime
+  - agent
+source:
+  repository: https://github.com/lxp731/agents-plugins
+  repositoryNodeId: R_kgDOTsoS1A
+  subpath: task-complete-notify-for-dsh
+  commit: 1111322693088c94443d9b217a010816c31cc891
+creator:
+  github: lxp731
+package:
+  ecosystem: npm
+  name: task-complete-notify-for-dsh
+  version: 0.2.0
+  integrity: sha512-xc22PcpJ9UpV2UrhNNa7M05WEFJ7lJlfgkchVzNbR9Qr1CCwRT67Sz1rLDrbt7i3iFSQW04pWbigvQmENLgVFQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: task-complete-notify-for-dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:49:01.592Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lxp731-task-complete-notify-for-dsh`
- Submission type: community curation
- Created by `lxp731` — https://github.com/lxp731
- Original source repository: https://github.com/lxp731/agents-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.