### PR TITLE
catalog: add nwflower-dsh-file-claim (community curation, created by @Nwflower)

### DIFF
--- a/catalog/plugins/nwflower-dsh-file-claim.yaml
+++ b/catalog/plugins/nwflower-dsh-file-claim.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: nwflower-dsh-file-claim
+name: dsh-file-claim
+description:
+  en: "Write in parallel, never overwrite — file claim / protection for concurrent DeepSeek Harness (DSH) sessions working the same workspace: claim/release, heartbeat stale takeover, and an async pending merge area (git 3-way merge)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - host-plugin
+  - file-claim
+  - file-lock
+  - file-protection
+  - concurrency
+  - parallel-sessions
+  - parallel-agents
+  - coordination
+  - session-coordination
+  - merge
+  - 3-way-merge
+  - pending-merge
+source:
+  repository: https://github.com/Nwflower/dsh-file-claim
+  repositoryNodeId: R_kgDOT39Vmw
+  subpath: null
+  commit: 50f60f3b02485af99c5425574b5fd94b370b793f
+creator:
+  github: Nwflower
+package:
+  ecosystem: npm
+  name: dsh-file-claim
+  version: 0.1.7
+  integrity: sha512-AILTRlOVgQ4ZBEi2g1aGvTYCiTrbFWNiY6sruE9TzCw9toubOgMlSnbs66XzoQV5r88hKswtKhkXRkxQVo2Q8A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:45.175Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nwflower-dsh-file-claim`
- Submission type: community curation
- Created by `Nwflower` — https://github.com/Nwflower
- Original source repository: https://github.com/Nwflower/dsh-file-claim
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.