### PR TITLE
catalog: add vibebill-dsh-web-search-free (community curation, created by @vibeBill)

### DIFF
--- a/catalog/plugins/vibebill-dsh-web-search-free.yaml
+++ b/catalog/plugins/vibebill-dsh-web-search-free.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: vibebill-dsh-web-search-free
+name: dsh-web-search-free
+description:
+  en: Free web search plugin for dsh supporting firecrawl and tavily
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - web-search
+  - dsh
+source:
+  repository: https://github.com/MochiNek0/dsh-web-search-free
+  repositoryNodeId: R_kgDOT-dKyw
+  subpath: null
+  commit: e5004427f115b7535ecde57f00feba019d8732d0
+creator:
+  github: vibeBill
+package:
+  ecosystem: npm
+  name: dsh-web-search-free
+  version: 1.2.3
+  integrity: sha512-8Vye6yK8EXktzXmi4pvyqJTMz2JATmoNHCYtbAjcmMjC1maD1JiADrOqkyt3Db+eG1iKVsntKTGVGnxJw7jyUQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T09:35:45.730Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vibebill-dsh-web-search-free`
- Submission type: community curation
- Created by `vibeBill` — https://github.com/vibeBill
- Original source repository: https://github.com/MochiNek0/dsh-web-search-free
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.