### PR TITLE
catalog: add marshfolx-dsh-subagent-setting (community curation, created by @marshfolx)

### DIFF
--- a/catalog/plugins/marshfolx-dsh-subagent-setting.yaml
+++ b/catalog/plugins/marshfolx-dsh-subagent-setting.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: marshfolx-dsh-subagent-setting
+name: dsh-subagent-setting
+description:
+  en: Configure the default provider / model / reasoning effort for subagents from the DeepSeek Harness Web settings page. Newly created subagents pick the values up immediately; an optional switch also lets later settings changes reach subagents that were created earlier.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - subagent
+  - model
+  - reasoning
+  - reasoning-effort
+  - settings
+  - llm
+source:
+  repository: https://github.com/marshfolx/dsh-subagent-setting
+  repositoryNodeId: R_kgDOT-mGjg
+  subpath: null
+  commit: 18fffce7ed59ed41f22eefb95513654c29b66c39
+creator:
+  github: marshfolx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:54.653Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `marshfolx-dsh-subagent-setting`
- Submission type: community curation
- Created by `marshfolx` — https://github.com/marshfolx
- Original source repository: https://github.com/marshfolx/dsh-subagent-setting
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.