### PR TITLE
catalog: add moonlitdropofblood-dsh-archive-manager (community curation, created by @MoonlitDropOfBlood)

### DIFF
--- a/catalog/plugins/moonlitdropofblood-dsh-archive-manager.yaml
+++ b/catalog/plugins/moonlitdropofblood-dsh-archive-manager.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: moonlitdropofblood-dsh-archive-manager
+name: "@duke-dsh-plugins/dsh-archive-manager"
+description:
+  en: "Archive manager for DeepSeek Harness: group archived sessions by project, newest-first, with search, restore and delete."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session
+  - archive
+source:
+  repository: https://github.com/MoonlitDropOfBlood/dsh-archive-manager
+  repositoryNodeId: R_kgDOT8bc4w
+  subpath: null
+  commit: 891d2b78c1cca04d00b91edc57bb9d689d7afe54
+creator:
+  github: MoonlitDropOfBlood
+package:
+  ecosystem: npm
+  name: "@duke-dsh-plugins/dsh-archive-manager"
+  version: 1.3.4
+  integrity: sha512-4mBAlpgskPztuuIuUTBVudbpyTaT4HiE7RccW70XeYjKPrukxswGJuUlfcJ/Q2s7hsgxtde6VXu6h1n1+ZRBJw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:49.307Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moonlitdropofblood-dsh-archive-manager`
- Submission type: community curation
- Created by `MoonlitDropOfBlood` — https://github.com/MoonlitDropOfBlood
- Original source repository: https://github.com/MoonlitDropOfBlood/dsh-archive-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.