### PR TITLE
catalog: add paomoxml-dsh-paste-names (community curation, created by @PaoMoXML)

### DIFF
--- a/catalog/plugins/paomoxml-dsh-paste-names.yaml
+++ b/catalog/plugins/paomoxml-dsh-paste-names.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: paomoxml-dsh-paste-names
+name: dsh-paste-names
+description:
+  en: "Paste/drop non-image files or folders into the DSH chat composer: paste inserts native @path references, drop inserts absolute paths."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - web-ui
+  - paste
+  - file-reference
+source:
+  repository: https://github.com/PaoMoXML/dsh-paste-names
+  repositoryNodeId: R_kgDOT_K7YA
+  subpath: null
+  commit: 5e56dc77fc51d486292f6cca80688f803ec76cef
+creator:
+  github: PaoMoXML
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:59.059Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `paomoxml-dsh-paste-names`
- Submission type: community curation
- Created by `PaoMoXML` — https://github.com/PaoMoXML
- Original source repository: https://github.com/PaoMoXML/dsh-paste-names
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.