### PR TITLE
catalog: add niyongsheng-free-vision-skill (community curation, created by @niyongsheng)

### DIFF
--- a/catalog/plugins/niyongsheng-free-vision-skill.yaml
+++ b/catalog/plugins/niyongsheng-free-vision-skill.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: niyongsheng-free-vision-skill
+name: "@niyongsheng/free-vision-skill"
+description:
+  en: "DSH-Plugin for DeepSeek-Harness: fully-local image understanding & OCR powered by macOS Vision Framework"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - vision
+  - ocr
+  - dsh
+source:
+  repository: https://github.com/niyongsheng/free-vision-skill
+  repositoryNodeId: R_kgDOTyAUSw
+  subpath: null
+  commit: afcfe088d575fa2287601ed10e22245b7bfabb1b
+creator:
+  github: niyongsheng
+package:
+  ecosystem: npm
+  name: "@niyongsheng/free-vision-skill"
+  version: 0.3.1
+  integrity: sha512-NYtYv9w3GYr2pPXCcOkvAL1v0+dv3Z+DWGtSz3JwFp+sf/83Mf/4z41l5CDLxDxcIzPLcyIz+AXm0tByapsNQA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:42.134Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `niyongsheng-free-vision-skill`
- Submission type: community curation
- Created by `niyongsheng` — https://github.com/niyongsheng
- Original source repository: https://github.com/niyongsheng/free-vision-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.