### PR TITLE
catalog: add oscar-williams-dsh-deepatlas (community curation, created by @Oscar-Williams)

### DIFF
--- a/catalog/plugins/oscar-williams-dsh-deepatlas.yaml
+++ b/catalog/plugins/oscar-williams-dsh-deepatlas.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: oscar-williams-dsh-deepatlas
+name: dsh-deepatlas
+description:
+  en: DeepAtlas helps DeepSeek Harness (DSH) users decide whether a plugin capability change is worth making, with a reviewable record of discovery, verification, and installation. Describe a goal such as cross-session memory, messaging, or browser automation, and the DSH host model can call DeepAtlas on demand to compare th
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - capability-assurance
+  - plugin-preflight
+  - plugin-discovery
+  - plugin-navigation
+source:
+  repository: https://github.com/Oscar-Williams/dsh-deepatlas
+  repositoryNodeId: R_kgDOUAdlYA
+  subpath: null
+  commit: cb6ba6055b5fb58088cf68ae34b4845a6728b627
+creator:
+  github: Oscar-Williams
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:16.143Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `oscar-williams-dsh-deepatlas`
- Submission type: community curation
- Created by `Oscar-Williams` — https://github.com/Oscar-Williams
- Original source repository: https://github.com/Oscar-Williams/dsh-deepatlas
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.