### PR TITLE
catalog: add op7418-dsh-ui-worktree (community curation, created by @op7418)

### DIFF
--- a/catalog/plugins/op7418-dsh-ui-worktree.yaml
+++ b/catalog/plugins/op7418-dsh-ui-worktree.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: op7418-dsh-ui-worktree
+name: "@deepseek-ai/dsh-ui-worktree"
+description:
+  en: Plugin-owned workspace file tree and row actions for DeepSeek Harness
+  evidencePath: packages/workspace/ui-worktree/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - owned
+  - workspace
+  - file
+  - tree
+  - actions
+  - dsh
+source:
+  repository: https://github.com/op7418/pilot-harness
+  repositoryNodeId: R_kgDOT63ahg
+  subpath: packages/workspace/ui-worktree
+  commit: d1fa9c15fc00c05ea6931aafd724554ca34d5a6d
+creator:
+  github: op7418
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/workspace/ui-worktree/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:13.749Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `op7418-dsh-ui-worktree`
- Submission type: community curation
- Created by `op7418` — https://github.com/op7418
- Original source repository: https://github.com/op7418/pilot-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.