### PR TITLE
catalog: add mtty-ai-mmx-quota-tool (community curation, created by @mtty-ai)

### DIFF
--- a/catalog/plugins/mtty-ai-mmx-quota-tool.yaml
+++ b/catalog/plugins/mtty-ai-mmx-quota-tool.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: mtty-ai-mmx-quota-tool
+name: mmx-quota-tool
+description:
+  en: MiniMax token-plan quota dock for DSH web — drop-shape 5h usage %, click for detail panel, auto-hides for non-MiniMax models.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - minimax
+  - mmx
+  - quota
+  - token-plan
+source:
+  repository: https://github.com/mtty-ai/mmx-quota-tool
+  repositoryNodeId: R_kgDOT5rz2w
+  subpath: null
+  commit: 98cdac017137117a9396a440a44ab39b9fb37335
+creator:
+  github: mtty-ai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:53.225Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mtty-ai-mmx-quota-tool`
- Submission type: community curation
- Created by `mtty-ai` — https://github.com/mtty-ai
- Original source repository: https://github.com/mtty-ai/mmx-quota-tool
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.