### PR TITLE
catalog: add maxwell-feng-dsh-searxng-web (community curation, created by @maxwell-feng)

### DIFF
--- a/catalog/plugins/maxwell-feng-dsh-searxng-web.yaml
+++ b/catalog/plugins/maxwell-feng-dsh-searxng-web.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: maxwell-feng-dsh-searxng-web
+name: "@maxwell-feng/dsh-searxng-web"
+description:
+  en: "dsh plugin: back the native web search / web fetch tools with your self-hosted SearXNG instance - keyless, private, no third-party search vendor."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - searxng
+  - web-search
+  - self-hosted
+  - privacy
+source:
+  repository: https://github.com/maxwell-feng/dsh-searxng-web
+  repositoryNodeId: R_kgDOUA1QGg
+  subpath: null
+  commit: deaa2a6b546513abd083252e28fa0894e3fb3938
+creator:
+  github: maxwell-feng
+package:
+  ecosystem: npm
+  name: "@maxwell-feng/dsh-searxng-web"
+  version: 0.4.0
+  integrity: sha512-WWmNolATkRc2XXK3NHtmPRAHE2MlfVKVCYz6PgAjzxV3iNKUAEw/VJtBoxTsk7hQrUDzJ6UnwYArJmD2m9tTSQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:27.990Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `maxwell-feng-dsh-searxng-web`
- Submission type: community curation
- Created by `maxwell-feng` — https://github.com/maxwell-feng
- Original source repository: https://github.com/maxwell-feng/dsh-searxng-web
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.