### PR TITLE
catalog: add opentritium-dsh-codex-shim (community curation, created by @OpenTritium)

### DIFF
--- a/catalog/plugins/opentritium-dsh-codex-shim.yaml
+++ b/catalog/plugins/opentritium-dsh-codex-shim.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: opentritium-dsh-codex-shim
+name: "@opentritium/dsh-codex-shim"
+description:
+  en: Route-aware Codex environment simulation for DeepSeek Harness, improving tool-call reliability for GPT and other Codex-adapted models
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - route
+  - aware
+  - codex
+  - environment
+  - simulation
+  - improving
+  - tool
+  - call
+  - reliability
+  - other
+  - adapted
+  - models
+  - dsh
+source:
+  repository: https://github.com/OpenTritium/dsh-codex-shim
+  repositoryNodeId: R_kgDOT5LrvA
+  subpath: null
+  commit: a35d66378542e97cc862c8dee08007f08d586781
+creator:
+  github: OpenTritium
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:45.273Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `opentritium-dsh-codex-shim`
- Submission type: community curation
- Created by `OpenTritium` — https://github.com/OpenTritium
- Original source repository: https://github.com/OpenTritium/dsh-codex-shim
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.