### PR TITLE
catalog: add pionai-dsh-web-search-firecrawl (community curation, created by @PionAI)

### DIFF
--- a/catalog/plugins/pionai-dsh-web-search-firecrawl.yaml
+++ b/catalog/plugins/pionai-dsh-web-search-firecrawl.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: pionai-dsh-web-search-firecrawl
+name: "@pionai/dsh-web-search-firecrawl"
+description:
+  en: Firecrawl-backed search provider for the DeepSeek Harness web capability seam (ctx.web)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - firecrawl
+  - backed
+  - search
+  - provider
+  - capability
+  - seam
+  - dsh
+source:
+  repository: https://github.com/PionsAI/dsh-web-search-firecrawl
+  repositoryNodeId: R_kgDOT57ndg
+  subpath: null
+  commit: d6f7ae7e723acea49faf3151538607e13cc85b96
+creator:
+  github: PionAI
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:01.981Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pionai-dsh-web-search-firecrawl`
- Submission type: community curation
- Created by `PionAI` — https://github.com/PionAI
- Original source repository: https://github.com/PionsAI/dsh-web-search-firecrawl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.