### PR TITLE
catalog: add mjylfz-dsh-subagent-codex (community curation, created by @mjylfz)

### DIFF
--- a/catalog/plugins/mjylfz-dsh-subagent-codex.yaml
+++ b/catalog/plugins/mjylfz-dsh-subagent-codex.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: mjylfz-dsh-subagent-codex
+name: dsh-subagent-codex
+description:
+  en: DSH subagent provider that delegates tasks to the OpenAI Codex CLI (codex exec), exposing the subagent codex tool
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - subagent
+  - codex
+  - openai
+source:
+  repository: https://github.com/mjylfz/dsh-subagent-codex
+  repositoryNodeId: R_kgDOT9qkuA
+  subpath: null
+  commit: 8d0151e02924dcfb2e0ab38712806f3ba3f76c31
+creator:
+  github: mjylfz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:59.353Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mjylfz-dsh-subagent-codex`
- Submission type: community curation
- Created by `mjylfz` — https://github.com/mjylfz
- Original source repository: https://github.com/mjylfz/dsh-subagent-codex
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.