### PR TITLE
catalog: add moyu-good-dsh-lark-bridge (community curation, created by @moyu-good)

### DIFF
--- a/catalog/plugins/moyu-good-dsh-lark-bridge.yaml
+++ b/catalog/plugins/moyu-good-dsh-lark-bridge.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: moyu-good-dsh-lark-bridge
+name: "@moyu-good/dsh-lark-bridge"
+description:
+  en: Feishu (Lark) IM bot channel for DeepSeek Harness agents — per-chat sessions, native thinking process, interactive approval cards, WebSocket long connection.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - feishu
+  - lark
+  - messaging
+  - extension
+source:
+  repository: https://github.com/moyu-good/dsh-lark-bridge
+  repositoryNodeId: R_kgDOT38HKA
+  subpath: null
+  commit: 420a2b7aa5ee484a532f798bffae2153c59037ed
+creator:
+  github: moyu-good
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:52.419Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moyu-good-dsh-lark-bridge`
- Submission type: community curation
- Created by `moyu-good` — https://github.com/moyu-good
- Original source repository: https://github.com/moyu-good/dsh-lark-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.