### PR TITLE
catalog: add m-guo-2-dsh-delayed-task (community curation, created by @m-guo-2)

### DIFF
--- a/catalog/plugins/m-guo-2-dsh-delayed-task.yaml
+++ b/catalog/plugins/m-guo-2-dsh-delayed-task.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: m-guo-2-dsh-delayed-task
+name: dsh-delayed-task
+description:
+  en: Durable delayed decisions that wake cold DeepSeek Harness sessions with bounded authorization
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - agent
+  - scheduler
+  - delayed-task
+  - dsh
+source:
+  repository: https://github.com/m-guo-2/dsh-delayed-task
+  repositoryNodeId: R_kgDOT4HruQ
+  subpath: null
+  commit: 0c5352a325836267b4dc01b374655fb5f541a44c
+creator:
+  github: m-guo-2
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:51.700Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `m-guo-2-dsh-delayed-task`
- Submission type: community curation
- Created by `m-guo-2` — https://github.com/m-guo-2
- Original source repository: https://github.com/m-guo-2/dsh-delayed-task
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.