### PR TITLE
catalog: add nattocb-dsh-plugin-memory (community curation, created by @NattoCB)

### DIFF
--- a/catalog/plugins/nattocb-dsh-plugin-memory.yaml
+++ b/catalog/plugins/nattocb-dsh-plugin-memory.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: nattocb-dsh-plugin-memory
+name: "@deepseek-ai/dsh-plugin-memory"
+description:
+  en: Persistent 5-layer memory system for DeepSeek Harness (entry injection, relevance retrieval, agent tools, and LLM-backed auto-extraction).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - memory
+  - agent-memory
+source:
+  repository: https://github.com/NattoCB/dsh-plugin-memory
+  repositoryNodeId: R_kgDOT7OhVg
+  subpath: null
+  commit: a83fccef21f74d5242df5df0ab5c0be7ae8ddf8b
+creator:
+  github: NattoCB
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:02.579Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nattocb-dsh-plugin-memory`
- Submission type: community curation
- Created by `NattoCB` — https://github.com/NattoCB
- Original source repository: https://github.com/NattoCB/dsh-plugin-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.