### PR TITLE
catalog: add ovdoesw-dsh-xiangqi (community curation, created by @ovdoesw)

### DIFF
--- a/catalog/plugins/ovdoesw-dsh-xiangqi.yaml
+++ b/catalog/plugins/ovdoesw-dsh-xiangqi.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: ovdoesw-dsh-xiangqi
+name: dsh-xiangqi
+description:
+  en: DSH Chinese chess pastime plugin — a draggable mascot that invites you to play Xiangqi while the AI thinks
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - chinese
+  - chess
+  - pastime
+  - draggable
+  - mascot
+  - invites
+  - play
+  - xiangqi
+  - while
+  - thinks
+  - dsh
+source:
+  repository: https://github.com/ovdoesw/dsh-xiangqi
+  repositoryNodeId: R_kgDOT4-RyA
+  subpath: null
+  commit: 7ef61de3571730e0faa5fad381f7572c7cdaaa1e
+creator:
+  github: ovdoesw
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:09.538Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ovdoesw-dsh-xiangqi`
- Submission type: community curation
- Created by `ovdoesw` — https://github.com/ovdoesw
- Original source repository: https://github.com/ovdoesw/dsh-xiangqi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.