### PR TITLE
catalog: add neorrrr-dsh-project-skill-paths (community curation, created by @NeoRrrr)

### DIFF
--- a/catalog/plugins/neorrrr-dsh-project-skill-paths.yaml
+++ b/catalog/plugins/neorrrr-dsh-project-skill-paths.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: neorrrr-dsh-project-skill-paths
+name: dsh-project-skill-paths
+description:
+  en: Project-scoped custom SKILL roots for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skills
+  - project-configuration
+source:
+  repository: https://github.com/NeoRrrr/dsh-project-skill-paths
+  repositoryNodeId: R_kgDOUDSzLw
+  subpath: null
+  commit: a1afff4122ccbb7efbe2b91123f97b7da637760d
+creator:
+  github: NeoRrrr
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:16.107Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `neorrrr-dsh-project-skill-paths`
- Submission type: community curation
- Created by `NeoRrrr` — https://github.com/NeoRrrr
- Original source repository: https://github.com/NeoRrrr/dsh-project-skill-paths
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.