### PR TITLE
catalog: add nikoart-liu-dsh-open-in-x (community curation, created by @nikoart-liu)

### DIFF
--- a/catalog/plugins/nikoart-liu-dsh-open-in-x.yaml
+++ b/catalog/plugins/nikoart-liu-dsh-open-in-x.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: nikoart-liu-dsh-open-in-x
+name: dsh-open-in-x
+description:
+  en: Open a DeepSeek Harness workspace in a file manager, terminal, or supported editor from the Web UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - open
+  - workspace
+  - file
+  - manager
+  - terminal
+  - supported
+  - editor
+  - dsh
+source:
+  repository: https://github.com/nikoart-liu/dsh-open-in-x
+  repositoryNodeId: R_kgDOUCb8nw
+  subpath: null
+  commit: 5f1eed57fee0d47993c25b13886e7514b080a604
+creator:
+  github: nikoart-liu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:05.933Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nikoart-liu-dsh-open-in-x`
- Submission type: community curation
- Created by `nikoart-liu` — https://github.com/nikoart-liu
- Original source repository: https://github.com/nikoart-liu/dsh-open-in-x
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.