### PR TITLE
catalog: add noelune-dsh-unified-agent-memory (community curation, created by @Noelune)

### DIFF
--- a/catalog/plugins/noelune-dsh-unified-agent-memory.yaml
+++ b/catalog/plugins/noelune-dsh-unified-agent-memory.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: noelune-dsh-unified-agent-memory
+name: dsh-unified-agent-memory
+description:
+  en: Unified agent memory for DeepSeek Harness — one shared Obsidian vault for every agent (dsh, Codex, Claude, Hermes). Ships the dependency-free Python core (search/promote/adjudicate/forget), a vault template, and a dsh plugin with memory search / memory show / memory submit / memory status tools. · 统一 Agent 记忆系统：多 Agent
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - memory
+  - obsidian
+  - multi-agent
+  - knowledge-base
+source:
+  repository: https://github.com/Noelune/unified-agent-memory
+  repositoryNodeId: R_kgDOT4jYbA
+  subpath: null
+  commit: bba1f0838de3f82c3ee8c4a990e678dd926005c6
+creator:
+  github: Noelune
+package:
+  ecosystem: npm
+  name: dsh-unified-agent-memory
+  version: 0.2.1
+  integrity: sha512-Tbnu4st3cixtUlZLkt1GSTh3/HhDSvyQ1OSmqYv748XjGw/jI05wRUenhTOcthxz9dYdZ+tUMesHolDamqXjAQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:42.135Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noelune-dsh-unified-agent-memory`
- Submission type: community curation
- Created by `Noelune` — https://github.com/Noelune
- Original source repository: https://github.com/Noelune/unified-agent-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.