### PR TITLE
catalog: add mervyn-teo-dsh-plugin-collapsible-steps (community curation, created by @mervyn-teo)

### DIFF
--- a/catalog/plugins/mervyn-teo-dsh-plugin-collapsible-steps.yaml
+++ b/catalog/plugins/mervyn-teo-dsh-plugin-collapsible-steps.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: mervyn-teo-dsh-plugin-collapsible-steps
+name: dsh-plugin-collapsible-steps
+description:
+  en: "DSH Web plugin: collapse consecutive tool-use and thinking steps between messages into a single bracketed, expandable item"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - cordis
+  - conversation
+  - collapse
+  - steps
+source:
+  repository: https://github.com/mervyn-teo/dsh-plugin-collapsible-steps
+  repositoryNodeId: R_kgDOT5mCRQ
+  subpath: null
+  commit: 667ed25de8c3a45abe001725d6916cf5cc6a2fec
+creator:
+  github: mervyn-teo
+package:
+  ecosystem: npm
+  name: dsh-plugin-collapsible-steps
+  version: 0.1.1
+  integrity: sha512-55Q9Vbs07ZM1Hsdi3KW586JLI5TxxTIUJBtt69THHMCSrD5w3ctZCLpWGyuuA+tYxy2OFA+y3NcJavgjnztQ4A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:56.519Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mervyn-teo-dsh-plugin-collapsible-steps`
- Submission type: community curation
- Created by `mervyn-teo` — https://github.com/mervyn-teo
- Original source repository: https://github.com/mervyn-teo/dsh-plugin-collapsible-steps
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.