### PR TITLE
catalog: add moranyue-dsh-openrouter-providers (community curation, created by @MoRanYue)

### DIFF
--- a/catalog/plugins/moranyue-dsh-openrouter-providers.yaml
+++ b/catalog/plugins/moranyue-dsh-openrouter-providers.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: moranyue-dsh-openrouter-providers
+name: dsh-openrouter-providers
+description:
+  en: bash pnpm add dsh-openrouter-providers@latest
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - openrouter
+  - provider-routing
+source:
+  repository: https://github.com/MoRanYue/dsh-openrouter-providers
+  repositoryNodeId: R_kgDOT-GeBg
+  subpath: null
+  commit: f61d7a89545cf0a8c8ad40bbd80ec8978c5caa07
+creator:
+  github: MoRanYue
+package:
+  ecosystem: npm
+  name: dsh-openrouter-providers
+  version: 1.0.6
+  integrity: sha512-OB496bdIwJ/MgSoGBEAMgTxvn2c4xqlJyk2hBfZNf/gmvaaA8KNK/mjcL0zqM5HbAPG/0idpL3LIqAKZwlRHyg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:01.130Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moranyue-dsh-openrouter-providers`
- Submission type: community curation
- Created by `MoRanYue` — https://github.com/MoRanYue
- Original source repository: https://github.com/MoRanYue/dsh-openrouter-providers
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.