### PR TITLE
catalog: add mario03690-dsh-netcafe (community curation, created by @mario03690)

### DIFF
--- a/catalog/plugins/mario03690-dsh-netcafe.yaml
+++ b/catalog/plugins/mario03690-dsh-netcafe.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: mario03690-dsh-netcafe
+name: dsh-netcafe
+description:
+  en: DeepSeek Harness bundle for AI NetCafé's hosted tools. One install for the full catalogue, or pick one of four focused packs (tables, dev kit, doc flow, China facts) so you only pay the context cost of what you use.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - mcp
+  - agent-tools
+source:
+  repository: https://github.com/mario03690/dsh-netcafe
+  repositoryNodeId: R_kgDOT37pZA
+  subpath: null
+  commit: c431a433070913232ebe6c31899d761e08e3b0fe
+creator:
+  github: mario03690
+package:
+  ecosystem: npm
+  name: dsh-netcafe
+  version: 0.3.1
+  integrity: sha512-r5TRrWCYqEUYN+nlxAI3ni7AC4R0MeQlplWNVlKfwUekd41DUOWJnyn8l5EPo5oBEHJrlGWAkgi68GyyAVFACQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:53.057Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mario03690-dsh-netcafe`
- Submission type: community curation
- Created by `mario03690` — https://github.com/mario03690
- Original source repository: https://github.com/mario03690/dsh-netcafe
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.