### PR TITLE
catalog: add mqhe2007-dsh-pm (community curation, created by @mqhe2007)

### DIFF
--- a/catalog/plugins/mqhe2007-dsh-pm.yaml
+++ b/catalog/plugins/mqhe2007-dsh-pm.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: mqhe2007-dsh-pm
+name: dsh-pm
+description:
+  en: dsh-pm (pm = project management) is powered by ChunSun — a first-class DeepSeek Harness (DSH) plugin that deeply integrates ChunSun’s AI-native project delivery platform.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - chunsun
+  - project-management
+source:
+  repository: https://github.com/mqhe2007/dsh-pm
+  repositoryNodeId: R_kgDOT_Y20g
+  subpath: null
+  commit: e1db9ebe29fd30701d0bc327df7800a4eeec2481
+creator:
+  github: mqhe2007
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:52.417Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mqhe2007-dsh-pm`
- Submission type: community curation
- Created by `mqhe2007` — https://github.com/mqhe2007
- Original source repository: https://github.com/mqhe2007/dsh-pm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.