### PR TITLE
catalog: add meghanbao-dsh-backstory (community curation, created by @MeghanBao)

### DIFF
--- a/catalog/plugins/meghanbao-dsh-backstory.yaml
+++ b/catalog/plugins/meghanbao-dsh-backstory.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: meghanbao-dsh-backstory
+name: dsh-backstory
+description:
+  en: "Ask any line of code its backstory: what it does, and why it's here — grounded in git history and the agent's own session log."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - git-blame
+  - provenance
+  - code-explanation
+  - dsh
+source:
+  repository: https://github.com/MeghanBao/dsh-backstory
+  repositoryNodeId: R_kgDOT-qJJQ
+  subpath: null
+  commit: 93ca70cf5126272164a7cd5c39c6dd638ef7c83a
+creator:
+  github: MeghanBao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:55.942Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `meghanbao-dsh-backstory`
- Submission type: community curation
- Created by `MeghanBao` — https://github.com/MeghanBao
- Original source repository: https://github.com/MeghanBao/dsh-backstory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.