### PR TITLE
catalog: add nonentity303-dsh-plugin-manager-pro (community curation, created by @nonentity303)

### DIFF
--- a/catalog/plugins/nonentity303-dsh-plugin-manager-pro.yaml
+++ b/catalog/plugins/nonentity303-dsh-plugin-manager-pro.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: nonentity303-dsh-plugin-manager-pro
+name: dsh-plugin-manager-pro
+description:
+  en: sh dsh plugin --profile web add dsh-plugin-manager-pro
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - plugin-manager
+  - plugin-management
+  - dsh-plugin
+  - rescue
+source:
+  repository: https://github.com/nonentity303/dsh-plugin-manager
+  repositoryNodeId: R_kgDOT5ACfA
+  subpath: null
+  commit: bf11126bf5716fc3f036806e74bca1ed99680994
+creator:
+  github: nonentity303
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:44.089Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nonentity303-dsh-plugin-manager-pro`
- Submission type: community curation
- Created by `nonentity303` — https://github.com/nonentity303
- Original source repository: https://github.com/nonentity303/dsh-plugin-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.