### PR TITLE
catalog: add mantonlove-dsh-conversation-landmarks (community curation, created by @mantonlove)

### DIFF
--- a/catalog/plugins/mantonlove-dsh-conversation-landmarks.yaml
+++ b/catalog/plugins/mantonlove-dsh-conversation-landmarks.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: mantonlove-dsh-conversation-landmarks
+name: dsh-conversation-landmarks
+description:
+  en: Fixed rail of conversation landmarks with hover previews and click-to-jump navigation for DeepSeek Harness Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - conversation-navigation
+  - chat-ui
+source:
+  repository: https://github.com/mantonlove/dsh-conversation-landmarks
+  repositoryNodeId: R_kgDOT7qjIQ
+  subpath: null
+  commit: b934f8703faaf63c73836d9e42f6fbb7652ec326
+creator:
+  github: mantonlove
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:19.284Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mantonlove-dsh-conversation-landmarks`
- Submission type: community curation
- Created by `mantonlove` — https://github.com/mantonlove
- Original source repository: https://github.com/mantonlove/dsh-conversation-landmarks
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.