### PR TITLE
catalog: add jjxjjjjiik-bot-dsh-chat-timeline-plus (community curation, created by @jjxjjjjiik-bot)

### DIFF
--- a/catalog/plugins/jjxjjjjiik-bot-dsh-chat-timeline-plus.yaml
+++ b/catalog/plugins/jjxjjjjiik-bot-dsh-chat-timeline-plus.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: jjxjjjjiik-bot-dsh-chat-timeline-plus
+name: dsh-chat-timeline-plus
+description:
+  en: "A message timeline for DeepSeek Harness (DSH): persistent right rail + hover panel, hover to preview the Q&A, pin to keep it open ."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - conversation
+  - navigation
+  - timeline
+  - bookmarks
+  - rewind
+  - hover-preview
+  - pin
+  - plus
+source:
+  repository: https://github.com/NIU-001-LIU/dsh-chat-timeline-plus
+  repositoryNodeId: R_kgDOUDVpfQ
+  subpath: null
+  commit: 7a7f2ea88484b35611a696096aa5980bbb00a975
+creator:
+  github: jjxjjjjiik-bot
+package:
+  ecosystem: npm
+  name: dsh-chat-timeline-plus
+  version: 0.3.2
+  integrity: sha512-QwodphxVcBJ5rjFLEAXSPr1le+HYWuhlSHB8Ka5vrzgJQA6YxgtzIAwCJ8856jS0qoGqB7j9pglc++SMPDTeaA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:06.901Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jjxjjjjiik-bot-dsh-chat-timeline-plus`
- Submission type: community curation
- Created by `jjxjjjjiik-bot` — https://github.com/jjxjjjjiik-bot
- Original source repository: https://github.com/NIU-001-LIU/dsh-chat-timeline-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.