### PR TITLE
catalog: add mercy719-dsh-client-ui-weather (community curation, created by @mercy719)

### DIFF
--- a/catalog/plugins/mercy719-dsh-client-ui-weather.yaml
+++ b/catalog/plugins/mercy719-dsh-client-ui-weather.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: mercy719-dsh-client-ui-weather
+name: "@deepseek-ai/dsh-client-ui-weather"
+description:
+  en: Weather dashboard overlay for the DeepSeek Harness Web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - weather
+  - weather-dashboard
+  - open-meteo
+  - dsh
+source:
+  repository: https://github.com/mercy719/dsh-client-ui-weather
+  repositoryNodeId: R_kgDOT8SfPQ
+  subpath: null
+  commit: 064d7fe07b3164b5315e0c9d91a921c0854ad684
+creator:
+  github: mercy719
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:49:10.635Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mercy719-dsh-client-ui-weather`
- Submission type: community curation
- Created by `mercy719` — https://github.com/mercy719
- Original source repository: https://github.com/mercy719/dsh-client-ui-weather
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.