### PR TITLE
catalog: add nxz1026-dsh-tray (community curation, created by @nxz1026)

### DIFF
--- a/catalog/plugins/nxz1026-dsh-tray.yaml
+++ b/catalog/plugins/nxz1026-dsh-tray.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: nxz1026-dsh-tray
+name: dsh-tray
+description:
+  en: "Windows system-tray launcher for DeepSeek Harness Web: start/stop/restart/open UI/show logs from the tray icon."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - deepseek-harness
+  - tray
+  - systray
+  - windows
+  - launcher
+source:
+  repository: https://github.com/nxz1026/dsh-tray
+  repositoryNodeId: R_kgDOT9Ybnw
+  subpath: null
+  commit: d489100a11ae2ca84073e4921c1e1d5dd79eab93
+creator:
+  github: nxz1026
+package:
+  ecosystem: npm
+  name: dsh-tray
+  version: 0.1.0
+  integrity: sha512-xaixLleIgaCpuguW7fWSP2qnsj61ap2pqzD/9JVSdTTJ7zbsRt4Ep+/LR26Wh+mEDZZtkq7f8k0ymipSH82EIA==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:56.826Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nxz1026-dsh-tray`
- Submission type: community curation
- Created by `nxz1026` — https://github.com/nxz1026
- Original source repository: https://github.com/nxz1026/dsh-tray
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.