### PR TITLE
catalog: add moononnn-dsh-biaoqingbao (community curation, created by @moononnn)

### DIFF
--- a/catalog/plugins/moononnn-dsh-biaoqingbao.yaml
+++ b/catalog/plugins/moononnn-dsh-biaoqingbao.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: moononnn-dsh-biaoqingbao
+name: dsh-biaoqingbao
+description:
+  en: Let the assistant in DeepSeek Harness express emotions with stickers.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - sticker
+  - emoji
+  - expression
+  - dialect
+source:
+  repository: https://github.com/moononnn/DeepSeek-Harness-biaoqingbao
+  repositoryNodeId: R_kgDOT44UuQ
+  subpath: null
+  commit: e8a81042230b33a4800d7c4f01238d368998b0d5
+creator:
+  github: moononnn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:47.452Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moononnn-dsh-biaoqingbao`
- Submission type: community curation
- Created by `moononnn` — https://github.com/moononnn
- Original source repository: https://github.com/moononnn/DeepSeek-Harness-biaoqingbao
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.