### PR TITLE
catalog: add nattocb-dsh-plugin-pin-session (community curation, created by @NattoCB)

### DIFF
--- a/catalog/plugins/nattocb-dsh-plugin-pin-session.yaml
+++ b/catalog/plugins/nattocb-dsh-plugin-pin-session.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: nattocb-dsh-plugin-pin-session
+name: dsh-plugin-pin-session
+description:
+  en: "Pin sessions: adds Pin/Unpin to the sidebar session-row ... menu and a collapsible Pinned Sessions group above the session list."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - sessions
+  - sidebar
+source:
+  repository: https://github.com/NattoCB/dsh-plugin-pin-session
+  repositoryNodeId: R_kgDOUBHHFw
+  subpath: null
+  commit: fad6d8f771e2706845737ef5dfdc41064a1aa73d
+creator:
+  github: NattoCB
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:05.281Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nattocb-dsh-plugin-pin-session`
- Submission type: community curation
- Created by `NattoCB` — https://github.com/NattoCB
- Original source repository: https://github.com/NattoCB/dsh-plugin-pin-session
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.