### PR TITLE
catalog: add pg527322814-dsh-bayes-predict (community curation, created by @pg527322814)

### DIFF
--- a/catalog/plugins/pg527322814-dsh-bayes-predict.yaml
+++ b/catalog/plugins/pg527322814-dsh-bayes-predict.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: pg527322814-dsh-bayes-predict
+name: dsh-bayes-predict
+description:
+  en: "yaml - insert: - id: bayes-predict name: 'dsh-bayes-predict'"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - stock
+  - bayes
+  - prediction
+  - finance
+  - a-share
+  - quant
+source:
+  repository: https://github.com/pg527322814/dsh-bayes-predict
+  repositoryNodeId: R_kgDOT_0Inw
+  subpath: null
+  commit: 1145b7170d5d2b92b5d382d74fc4cb25ea210d11
+creator:
+  github: pg527322814
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:00.836Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pg527322814-dsh-bayes-predict`
- Submission type: community curation
- Created by `pg527322814` — https://github.com/pg527322814
- Original source repository: https://github.com/pg527322814/dsh-bayes-predict
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.