### PR TITLE
catalog: add mittermeiergithub-dsh-darksoft-theme (community curation, created by @MitterMeierGithub)

### DIFF
--- a/catalog/plugins/mittermeiergithub-dsh-darksoft-theme.yaml
+++ b/catalog/plugins/mittermeiergithub-dsh-darksoft-theme.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: mittermeiergithub-dsh-darksoft-theme
+name: dsh-darksoft-theme
+description:
+  en: "Obsidian things-soft-colorful-headings port for dsh web dark theme: warm-gray dimmed text via --dsw-alias-label- token overrides plus soft colorful h1-h6 headings. Zero dependencies."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - theme
+  - obsidian
+  - colorful-headings
+  - dark-theme
+source:
+  repository: https://github.com/MitterMeierGithub/dsh-darksoft-theme
+  repositoryNodeId: R_kgDOUBGzAQ
+  subpath: null
+  commit: 5c8fc05e545d7e135be7afc786d00ba0b160b3c5
+creator:
+  github: MitterMeierGithub
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:59.359Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mittermeiergithub-dsh-darksoft-theme`
- Submission type: community curation
- Created by `MitterMeierGithub` — https://github.com/MitterMeierGithub
- Original source repository: https://github.com/MitterMeierGithub/dsh-darksoft-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.