### PR TITLE
catalog: add lxxz1918-dsh-theme-customizer (community curation, created by @lxxz1918)

### DIFF
--- a/catalog/plugins/lxxz1918-dsh-theme-customizer.yaml
+++ b/catalog/plugins/lxxz1918-dsh-theme-customizer.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lxxz1918-dsh-theme-customizer
+name: dsh-theme-customizer
+description:
+  en: A theme customizer plugin for the DeepSeek Harness (DSH) web UI. Backgrounds, text colors, borders and details — all adjustable visually, persisted across restarts. Config is stored in localStorage; presets can be exported as .tczp files (images included) and shared with any machine.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - theme
+  - customizer
+  - web-ui
+source:
+  repository: https://github.com/lxxz1918/dsh-theme-customizer
+  repositoryNodeId: R_kgDOUAJLCg
+  subpath: null
+  commit: 600592a51a52dad8c6a81438540e4236e42c3c79
+creator:
+  github: lxxz1918
+package:
+  ecosystem: npm
+  name: dsh-theme-customizer
+  version: 1.0.5
+  integrity: sha512-M0UGDfurCEFYm4n8lFk+xwkebKYklrUxRGqrNyI1mF1yh/Lh5Wu9+ilnxEntBAPxQqat2Sph34nHqwRwEp6xnQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:49.142Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lxxz1918-dsh-theme-customizer`
- Submission type: community curation
- Created by `lxxz1918` — https://github.com/lxxz1918
- Original source repository: https://github.com/lxxz1918/dsh-theme-customizer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.