### PR TITLE
catalog: add mingzeng21-dsh-obsidian (community curation, created by @mingzeng21)

### DIFF
--- a/catalog/plugins/mingzeng21-dsh-obsidian.yaml
+++ b/catalog/plugins/mingzeng21-dsh-obsidian.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: mingzeng21-dsh-obsidian
+name: dsh-obsidian
+description:
+  en: "Connect DeepSeek Harness (dsh) to a local Obsidian vault: search, read, write, move, and trash notes."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - obsidian
+  - deepseek-harness
+source:
+  repository: https://github.com/mingzeng21/dsh-obsidian
+  repositoryNodeId: R_kgDOT5vWvg
+  subpath: null
+  commit: 4eeec8d525330b94545acde965cfc12cd399eb79
+creator:
+  github: mingzeng21
+package:
+  ecosystem: npm
+  name: dsh-obsidian
+  version: 0.2.2
+  integrity: sha512-S+0QdIE0LzHn0RDajkRFfy77YX0NdWKXE8/o1KVDocxeadrgxVOccnCIWmr49t6JP7AeUUIIH33+sVpKPYnDOg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:35.367Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mingzeng21-dsh-obsidian`
- Submission type: community curation
- Created by `mingzeng21` — https://github.com/mingzeng21
- Original source repository: https://github.com/mingzeng21/dsh-obsidian
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.