### PR TITLE
catalog: add nixz0824-dsh-composer-alcove (community curation, created by @Nixz0824)

### DIFF
--- a/catalog/plugins/nixz0824-dsh-composer-alcove.yaml
+++ b/catalog/plugins/nixz0824-dsh-composer-alcove.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: nixz0824-dsh-composer-alcove
+name: dsh-composer-alcove
+description:
+  en: bash dsh plugin --profile web add https://github.com/Nixz0824/dsh-composer-alcove/releases/latest/download/dsh-composer-alcove-0.5.8.tgz
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - composer
+  - scroll
+source:
+  repository: https://github.com/Nixz0824/dsh-composer-alcove
+  repositoryNodeId: R_kgDOT9SfbA
+  subpath: null
+  commit: 3c3b16007e0f00354d43f662205cf72e39e5b57d
+creator:
+  github: Nixz0824
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:19.053Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nixz0824-dsh-composer-alcove`
- Submission type: community curation
- Created by `Nixz0824` — https://github.com/Nixz0824
- Original source repository: https://github.com/Nixz0824/dsh-composer-alcove
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.