### PR TITLE
catalog: add moeblack-dsh-prompt-studio (community curation, created by @Moeblack)

### DIFF
--- a/catalog/plugins/moeblack-dsh-prompt-studio.yaml
+++ b/catalog/plugins/moeblack-dsh-prompt-studio.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: moeblack-dsh-prompt-studio
+name: dsh-prompt-studio
+description:
+  en: "Prompt Studio plugin for DeepSeek Harness: compose runtime prompts, overrides, and request-local synthetic turns in one live editor"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - prompt
+  - studio
+  - compose
+  - runtime
+  - prompts
+  - overrides
+  - request
+  - local
+  - synthetic
+  - turns
+  - live
+  - editor
+  - dsh
+source:
+  repository: https://github.com/Moeblack/dsh-prompt-studio
+  repositoryNodeId: R_kgDOTvKJYg
+  subpath: null
+  commit: be5e97d6ea4e882067d9f3a6385f486f7f192e92
+creator:
+  github: Moeblack
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:46.939Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moeblack-dsh-prompt-studio`
- Submission type: community curation
- Created by `Moeblack` — https://github.com/Moeblack
- Original source repository: https://github.com/Moeblack/dsh-prompt-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.