### PR TITLE
catalog: add momojie-s-dsh-workspace-mcp (community curation, created by @Momojie-S)

### DIFF
--- a/catalog/plugins/momojie-s-dsh-workspace-mcp.yaml
+++ b/catalog/plugins/momojie-s-dsh-workspace-mcp.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: momojie-s-dsh-workspace-mcp
+name: "@momojie-s/dsh-workspace-mcp"
+description:
+  en: 'yaml servers: my-server: transport: stdio command: npx args: ["-y", "some-mcp-server@latest"] env: {} remote: transport: streamable-http url: https://example.com/mcp headers: Authorization: "Bearer <token "'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - yaml
+  - servers
+  - server
+  - transport
+  - stdio
+  - command
+  - args
+  - some
+  - latest
+  - remote
+  - streamable
+  - example
+  - headers
+  - authorization
+  - bearer
+  - token
+source:
+  repository: https://github.com/Momojie-S/dsh-workspace-mcp
+  repositoryNodeId: R_kgDOT39Yig
+  subpath: null
+  commit: 9273549552978bbc7676e6d3dc94422760c3fcf1
+creator:
+  github: Momojie-S
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:39.803Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `momojie-s-dsh-workspace-mcp`
- Submission type: community curation
- Created by `Momojie-S` — https://github.com/Momojie-S
- Original source repository: https://github.com/Momojie-S/dsh-workspace-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.