### PR TITLE
catalog: add muyuanjin-dsh-element-inspector (community curation, created by @muyuanjin)

### DIFF
--- a/catalog/plugins/muyuanjin-dsh-element-inspector.yaml
+++ b/catalog/plugins/muyuanjin-dsh-element-inspector.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: muyuanjin-dsh-element-inspector
+name: dsh-element-inspector
+description:
+  en: Identify whether a DSH UI element belongs to the host interface or an installed plugin, then export or hide it.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - element-inspector
+  - element-screenshot
+  - plugin-inspector
+source:
+  repository: https://github.com/muyuanjin/dsh-element-inspector
+  repositoryNodeId: R_kgDOT-TgGQ
+  subpath: null
+  commit: 6b9e1e7064bb1cddb5c62e015624ceb623dfd4f2
+creator:
+  github: muyuanjin
+package:
+  ecosystem: npm
+  name: dsh-element-inspector
+  version: 0.7.0
+  integrity: sha512-oilHs+lPbXcJ/BJlskC2obamQBhybPsgXtm16m6lM3HoAuu1YvHNdCNhqb+3VFXHWNd8aHQsMj3+GSocxsHEgA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:12.514Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `muyuanjin-dsh-element-inspector`
- Submission type: community curation
- Created by `muyuanjin` — https://github.com/muyuanjin
- Original source repository: https://github.com/muyuanjin/dsh-element-inspector
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.