### PR TITLE
catalog: add moononnn-dsh-assistant-manager (community curation, created by @moononnn)

### DIFF
--- a/catalog/plugins/moononnn-dsh-assistant-manager.yaml
+++ b/catalog/plugins/moononnn-dsh-assistant-manager.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: moononnn-dsh-assistant-manager
+name: dsh-assistant-manager
+description:
+  en: "- hanako → MOOD （Vibe / Sparks / Reflections / Will） - butter → PULSE （Vibe / Echo / Read / Will） - ming → 沉思 （Premise / Conduct / Reflection / Act） - kong → 没有意识块，直接回答"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - hanako
+  - mood
+  - vibe
+  - sparks
+  - reflections
+  - butter
+  - pulse
+  - echo
+  - read
+  - ming
+  - premise
+  - conduct
+  - reflection
+  - kong
+  - dsh
+source:
+  repository: https://github.com/moononnn/DeepSeek-Harness-Hanako-Memory
+  repositoryNodeId: R_kgDOT5TKIA
+  subpath: null
+  commit: d998f89f88f0666f04c9c1cae1a4792179f38990
+creator:
+  github: moononnn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:50.559Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moononnn-dsh-assistant-manager`
- Submission type: community curation
- Created by `moononnn` — https://github.com/moononnn
- Original source repository: https://github.com/moononnn/DeepSeek-Harness-Hanako-Memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.