### PR TITLE
catalog: add mayf3-dsh-session-doctor (community curation, created by @mayf3)

### DIFF
--- a/catalog/plugins/mayf3-dsh-session-doctor.yaml
+++ b/catalog/plugins/mayf3-dsh-session-doctor.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: mayf3-dsh-session-doctor
+name: dsh-session-doctor
+description:
+  en: "Diagnose, unstick, and read DeepSeek Harness sessions. Five tools for every session: list, read, diagnose, recover, and message other Agent sessions."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - session
+  - agent
+  - diagnosis
+  - recover
+  - stuck
+source:
+  repository: https://github.com/mayf3/dsh-session-doctor
+  repositoryNodeId: R_kgDOT4xvWA
+  subpath: null
+  commit: 8147c144075ad7f7d86541f1393193cf3d522224
+creator:
+  github: mayf3
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:27.918Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mayf3-dsh-session-doctor`
- Submission type: community curation
- Created by `mayf3` — https://github.com/mayf3
- Original source repository: https://github.com/mayf3/dsh-session-doctor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.