### PR TITLE
catalog: add minglu6-dsh-provider-qoder (community curation, created by @minglu6)

### DIFF
--- a/catalog/plugins/minglu6-dsh-provider-qoder.yaml
+++ b/catalog/plugins/minglu6-dsh-provider-qoder.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: minglu6-dsh-provider-qoder
+name: dsh-provider-qoder
+description:
+  en: "Qoder CN adapter plugin for DeepSeek Harness: COSY-signed, WAF-encoded streaming against gateway.qoder.com.cn"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - qoder
+  - llm
+  - provider
+source:
+  repository: https://github.com/minglu6/dsh-provider-qoder
+  repositoryNodeId: R_kgDOT-K0Vg
+  subpath: null
+  commit: c91610f96cc161c2b7d3b314507bf924707358ff
+creator:
+  github: minglu6
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:10.491Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `minglu6-dsh-provider-qoder`
- Submission type: community curation
- Created by `minglu6` — https://github.com/minglu6
- Original source repository: https://github.com/minglu6/dsh-provider-qoder
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.