### PR TITLE
catalog: add pwnky-dsh-session-link (community curation, created by @PwnKY)

### DIFF
--- a/catalog/plugins/pwnky-dsh-session-link.yaml
+++ b/catalog/plugins/pwnky-dsh-session-link.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: pwnky-dsh-session-link
+name: dsh-session-link
+description:
+  en: "Codex-style session deep links for DeepSeek Harness (dsh): copy a dsh:// link from any conversation, open it in the browser, or paste it into another conversation to read that session's context."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - deep-link
+  - session
+  - context
+  - codex
+source:
+  repository: https://github.com/PwnKY/dsh-session-link
+  repositoryNodeId: R_kgDOT4kTiw
+  subpath: null
+  commit: ef09612820ea4974e1d35f114480d2f48829b850
+creator:
+  github: PwnKY
+package:
+  ecosystem: npm
+  name: dsh-session-link
+  version: 0.1.4
+  integrity: sha512-YSVKIUHdO1gH/h2wqd/PjPiUqHQEQTqlOnmkpMXBHbvRe/hNQaOCwM8e6IfLOt8Geil8HBJYZNlU9Lg7ac59lg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:47.092Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pwnky-dsh-session-link`
- Submission type: community curation
- Created by `PwnKY` — https://github.com/PwnKY
- Original source repository: https://github.com/PwnKY/dsh-session-link
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.