### PR TITLE
catalog: add muyuanjin-dsh-ptc-plus (community curation, created by @muyuanjin)

### DIFF
--- a/catalog/plugins/muyuanjin-dsh-ptc-plus.yaml
+++ b/catalog/plugins/muyuanjin-dsh-ptc-plus.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: muyuanjin-dsh-ptc-plus
+name: dsh-ptc-plus
+description:
+  en: A session-bound agent-native REPL for DeepSeek Harness PTC mode.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ptc
+  - ptc-mode
+  - repl
+source:
+  repository: https://github.com/muyuanjin/dsh-ptc-plus
+  repositoryNodeId: R_kgDOT-qU5A
+  subpath: null
+  commit: 2a6413a920b8aaa086d29981f17ced9af1793c36
+creator:
+  github: muyuanjin
+package:
+  ecosystem: npm
+  name: dsh-ptc-plus
+  version: 0.2.3
+  integrity: sha512-ShNkTUktbl5C1TD53G4hpzrls17zgTqnOp+jR1f1HR4IlJvjWz0AjayLSDfrVLePBQmYZJPipeaiuJkqqFDwkQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:02.518Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `muyuanjin-dsh-ptc-plus`
- Submission type: community curation
- Created by `muyuanjin` — https://github.com/muyuanjin
- Original source repository: https://github.com/muyuanjin/dsh-ptc-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.