### PR TITLE
catalog: add mingzeng21-dsh-notion-mcp (community curation, created by @mingzeng21)

### DIFF
--- a/catalog/plugins/mingzeng21-dsh-notion-mcp.yaml
+++ b/catalog/plugins/mingzeng21-dsh-notion-mcp.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: mingzeng21-dsh-notion-mcp
+name: dsh-notion-mcp
+description:
+  en: Connect DeepSeek Harness (dsh) to Notion via the official Notion MCP (OAuth + PKCE)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - notion
+  - mcp
+  - deepseek-harness
+source:
+  repository: https://github.com/mingzeng21/dsh-notion
+  repositoryNodeId: R_kgDOT5TJpg
+  subpath: null
+  commit: 07122b8e89273f2bcaaf765f11609afedc5b065f
+creator:
+  github: mingzeng21
+package:
+  ecosystem: npm
+  name: dsh-notion-mcp
+  version: 0.1.0
+  integrity: sha512-s+NSAPhTNtT7yU5ojF2NBQlYsLzZ0p8KCnrm5DsXGkBLO01nUHNoIO11lbLnWYBJEyQgVvx9j6t9UFf7Bxopag==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:45.888Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mingzeng21-dsh-notion-mcp`
- Submission type: community curation
- Created by `mingzeng21` — https://github.com/mingzeng21
- Original source repository: https://github.com/mingzeng21/dsh-notion
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.