### PR TITLE
catalog: add inschrift-spruch-raum-dsh-ex-setting (community curation, created by @inschrift-spruch-raum)

### DIFF
--- a/catalog/plugins/inschrift-spruch-raum-dsh-ex-setting.yaml
+++ b/catalog/plugins/inschrift-spruch-raum-dsh-ex-setting.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: inschrift-spruch-raum-dsh-ex-setting
+name: "@deepseek-ai/dsh-ex-setting"
+description:
+  en: Automatic Web settings and composition configuration bundle for DSH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - automatic
+  - settings
+  - composition
+  - configuration
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/ex-setting
+  repositoryNodeId: R_kgDOTt2CZg
+  subpath: null
+  commit: 9bc01b547d22af6a69d3392916aaaf8ccc533d1d
+creator:
+  github: inschrift-spruch-raum
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:56.855Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `inschrift-spruch-raum-dsh-ex-setting`
- Submission type: community curation
- Created by `inschrift-spruch-raum` — https://github.com/inschrift-spruch-raum
- Original source repository: https://github.com/omdsh-dev/ex-setting
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.