### PR TITLE
catalog: add magicof2-dsh-schedule (community curation, created by @magicOF2)

### DIFF
--- a/catalog/plugins/magicof2-dsh-schedule.yaml
+++ b/catalog/plugins/magicof2-dsh-schedule.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: magicof2-dsh-schedule
+name: dsh-schedule
+description:
+  en: "A local long-term schedule plugin for DeepSeek Harness: sidebar entry plus a full-height drawer schedule panel (today / week / history calendar), schedule↔conversation links, inline editing with a detail view, completion checkmarks, recurring tasks, optional auto carry-over, and agent tools. Data persists in a local fi"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - schedule
+  - todo
+  - calendar
+  - task
+  - dailytask
+source:
+  repository: https://github.com/magicOF2/dsh-schedule
+  repositoryNodeId: R_kgDOT6P5mg
+  subpath: null
+  commit: e16a386244b2d4de626f6feacc8f401fd875321d
+creator:
+  github: magicOF2
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:52.483Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `magicof2-dsh-schedule`
- Submission type: community curation
- Created by `magicOF2` — https://github.com/magicOF2
- Original source repository: https://github.com/magicOF2/dsh-schedule
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.