### PR TITLE
catalog: add phant0meow-meow-cachebilling (community curation, created by @Phant0Meow)

### DIFF
--- a/catalog/plugins/phant0meow-meow-cachebilling.yaml
+++ b/catalog/plugins/phant0meow-meow-cachebilling.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: phant0meow-meow-cachebilling
+name: meow-cachebilling
+description:
+  en: Am I the only one who cares about saving money? Are you all made of money or something...
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - billing
+  - cache-hit
+  - cost
+  - peak-offpeak
+source:
+  repository: https://github.com/Phant0Meow/dsh-meow-cachebilling
+  repositoryNodeId: R_kgDOUAyZLw
+  subpath: null
+  commit: 7365b38f19771d9f64ce111016941d170ebf7f1f
+creator:
+  github: Phant0Meow
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:01.557Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `phant0meow-meow-cachebilling`
- Submission type: community curation
- Created by `Phant0Meow` — https://github.com/Phant0Meow
- Original source repository: https://github.com/Phant0Meow/dsh-meow-cachebilling
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.