### PR TITLE
catalog: add mr-neutr0n-dsh-medseek (community curation, created by @Mr-Neutr0n)

### DIFF
--- a/catalog/plugins/mr-neutr0n-dsh-medseek.yaml
+++ b/catalog/plugins/mr-neutr0n-dsh-medseek.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: mr-neutr0n-dsh-medseek
+name: dsh-medseek
+description:
+  en: "Clinical documentation toolkit for DeepSeek Harness: SBAR and I-PASS handovers, SOAP and APSO notes, admission H&P, discharge summaries with pending-results enforcement, patient-instruction readability scoring, HIPAA Safe Harbor de-identification, and cited FDA label/FAERS/recalls/Drugs@FDA, MedlinePlus, PubMed/PMC/Eur"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - healthcare
+  - clinical
+  - clinical-documentation
+  - sbar
+  - i-pass
+  - soap-note
+  - hipaa
+  - phi
+  - de-identification
+  - deidentification
+  - patient-education
+  - medical-notes
+  - nursing
+source:
+  repository: https://github.com/Mr-Neutr0n/dsh-medseek
+  repositoryNodeId: R_kgDOT97obA
+  subpath: null
+  commit: 5f1817feb95054e3646527d27e5786e935b6ee9f
+creator:
+  github: Mr-Neutr0n
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:53.213Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mr-neutr0n-dsh-medseek`
- Submission type: community curation
- Created by `Mr-Neutr0n` — https://github.com/Mr-Neutr0n
- Original source repository: https://github.com/Mr-Neutr0n/dsh-medseek
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.