### PR TITLE
catalog: add mangomt-dsh-power (community curation, created by @mangomt)

### DIFF
--- a/catalog/plugins/mangomt-dsh-power.yaml
+++ b/catalog/plugins/mangomt-dsh-power.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: mangomt-dsh-power
+name: dsh-power
+description:
+  en: "Floating power dock for the DeepSeek Harness web GUI: one-click restart or graceful shutdown of the dsh web host, loopback-guarded and dependency-free."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - shutdown
+  - power
+  - web
+source:
+  repository: https://github.com/mangomt/dsh-power
+  repositoryNodeId: R_kgDOT-3wDA
+  subpath: null
+  commit: 575c15f85a834bae18f6eef4381b2c1ad8aeb4f9
+creator:
+  github: mangomt
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:52.450Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mangomt-dsh-power`
- Submission type: community curation
- Created by `mangomt` — https://github.com/mangomt
- Original source repository: https://github.com/mangomt/dsh-power
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.