### PR TITLE
catalog: add lyaxz-dsh-quick-toc (community curation, created by @LyaxZ)

### DIFF
--- a/catalog/plugins/lyaxz-dsh-quick-toc.yaml
+++ b/catalog/plugins/lyaxz-dsh-quick-toc.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: lyaxz-dsh-quick-toc
+name: dsh-quick-toc
+description:
+  en: "Quick conversation TOC for DeepSeek Harness: markdown heading outline grouped by turn, with auto-follow highlight and smooth jump navigation"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - toc
+  - outline
+  - markdown
+source:
+  repository: https://github.com/LyaxZ/dsh-quick-toc
+  repositoryNodeId: R_kgDOT6r4cw
+  subpath: null
+  commit: a942891ff67f6aff40b8de38179e567866e4462a
+creator:
+  github: LyaxZ
+package:
+  ecosystem: npm
+  name: dsh-quick-toc
+  version: 0.2.2
+  integrity: sha512-VROIq75iNoOrrsQhGLIjt2URa6TwpdI++NrIgXYcNSL6LnCL+X7QTZC0Ntd71Mzmd3uXjMHn8Ol9sqlhiTlnbQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:49.675Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lyaxz-dsh-quick-toc`
- Submission type: community curation
- Created by `LyaxZ` — https://github.com/LyaxZ
- Original source repository: https://github.com/LyaxZ/dsh-quick-toc
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.