### PR TITLE
catalog: add newdanew-dsh-plugin-voice-input (community curation, created by @NewDaNew)

### DIFF
--- a/catalog/plugins/newdanew-dsh-plugin-voice-input.yaml
+++ b/catalog/plugins/newdanew-dsh-plugin-voice-input.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: newdanew-dsh-plugin-voice-input
+name: "@local/dsh-plugin-voice-input"
+description:
+  en: "Voice input plugin for DeepSeek Harness web: a mic button in the composer that recognizes speech (Web Speech API) and fills the draft, with optional auto-send."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - voice
+  - input
+  - button
+  - composer
+  - recognizes
+  - speech
+  - fills
+  - draft
+  - optional
+  - auto
+  - send
+  - dsh
+source:
+  repository: https://github.com/NewDaNew/dsh-voice-input
+  repositoryNodeId: R_kgDOT5DaLg
+  subpath: null
+  commit: abb8c9986a621f37fc0f9b0fc75181b074c1a83a
+creator:
+  github: NewDaNew
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:05.924Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `newdanew-dsh-plugin-voice-input`
- Submission type: community curation
- Created by `NewDaNew` — https://github.com/NewDaNew
- Original source repository: https://github.com/NewDaNew/dsh-voice-input
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.