### PR TITLE
catalog: add moon16u-dsh-pouch (community curation, created by @moon16u)

### DIFF
--- a/catalog/plugins/moon16u-dsh-pouch.yaml
+++ b/catalog/plugins/moon16u-dsh-pouch.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: moon16u-dsh-pouch
+name: "@moon16u/dsh-pouch"
+description:
+  en: A collection of small, beautiful, and practical plugins for DeepSeek Harness (DSH)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+source:
+  repository: https://github.com/moon16u/dsh-pouch
+  repositoryNodeId: R_kgDOT-10Xw
+  subpath: null
+  commit: 6c8963610a217509e74670b6a96cc843888cfbee
+creator:
+  github: moon16u
+package:
+  ecosystem: npm
+  name: "@moon16u/dsh-pouch"
+  version: 0.2.0
+  integrity: sha512-0WlkaROMvq1I1/hxzSVaDtyKygh688MLbRbsacjdPOqsOguiVp6Uh4A9O3TTx+7le6l9mPYuwqEBIuaWqYEJEw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:10.491Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moon16u-dsh-pouch`
- Submission type: community curation
- Created by `moon16u` — https://github.com/moon16u
- Original source repository: https://github.com/moon16u/dsh-pouch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.