### PR TITLE
catalog: add peefy-dsh-opencontext (community curation, created by @Peefy)

### DIFF
--- a/catalog/plugins/peefy-dsh-opencontext.yaml
+++ b/catalog/plugins/peefy-dsh-opencontext.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: peefy-dsh-opencontext
+name: dsh-opencontext
+description:
+  en: DeepSeek Harness plugin that wires DSH agents to OpenContext for durable memory + retrieval-augmented context.
+  evidencePath: plugins/dsh-opencontext/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - opencontext
+  - melandlabs
+  - memory
+  - rag
+  - agent
+source:
+  repository: https://github.com/melandlabs/opencontext
+  repositoryNodeId: R_kgDOTz5TWQ
+  subpath: plugins/dsh-opencontext
+  commit: dec7351e77d7a29bc4119c0ac06e8cee9fadae26
+creator:
+  github: Peefy
+package:
+  ecosystem: npm
+  name: dsh-opencontext
+  version: 0.3.2
+  integrity: sha512-aCw2sRBAkz+eDxOdzOrPWvWU2Sslu+o8CtuvGxj3mnJx0eeyEmM9IIPGdQVMuADkAPz2oDZeDYN/uSth80JNBw==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-opencontext/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:49:05.718Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `peefy-dsh-opencontext`
- Submission type: community curation
- Created by `Peefy` — https://github.com/Peefy
- Original source repository: https://github.com/melandlabs/opencontext
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.