### PR TITLE
catalog: add nicecx-dsh-relay (community curation, created by @nicecx)

### DIFF
--- a/catalog/plugins/nicecx-dsh-relay.yaml
+++ b/catalog/plugins/nicecx-dsh-relay.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: nicecx-dsh-relay
+name: dsh-relay
+description:
+  en: bash node ~/.dsh/plugins/dsh-relay/cli.js 罗列待回复诉求 node ~/.dsh/plugins/dsh-relay/cli.js status 状态总览 node ~/.dsh/plugins/dsh-relay/cli.js --json JSON 输出（脚本友好）
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - imessage
+  - email
+  - wechat
+  - approval
+  - remote
+  - relay
+  - notify
+source:
+  repository: https://github.com/nicecx/dsh-relay
+  repositoryNodeId: R_kgDOT8TcMQ
+  subpath: null
+  commit: f603f8570283f82deda1f82a41698e053fc4a589
+creator:
+  github: nicecx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:55.623Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nicecx-dsh-relay`
- Submission type: community curation
- Created by `nicecx` — https://github.com/nicecx
- Original source repository: https://github.com/nicecx/dsh-relay
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.