### PR TITLE
catalog: add max-null-dsh-skill-mcp-center (community curation, created by @Max-Null)

### DIFF
--- a/catalog/plugins/max-null-dsh-skill-mcp-center.yaml
+++ b/catalog/plugins/max-null-dsh-skill-mcp-center.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: max-null-dsh-skill-mcp-center
+name: "@max-null/dsh-skill-mcp-center"
+description:
+  en: Skill & MCP management center for DeepSeek Harness — manage skills and MCP servers in Settings, live MCP status in the sidebar
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - skill
+  - mcp
+  - cordis
+source:
+  repository: https://github.com/Max-Null/dsh-skill-mcp-center
+  repositoryNodeId: R_kgDOT7cLUQ
+  subpath: null
+  commit: 303596fcf59891f74dbd0b5431709b362aac45d0
+creator:
+  github: Max-Null
+package:
+  ecosystem: npm
+  name: "@max-null/dsh-skill-mcp-center"
+  version: 0.4.1
+  integrity: sha512-EQtWMxMZU+j2zhKj7S80FFH02YxbIqhIPjoYp84WlvolfwWfyqkAZStsxsRVui+xNAHfcBoBPLILlRxdBhnFyw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:39.575Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `max-null-dsh-skill-mcp-center`
- Submission type: community curation
- Created by `Max-Null` — https://github.com/Max-Null
- Original source repository: https://github.com/Max-Null/dsh-skill-mcp-center
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.