### PR TITLE
catalog: add miisaka19800-dsh-restart-fab (community curation, created by @miisaka19800)

### DIFF
--- a/catalog/plugins/miisaka19800-dsh-restart-fab.yaml
+++ b/catalog/plugins/miisaka19800-dsh-restart-fab.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: miisaka19800-dsh-restart-fab
+name: dsh-restart-fab
+description:
+  en: A floating one-click restart button for the DeepSeek Harness web GUI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - restart
+  - web
+source:
+  repository: https://github.com/miisaka19800/dsh-restart-fab
+  repositoryNodeId: R_kgDOT5OKNw
+  subpath: null
+  commit: 99cd34aa81f4a279935afdb6e892d0900fe531dd
+creator:
+  github: miisaka19800
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:45.608Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `miisaka19800-dsh-restart-fab`
- Submission type: community curation
- Created by `miisaka19800` — https://github.com/miisaka19800
- Original source repository: https://github.com/miisaka19800/dsh-restart-fab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.