### PR TITLE
catalog: add qianling-0831-dsh-memory-bundle (community curation, created by @QIANLING-0831)

### DIFF
--- a/catalog/plugins/qianling-0831-dsh-memory-bundle.yaml
+++ b/catalog/plugins/qianling-0831-dsh-memory-bundle.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: qianling-0831-dsh-memory-bundle
+name: dsh-memory-bundle
+description:
+  en: "Meta-bundle: installs all dsh-memory plugins (CJK search, dedup, hybrid memory index, memory tool, compaction locator, core memory, skill manager + self-evolution) into a DeepSeek Harness profile as one patch layer."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - bundle
+  - memory
+  - dsh
+source:
+  repository: https://github.com/QIANLING-0831/dsh-memory-plus
+  repositoryNodeId: R_kgDOT8uSyA
+  subpath: packages/dsh-memory-bundle
+  commit: 5a66aea598f946f88d3bef1bba989336dc6d3d58
+creator:
+  github: QIANLING-0831
+package:
+  ecosystem: npm
+  name: dsh-memory-bundle
+  version: 0.1.0
+  integrity: sha512-GLeQ6GvZlEPqzo52ZR08N4zwM9bWPXsZlJmtOJfxnzvWpVJ1vIgWydkDE3lQGxiwXjfZr3mhLJMJlvGNwc6oWA==
+dsh:
+  profiles:
+    - headless
+  evidencePath: packages/dsh-memory-bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:24.851Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qianling-0831-dsh-memory-bundle`
- Submission type: community curation
- Created by `QIANLING-0831` — https://github.com/QIANLING-0831
- Original source repository: https://github.com/QIANLING-0831/dsh-memory-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.