### PR TITLE
catalog: add mutx163-dsh-model-memory (community curation, created by @Mutx163)

### DIFF
--- a/catalog/plugins/mutx163-dsh-model-memory.yaml
+++ b/catalog/plugins/mutx163-dsh-model-memory.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: mutx163-dsh-model-memory
+name: dsh-model-memory
+description:
+  en: bash dsh plugin --profile web add dsh-model-memory
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - reasoning-effort
+  - thinking-level
+  - model-memory
+  - cordis
+source:
+  repository: https://github.com/Mutx163/dsh-model-memory
+  repositoryNodeId: R_kgDOT_kvdQ
+  subpath: null
+  commit: ced0378fe35c238645f4a9bdb84bb76129d178c2
+creator:
+  github: Mutx163
+package:
+  ecosystem: npm
+  name: dsh-model-memory
+  version: 0.1.11
+  integrity: sha512-CNIH77ifzvGiL1nVF3S/s0BagvjiIGoLFdnAsj19Yl1VvZE2s3u/bdkYmxyMMT93exrarbYFmogQ46CrJO7PNA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:54.751Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mutx163-dsh-model-memory`
- Submission type: community curation
- Created by `Mutx163` — https://github.com/Mutx163
- Original source repository: https://github.com/Mutx163/dsh-model-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.