### PR TITLE
catalog: add pasumao-dsh-plugin-dev-kb (community curation, created by @Pasumao)

### DIFF
--- a/catalog/plugins/pasumao-dsh-plugin-dev-kb.yaml
+++ b/catalog/plugins/pasumao-dsh-plugin-dev-kb.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: pasumao-dsh-plugin-dev-kb
+name: dsh-plugin-dev-kb
+description:
+  en: powershell dsh plugin --profile web add dsh-plugin-dev-kb dsh plugin --profile web add github:Pasumao/dsh-plugin-dev-kb
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - cordis
+  - knowledge
+  - documentation
+  - kb
+  - plugin-development
+source:
+  repository: https://github.com/Pasumao/dsh-plugin-dev-kb
+  repositoryNodeId: R_kgDOT7N0pA
+  subpath: null
+  commit: 541f71701cc78fc328141b69d30e57d213512fcc
+creator:
+  github: Pasumao
+package:
+  ecosystem: npm
+  name: dsh-plugin-dev-kb
+  version: 1.0.7
+  integrity: sha512-AQz9SF0Ev54BJQ5tca1fEFlQs7cr5xM2Y3errk3gvoM5NQZcYtpLGn7TcN58YxG6dX2IITRRln4Qg7WSEZo/2g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:59.459Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pasumao-dsh-plugin-dev-kb`
- Submission type: community curation
- Created by `Pasumao` — https://github.com/Pasumao
- Original source repository: https://github.com/Pasumao/dsh-plugin-dev-kb
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.