### PR TITLE
catalog: add mattheliu-dsh-accessibility (community curation, created by @mattheliu)

### DIFF
--- a/catalog/plugins/mattheliu-dsh-accessibility.yaml
+++ b/catalog/plugins/mattheliu-dsh-accessibility.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: mattheliu-dsh-accessibility
+name: "@oh-my-dsh/dsh-accessibility"
+description:
+  en: Screen-reader guidance and in-app accessibility diagnostics for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - accessibility
+  - screen-reader
+  - voiceover
+  - nvda
+  - wcag
+source:
+  repository: https://github.com/omdsh-dev/dsh-accessibility
+  repositoryNodeId: R_kgDOUEGeyw
+  subpath: null
+  commit: 356876276c361899fa11b49e2d616efd56ca2b71
+creator:
+  github: mattheliu
+package:
+  ecosystem: npm
+  name: "@oh-my-dsh/dsh-accessibility"
+  version: 0.1.0-beta.5
+  integrity: sha512-LGbIzIUIQoX73NM4v6w24od7tLOVQerUHb7vkBuI1QDRZWQA8KpAHj/NIvxHSSRFu4P4v0TTfOb0pMTSeiXAQw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:07.646Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mattheliu-dsh-accessibility`
- Submission type: community curation
- Created by `mattheliu` — https://github.com/mattheliu
- Original source repository: https://github.com/omdsh-dev/dsh-accessibility
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.