### PR TITLE
catalog: add madage-dsh-self-improved (community curation, created by @madage)

### DIFF
--- a/catalog/plugins/madage-dsh-self-improved.yaml
+++ b/catalog/plugins/madage-dsh-self-improved.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: madage-dsh-self-improved
+name: dsh-self-improved
+description:
+  en: Long-term memory & self-evolving plugin for DeepSeek Harness (fully local).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - memory
+  - self-improvement
+  - long-term-memory
+source:
+  repository: https://github.com/madage/dsh-self-improved
+  repositoryNodeId: R_kgDOT5aYSg
+  subpath: null
+  commit: 4f134c9a93dbaccedbeee339fe8cc942d1740cca
+creator:
+  github: madage
+package:
+  ecosystem: npm
+  name: dsh-self-improved
+  version: 0.1.1
+  integrity: sha512-tsbwYzs4Zn4bbLX6schBJpcWM2ICEuMTPh8mND9GSKKiYnSd9U3icwt1e7VyAO2eqHdWbib5eFx+eog6yijN0g==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:11.271Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `madage-dsh-self-improved`
- Submission type: community curation
- Created by `madage` — https://github.com/madage
- Original source repository: https://github.com/madage/dsh-self-improved
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.