### PR TITLE
catalog: add pudge1996-dsh-composer-stretch (community curation, created by @Pudge1996)

### DIFF
--- a/catalog/plugins/pudge1996-dsh-composer-stretch.yaml
+++ b/catalog/plugins/pudge1996-dsh-composer-stretch.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: pudge1996-dsh-composer-stretch
+name: dsh-composer-stretch
+description:
+  en: "Auto-expand composer for DeepSeek Harness: a ⤢ button appears at the top-right of the composer card when the text wraps to 3+ visual lines, stretching the input to near-fullscreen height on click."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - composer
+  - expand
+  - textarea
+  - stretch
+  - dsh
+source:
+  repository: https://github.com/Pudge1996/dsh-composer-stretch
+  repositoryNodeId: R_kgDOUCICPw
+  subpath: null
+  commit: ec8a5186b00261edab877ad922ed027fc0b4500f
+creator:
+  github: Pudge1996
+package:
+  ecosystem: npm
+  name: dsh-composer-stretch
+  version: 0.1.1
+  integrity: sha512-g/qwdpyHfTRe4I42gqsd3ZfRIVZSZBUdDy41aqKpNNWG2oj341CdOtuSJIqTtVxY8MHmGv7DaxWsMsXwlyuC8g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:22.839Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pudge1996-dsh-composer-stretch`
- Submission type: community curation
- Created by `Pudge1996` — https://github.com/Pudge1996
- Original source repository: https://github.com/Pudge1996/dsh-composer-stretch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.