### PR TITLE
catalog: add mouliangyu-dsh-esc-stop (community curation, created by @mouliangyu)

### DIFF
--- a/catalog/plugins/mouliangyu-dsh-esc-stop.yaml
+++ b/catalog/plugins/mouliangyu-dsh-esc-stop.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: mouliangyu-dsh-esc-stop
+name: dsh-esc-stop
+description:
+  en: Escape stops the running generation in the DeepSeek Harness web GUI composer — press Esc while a turn is in flight to stop it, exactly like the Stop button. Popups and menus keep the first Esc; the second Esc stops.
+  evidencePath: packages/esc-stop/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - escape
+  - stops
+  - running
+  - generation
+  - composer
+  - press
+  - while
+  - turn
+  - flight
+  - stop
+  - exactly
+  - button
+  - popups
+  - menus
+  - keep
+  - first
+source:
+  repository: https://github.com/mouliangyu/dsh-plugins
+  repositoryNodeId: R_kgDOT395xQ
+  subpath: packages/esc-stop
+  commit: 8064bf02961de5f1f2777084d97cd2b32608e6f0
+creator:
+  github: mouliangyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/esc-stop/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:12.481Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mouliangyu-dsh-esc-stop`
- Submission type: community curation
- Created by `mouliangyu` — https://github.com/mouliangyu
- Original source repository: https://github.com/mouliangyu/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.