### PR TITLE
catalog: add maxmilian-dsh-forge (community curation, created by @maxmilian)

### DIFF
--- a/catalog/plugins/maxmilian-dsh-forge.yaml
+++ b/catalog/plugins/maxmilian-dsh-forge.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: maxmilian-dsh-forge
+name: "@maxhsu/dsh-forge"
+description:
+  en: DeepSeek Harness tools for self-hosted Gitea and Forgejo instances.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - forgejo
+  - gitea
+  - git
+  - agent
+  - dsh
+source:
+  repository: https://github.com/maxmilian/dsh-forge
+  repositoryNodeId: R_kgDOUCWIzg
+  subpath: null
+  commit: dbf321896b23d5a41309519f04c27357eefb620a
+creator:
+  github: maxmilian
+package:
+  ecosystem: npm
+  name: "@maxhsu/dsh-forge"
+  version: 0.3.3
+  integrity: sha512-iwCvuAQuFxwW2SkrNusCibjy+VlvmWZ2ooPw38VspgTC0ECNTpHKfaenZI0QtYe9n8M4Q/V5UbwiACcxGgcD7A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:55.392Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `maxmilian-dsh-forge`
- Submission type: community curation
- Created by `maxmilian` — https://github.com/maxmilian
- Original source repository: https://github.com/maxmilian/dsh-forge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.