### PR TITLE
catalog: add moon09300731-dsh-approval-gate (community curation, created by @moon09300731)

### DIFF
--- a/catalog/plugins/moon09300731-dsh-approval-gate.yaml
+++ b/catalog/plugins/moon09300731-dsh-approval-gate.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: moon09300731-dsh-approval-gate
+name: dsh-approval-gate
+description:
+  en: "Auto-approval gate for DeepSeek Harness — minimal human intervention: safe operations auto-approve, risky ones go to a human (fail-safe)."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - approval
+source:
+  repository: https://github.com/moon09300731/dsh-approval-gate
+  repositoryNodeId: R_kgDOT4H61Q
+  subpath: null
+  commit: 8419bc3722a237a85c033565be6ac06074f05d92
+creator:
+  github: moon09300731
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:42.064Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moon09300731-dsh-approval-gate`
- Submission type: community curation
- Created by `moon09300731` — https://github.com/moon09300731
- Original source repository: https://github.com/moon09300731/dsh-approval-gate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.