### PR TITLE
catalog: add moresyl-dsh-studio-integration (community curation, created by @Moresyl)

### DIFF
--- a/catalog/plugins/moresyl-dsh-studio-integration.yaml
+++ b/catalog/plugins/moresyl-dsh-studio-integration.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: moresyl-dsh-studio-integration
+name: "@moresyl/dsh-studio-integration"
+description:
+  en: A native desktop shell for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - native
+  - desktop
+  - shell
+  - dsh
+source:
+  repository: https://github.com/Moresyl/dsh-studio
+  repositoryNodeId: R_kgDOT49MhA
+  subpath: src-tauri/runtime-contract/dsh-studio-integration
+  commit: 4791b56330066a88f78ba0e8ea7daa499896f5b3
+creator:
+  github: Moresyl
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: src-tauri/runtime-contract/dsh-studio-integration/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:10.896Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moresyl-dsh-studio-integration`
- Submission type: community curation
- Created by `Moresyl` — https://github.com/Moresyl
- Original source repository: https://github.com/Moresyl/dsh-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.