### PR TITLE
catalog: add ook826092-cloud-dsh-mobile-css (community curation, created by @ook826092-cloud)

### DIFF
--- a/catalog/plugins/ook826092-cloud-dsh-mobile-css.yaml
+++ b/catalog/plugins/ook826092-cloud-dsh-mobile-css.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ook826092-cloud-dsh-mobile-css
+name: dsh-mobile-css
+description:
+  en: "Mobile adaptation for the DeepSeek Harness Web UI: compact typography, drawer sidebar, two-page settings, responsive tables and stats, safe touch targets. Pure CSS injection, no source modification."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - web-ui
+  - mobile
+  - responsive
+source:
+  repository: https://github.com/ook826092-cloud/dsh-mobile-css
+  repositoryNodeId: R_kgDOT47HEg
+  subpath: null
+  commit: 6f4f27aa99a9c041812c87ec9cc1d464a35ed541
+creator:
+  github: ook826092-cloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:52.002Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ook826092-cloud-dsh-mobile-css`
- Submission type: community curation
- Created by `ook826092-cloud` — https://github.com/ook826092-cloud
- Original source repository: https://github.com/ook826092-cloud/dsh-mobile-css
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.