### PR TITLE
catalog: add mafeis-dsh-net-proxy (community curation, created by @mafeis)

### DIFF
--- a/catalog/plugins/mafeis-dsh-net-proxy.yaml
+++ b/catalog/plugins/mafeis-dsh-net-proxy.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: mafeis-dsh-net-proxy
+name: dsh-net-proxy
+description:
+  en: "DeepSeek Harness network-proxy plugin: route the agent's own network requests (web search / web fetch / external APIs) through a configured HTTP/HTTPS-CONNECT/SOCKS5 proxy, persisted and auto-applied at startup, with a settings UI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - proxy
+  - socks5
+  - network
+source:
+  repository: https://github.com/mafeis/dsh-net-proxy
+  repositoryNodeId: R_kgDOT4Poew
+  subpath: null
+  commit: 61dd838ce92b3f84b787c5b15690328c08467d2a
+creator:
+  github: mafeis
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:11.278Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mafeis-dsh-net-proxy`
- Submission type: community curation
- Created by `mafeis` — https://github.com/mafeis
- Original source repository: https://github.com/mafeis/dsh-net-proxy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.