### PR TITLE
catalog: add ne-ilyxa-dsh-session-drafts (community curation, created by @ne-ilyxa)

### DIFF
--- a/catalog/plugins/ne-ilyxa-dsh-session-drafts.yaml
+++ b/catalog/plugins/ne-ilyxa-dsh-session-drafts.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: ne-ilyxa-dsh-session-drafts
+name: "@ne-ilyxa/dsh-session-drafts"
+description:
+  en: "Cursor-style drafts for DeepSeek Harness: New Session reuses the empty draft or mints a fresh one; drafts live in the sidebar tree with live preview titles, a gray tint and a single × to discard"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - new-session
+  - drafts
+  - session-persistence
+  - cursor-like
+source:
+  repository: https://github.com/ne-ilyxa/dsh-session-drafts
+  repositoryNodeId: R_kgDOT_hWIw
+  subpath: null
+  commit: 2b1f8e3a9f2dbb2f8e25fa6f79b87f3b066193ed
+creator:
+  github: ne-ilyxa
+package:
+  ecosystem: npm
+  name: "@ne-ilyxa/dsh-session-drafts"
+  version: 0.6.1
+  integrity: sha512-gs2D7k7ScKBBOI1G4uLKC47wKdftzPPvXo1/scJLNPe7CMIiUn7HH4lvr6ekULYm58MInDCmNpjvLIfKN0xRHg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:55.635Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ne-ilyxa-dsh-session-drafts`
- Submission type: community curation
- Created by `ne-ilyxa` — https://github.com/ne-ilyxa
- Original source repository: https://github.com/ne-ilyxa/dsh-session-drafts
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.