### PR TITLE
catalog: add nattocb-dsh-plugin-wechat-bridge (community curation, created by @NattoCB)

### DIFF
--- a/catalog/plugins/nattocb-dsh-plugin-wechat-bridge.yaml
+++ b/catalog/plugins/nattocb-dsh-plugin-wechat-bridge.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: nattocb-dsh-plugin-wechat-bridge
+name: dsh-plugin-wechat-bridge
+description:
+  en: "DSH bundle plugin: bridge WeChat (ilink bot) messages into a DSH agent session, with runtime enable/disable hot-plug and a Settings UI tab."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - bundle
+  - bridge
+  - wechat
+  - ilink
+  - messages
+  - agent
+  - session
+  - runtime
+  - enable
+  - disable
+  - plug
+  - settings
+  - dsh
+source:
+  repository: https://github.com/NattoCB/dsh-plugin-wechat-bridge
+  repositoryNodeId: R_kgDOT5RaUQ
+  subpath: null
+  commit: 88257abad5bd3c676c1c2528fb8e2d1d97a5f50e
+creator:
+  github: NattoCB
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:54.743Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nattocb-dsh-plugin-wechat-bridge`
- Submission type: community curation
- Created by `NattoCB` — https://github.com/NattoCB
- Original source repository: https://github.com/NattoCB/dsh-plugin-wechat-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.