### PR TITLE
catalog: add nunchakus888-dsh-turn-budget (community curation, created by @Nunchakus888)

### DIFF
--- a/catalog/plugins/nunchakus888-dsh-turn-budget.yaml
+++ b/catalog/plugins/nunchakus888-dsh-turn-budget.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: nunchakus888-dsh-turn-budget
+name: dsh-turn-budget
+description:
+  en: Fail-closed per-turn step, tool-call, and provider-token budgets for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - agent-governance
+  - resource-budget
+  - ai-agent
+  - dsh
+source:
+  repository: https://github.com/Nunchakus888/dsh-turn-budget
+  repositoryNodeId: R_kgDOT39gfw
+  subpath: null
+  commit: 9583ad34682455a0d9be3bc35ec809908e21d1d2
+creator:
+  github: Nunchakus888
+package:
+  ecosystem: npm
+  name: dsh-turn-budget
+  version: 0.1.0
+  integrity: sha512-H7X+ywcpumBJU1WcHN82zlA7MM0w3TjJTofwxb9OKKbkLrPzWEZD+F58jhKe72aJ7NO9V7QLOjY8B36nSrzfeQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:07.105Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nunchakus888-dsh-turn-budget`
- Submission type: community curation
- Created by `Nunchakus888` — https://github.com/Nunchakus888
- Original source repository: https://github.com/Nunchakus888/dsh-turn-budget
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.