### PR TITLE
catalog: add lzh3070-dsh-session-cost (community curation, created by @Lzh3070)

### DIFF
--- a/catalog/plugins/lzh3070-dsh-session-cost.yaml
+++ b/catalog/plugins/lzh3070-dsh-session-cost.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: lzh3070-dsh-session-cost
+name: "@phynez_1103/dsh-session-cost"
+description:
+  en: "DSH web plugin: shows the current session's DeepSeek API cost as a small chip in the composer button row (conversation.input.right). Prices every assistant/message by its timestamp with the official DeepSeek pricing table, including the 2026-08-17 peak/off-peak policy."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - shows
+  - current
+  - session
+  - cost
+  - small
+  - chip
+  - composer
+  - button
+  - conversation
+  - input
+  - right
+  - prices
+  - every
+  - assistant
+  - message
+  - timestamp
+source:
+  repository: https://github.com/Lzh3070/dsh-session-cost
+  repositoryNodeId: R_kgDOT5wf1Q
+  subpath: null
+  commit: 986c34e1445ca5012d32e2d9d02768c5cb0cb12c
+creator:
+  github: Lzh3070
+package:
+  ecosystem: npm
+  name: "@phynez_1103/dsh-session-cost"
+  version: 0.1.1
+  integrity: sha512-pCtiMspD2AhDeIOBqladVpcuMiIyDO0QiWtDRqMrfu/4AWiQT4gcs8+y91XitPhUn8ot6/yBmcDIS5HGEVmMVg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:50.684Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lzh3070-dsh-session-cost`
- Submission type: community curation
- Created by `Lzh3070` — https://github.com/Lzh3070
- Original source repository: https://github.com/Lzh3070/dsh-session-cost
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.