### PR TITLE
catalog: add memz-jzy-dsh-client-ui-effort-slider (community curation, created by @MEMZ-JZY)

### DIFF
--- a/catalog/plugins/memz-jzy-dsh-client-ui-effort-slider.yaml
+++ b/catalog/plugins/memz-jzy-dsh-client-ui-effort-slider.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: memz-jzy-dsh-client-ui-effort-slider
+name: dsh-client-ui-effort-slider
+description:
+  en: Animated reasoning-level slider for DeepSeek Harness model selection.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - animated
+  - reasoning
+  - level
+  - slider
+  - model
+  - selection
+  - dsh
+source:
+  repository: https://github.com/MEMZ-JZY/DSH-Claude-Style-Reasoning-Slider
+  repositoryNodeId: R_kgDOT5Spnw
+  subpath: null
+  commit: f1aa4b4728725076f70d3dc21c9d95ca281b30d7
+creator:
+  github: MEMZ-JZY
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:42.499Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `memz-jzy-dsh-client-ui-effort-slider`
- Submission type: community curation
- Created by `MEMZ-JZY` — https://github.com/MEMZ-JZY
- Original source repository: https://github.com/MEMZ-JZY/DSH-Claude-Style-Reasoning-Slider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.