### PR TITLE
catalog: add norman-else-dsh-claude (community curation, created by @Norman-else)

### DIFF
--- a/catalog/plugins/norman-else-dsh-claude.yaml
+++ b/catalog/plugins/norman-else-dsh-claude.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: norman-else-dsh-claude
+name: "@norman-else/dsh-claude"
+description:
+  en: Run the local Claude Code CLI as a first-class main conversation inside DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - local
+  - claude
+  - code
+  - first
+  - class
+  - main
+  - conversation
+  - inside
+  - dsh
+source:
+  repository: https://github.com/Norman-else/dsh-claude
+  repositoryNodeId: R_kgDOT5G7pA
+  subpath: null
+  commit: d4f6eb6e9ff275d2d6a75c111ac6bdd47d9ba36d
+creator:
+  github: Norman-else
+package:
+  ecosystem: npm
+  name: "@norman-else/dsh-claude"
+  version: 0.1.25
+  integrity: sha512-V7T9Gnl/I/z3OW3x4SFz9MKqp/O+DzwdowuXg8UTLbq80SC59pmvrRrAfb2M1GT2OfxQWIto69NYjxfudGIa0g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:06.331Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `norman-else-dsh-claude`
- Submission type: community curation
- Created by `Norman-else` — https://github.com/Norman-else
- Original source repository: https://github.com/Norman-else/dsh-claude
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.