### PR TITLE
catalog: add mooncoder-happy-specworkflow (community curation, created by @MoonCoder-HAPPY)

### DIFF
--- a/catalog/plugins/mooncoder-happy-specworkflow.yaml
+++ b/catalog/plugins/mooncoder-happy-specworkflow.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: mooncoder-happy-specworkflow
+name: specworkflow
+description:
+  en: "Workflow skill pack for DeepSeek Harness: requirement grilling, specs, implementation, delivery review, repair planning, bug diagnosis, and source-backed research."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - skills
+  - agent-skills
+  - workflow
+  - spec
+source:
+  repository: https://github.com/MoonCoder-HAPPY/SpecWorkflow
+  repositoryNodeId: R_kgDOT4YfXQ
+  subpath: null
+  commit: af366bbc55a6066541afadf34988690414a187da
+creator:
+  github: MoonCoder-HAPPY
+package:
+  ecosystem: npm
+  name: specworkflow
+  version: 0.1.0
+  integrity: sha512-aSZ8cv78mtdRb0DRd3+CHms6CJ3rxKU8DNpNjLumwXFIi1WbSZqRfeo1FzPJQ+zDOeo/OYpevtII3D//Dadlvw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:49.216Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mooncoder-happy-specworkflow`
- Submission type: community curation
- Created by `MoonCoder-HAPPY` — https://github.com/MoonCoder-HAPPY
- Original source repository: https://github.com/MoonCoder-HAPPY/SpecWorkflow
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.