### PR TITLE
catalog: add marvekg-dsh-plugins (community curation, created by @MarvekG)

### DIFF
--- a/catalog/plugins/marvekg-dsh-plugins.yaml
+++ b/catalog/plugins/marvekg-dsh-plugins.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: marvekg-dsh-plugins
+name: "@marvekg/dsh-plugins"
+description:
+  en: Out-of-tree DSH plugin collection (compatibility fixes and enhancements)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - tree
+  - collection
+  - compatibility
+  - fixes
+  - enhancements
+  - dsh
+source:
+  repository: https://github.com/MarvekG/dsh-plugins
+  repositoryNodeId: R_kgDOUBMVow
+  subpath: null
+  commit: fb852ebfcefa8c860826b25a2223a7579f7115bc
+creator:
+  github: MarvekG
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:19.287Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `marvekg-dsh-plugins`
- Submission type: community curation
- Created by `MarvekG` — https://github.com/MarvekG
- Original source repository: https://github.com/MarvekG/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.