### PR TITLE
catalog: add gsq-dsh-honcho-sync (community curation, created by @gsq)

### DIFF
--- a/catalog/plugins/gsq-dsh-honcho-sync.yaml
+++ b/catalog/plugins/gsq-dsh-honcho-sync.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: gsq-dsh-honcho-sync
+name: "@nanpaidashi/dsh-honcho-sync"
+description:
+  en: Honcho Memory Plugin for DeepSeek Harness — persistent AI memory with auto-sync, hybrid recall, and 25 API tools
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - honcho
+  - memory
+  - persistent-memory
+  - ai-memory
+source:
+  repository: https://github.com/nanpaidashi/dsh-honcho-sync
+  repositoryNodeId: R_kgDOT5XmqQ
+  subpath: null
+  commit: 83e77920c915aea05beebb7504b3bd38c5028a27
+creator:
+  github: gsq
+package:
+  ecosystem: npm
+  name: "@nanpaidashi/dsh-honcho-sync"
+  version: 0.8.1
+  integrity: sha512-YGWrrIDakgOt4GoyRQ/1q27NFCABa455AyavUmpG/UVB2d6HGGBuB00BFyoNtaIT9mErbI/BPK84qCjdnPL+BQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:39.804Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gsq-dsh-honcho-sync`
- Submission type: community curation
- Created by `gsq` — https://github.com/gsq
- Original source repository: https://github.com/nanpaidashi/dsh-honcho-sync
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.