### PR TITLE
catalog: add palaiologos1453-dsh-worktree-studio (community curation, created by @Palaiologos1453)

### DIFF
--- a/catalog/plugins/palaiologos1453-dsh-worktree-studio.yaml
+++ b/catalog/plugins/palaiologos1453-dsh-worktree-studio.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: palaiologos1453-dsh-worktree-studio
+name: dsh-worktree-studio
+description:
+  en: Session-linked Git worktree task board and guarded delivery workflow for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - git-worktree
+  - task-board
+  - agent
+  - dsh
+source:
+  repository: https://github.com/Palaiologos1453/dsh-worktree-studio
+  repositoryNodeId: R_kgDOT80uAw
+  subpath: null
+  commit: 6265c9691d297a559498ca81327b07c0140d7c8f
+creator:
+  github: Palaiologos1453
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:09.741Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `palaiologos1453-dsh-worktree-studio`
- Submission type: community curation
- Created by `Palaiologos1453` — https://github.com/Palaiologos1453
- Original source repository: https://github.com/Palaiologos1453/dsh-worktree-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.