### PR TITLE
catalog: add qinyre-dsh-plugin-atlas (community curation, created by @qinyre)

### DIFF
--- a/catalog/plugins/qinyre-dsh-plugin-atlas.yaml
+++ b/catalog/plugins/qinyre-dsh-plugin-atlas.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: qinyre-dsh-plugin-atlas
+name: dsh-plugin-atlas
+description:
+  en: sh dsh plugin --profile web add dsh-plugin-atlas
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - archive
+  - navigation
+source:
+  repository: https://github.com/qinyre/dsh-plugin-atlas
+  repositoryNodeId: R_kgDOT79ZJw
+  subpath: null
+  commit: b9469056d7af0278ca1c0f4a791ea85d8483de70
+creator:
+  github: qinyre
+package:
+  ecosystem: npm
+  name: dsh-plugin-atlas
+  version: 0.2.5
+  integrity: sha512-cyTVL63ttz0pPEHTTwNraHCK3WUYpQ6ICryFbrbFMeZ3HqM5OKFS3H/hOOQqtqjBiiyynd9y6Q1n6ZF3Hbl9ig==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:03.774Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qinyre-dsh-plugin-atlas`
- Submission type: community curation
- Created by `qinyre` — https://github.com/qinyre
- Original source repository: https://github.com/qinyre/dsh-plugin-atlas
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.