### PR TITLE
catalog: add particlelight-dsh-ultracode (community curation, created by @ParticleLight)

### DIFF
--- a/catalog/plugins/particlelight-dsh-ultracode.yaml
+++ b/catalog/plugins/particlelight-dsh-ultracode.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: particlelight-dsh-ultracode
+name: dsh-ultracode
+description:
+  en: UltraCode agent preset for DeepSeek Harness 鈥?maximum-depth reasoning, plan 鈫?execute 鈫?verify, and parallel subagent orchestration, as a one-command-install mode.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - ultracode
+  - agent-preset
+  - workflow
+source:
+  repository: https://github.com/ParticleLight/dsh-ultracode
+  repositoryNodeId: R_kgDOT4OTQA
+  subpath: null
+  commit: 339970f463b74fee50f8369c9c85b84465a57d57
+creator:
+  github: ParticleLight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:09.898Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `particlelight-dsh-ultracode`
- Submission type: community curation
- Created by `ParticleLight` — https://github.com/ParticleLight
- Original source repository: https://github.com/ParticleLight/dsh-ultracode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.