### PR TITLE
catalog: add passingby000-dsh-nl-model-switch (community curation, created by @passingby000)

### DIFF
--- a/catalog/plugins/passingby000-dsh-nl-model-switch.yaml
+++ b/catalog/plugins/passingby000-dsh-nl-model-switch.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: passingby000-dsh-nl-model-switch
+name: dsh-nl-model-switch
+description:
+  en: Switch the current DSH session's model with a natural-language sentence, on web, TUI, or IM bridges (WeChat, Feishu, etc.).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - model-switch
+  - deepseek-harness
+  - natural-language
+source:
+  repository: https://github.com/passingby000/dsh-nl-model-switch
+  repositoryNodeId: R_kgDOT9tzrQ
+  subpath: null
+  commit: 74a646c9c1267d8c78098767dc0c26b330f596ed
+creator:
+  github: passingby000
+package:
+  ecosystem: npm
+  name: dsh-nl-model-switch
+  version: 0.1.1
+  integrity: sha512-qrQptmOjJeiKM1Jd9OttHF1pQrfSkOYCSjlH41nJMU4xLjKGWw58+7luesXahkTeu5ZV89qaeHofMrLxkprFaA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:59.448Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `passingby000-dsh-nl-model-switch`
- Submission type: community curation
- Created by `passingby000` — https://github.com/passingby000
- Original source repository: https://github.com/passingby000/dsh-nl-model-switch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.