### PR TITLE
catalog: add mienfong-dsh-session-mgr (community curation, created by @mienfong)

### DIFF
--- a/catalog/plugins/mienfong-dsh-session-mgr.yaml
+++ b/catalog/plugins/mienfong-dsh-session-mgr.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: mienfong-dsh-session-mgr
+name: dsh-session-mgr
+description:
+  en: Session Manager for the DeepSeek Harness Web UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - web
+  - workspace
+  - session
+  - session-management
+  - move-session
+  - backup
+  - archived-sessions
+source:
+  repository: https://github.com/mienfong/dsh-session-mgr
+  repositoryNodeId: R_kgDOUCs1XQ
+  subpath: null
+  commit: d0773bf409a8e1143c36ef80d940573b9211b2d1
+creator:
+  github: mienfong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:07.940Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mienfong-dsh-session-mgr`
- Submission type: community curation
- Created by `mienfong` — https://github.com/mienfong
- Original source repository: https://github.com/mienfong/dsh-session-mgr
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.