### PR TITLE
catalog: add polaris-smart-dsh-devices (community curation, created by @polaris-smart)

### DIFF
--- a/catalog/plugins/polaris-smart-dsh-devices.yaml
+++ b/catalog/plugins/polaris-smart-dsh-devices.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: polaris-smart-dsh-devices
+name: dsh-devices
+description:
+  en: <p align="center" <strong Turn your devices into a fleet.</strong </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - fleet
+  - multi-device
+  - mdns
+  - ssh
+  - sftp
+  - file-transfer
+source:
+  repository: https://github.com/polaris-smart/dsh-devices
+  repositoryNodeId: R_kgDOT7jO1w
+  subpath: null
+  commit: cabd2deb9e43df674e7c49bffe0bc2b6030d2d41
+creator:
+  github: polaris-smart
+package:
+  ecosystem: npm
+  name: dsh-devices
+  version: 0.1.2
+  integrity: sha512-LsXOcAWCyWRhdaNkAhFAgJiWC1sU5ZH97i0zrDIaVHKTFW6M37xKHV9l1mvGI3KpAV0BuQoXlPvfaZ4PaAk6rw==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:45.181Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `polaris-smart-dsh-devices`
- Submission type: community curation
- Created by `polaris-smart` — https://github.com/polaris-smart
- Original source repository: https://github.com/polaris-smart/dsh-devices
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.