### PR TITLE
catalog: add pananfly-dsh-auth-access (community curation, created by @pananfly)

### DIFF
--- a/catalog/plugins/pananfly-dsh-auth-access.yaml
+++ b/catalog/plugins/pananfly-dsh-auth-access.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: pananfly-dsh-auth-access
+name: "@pananfly/dsh-auth-access"
+description:
+  en: "Auth + LAN proxy for dsh web: password/TOTP gate via :: proxy, internal 127.0.0.1 webServer, optional isLoopback patch"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - auth
+  - proxy
+  - cordis
+  - totp
+source:
+  repository: https://github.com/pananfly/dsh-auth-access
+  repositoryNodeId: R_kgDOUCSSkw
+  subpath: null
+  commit: 8738d8a7662ceba1930dc397dfe8bc9b5a3ef3ff
+creator:
+  github: pananfly
+package:
+  ecosystem: npm
+  name: "@pananfly/dsh-auth-access"
+  version: 0.1.0
+  integrity: sha512-7acIqdKh1vl/pXBYtWgsxSbO1RlswhP+ETuvJcdDoa0efBgUnvNiODHhfq1Mr71GUCxCa3dhJPoVY3d2HehgUQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:17.442Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pananfly-dsh-auth-access`
- Submission type: community curation
- Created by `pananfly` — https://github.com/pananfly
- Original source repository: https://github.com/pananfly/dsh-auth-access
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.