### PR TITLE
catalog: add pitetow-dsh-notify-on-complete (community curation, created by @pitetow)

### DIFF
--- a/catalog/plugins/pitetow-dsh-notify-on-complete.yaml
+++ b/catalog/plugins/pitetow-dsh-notify-on-complete.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: pitetow-dsh-notify-on-complete
+name: dsh-notify-on-complete
+description:
+  en: "Desktop notifications for DeepSeek Harness (dsh): run completion, model questions, and approval requests. Zero runtime dependencies — all peers provided by the dsh CLI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - notifications
+  - desktop-notifications
+  - notify
+  - cordis
+  - cli
+  - nodejs
+  - typescript
+source:
+  repository: https://github.com/pitetow/dsh-notify-on-complete
+  repositoryNodeId: R_kgDOT4h62A
+  subpath: null
+  commit: 21eefda31f414320b900557086f65c4a22ac13c8
+creator:
+  github: pitetow
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:46.959Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pitetow-dsh-notify-on-complete`
- Submission type: community curation
- Created by `pitetow` — https://github.com/pitetow
- Original source repository: https://github.com/pitetow/dsh-notify-on-complete
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.