### PR TITLE
catalog: add mrzhangkris-dsh-session-pruner (community curation, created by @mrzhangkris)

### DIFF
--- a/catalog/plugins/mrzhangkris-dsh-session-pruner.yaml
+++ b/catalog/plugins/mrzhangkris-dsh-session-pruner.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: mrzhangkris-dsh-session-pruner
+name: dsh-session-pruner
+description:
+  en: "DSH session lifecycle management plugin — full-type session lifecycle management: one-shot subagents archived on completion, continuable subagents and main sessions archived when idle, a capacity cap, and projection-cache cleanup. Prevents session-library accumulation stalls at the source."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - session
+  - lifecycle
+  - subagent
+  - cleanup
+  - projcache
+source:
+  repository: https://github.com/mrzhangkris/dsh-session-pruner
+  repositoryNodeId: R_kgDOT9foIA
+  subpath: null
+  commit: fdf52d9415a8b606cb91cd532e4d82df336b78f0
+creator:
+  github: mrzhangkris
+package:
+  ecosystem: npm
+  name: dsh-session-pruner
+  version: 0.1.4
+  integrity: sha512-Ar4KKOF1jREN7hLiYydcUWZ9BYqpyGtX6e1XbAPQHF/OD1Kjpg2RA6OtiX9BaJUPh0fz6/OsoKOLeM2henmf5Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:52.705Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mrzhangkris-dsh-session-pruner`
- Submission type: community curation
- Created by `mrzhangkris` — https://github.com/mrzhangkris
- Original source repository: https://github.com/mrzhangkris/dsh-session-pruner
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.