### PR TITLE
catalog: add nattocb-dsh-plugin-notifications (community curation, created by @NattoCB)

### DIFF
--- a/catalog/plugins/nattocb-dsh-plugin-notifications.yaml
+++ b/catalog/plugins/nattocb-dsh-plugin-notifications.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: nattocb-dsh-plugin-notifications
+name: dsh-plugin-notifications
+description:
+  en: "DSH bundle plugin: a General-settings Notifications card that pops a system notification (and optional chime) when a conversation turn completes."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - bundle
+  - general
+  - settings
+  - notifications
+  - card
+  - pops
+  - system
+  - notification
+  - optional
+  - chime
+  - conversation
+  - turn
+  - completes
+  - dsh
+source:
+  repository: https://github.com/NattoCB/dsh-plugin-notifications
+  repositoryNodeId: R_kgDOT5UPfg
+  subpath: null
+  commit: b19696036b2402d71ab87d673714595914b95eb2
+creator:
+  github: NattoCB
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:03.641Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nattocb-dsh-plugin-notifications`
- Submission type: community curation
- Created by `NattoCB` — https://github.com/NattoCB
- Original source repository: https://github.com/NattoCB/dsh-plugin-notifications
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.