### PR TITLE
catalog: add nothree-code-voco-input-sh (community curation, created by @Nothree-code)

### DIFF
--- a/catalog/plugins/nothree-code-voco-input-sh.yaml
+++ b/catalog/plugins/nothree-code-voco-input-sh.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: nothree-code-voco-input-sh
+name: voco-input-sh
+description:
+  en: "VocoType voice input bridge for DSH Web: mic button + recording panel in the composer, auto-insert recognized text (dedupe, auto-launch/deploy, mtime-optimized polling)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - vocotype
+  - voice
+  - input
+  - bridge
+  - button
+  - recording
+  - panel
+  - composer
+  - auto
+  - insert
+  - recognized
+  - text
+  - dedupe
+  - launch
+  - deploy
+  - mtime
+source:
+  repository: https://github.com/Nothree-code/voco-input-sh
+  repositoryNodeId: R_kgDOT5AesA
+  subpath: null
+  commit: 8ffb18956266a8a167bcfa49acd73eb037d094f2
+creator:
+  github: Nothree-code
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:50.460Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nothree-code-voco-input-sh`
- Submission type: community curation
- Created by `Nothree-code` — https://github.com/Nothree-code
- Original source repository: https://github.com/Nothree-code/voco-input-sh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.