### PR TITLE
catalog: add margbug01-dsh-oracle (community curation, created by @margbug01)

### DIFF
--- a/catalog/plugins/margbug01-dsh-oracle.yaml
+++ b/catalog/plugins/margbug01-dsh-oracle.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: margbug01-dsh-oracle
+name: dsh-oracle
+description:
+  en: Strongly read-only, secret-aware Oracle second-opinion subagent for DeepSeek Harness.
+  evidencePath: dsh-oracle/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - oracle
+  - subagent
+source:
+  repository: https://github.com/margbug01/dsh-ma-plugins
+  repositoryNodeId: R_kgDOT5HqkQ
+  subpath: dsh-oracle
+  commit: d554ce499f792fc3434f071262af76becb0b7634
+creator:
+  github: margbug01
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-oracle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:49:02.290Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `margbug01-dsh-oracle`
- Submission type: community curation
- Created by `margbug01` — https://github.com/margbug01
- Original source repository: https://github.com/margbug01/dsh-ma-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.