### PR TITLE
catalog: add poiuyjie-dsh-md-preview (community curation, created by @poiuyjie)

### DIFF
--- a/catalog/plugins/poiuyjie-dsh-md-preview.yaml
+++ b/catalog/plugins/poiuyjie-dsh-md-preview.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: poiuyjie-dsh-md-preview
+name: dsh-md-preview
+description:
+  en: "DeepSeek Harness plugin: dockable Markdown preview panel that opens side-by-side with the conversation, tracks recently accessed .md files per session, and intercepts in-chat .md references so they preview instead of launching the system editor. Built on top of dsh-vision-opencode for a visual-verification + source-pre"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - markdown
+  - preview
+  - docs
+  - vision
+source:
+  repository: https://github.com/poiuyjie/dsh-md-preview
+  repositoryNodeId: R_kgDOT5-xTw
+  subpath: null
+  commit: a14484dd3ca8ea3537dbe847ac65f3496eff20dc
+creator:
+  github: poiuyjie
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:54.345Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `poiuyjie-dsh-md-preview`
- Submission type: community curation
- Created by `poiuyjie` — https://github.com/poiuyjie
- Original source repository: https://github.com/poiuyjie/dsh-md-preview
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.