### PR TITLE
catalog: add nexlineai-dsh-tui (community curation, created by @nexlineai)

### DIFF
--- a/catalog/plugins/nexlineai-dsh-tui.yaml
+++ b/catalog/plugins/nexlineai-dsh-tui.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: nexlineai-dsh-tui
+name: "@nexlineai/dsh-tui"
+description:
+  en: A full-screen interactive terminal UI for the DeepSeek Harness agent runtime — live streaming, reasoning blocks, tool cards, sessions, permissions, plan mode, and a full slash-command suite. The web UI, reimagined for the terminal.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cli
+  - tui
+  - terminal
+  - agent
+  - coding-agent
+source:
+  repository: https://github.com/nexlineai/dsh-tui
+  repositoryNodeId: R_kgDOT-3tMQ
+  subpath: null
+  commit: 52446da043e86032e14c65f4cbdde642771e57bf
+creator:
+  github: nexlineai
+package:
+  ecosystem: npm
+  name: "@nexlineai/dsh-tui"
+  version: 0.1.1
+  integrity: sha512-jT+d+riFJyOaBlob6PQpRd+d/2auVobVz3iVRBR6fJfY+g7MyIFfGdowUv6XQBGZPynjL9AJxg+uJyQGLLYu3g==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:05.935Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nexlineai-dsh-tui`
- Submission type: community curation
- Created by `nexlineai` — https://github.com/nexlineai
- Original source repository: https://github.com/nexlineai/dsh-tui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.