### PR TITLE
catalog: add niuzhuang-dsh-git-ai (community curation, created by @NiuZhuang)

### DIFF
--- a/catalog/plugins/niuzhuang-dsh-git-ai.yaml
+++ b/catalog/plugins/niuzhuang-dsh-git-ai.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: niuzhuang-dsh-git-ai
+name: dsh-git-ai
+description:
+  en: DeepSeek Harness plugin that records agent edits with git-ai (agent-v1 checkpoints)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - records
+  - agent
+  - edits
+  - checkpoints
+  - dsh
+source:
+  repository: https://github.com/NiuZhuang/dsh-git-ai
+  repositoryNodeId: R_kgDOUAJO5A
+  subpath: null
+  commit: 7a6dfa30f198f1dab8d38458049685377afef339
+creator:
+  github: NiuZhuang
+package:
+  ecosystem: npm
+  name: dsh-git-ai
+  version: 0.1.2
+  integrity: sha512-2ziBGWeLSChXJbvgfh7DQW3tH85Bgcor96z2iSz8S0AA2Tt9vBajraLrQ+vJAWCzPQu54hKc1TF6oB1HcYrAqA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:18.625Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `niuzhuang-dsh-git-ai`
- Submission type: community curation
- Created by `NiuZhuang` — https://github.com/NiuZhuang
- Original source repository: https://github.com/NiuZhuang/dsh-git-ai
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.