### PR TITLE
catalog: add akqwpeter-dsh-agent-conductor (community curation, created by @akqwpeter)

### DIFF
--- a/catalog/plugins/akqwpeter-dsh-agent-conductor.yaml
+++ b/catalog/plugins/akqwpeter-dsh-agent-conductor.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: akqwpeter-dsh-agent-conductor
+name: dsh-agent-conductor
+description:
+  en: "In-session cross-agent dispatch for DeepSeek Harness: a zero-dependency skill and a host-only bundle that send self-contained tasks to 11 external agent CLIs (Codex, Claude Code, TraeCode, OpenCode, Gemini, Cursor, Kimi, Qwen, Copilot, WorkBuddy, Grok)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent
+  - codex
+  - claude-code
+  - multica
+  - conductor
+  - dispatch
+source:
+  repository: https://github.com/MJorgin/dsh-agent-conductor
+  repositoryNodeId: R_kgDOT5UycQ
+  subpath: null
+  commit: e2b4d7010b8854109555f8a6476c3dc985df82ca
+creator:
+  github: akqwpeter
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:35.483Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `akqwpeter-dsh-agent-conductor`
- Submission type: community curation
- Created by `akqwpeter` — https://github.com/akqwpeter
- Original source repository: https://github.com/MJorgin/dsh-agent-conductor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.