### PR TITLE
catalog: add nono-neko-dsh-browser (community curation, created by @Nono-neko)

### DIFF
--- a/catalog/plugins/nono-neko-dsh-browser.yaml
+++ b/catalog/plugins/nono-neko-dsh-browser.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: nono-neko-dsh-browser
+name: "@nono-neko/dsh-browser"
+description:
+  en: "Embedded browser for the DSH web and desktop GUI: a sidebar entry plus a center-column panel with multi-tab iframe browsing (address bar, back/forward, per-workspace persistence), a workspace file viewer, agent tools (browser open, browser read), a plugin settings card, and a system-prompt announcement. Hot-pluggable a"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - embedded
+  - browser
+  - desktop
+  - sidebar
+  - entry
+  - plus
+  - center
+  - column
+  - panel
+  - multi
+  - iframe
+  - browsing
+  - address
+  - back
+  - forward
+  - workspace
+source:
+  repository: https://github.com/Nono-neko/dsh-browser
+  repositoryNodeId: R_kgDOT_3cdQ
+  subpath: null
+  commit: ee2805c26d30769e7adc641d1c666cbfc4110a36
+creator:
+  github: Nono-neko
+package:
+  ecosystem: npm
+  name: "@nono-neko/dsh-browser"
+  version: 0.1.1
+  integrity: sha512-qvxruh4KITAXjGfSIywOdijXsnZYoYU95Rm7G3uvS/aI0Lxo7Ou9sMNxESD8DFdbKqd0YCrAz1mqR1wtnxeI6w==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:43.910Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nono-neko-dsh-browser`
- Submission type: community curation
- Created by `Nono-neko` — https://github.com/Nono-neko
- Original source repository: https://github.com/Nono-neko/dsh-browser
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.