### PR TITLE
catalog: add michaelcode-wang-dsh-wecom (community curation, created by @michaelcode-wang)

### DIFF
--- a/catalog/plugins/michaelcode-wang-dsh-wecom.yaml
+++ b/catalog/plugins/michaelcode-wang-dsh-wecom.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: michaelcode-wang-dsh-wecom
+name: dsh-wecom
+description:
+  en: WeCom (Enterprise WeChat) Smart Robot bridge for DeepSeek Harness — two-way chat over the aibot WebSocket gateway (bot id + secret), no public endpoint needed.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - bundle
+  - wecom
+  - wechat-work
+  - enterprise-wechat
+  - im
+  - chatbot
+  - agent
+source:
+  repository: https://github.com/michaelcode-wang/dsh-wecom
+  repositoryNodeId: R_kgDOT5z0NA
+  subpath: null
+  commit: 2ea09993e85bf52181510acb7868a30c5ec15a59
+creator:
+  github: michaelcode-wang
+package:
+  ecosystem: npm
+  name: dsh-wecom
+  version: 0.1.0
+  integrity: sha512-ObzXUeDTzRqld6y2jZ/CLZvt6oybnpIiHxUbGpSKfrmduluJkM53OQ9rpCQeTPxDy6F9X0mg7Yh2on1eB4/5Yg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:49.306Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `michaelcode-wang-dsh-wecom`
- Submission type: community curation
- Created by `michaelcode-wang` — https://github.com/michaelcode-wang
- Original source repository: https://github.com/michaelcode-wang/dsh-wecom
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.