### PR TITLE
catalog: add q00-dsh-ouroboros (community curation, created by @Q00)

### DIFF
--- a/catalog/plugins/q00-dsh-ouroboros.yaml
+++ b/catalog/plugins/q00-dsh-ouroboros.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: q00-dsh-ouroboros
+name: dsh-ouroboros
+description:
+  en: Mount Ouroboros (spec-first AI dev workflow engine) into DeepSeek Harness as native tools — type "ooo interview" or "ooo auto" in chat.
+  evidencePath: integrations/dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - ouroboros
+  - mcp
+  - dsh
+source:
+  repository: https://github.com/Q00/ouroboros
+  repositoryNodeId: R_kgDOQ5X3RQ
+  subpath: integrations/dsh-plugin
+  commit: c80144781ac3d87fe7a7d40ab93b14ddf15a191c
+creator:
+  github: Q00
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: integrations/dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:26.275Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `q00-dsh-ouroboros`
- Submission type: community curation
- Created by `Q00` — https://github.com/Q00
- Original source repository: https://github.com/Q00/ouroboros
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.