### PR TITLE
catalog: add maxhou-infinity-dsh-scout (community curation, created by @MaxHou-infinity)

### DIFF
--- a/catalog/plugins/maxhou-infinity-dsh-scout.yaml
+++ b/catalog/plugins/maxhou-infinity-dsh-scout.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: maxhou-infinity-dsh-scout
+name: dsh-scout
+description:
+  en: Evidence-driven company and job intelligence plugin for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - company-research
+  - job-intelligence
+  - hrbp
+  - dsh
+source:
+  repository: https://github.com/MaxHou-infinity/dsh-scout
+  repositoryNodeId: R_kgDOT4L5AA
+  subpath: null
+  commit: 31dd63376b18db391faa984ecd4af03221e5abda
+creator:
+  github: MaxHou-infinity
+package:
+  ecosystem: npm
+  name: dsh-scout
+  version: 0.8.1
+  integrity: sha512-tlSd2J3XQhdI8xVjTKi8sjLwmjHa/MN4IRcLbKGNWYbm5PLMsw/iWKRClUopfjSli3a3UsdOQm9zD9GVOQgfRg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:55.386Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `maxhou-infinity-dsh-scout`
- Submission type: community curation
- Created by `MaxHou-infinity` — https://github.com/MaxHou-infinity
- Original source repository: https://github.com/MaxHou-infinity/dsh-scout
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.