### PR TITLE
catalog: add philmingdao-anno-dsh (community curation, created by @philmingdao)

### DIFF
--- a/catalog/plugins/philmingdao-anno-dsh.yaml
+++ b/catalog/plugins/philmingdao-anno-dsh.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: philmingdao-anno-dsh
+name: "@philmingdao/anno-dsh"
+description:
+  en: Native DeepSeek Harness bundle for Anno HTML review and annotation.
+  evidencePath: adapters/dsh/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - html
+  - annotation
+source:
+  repository: https://github.com/philmingdao/anno
+  repositoryNodeId: R_kgDOT5xPCw
+  subpath: adapters/dsh
+  commit: 69db95d533c93d310f4e05ae789679f2e096e844
+creator:
+  github: philmingdao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: adapters/dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:19.788Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `philmingdao-anno-dsh`
- Submission type: community curation
- Created by `philmingdao` — https://github.com/philmingdao
- Original source repository: https://github.com/philmingdao/anno
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.