### PR TITLE
catalog: add no-prm-dsh-explorer (community curation, created by @No-PRM)

### DIFF
--- a/catalog/plugins/no-prm-dsh-explorer.yaml
+++ b/catalog/plugins/no-prm-dsh-explorer.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: no-prm-dsh-explorer
+name: dsh-explorer
+description:
+  en: "Host half of the file-tree sidebar: read-only /filetree/list · root · read · search · gitstatus · raw (JSON + media streaming) over the dsh web server."
+  evidencePath: dsh-plugins/dsh-explorer/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - host
+  - half
+  - file
+  - tree
+  - sidebar
+  - read
+  - only
+  - filetree
+  - list
+  - root
+  - search
+  - gitstatus
+  - json
+  - media
+  - streaming
+  - over
+source:
+  repository: https://github.com/No-PRM/dsh-explorer
+  repositoryNodeId: R_kgDOT5ek6Q
+  subpath: dsh-plugins/dsh-explorer
+  commit: f0835e20914d1db9cd9f3a558b5977d678c84e47
+creator:
+  github: No-PRM
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugins/dsh-explorer/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:36:18.622Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `no-prm-dsh-explorer`
- Submission type: community curation
- Created by `No-PRM` — https://github.com/No-PRM
- Original source repository: https://github.com/No-PRM/dsh-explorer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.