### PR TITLE
catalog: add nothree-code-review-quote-sh (community curation, created by @Nothree-code)

### DIFF
--- a/catalog/plugins/nothree-code-review-quote-sh.yaml
+++ b/catalog/plugins/nothree-code-review-quote-sh.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: nothree-code-review-quote-sh
+name: review-quote-sh
+description:
+  en: Message review (multi-model cross review) + quote (Q&A chips) for the DSH conversation UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - message
+  - review
+  - multi
+  - model
+  - cross
+  - quote
+  - chips
+  - conversation
+  - dsh
+source:
+  repository: https://github.com/Nothree-code/review-quote-sh
+  repositoryNodeId: R_kgDOT47tug
+  subpath: null
+  commit: 546855f2a109fffdb4e6eb6f910e405884364889
+creator:
+  github: Nothree-code
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:55.528Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nothree-code-review-quote-sh`
- Submission type: community curation
- Created by `Nothree-code` — https://github.com/Nothree-code
- Original source repository: https://github.com/Nothree-code/review-quote-sh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.