### PR TITLE
catalog: add perrylink-dsh-local-ai (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/perrylink-dsh-local-ai.yaml
+++ b/catalog/plugins/perrylink-dsh-local-ai.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: perrylink-dsh-local-ai
+name: dsh-local-ai
+description:
+  en: "Local-model (Ollama) integration for DeepSeek Harness: discover, pull, remove, and inspect local models, route requests to them by task type or keyword with automatic fallback to the cloud, and get a one-shot status overview via /ollama."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - ollama
+  - local-llm
+  - local-models
+  - offline
+  - privacy
+  - model-routing
+source:
+  repository: https://github.com/PerryLink/dsh-local-ai
+  repositoryNodeId: R_kgDOT6oSWA
+  subpath: null
+  commit: bc9270d8e2cf5dd81544717c639fb69d96c3ce75
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-local-ai
+  version: 0.2.0
+  integrity: sha512-9yi5ZXmDNPuh/hxYLBkjtVJF93wiwVCZwnatTh0TXqFpy6aReDYY/SPGjMUwvWaFYBKPkMst0DRZsrl2wQvUJA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:53.084Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `perrylink-dsh-local-ai`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-local-ai
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.