### PR TITLE
catalog: add mjylfz-dsh-skill-mover (community curation, created by @mjylfz)

### DIFF
--- a/catalog/plugins/mjylfz-dsh-skill-mover.yaml
+++ b/catalog/plugins/mjylfz-dsh-skill-mover.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: mjylfz-dsh-skill-mover
+name: dsh-skill-mover
+description:
+  en: <p align="center" <a href="README.en.md" English</a &nbsp;&nbsp; &nbsp;&nbsp;<a href="README.md" 简体中文</a </p
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - align
+  - center
+  - href
+  - english
+  - nbsp
+  - dsh
+source:
+  repository: https://github.com/mjylfz/dsh-skill-mover
+  repositoryNodeId: R_kgDOT-eERw
+  subpath: null
+  commit: 9f9d087cb4e32d03f9e3357cd950829ff1bb9404
+creator:
+  github: mjylfz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:49.238Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mjylfz-dsh-skill-mover`
- Submission type: community curation
- Created by `mjylfz` — https://github.com/mjylfz
- Original source repository: https://github.com/mjylfz/dsh-skill-mover
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.