### PR TITLE
catalog: add lyhue1991-dsh-soup (community curation, created by @lyhue1991)

### DIFF
--- a/catalog/plugins/lyhue1991-dsh-soup.yaml
+++ b/catalog/plugins/lyhue1991-dsh-soup.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: lyhue1991-dsh-soup
+name: "@lyhue1991/dsh-soup"
+description:
+  en: sh dsh plugin add @lyhue1991/dsh-soup
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - file-explorer
+  - tree
+  - speed
+  - tps
+  - throughput
+  - deepseek-harness
+source:
+  repository: https://github.com/lyhue1991/dsh-soup
+  repositoryNodeId: R_kgDOT89f8A
+  subpath: null
+  commit: ae8ab512264d93417152800c6498ef63ecedd271
+creator:
+  github: lyhue1991
+package:
+  ecosystem: npm
+  name: "@lyhue1991/dsh-soup"
+  version: 0.4.1
+  integrity: sha512-KNv+Z+JUDEjBJjZluxdQyWemNeaCkFS3lAHCSs8EHn7/scWA8/N+kXeSlG2vkCRL+6sb1Y75VlHPbP8dKASodg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:49.659Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lyhue1991-dsh-soup`
- Submission type: community curation
- Created by `lyhue1991` — https://github.com/lyhue1991
- Original source repository: https://github.com/lyhue1991/dsh-soup
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.