### PR TITLE
catalog: add mrweicodes-dsh-permgate (community curation, created by @MrWeiCodes)

### DIFF
--- a/catalog/plugins/mrweicodes-dsh-permgate.yaml
+++ b/catalog/plugins/mrweicodes-dsh-permgate.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: mrweicodes-dsh-permgate
+name: dsh-permgate
+description:
+  en: "Permission gateway for DSH (DeepSeek Harness): reviews tool calls per category (directory/command/read/edit/subagent/doom loop) with global/project config, exceptions, quick-tool defaults, custom rules, bilingual approval modal and sandbox-upgrade flow. Config persisted at $DSH HOME/dsh-permgate/config.json."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - permission
+  - gateway
+  - reviews
+  - tool
+  - calls
+  - category
+  - directory
+  - command
+  - read
+  - edit
+  - subagent
+  - doom
+  - loop
+  - global
+  - config
+  - exceptions
+source:
+  repository: https://github.com/MrWeiCodes/dsh-permgate
+  repositoryNodeId: R_kgDOT5QDzg
+  subpath: null
+  commit: acfbbeef404e6ac1e1efe7ac8935b9f5b60d5671
+creator:
+  github: MrWeiCodes
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:41.705Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mrweicodes-dsh-permgate`
- Submission type: community curation
- Created by `MrWeiCodes` — https://github.com/MrWeiCodes
- Original source repository: https://github.com/MrWeiCodes/dsh-permgate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.