### PR TITLE
catalog: add bg4jts-dsh-settings-plus (community curation, created by @BG4JTS)

### DIFF
--- a/catalog/plugins/bg4jts-dsh-settings-plus.yaml
+++ b/catalog/plugins/bg4jts-dsh-settings-plus.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: bg4jts-dsh-settings-plus
+name: "@oneinitai/dsh-settings-plus"
+description:
+  en: "Advanced settings management plugin for DeepSeek Harness: form-level and file-level configuration editing with an open plugin registration SDK"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - advanced
+  - settings
+  - management
+  - form
+  - level
+  - file
+  - configuration
+  - editing
+  - open
+  - registration
+  - dsh
+source:
+  repository: https://github.com/oneinitAI/dsh-settings-plus
+  repositoryNodeId: R_kgDOT4Rcbg
+  subpath: null
+  commit: 2aafa7a38fb32ed8718f4de7d740ab4642c1dfe4
+creator:
+  github: BG4JTS
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:50.821Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bg4jts-dsh-settings-plus`
- Submission type: community curation
- Created by `BG4JTS` — https://github.com/BG4JTS
- Original source repository: https://github.com/oneinitAI/dsh-settings-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.