### PR TITLE
catalog: add onlyqzq-dsh-riskproof (community curation, created by @onlyqzq)

### DIFF
--- a/catalog/plugins/onlyqzq-dsh-riskproof.yaml
+++ b/catalog/plugins/onlyqzq-dsh-riskproof.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: onlyqzq-dsh-riskproof
+name: dsh-riskproof
+description:
+  en: Provenance-aware execution security for DeepSeek Harness. Track sensitive data across tool calls and stop risky side effects before execution.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - ai-agent
+  - agent-security
+  - provenance
+  - information-flow-control
+  - tool-security
+  - taint-tracking
+  - execution-security
+  - policy-engine
+  - dsh
+source:
+  repository: https://github.com/onlyqzq/dsh-riskproof
+  repositoryNodeId: R_kgDOTW4VAw
+  subpath: null
+  commit: 3fda8506fbc9d442ee635aae09e5c0070962e913
+creator:
+  github: onlyqzq
+package:
+  ecosystem: npm
+  name: dsh-riskproof
+  version: 0.2.0
+  integrity: sha512-16JESQR0MfEXOxXxd3GGy/mEyFMAbYkLABCgVyOkP9GzDzu7gUbnBBA+bwHN9dxKTuIWj8Y8B372mJKCRGUkBA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:57.139Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `onlyqzq-dsh-riskproof`
- Submission type: community curation
- Created by `onlyqzq` — https://github.com/onlyqzq
- Original source repository: https://github.com/onlyqzq/dsh-riskproof
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.