### PR TITLE
catalog: add microherox-dsh-kimi-webbridge (community curation, created by @MicroHEROX)

### DIFF
--- a/catalog/plugins/microherox-dsh-kimi-webbridge.yaml
+++ b/catalog/plugins/microherox-dsh-kimi-webbridge.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: microherox-dsh-kimi-webbridge
+name: dsh-kimi-webbridge
+description:
+  en: "Kimi WebBridge for DeepSeek Harness: drive the user's real browser (navigate, click, fill, snapshot, screenshot, evaluate, network, upload, PDF) through the local Kimi WebBridge daemon"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - kimi
+  - webbridge
+  - browser
+  - web-automation
+  - dsh
+source:
+  repository: https://github.com/MicroHEROX/dsh-Kimi-WebBridge
+  repositoryNodeId: R_kgDOT38NYQ
+  subpath: null
+  commit: 098e041fd2e3c60190a46c4dc5ca6463ab2a4956
+creator:
+  github: MicroHEROX
+package:
+  ecosystem: npm
+  name: dsh-kimi-webbridge
+  version: 0.1.0
+  integrity: sha512-ebp+V/Km0IePUqW8FcXBIWlCQkOtvei04Q+fb201DKlvZpshbJb6xPDjUwT9KSVAuZlejWlHC1MkR2v/89ZWsw==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:45.607Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `microherox-dsh-kimi-webbridge`
- Submission type: community curation
- Created by `MicroHEROX` — https://github.com/MicroHEROX
- Original source repository: https://github.com/MicroHEROX/dsh-Kimi-WebBridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.