### PR TITLE
catalog: add wsqstar-dsh-tool-vision-read (community curation, created by @wsqstar)

### DIFF
--- a/catalog/plugins/wsqstar-dsh-tool-vision-read.yaml
+++ b/catalog/plugins/wsqstar-dsh-tool-vision-read.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: wsqstar-dsh-tool-vision-read
+name: "@deepseek-ai/dsh-tool-vision-read"
+description:
+  en: "DSH plugin: vision read — route image reading to a dedicated vision model (e.g. Kimi K3) so text-only agents can see images"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - vision
+  - read
+  - route
+  - image
+  - reading
+  - dedicated
+  - model
+  - kimi
+  - text
+  - only
+  - agents
+  - images
+  - dsh
+source:
+  repository: https://github.com/Mappedinfo/dsh-tool-vision-read
+  repositoryNodeId: R_kgDOT5ox1Q
+  subpath: null
+  commit: 921d4af1a2333d58d1020703c20b0c2ab93833ab
+creator:
+  github: wsqstar
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T08:48:39.580Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wsqstar-dsh-tool-vision-read`
- Submission type: community curation
- Created by `wsqstar` — https://github.com/wsqstar
- Original source repository: https://github.com/Mappedinfo/dsh-tool-vision-read
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.