### PR TITLE
catalog: add nothree-code-folder-tree-sh (community curation, created by @Nothree-code)

### DIFF
--- a/catalog/plugins/nothree-code-folder-tree-sh.yaml
+++ b/catalog/plugins/nothree-code-folder-tree-sh.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: nothree-code-folder-tree-sh
+name: folder-tree-sh
+description:
+  en: "Persistent workspace file tree for DSH Web: explorer + preview (text/docx/image/PDF/Markdown/CSV), multi-tab, inline editing, Git changes panel, file operations (rename/delete/copy/move/create), search filter, sorting"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - persistent
+  - workspace
+  - file
+  - tree
+  - explorer
+  - preview
+  - text
+  - docx
+  - image
+  - markdown
+  - multi
+  - inline
+  - editing
+  - changes
+  - panel
+  - operations
+source:
+  repository: https://github.com/Nothree-code/folder-tree-sh
+  repositoryNodeId: R_kgDOT42Jsg
+  subpath: null
+  commit: bd26b1635ae0b55ad0471d71f0fcda8cd27d769c
+creator:
+  github: Nothree-code
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:47.092Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nothree-code-folder-tree-sh`
- Submission type: community curation
- Created by `Nothree-code` — https://github.com/Nothree-code
- Original source repository: https://github.com/Nothree-code/folder-tree-sh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.