### PR TITLE
catalog: add paicat1-dsh-screenshot (community curation, created by @paicat1)

### DIFF
--- a/catalog/plugins/paicat1-dsh-screenshot.yaml
+++ b/catalog/plugins/paicat1-dsh-screenshot.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: paicat1-dsh-screenshot
+name: "@paicat1/dsh-screenshot"
+description:
+  en: "Standalone screen capture for DeepSeek Harness (dsh): browser hotkeys plus an agent-facing capture+read tool. Forked out of @liustack/modlens 48 (upstream declined the feature)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - standalone
+  - screen
+  - capture
+  - browser
+  - hotkeys
+  - plus
+  - agent
+  - facing
+  - read
+  - tool
+  - forked
+  - liustack
+  - modlens
+  - upstream
+  - declined
+  - feature
+source:
+  repository: https://github.com/paicat1/dsh-screenshot
+  repositoryNodeId: R_kgDOT6GzPQ
+  subpath: null
+  commit: b9a9083b933b561dd64ffd8ad60da80032e1d8f6
+creator:
+  github: paicat1
+package:
+  ecosystem: npm
+  name: "@paicat1/dsh-screenshot"
+  version: 1.0.1
+  integrity: sha512-T1XwBAUV40D3NTZ/vSqjkfheSXO26Hz5TA0ELprN9TdImlYynLCRUJ0el8QkSla4mK85ekBEhAm64/9+14jp6g==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:51.970Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `paicat1-dsh-screenshot`
- Submission type: community curation
- Created by `paicat1` — https://github.com/paicat1
- Original source repository: https://github.com/paicat1/dsh-screenshot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.