### PR TITLE
catalog: add nattocb-dsh-plugin-petdex-market (community curation, created by @NattoCB)

### DIFF
--- a/catalog/plugins/nattocb-dsh-plugin-petdex-market.yaml
+++ b/catalog/plugins/nattocb-dsh-plugin-petdex-market.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: nattocb-dsh-plugin-petdex-market
+name: "@jasper/dsh-plugin-petdex-market"
+description:
+  en: "DSH bundle plugin: a petdex.dev companion-pet market in the Settings UI with a native macOS desktop pet. Browse, search, install, enable, rename, and delete pets; previews are proxied same-origin to dodge CORS."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - bundle
+  - petdex
+  - companion
+  - market
+  - settings
+  - native
+  - macos
+  - desktop
+  - browse
+  - search
+  - install
+  - enable
+  - rename
+  - delete
+  - pets
+  - previews
+source:
+  repository: https://github.com/NattoCB/dsh-plugin-petdex-market
+  repositoryNodeId: R_kgDOT5N2Sw
+  subpath: null
+  commit: 1a1f7ce1d36dd62e553ed7a851c5d0bacbe750f3
+creator:
+  github: NattoCB
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:02.923Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nattocb-dsh-plugin-petdex-market`
- Submission type: community curation
- Created by `NattoCB` — https://github.com/NattoCB
- Original source repository: https://github.com/NattoCB/dsh-plugin-petdex-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.