### PR TITLE
catalog: add qie2035-dsh-llm-headers (community curation, created by @QiE2035)

### DIFF
--- a/catalog/plugins/qie2035-dsh-llm-headers.yaml
+++ b/catalog/plugins/qie2035-dsh-llm-headers.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: qie2035-dsh-llm-headers
+name: dsh-llm-headers
+description:
+  en: Inject custom HTTP headers (user-agent etc.) into DeepSeek Harness LLM provider requests, configured through cordis.yml or the Web UI settings surface.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - inject
+  - custom
+  - headers
+  - user
+  - agent
+  - provider
+  - requests
+  - configured
+  - through
+  - cordis
+  - settings
+  - surface
+  - dsh
+source:
+  repository: https://github.com/QiE2035/dsh-llm-headers
+  repositoryNodeId: R_kgDOT5p18A
+  subpath: null
+  commit: 9565595b15ec864eb3e523c567798ebd940dad4a
+creator:
+  github: QiE2035
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:03.456Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qie2035-dsh-llm-headers`
- Submission type: community curation
- Created by `QiE2035` — https://github.com/QiE2035
- Original source repository: https://github.com/QiE2035/dsh-llm-headers
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.