### PR TITLE
catalog: add maxmilian-dsh-sonarqube (community curation, created by @maxmilian)

### DIFF
--- a/catalog/plugins/maxmilian-dsh-sonarqube.yaml
+++ b/catalog/plugins/maxmilian-dsh-sonarqube.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: maxmilian-dsh-sonarqube
+name: dsh-sonarqube
+description:
+  en: Read-only SonarQube Community Build tools for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - sonarqube
+  - code-quality
+  - dsh
+source:
+  repository: https://github.com/maxmilian/dsh-sonarqube
+  repositoryNodeId: R_kgDOUCWUiQ
+  subpath: null
+  commit: f081eece10746f0c91f3a3fe13e605e1fafd1b14
+creator:
+  github: maxmilian
+package:
+  ecosystem: npm
+  name: dsh-sonarqube
+  version: 0.1.0
+  integrity: sha512-mng+RDTW6X33XckQq1hZIyNhM9QRrIRi0M1VHp1Qv4zdCZx0hL5KM4GoxB1KfKdXfOgDWD0XZrqfpazLxpvpog==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:40.663Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `maxmilian-dsh-sonarqube`
- Submission type: community curation
- Created by `maxmilian` — https://github.com/maxmilian
- Original source repository: https://github.com/maxmilian/dsh-sonarqube
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.