### PR TITLE
catalog: add polarskicpl-dsh-codex-migrate (community curation, created by @polarskicpl)

### DIFF
--- a/catalog/plugins/polarskicpl-dsh-codex-migrate.yaml
+++ b/catalog/plugins/polarskicpl-dsh-codex-migrate.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: polarskicpl-dsh-codex-migrate
+name: dsh-codex-migrate
+description:
+  en: Migrate Codex CLI conversations, MCP servers, memories and project files into DeepSeek Harness sessions, workspaces and MCP registrations. 把 Codex CLI 的对话、MCP、记忆与项目文件迁移为 DSH 会话、工作区与 MCP 注册。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - codex
+  - migration
+  - dsh-plugin
+source:
+  repository: https://github.com/polarskicpl/dsh-codex-migrate
+  repositoryNodeId: R_kgDOT5NdXA
+  subpath: null
+  commit: 487c46cc6ddc2cdfce13322c858bdf0d0f6e5ea1
+creator:
+  github: polarskicpl
+package:
+  ecosystem: npm
+  name: dsh-codex-migrate
+  version: 0.1.3
+  integrity: sha512-C+SCA8MLB2w0/5qklZAamaeN3yPmwK3vc7qBCqIwnNHFqEGd0K+FRhEb0BS2TverCTqHpeN4MTRx0QzGbo0KKw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:49.540Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `polarskicpl-dsh-codex-migrate`
- Submission type: community curation
- Created by `polarskicpl` — https://github.com/polarskicpl
- Original source repository: https://github.com/polarskicpl/dsh-codex-migrate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.