### PR TITLE
catalog: add mrmaii-knotline-dsh (community curation, created by @MrMaii)

### DIFF
--- a/catalog/plugins/mrmaii-knotline-dsh.yaml
+++ b/catalog/plugins/mrmaii-knotline-dsh.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: mrmaii-knotline-dsh
+name: knotline-dsh
+description:
+  en: A single project operating map for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - project-map
+  - agent-orchestration
+source:
+  repository: https://github.com/MrMaii/knotline
+  repositoryNodeId: R_kgDOT7VV5Q
+  subpath: null
+  commit: 1775b051dc21714a6d1de71827e2d00e4da64b28
+creator:
+  github: MrMaii
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:53.212Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mrmaii-knotline-dsh`
- Submission type: community curation
- Created by `MrMaii` — https://github.com/MrMaii
- Original source repository: https://github.com/MrMaii/knotline
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.