### PR TITLE
catalog: add optttt-dsh-auth (community curation, created by @optttt)

### DIFF
--- a/catalog/plugins/optttt-dsh-auth.yaml
+++ b/catalog/plugins/optttt-dsh-auth.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: optttt-dsh-auth
+name: "@tyler9061/dsh-auth"
+description:
+  en: "Authentication plugin for DeepSeek Harness: accessing dsh web requires sign-in (username + password); idle sessions log out automatically; sessions expire after a configurable max age; single sign-on mode; the settings UI changes the username / password / expiry times; dsh web p resets the password and dsh web u change"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - auth
+  - authentication
+  - security
+source:
+  repository: https://github.com/optttt/dsh-auth
+  repositoryNodeId: R_kgDOT67n-g
+  subpath: null
+  commit: 109666e8679f099f880c7da185b45c9e6ecf8ae7
+creator:
+  github: optttt
+package:
+  ecosystem: npm
+  name: "@tyler9061/dsh-auth"
+  version: 0.1.7
+  integrity: sha512-GUASUVLER+ryGeeWJkzYCKr/60Gt6HspBBajx3clnfe2IBArKtAFPEIMs/mDoPCEfQ6qTp0muw+ljI8AIcId4A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:08.565Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `optttt-dsh-auth`
- Submission type: community curation
- Created by `optttt` — https://github.com/optttt
- Original source repository: https://github.com/optttt/dsh-auth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.