### PR TITLE
catalog: add mervyn-teo-dsh-plugin-qr-connect (community curation, created by @mervyn-teo)

### DIFF
--- a/catalog/plugins/mervyn-teo-dsh-plugin-qr-connect.yaml
+++ b/catalog/plugins/mervyn-teo-dsh-plugin-qr-connect.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: mervyn-teo-dsh-plugin-qr-connect
+name: dsh-plugin-qr-connect
+description:
+  en: "DeepSeek Harness (DSH) Web plugin: a QR-code button above Settings that lets phones connect to the web UI through an auth-gated reverse proxy."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - cordis
+  - qr-code
+source:
+  repository: https://github.com/mervyn-teo/dsh-plugin-qr-connect
+  repositoryNodeId: R_kgDOT4SjXA
+  subpath: null
+  commit: 430ad448366fdf5303674295c793f85240ce0da5
+creator:
+  github: mervyn-teo
+package:
+  ecosystem: npm
+  name: dsh-plugin-qr-connect
+  version: 0.1.3
+  integrity: sha512-9z9FRnd/8UrE1ZmHx85CEO6s++QHF6NZeKAaIqFax+IqZAyYxdA81Z2YcGjBSTBwEOUjUewejRoXRxYlQSxLSA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:45.052Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mervyn-teo-dsh-plugin-qr-connect`
- Submission type: community curation
- Created by `mervyn-teo` — https://github.com/mervyn-teo
- Original source repository: https://github.com/mervyn-teo/dsh-plugin-qr-connect
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.