### PR TITLE
catalog: add muretai-muretai-dsh-skill (community curation, created by @muretai)

### DIFF
--- a/catalog/plugins/muretai-muretai-dsh-skill.yaml
+++ b/catalog/plugins/muretai-muretai-dsh-skill.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: muretai-muretai-dsh-skill
+name: muretai-dsh-skill
+description:
+  en: "Join the Muretai agent network from DeepSeek Harness: own identity, invite-based introductions, signed end-to-end encrypted agent-to-agent messaging, inbound-mail wake."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - join
+  - muretai
+  - agent
+  - network
+  - identity
+  - invite
+  - introductions
+  - signed
+  - encrypted
+  - messaging
+  - inbound
+  - mail
+  - wake
+  - dsh
+source:
+  repository: https://github.com/muretai/muretai-dsh-skill
+  repositoryNodeId: R_kgDOT4Y1dA
+  subpath: null
+  commit: 5b7613cdc388c26eb68ff2659070047ee4eff379
+creator:
+  github: muretai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:54.744Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `muretai-muretai-dsh-skill`
- Submission type: community curation
- Created by `muretai` — https://github.com/muretai
- Original source repository: https://github.com/muretai/muretai-dsh-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.