### PR TITLE
catalog: add momojie-s-dsh-workspace-env (community curation, created by @Momojie-S)

### DIFF
--- a/catalog/plugins/momojie-s-dsh-workspace-env.yaml
+++ b/catalog/plugins/momojie-s-dsh-workspace-env.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: momojie-s-dsh-workspace-env
+name: "@momojie-s/dsh-workspace-env"
+description:
+  en: npm 包名： @momojie-s/dsh-workspace-env
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - momojie
+  - workspace
+  - dsh
+source:
+  repository: https://github.com/Momojie-S/dsh-workspace-env
+  repositoryNodeId: R_kgDOT4QUsA
+  subpath: null
+  commit: f60cce4fb77fffe765191cde91fc32ef400d8117
+creator:
+  github: Momojie-S
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:47.418Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `momojie-s-dsh-workspace-env`
- Submission type: community curation
- Created by `Momojie-S` — https://github.com/Momojie-S
- Original source repository: https://github.com/Momojie-S/dsh-workspace-env
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.