### PR TITLE
catalog: add michengai-dsh-archive-manager (community curation, created by @MichengAI)

### DIFF
--- a/catalog/plugins/michengai-dsh-archive-manager.yaml
+++ b/catalog/plugins/michengai-dsh-archive-manager.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: michengai-dsh-archive-manager
+name: "@michengai/dsh-archive-manager"
+description:
+  en: NPM-installable DSH Web plugin for managing archived sessions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - archive
+  - session-management
+  - cordis
+  - typert
+  - workspace
+  - nodejs
+  - esm
+source:
+  repository: https://github.com/MichengAI/dsh-archive-manager
+  repositoryNodeId: R_kgDOT5sqnA
+  subpath: null
+  commit: 090612b8beb45e3f6be496db1b4502e1140b5a27
+creator:
+  github: MichengAI
+package:
+  ecosystem: npm
+  name: "@michengai/dsh-archive-manager"
+  version: 0.1.16
+  integrity: sha512-U48DeBPueizLvC0HkheJKODAUwpHn4HUSwVVhxcYuvCkZfWHUcj7yT0U0b6vkHtqNecNCnx+Urh3wW+EeyTR+w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:35.426Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 27
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `michengai-dsh-archive-manager`
- Submission type: community curation
- Created by `MichengAI` — https://github.com/MichengAI
- Original source repository: https://github.com/MichengAI/dsh-archive-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.