### PR TITLE
catalog: add max-null-dsh-draft-polish (community curation, created by @Max-Null)

### DIFF
--- a/catalog/plugins/max-null-dsh-draft-polish.yaml
+++ b/catalog/plugins/max-null-dsh-draft-polish.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: max-null-dsh-draft-polish
+name: "@max-null/dsh-draft-polish"
+description:
+  en: 本插件属于 @max-null/ 插件系列 ——这一系列共同构成 SSID（思灵 · Seek Soul in Darkness） 桌面体验。SSID 是整合它们的盒： dsh-capture · dsh-chat-rail · dsh-chinese-thinking · dsh-draft-polish · dsh-guardian · dsh-habit · dsh-header-unify · dsh-memory · dsh-node-appearance · dsh-plugin-center · dsh-skill-mcp-center · dsh-ssid-panels · dsh-ssid-zh-ui 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ssid
+  - polish
+  - draft
+  - composer
+  - llm
+source:
+  repository: https://github.com/Max-Null/dsh-draft-polish
+  repositoryNodeId: R_kgDOT_7bkw
+  subpath: null
+  commit: c42015d25ed19187c123ecf3a634afed4c642062
+creator:
+  github: Max-Null
+package:
+  ecosystem: npm
+  name: "@max-null/dsh-draft-polish"
+  version: 0.2.1
+  integrity: sha512-olKO01NhDSCHCarYSlqjSPBk35+J39aPP3B4RddFDV5Oe22f9mLyBd2lOJ9qknbWOm3LDixo//Iu6OF9xKzLQg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:39.581Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `max-null-dsh-draft-polish`
- Submission type: community curation
- Created by `Max-Null` — https://github.com/Max-Null
- Original source repository: https://github.com/Max-Null/dsh-draft-polish
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.