### PR TITLE
catalog: add max-null-dsh-memory (community curation, created by @Max-Null)

### DIFF
--- a/catalog/plugins/max-null-dsh-memory.yaml
+++ b/catalog/plugins/max-null-dsh-memory.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: max-null-dsh-memory
+name: "@max-null/dsh-memory"
+description:
+  en: Cross-session plaintext memory plugin for the DeepSeek Harness — deterministic BM25 recall, human-owned, no embeddings
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - cordis
+source:
+  repository: https://github.com/Max-Null/dsh-memory
+  repositoryNodeId: R_kgDOT5BxrQ
+  subpath: null
+  commit: 92730eda00830f973d58da931648db544966cc83
+creator:
+  github: Max-Null
+package:
+  ecosystem: npm
+  name: "@max-null/dsh-memory"
+  version: 0.6.0
+  integrity: sha512-m9GR/CpL/3XcNfyL2TpxNzUW8zYSh3dF9pYcIYRS0QjNPbzuxXxpLJ7ez31w2zEG/PBSDaexh7RoQQxBSieqYg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:28.105Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `max-null-dsh-memory`
- Submission type: community curation
- Created by `Max-Null` — https://github.com/Max-Null
- Original source repository: https://github.com/Max-Null/dsh-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.