### PR TITLE
catalog: add noelune-dsh-agent-relay (community curation, created by @Noelune)

### DIFF
--- a/catalog/plugins/noelune-dsh-agent-relay.yaml
+++ b/catalog/plugins/noelune-dsh-agent-relay.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: noelune-dsh-agent-relay
+name: dsh-agent-relay
+description:
+  en: Multi-agent collaboration relay for DeepSeek Harness — send and receive messages between local agents (dsh, Codex, Claude, Hermes, OpenClaw, …) through a small loopback-first broker with HMAC auth. Ships the broker, the dsh plugin, a CLI client and a Python client. · DSH 多 Agent 协作中继：本地 Agent 之间经轻量 broker 安全互发消息。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - relay
+  - agent
+  - collaboration
+  - multi-agent
+source:
+  repository: https://github.com/Noelune/dsh-agent-relay
+  repositoryNodeId: R_kgDOT4jXUA
+  subpath: null
+  commit: 6d17ff49c3a59f85437cb061a4353b43198536b2
+creator:
+  github: Noelune
+package:
+  ecosystem: npm
+  name: dsh-agent-relay
+  version: 0.5.0
+  integrity: sha512-lOQHr2+KtLBJ/stgg+khi8VsdzwUjvNKvEa02X0oogYPEcVWW82kiZ2C2jUFWCcAfYlVolekdrKfeUoUvvKXJQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:43.891Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noelune-dsh-agent-relay`
- Submission type: community curation
- Created by `Noelune` — https://github.com/Noelune
- Original source repository: https://github.com/Noelune/dsh-agent-relay
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.