### PR TITLE
catalog: add mengyuil-dsh-ponytail (community curation, created by @MengYuil)

### DIFF
--- a/catalog/plugins/mengyuil-dsh-ponytail.yaml
+++ b/catalog/plugins/mengyuil-dsh-ponytail.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: mengyuil-dsh-ponytail
+name: "@mengyuly/dsh-ponytail"
+description:
+  en: "Lazy senior dev mode for DeepSeek Harness: always-on minimal-code ruleset, intensity switching, and short review/audit/debt/gain/help skills"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - lazy
+  - senior
+  - mode
+  - always
+  - minimal
+  - code
+  - ruleset
+  - intensity
+  - switching
+  - short
+  - review
+  - audit
+  - debt
+  - gain
+  - help
+  - skills
+source:
+  repository: https://github.com/MengYuil/dsh-ponytail
+  repositoryNodeId: R_kgDOUBYfjA
+  subpath: null
+  commit: c76ef3aa08d996427073fe0e5aa258eb34d678f6
+creator:
+  github: MengYuil
+package:
+  ecosystem: npm
+  name: "@mengyuly/dsh-ponytail"
+  version: 0.2.2
+  integrity: sha512-76qlZJak0TshQwnXgFlZTRqp2GaANj+ftHKMX5u5oGxkXc24LxeYgWof56H9CQYN1kMq52CJN9Dlsscq+YPhIg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:28.059Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mengyuil-dsh-ponytail`
- Submission type: community curation
- Created by `MengYuil` — https://github.com/MengYuil
- Original source repository: https://github.com/MengYuil/dsh-ponytail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.