### PR TITLE
catalog: add maxiaovivi-dsh-cloak-browser (community curation, created by @maxiaovivi)

### DIFF
--- a/catalog/plugins/maxiaovivi-dsh-cloak-browser.yaml
+++ b/catalog/plugins/maxiaovivi-dsh-cloak-browser.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: maxiaovivi-dsh-cloak-browser
+name: dsh-cloak-browser
+description:
+  en: Native CloakBrowser tools for DeepSeek Harness with per-agent browser sessions and snapshot references.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - cloakbrowser
+  - playwright
+  - browser-automation
+  - ai-agent
+source:
+  repository: https://github.com/maxiaovivi/dsh-cloak-browser
+  repositoryNodeId: R_kgDOT4m2aA
+  subpath: null
+  commit: d652020cebd601d24c1ed39fc00175558cfc166c
+creator:
+  github: maxiaovivi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:16.390Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `maxiaovivi-dsh-cloak-browser`
- Submission type: community curation
- Created by `maxiaovivi` — https://github.com/maxiaovivi
- Original source repository: https://github.com/maxiaovivi/dsh-cloak-browser
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.