### PR TITLE
catalog: add ossfrankfrank-dsh-dracula-theme (community curation, created by @ossFrankFrank)

### DIFF
--- a/catalog/plugins/ossfrankfrank-dsh-dracula-theme.yaml
+++ b/catalog/plugins/ossfrankfrank-dsh-dracula-theme.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: ossfrankfrank-dsh-dracula-theme
+name: dsh-dracula-theme
+description:
+  en: "🧛 Dracula theme for DeepSeek Harness: the classic dark palette (plus the Soft variant) registered into the built-in theme runtime"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - dracula
+  - skin
+  - web-ui
+source:
+  repository: https://github.com/ossFrankFrank/dsh-dracula-theme
+  repositoryNodeId: R_kgDOT68WWQ
+  subpath: null
+  commit: b8c7e809043296485ebff870a4c705e9139b3d5f
+creator:
+  github: ossFrankFrank
+package:
+  ecosystem: npm
+  name: dsh-dracula-theme
+  version: 1.0.0
+  integrity: sha512-RI/LoRKTPmjko2UbmtWeq72lCy0+PEooMlWMDWOLmVyXaJXAQmVMB3dV3dnXlIQpsenHwkarnspUV3F/JgQh5w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:57.192Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ossfrankfrank-dsh-dracula-theme`
- Submission type: community curation
- Created by `ossFrankFrank` — https://github.com/ossFrankFrank
- Original source repository: https://github.com/ossFrankFrank/dsh-dracula-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.