### PR TITLE
catalog: add meteornox-dsh-whale-widget (community curation, created by @MeteorNOX)

### DIFF
--- a/catalog/plugins/meteornox-dsh-whale-widget.yaml
+++ b/catalog/plugins/meteornox-dsh-whale-widget.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: meteornox-dsh-whale-widget
+name: dsh-whale-widget
+description:
+  en: powershell dsh plugin --profile web add github:MeteorNOX/DeepSeek-Balance-Whale-Widget
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - balance
+  - widget
+source:
+  repository: https://github.com/MeteorNOX/DeepSeek-Balance-Whale-Widget
+  repositoryNodeId: R_kgDOT78MdA
+  subpath: null
+  commit: 4448c61db7d180c4c307aa3fa734db7c8507658d
+creator:
+  github: MeteorNOX
+package:
+  ecosystem: npm
+  name: dsh-whale-widget
+  version: 0.2.10
+  integrity: sha512-s/9kFqQwGnSi3hLm7Gm4slHDrHL+738D8dcCjlWAxKtrvz/hu7bjoFH44ruWEKwxS0JoTS7qQLma2g0vRvFFBw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:35.400Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1285
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `meteornox-dsh-whale-widget`
- Submission type: community curation
- Created by `MeteorNOX` — https://github.com/MeteorNOX
- Original source repository: https://github.com/MeteorNOX/DeepSeek-Balance-Whale-Widget
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.