### PR TITLE
catalog: add niuniuaba-dsh-subagent-vision (community curation, created by @niuniuaba)

### DIFF
--- a/catalog/plugins/niuniuaba-dsh-subagent-vision.yaml
+++ b/catalog/plugins/niuniuaba-dsh-subagent-vision.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: niuniuaba-dsh-subagent-vision
+name: dsh-subagent-vision
+description:
+  en: "dsh bundle: subagent vision — delegate image reading to a vision-capable model from a text-only session, plus paste-to-path so pasted images reach the subagent as file paths."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - bundle
+  - vision
+  - subagent
+source:
+  repository: https://github.com/niuniuaba/dsh-subagent-vision
+  repositoryNodeId: R_kgDOT5PAkw
+  subpath: null
+  commit: 3026a48514a62ddb88684498e055ee38f8f619d4
+creator:
+  github: niuniuaba
+package:
+  ecosystem: npm
+  name: dsh-subagent-vision
+  version: 0.1.4
+  integrity: sha512-3zawJng3WQRgw5KYJDL1Lf8zvfOSixKe28TZrhJsmL+Zk07w9MphDZ5PHKnVAIKVvOTbIRGLyS6XEQBNQlupYQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:07.612Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `niuniuaba-dsh-subagent-vision`
- Submission type: community curation
- Created by `niuniuaba` — https://github.com/niuniuaba
- Original source repository: https://github.com/niuniuaba/dsh-subagent-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.