### PR TITLE
catalog: add magicof2-dsh-chat-width-customizer (community curation, created by @magicOF2)

### DIFF
--- a/catalog/plugins/magicof2-dsh-chat-width-customizer.yaml
+++ b/catalog/plugins/magicof2-dsh-chat-width-customizer.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: magicof2-dsh-chat-width-customizer
+name: dsh-chat-width-customizer
+description:
+  en: "DSH web UI plugin: a session-header button that cycles the conversation width (748-1600px) by overriding the chat content-width CSS variables, so the chat column, composer, and user bubbles all widen together."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - session
+  - header
+  - button
+  - cycles
+  - conversation
+  - width
+  - 1600px
+  - overriding
+  - chat
+  - content
+  - variables
+  - column
+  - composer
+  - user
+  - bubbles
+  - widen
+source:
+  repository: https://github.com/magicOF2/dsh-chat-width-customizer
+  repositoryNodeId: R_kgDOT4eZ3Q
+  subpath: null
+  commit: de11dccb6e6321185274b0fd34d5a8aa0ffebf90
+creator:
+  github: magicOF2
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:24.957Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `magicof2-dsh-chat-width-customizer`
- Submission type: community curation
- Created by `magicOF2` — https://github.com/magicOF2
- Original source repository: https://github.com/magicOF2/dsh-chat-width-customizer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.