### PR TITLE
catalog: add pocketswpu-dsh-serendipity (community curation, created by @PocketSWPU)

### DIFF
--- a/catalog/plugins/pocketswpu-dsh-serendipity.yaml
+++ b/catalog/plugins/pocketswpu-dsh-serendipity.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: pocketswpu-dsh-serendipity
+name: "@pocket30/dsh-serendipity"
+description:
+  en: sh npx @deepseek-ai/dsh plugin --profile web add @pocket30/dsh-serendipity@1.0.0
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - game
+  - adventure
+  - rpg
+  - serendipity
+source:
+  repository: https://github.com/PocketSWPU/dsh-serendipity
+  repositoryNodeId: R_kgDOT7MX0A
+  subpath: null
+  commit: ecb8ef85cf527b414cf0ced2e9af76e3e1b9128d
+creator:
+  github: PocketSWPU
+package:
+  ecosystem: npm
+  name: "@pocket30/dsh-serendipity"
+  version: 1.0.0
+  integrity: sha512-EjF3W2B51ohRVE9VlwLdwgv2C0jYrlok1O+PLIgCW05bc8iw0eifgN3+oOy9rJZOiZ3jMEf+Zd85naEWbwWODg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:01.980Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pocketswpu-dsh-serendipity`
- Submission type: community curation
- Created by `PocketSWPU` — https://github.com/PocketSWPU
- Original source repository: https://github.com/PocketSWPU/dsh-serendipity
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.