### PR TITLE
catalog: add orziz-odai-dsh-plugin (community curation, created by @orziz)

### DIFF
--- a/catalog/plugins/orziz-odai-dsh-plugin.yaml
+++ b/catalog/plugins/orziz-odai-dsh-plugin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: orziz-odai-dsh-plugin
+name: odai-dsh-plugin
+description:
+  en: Profile-wide odai governance and routing bundle for DeepSeek Harness.
+  evidencePath: dsh/plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - profile
+  - wide
+  - odai
+  - governance
+  - routing
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/orziz/odai
+  repositoryNodeId: R_kgDORq5Qhg
+  subpath: dsh/plugin
+  commit: 4a36ebf3c0a78510517bff6c14573f6591b0148f
+creator:
+  github: orziz
+package:
+  ecosystem: npm
+  name: odai-dsh-plugin
+  version: 0.2.9
+  integrity: sha512-143gpanu1HSiterfKtkf7ozXwrMAZr/IErgZFns16VaGws+9ayHVsVBpmKFrs+6IGFuw9eCKO+mx+sDjEEg8IQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh/plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:14.856Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `orziz-odai-dsh-plugin`
- Submission type: community curation
- Created by `orziz` — https://github.com/orziz
- Original source repository: https://github.com/orziz/odai
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.