### PR TITLE
catalog: add plolpl789-dsh-raw-html (community curation, created by @plolpl789)

### DIFF
--- a/catalog/plugins/plolpl789-dsh-raw-html.yaml
+++ b/catalog/plugins/plolpl789-dsh-raw-html.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: plolpl789-dsh-raw-html
+name: dsh-raw-html
+description:
+  en: 'Brings VCP (Visual-Synesthesia) to the DeepSeek Harness Web GUI: HTML in messages goes from "a blob of source code" to a genuinely rendered interface, and the agent outputs following a maintainable design system .'
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - vcp
+  - visual-synesthesia
+  - html
+  - rendering
+source:
+  repository: https://github.com/plolpl789/dsh-raw-html
+  repositoryNodeId: R_kgDOT_SZLg
+  subpath: null
+  commit: 95e658cd3f9cc74ab4402e86c90675eceee1c4ae
+creator:
+  github: plolpl789
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:41.830Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 25
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `plolpl789-dsh-raw-html`
- Submission type: community curation
- Created by `plolpl789` — https://github.com/plolpl789
- Original source repository: https://github.com/plolpl789/dsh-raw-html
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.