### PR TITLE
catalog: add muwinds-dsh-archived-sessions (community curation, created by @MuWinds)

### DIFF
--- a/catalog/plugins/muwinds-dsh-archived-sessions.yaml
+++ b/catalog/plugins/muwinds-dsh-archived-sessions.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: muwinds-dsh-archived-sessions
+name: "@muwinds/dsh-archived-sessions"
+description:
+  en: sh dsh plugin --profile web add github:MuWinds/dsh-archived-sessions
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - archived-sessions
+  - session-management
+source:
+  repository: https://github.com/MuWinds/dsh-archived-sessions
+  repositoryNodeId: R_kgDOT44TKg
+  subpath: null
+  commit: 7d3ba012d3ed08c1296446f709b34f25370c4547
+creator:
+  github: MuWinds
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:39.803Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `muwinds-dsh-archived-sessions`
- Submission type: community curation
- Created by `MuWinds` — https://github.com/MuWinds
- Original source repository: https://github.com/MuWinds/dsh-archived-sessions
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.