### PR TITLE
catalog: add neomei-dsh-tool-roundtable (community curation, created by @NeoMei)

### DIFF
--- a/catalog/plugins/neomei-dsh-tool-roundtable.yaml
+++ b/catalog/plugins/neomei-dsh-tool-roundtable.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: neomei-dsh-tool-roundtable
+name: "@neomei/dsh-tool-roundtable"
+description:
+  en: "Model-facing roundtable tool: run a single-round multi-agent discussion over ctx.roundtable"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - model
+  - facing
+  - roundtable
+  - tool
+  - single
+  - round
+  - multi
+  - agent
+  - discussion
+  - over
+  - dsh
+source:
+  repository: https://github.com/NeoMei/dsh-roundtable
+  repositoryNodeId: R_kgDOT8Xbqg
+  subpath: packages/roundtable/tool-roundtable
+  commit: 6c251e61e5acedda329df799013c84e1b8bd1e68
+creator:
+  github: NeoMei
+package:
+  ecosystem: npm
+  name: "@neomei/dsh-tool-roundtable"
+  version: 0.1.0-rc.6
+  integrity: sha512-7c8UqdxR/5M25wN1JDkmTn55HoKmei/26n4Hv7wX2cO+64N/rZ9hK69rNNxPcnuTMqnyn3/EUROq/qn51d9dQw==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/roundtable/tool-roundtable/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:14.917Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `neomei-dsh-tool-roundtable`
- Submission type: community curation
- Created by `NeoMei` — https://github.com/NeoMei
- Original source repository: https://github.com/NeoMei/dsh-roundtable
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.