### PR TITLE
catalog: add op7418-dsh-ui-schedule-summary (community curation, created by @op7418)

### DIFF
--- a/catalog/plugins/op7418-dsh-ui-schedule-summary.yaml
+++ b/catalog/plugins/op7418-dsh-ui-schedule-summary.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: op7418-dsh-ui-schedule-summary
+name: "@deepseek-ai/dsh-ui-schedule-summary"
+description:
+  en: Plugin-owned Schedule summary contribution for Workspace Session hover cards
+  evidencePath: packages/schedule/ui-schedule-summary/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - owned
+  - schedule
+  - summary
+  - contribution
+  - workspace
+  - session
+  - hover
+  - cards
+  - dsh
+source:
+  repository: https://github.com/op7418/pilot-harness
+  repositoryNodeId: R_kgDOT63ahg
+  subpath: packages/schedule/ui-schedule-summary
+  commit: d1fa9c15fc00c05ea6931aafd724554ca34d5a6d
+creator:
+  github: op7418
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/schedule/ui-schedule-summary/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:13.749Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `op7418-dsh-ui-schedule-summary`
- Submission type: community curation
- Created by `op7418` — https://github.com/op7418
- Original source repository: https://github.com/op7418/pilot-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.