### PR TITLE
catalog: add neaz71eve-dsh-tool-github (community curation, created by @NEAZ71eve)

### DIFF
--- a/catalog/plugins/neaz71eve-dsh-tool-github.yaml
+++ b/catalog/plugins/neaz71eve-dsh-tool-github.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: neaz71eve-dsh-tool-github
+name: "@dsh-external/dsh-tool-github"
+description:
+  en: "GitHub REST API tools for DeepSeek Harness: repositories, search, issues, pull requests, comments, account binding, and workspace integration, with a browser-side GitHub panel in the web GUI"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - rest
+  - tools
+  - repositories
+  - search
+  - issues
+  - pull
+  - requests
+  - comments
+  - account
+  - binding
+  - workspace
+  - integration
+  - browser
+  - side
+  - panel
+  - dsh
+source:
+  repository: https://github.com/NEAZ71eve/dsh-tool-github
+  repositoryNodeId: R_kgDOT5R5VQ
+  subpath: null
+  commit: c4279728dc1d6cad5359d66e00dab3302a55dd12
+creator:
+  github: NEAZ71eve
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:06.335Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `neaz71eve-dsh-tool-github`
- Submission type: community curation
- Created by `NEAZ71eve` — https://github.com/NEAZ71eve
- Original source repository: https://github.com/NEAZ71eve/dsh-tool-github
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.