### PR TITLE
catalog: add moon09300731-dsh-vision-tools (community curation, created by @moon09300731)

### DIFF
--- a/catalog/plugins/moon09300731-dsh-vision-tools.yaml
+++ b/catalog/plugins/moon09300731-dsh-vision-tools.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: moon09300731-dsh-vision-tools
+name: dsh-vision-tools
+description:
+  en: sh dsh plugin --profile web add dsh-vision-tools
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - vision
+source:
+  repository: https://github.com/moon09300731/dsh-vision-tools
+  repositoryNodeId: R_kgDOT4H6kw
+  subpath: null
+  commit: fd4a8227c0cd0a01576be93658f856afcbd63fc9
+creator:
+  github: moon09300731
+package:
+  ecosystem: npm
+  name: dsh-vision-tools
+  version: 0.1.2
+  integrity: sha512-7eMP0xCFSbwGz0unOoJLsoMXEp/Wlz7a0bthufUIAoEbcDFL/A8Q2YthSwz8OvmohGEkmz71R+zU5gjlY9/0Pw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:43.675Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moon09300731-dsh-vision-tools`
- Submission type: community curation
- Created by `moon09300731` — https://github.com/moon09300731
- Original source repository: https://github.com/moon09300731/dsh-vision-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.