### PR TITLE
catalog: add mov-eax-eax-dsh-token-anxiety (community curation, created by @mov-eax-eax)

### DIFF
--- a/catalog/plugins/mov-eax-eax-dsh-token-anxiety.yaml
+++ b/catalog/plugins/mov-eax-eax-dsh-token-anxiety.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: mov-eax-eax-dsh-token-anxiety
+name: dsh-token-anxiety
+description:
+  en: "Token Anxiety widget for DeepSeek Harness: live per-task cost tracking over the session projection — peak/valley pricing, sortable cost table, currency manager (COP/USD/CNY + add/remove), click-to-explain, i18n"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - bundle
+  - token
+  - cost
+  - pricing
+  - currency
+  - dsh
+source:
+  repository: https://github.com/mov-eax-eax/dsh-token-anxiety
+  repositoryNodeId: R_kgDOT5gCeg
+  subpath: null
+  commit: 78c60a47a26476bb3558fe65e9495fc003e80b60
+creator:
+  github: mov-eax-eax
+package:
+  ecosystem: npm
+  name: dsh-token-anxiety
+  version: 0.1.1
+  integrity: sha512-mob2W/Qt4T8LmGyvpQjH0Zx9aDjH7slkayPKxk20pM1oO3v3SrZbXAiadF7qDur4YW3csqJyUfeqLtkAg4jWtw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:02.233Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mov-eax-eax-dsh-token-anxiety`
- Submission type: community curation
- Created by `mov-eax-eax` — https://github.com/mov-eax-eax
- Original source repository: https://github.com/mov-eax-eax/dsh-token-anxiety
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.