### PR TITLE
catalog: add miuzel-dsh-subagent-workspace-ui (community curation, created by @miuzel)

### DIFF
--- a/catalog/plugins/miuzel-dsh-subagent-workspace-ui.yaml
+++ b/catalog/plugins/miuzel-dsh-subagent-workspace-ui.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: miuzel-dsh-subagent-workspace-ui
+name: dsh-subagent-workspace-ui
+description:
+  en: Searchable workspace subagent manager for DeepSeek Harness Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - searchable
+  - workspace
+  - subagent
+  - manager
+  - dsh
+source:
+  repository: https://github.com/miuzel/dsh-subagent-ui
+  repositoryNodeId: R_kgDOUFFqyQ
+  subpath: null
+  commit: 393cd3942d20d2fa1a1a11966a12205ce9ea0cae
+creator:
+  github: miuzel
+package:
+  ecosystem: npm
+  name: dsh-subagent-workspace-ui
+  version: 1.0.3
+  integrity: sha512-g9y882BbLipJ+VLhnVnPUAwHnL/JFdnrxprLIiCzg752MOKJn3tAUUDxjH791lHLvXJngZWHGes2WwVP/dZGkQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:10.492Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `miuzel-dsh-subagent-workspace-ui`
- Submission type: community curation
- Created by `miuzel` — https://github.com/miuzel
- Original source repository: https://github.com/miuzel/dsh-subagent-ui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.