### PR TITLE
catalog: add null5069-dsh-better-stats (community curation, created by @null5069)

### DIFF
--- a/catalog/plugins/null5069-dsh-better-stats.yaml
+++ b/catalog/plugins/null5069-dsh-better-stats.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: null5069-dsh-better-stats
+name: dsh-better-stats
+description:
+  en: "Enhanced DSH composer stats strip: official CNY cost, coherent live agent-team settlement, live LLM/tool timers, provider balance"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - stats
+  - cost
+  - balance
+source:
+  repository: https://github.com/null5069/dsh-better-stats
+  repositoryNodeId: R_kgDOT7850Q
+  subpath: null
+  commit: 380cfec816f400295f3d292a044eba8a23c30692
+creator:
+  github: null5069
+package:
+  ecosystem: npm
+  name: dsh-better-stats
+  version: 0.1.16
+  integrity: sha512-sp1TcItLSrfWVHTyy85p+C5gsfotOqpikJUHaTCer1zwem8OFl4h65wiIDvya/fOXiuZn0WX0ydBMYTIgLZTDQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:56.827Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `null5069-dsh-better-stats`
- Submission type: community curation
- Created by `null5069` — https://github.com/null5069
- Original source repository: https://github.com/null5069/dsh-better-stats
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.