### PR TITLE
catalog: add magicof2-dsh-autoload-history (community curation, created by @magicOF2)

### DIFF
--- a/catalog/plugins/magicof2-dsh-autoload-history.yaml
+++ b/catalog/plugins/magicof2-dsh-autoload-history.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: magicof2-dsh-autoload-history
+name: dsh-autoload-history
+description:
+  en: Automatically load the full conversation history when a session opens — no more clicking "Load earlier".
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - automatically
+  - load
+  - full
+  - conversation
+  - history
+  - session
+  - opens
+  - clicking
+  - earlier
+  - dsh
+source:
+  repository: https://github.com/magicOF2/dsh-autoload-history
+  repositoryNodeId: R_kgDOT8Kgmg
+  subpath: null
+  commit: 334063f32333c2c73c254beac258be34a3ee2a2e
+creator:
+  github: magicOF2
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:24.895Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `magicof2-dsh-autoload-history`
- Submission type: community curation
- Created by `magicOF2` — https://github.com/magicOF2
- Original source repository: https://github.com/magicOF2/dsh-autoload-history
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.