### PR TITLE
catalog: add pengzhou267-ai-dsh-shop-assistant (community curation, created by @pengzhou267-ai)

### DIFF
--- a/catalog/plugins/pengzhou267-ai-dsh-shop-assistant.yaml
+++ b/catalog/plugins/pengzhou267-ai-dsh-shop-assistant.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: pengzhou267-ai-dsh-shop-assistant
+name: dsh-shop-assistant
+description:
+  en: "DeepSeek Harness plugin for ecommerce operators: CSV batch tools, reproducible scoring, Chinese skills and store policy KB."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ecommerce
+  - shop
+  - csv
+source:
+  repository: https://github.com/pengzhou267-ai/dsh-shop-assistant
+  repositoryNodeId: R_kgDOT4f08w
+  subpath: null
+  commit: 7335654f5f194b25cb1a668dfb05ec28daf9cece
+creator:
+  github: pengzhou267-ai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:10.991Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pengzhou267-ai-dsh-shop-assistant`
- Submission type: community curation
- Created by `pengzhou267-ai` — https://github.com/pengzhou267-ai
- Original source repository: https://github.com/pengzhou267-ai/dsh-shop-assistant
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.