### PR TITLE
catalog: add nevstop-dsh-approval-mode (community curation, created by @nevstop)

### DIFF
--- a/catalog/plugins/nevstop-dsh-approval-mode.yaml
+++ b/catalog/plugins/nevstop-dsh-approval-mode.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: nevstop-dsh-approval-mode
+name: dsh-approval-mode
+description:
+  en: "Approval mode control for DeepSeek Harness: default approval (ask) or bypass approval (auto-approve every tool call), next to the permission selector. DSH 审批模式插件。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - approval
+  - permissions
+  - agent
+source:
+  repository: https://github.com/NEVSTOP-LAB/dsh-approval-mode
+  repositoryNodeId: R_kgDOT6B1rw
+  subpath: null
+  commit: 3ee61240cea8da4c43ef09ff77942466bbe9b482
+creator:
+  github: nevstop
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:48.087Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nevstop-dsh-approval-mode`
- Submission type: community curation
- Created by `nevstop` — https://github.com/nevstop
- Original source repository: https://github.com/NEVSTOP-LAB/dsh-approval-mode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.