### PR TITLE
catalog: add pc439527-dsh-side-monitor (community curation, created by @pc439527)

### DIFF
--- a/catalog/plugins/pc439527-dsh-side-monitor.yaml
+++ b/catalog/plugins/pc439527-dsh-side-monitor.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: pc439527-dsh-side-monitor
+name: dsh-side-monitor
+description:
+  en: "A read-only system monitor for DeepSeek Harness (DSH) Web: a “System Monitor” entry in the left sidebar footer opens a right-side monitor drawer that shows live host (the machine DSH runs on) overview, process list, and Docker container status."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - read
+  - only
+  - system
+  - monitor
+  - entry
+  - left
+  - sidebar
+  - footer
+  - opens
+  - right
+  - side
+  - drawer
+  - shows
+  - live
+  - host
+  - machine
+source:
+  repository: https://github.com/pc439527/dsh-side-monitor
+  repositoryNodeId: R_kgDOT5IGWA
+  subpath: null
+  commit: 83b35268edb2329fad71289378ce5a218e83669d
+creator:
+  github: pc439527
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:59.725Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pc439527-dsh-side-monitor`
- Submission type: community curation
- Created by `pc439527` — https://github.com/pc439527
- Original source repository: https://github.com/pc439527/dsh-side-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.