### PR TITLE
catalog: add max-null-dsh-chinese-thinking (community curation, created by @Max-Null)

### DIFF
--- a/catalog/plugins/max-null-dsh-chinese-thinking.yaml
+++ b/catalog/plugins/max-null-dsh-chinese-thinking.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: max-null-dsh-chinese-thinking
+name: "@max-null/dsh-chinese-thinking"
+description:
+  en: Injects one system-prompt section so a DeepSeek Harness agent thinks and replies in Chinese
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - chinese
+  - prompt
+  - cordis
+source:
+  repository: https://github.com/Max-Null/dsh-chinese-thinking
+  repositoryNodeId: R_kgDOT5JPMg
+  subpath: null
+  commit: 0ad74657a1699ff78cafb7e3a47009779d0843a7
+creator:
+  github: Max-Null
+package:
+  ecosystem: npm
+  name: "@max-null/dsh-chinese-thinking"
+  version: 0.3.0
+  integrity: sha512-gomFOfppfqUv95zLCLhjQ2RHl02S1ABDBCvllLZL+r8O2m6DpFYZB9KmMtNQjG2uCU+OFk1Hm5VXgUHvil+l4w==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:18.879Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `max-null-dsh-chinese-thinking`
- Submission type: community curation
- Created by `Max-Null` — https://github.com/Max-Null
- Original source repository: https://github.com/Max-Null/dsh-chinese-thinking
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.