### PR TITLE
catalog: add optttt-dsh-email (community curation, created by @optttt)

### DIFF
--- a/catalog/plugins/optttt-dsh-email.yaml
+++ b/catalog/plugins/optttt-dsh-email.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: optttt-dsh-email
+name: "@tyler9061/dsh-email"
+description:
+  en: "Email plugin for DeepSeek Harness: multi-account receive (IMAP) and reply/send (SMTP), exposed to the agent as tools, with auto-processing tasks that trigger a headless agent."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - email
+  - imap
+  - smtp
+  - mail
+source:
+  repository: https://github.com/optttt/dsh-email
+  repositoryNodeId: R_kgDOT7O2wQ
+  subpath: null
+  commit: 306f7617997f0fae06dc48d3deda45cadb2847d1
+creator:
+  github: optttt
+package:
+  ecosystem: npm
+  name: "@tyler9061/dsh-email"
+  version: 0.1.5
+  integrity: sha512-1kej4nu7YLYuBjFCcUGfa3kdlS7i3nF92vn+X2top5inRRHzqFjCfGlUiqJZHMdP+9IYLnuJuGK14/06M9jc8A==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:08.952Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `optttt-dsh-email`
- Submission type: community curation
- Created by `optttt` — https://github.com/optttt
- Original source repository: https://github.com/optttt/dsh-email
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.