### PR TITLE
catalog: add pc439527-dsh-notify-bark (community curation, created by @pc439527)

### DIFF
--- a/catalog/plugins/pc439527-dsh-notify-bark.yaml
+++ b/catalog/plugins/pc439527-dsh-notify-bark.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: pc439527-dsh-notify-bark
+name: dsh-notify-bark
+description:
+  en: "License: MIT · Requires: Node ^22.19 · Platform: DSH Host + Web settings page"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - license
+  - requires
+  - node
+  - platform
+  - host
+  - settings
+  - page
+  - dsh
+source:
+  repository: https://github.com/pc439527/dsh-notify-bark
+  repositoryNodeId: R_kgDOT4Kd3A
+  subpath: null
+  commit: 26e229876312b18cc46b7a7ba04daa73e0226603
+creator:
+  github: pc439527
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:59.764Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pc439527-dsh-notify-bark`
- Submission type: community curation
- Created by `pc439527` — https://github.com/pc439527
- Original source repository: https://github.com/pc439527/dsh-notify-bark
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.