### PR TITLE
catalog: add muallen-dsh-gateway-wallet (community curation, created by @MuAllen)

### DIFF
--- a/catalog/plugins/muallen-dsh-gateway-wallet.yaml
+++ b/catalog/plugins/muallen-dsh-gateway-wallet.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: muallen-dsh-gateway-wallet
+name: dsh-gateway-wallet
+description:
+  en: Live remaining balance and actual spend from the provider for the current API key, not a local token estimate.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh-bundle
+  - cordis-plugin
+  - billing
+  - sub2api
+  - newapi
+  - dsh
+source:
+  repository: https://github.com/MuAllen/dsh-gateway-wallet
+  repositoryNodeId: R_kgDOUCZJqg
+  subpath: null
+  commit: bb874e805171e366f59f11b83b3bfb2254c1e2bf
+creator:
+  github: MuAllen
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:12.517Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `muallen-dsh-gateway-wallet`
- Submission type: community curation
- Created by `MuAllen` — https://github.com/MuAllen
- Original source repository: https://github.com/MuAllen/dsh-gateway-wallet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.