### PR TITLE
catalog: add qinyre-dsh-plugin-capabilities (community curation, created by @qinyre)

### DIFF
--- a/catalog/plugins/qinyre-dsh-plugin-capabilities.yaml
+++ b/catalog/plugins/qinyre-dsh-plugin-capabilities.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: qinyre-dsh-plugin-capabilities
+name: dsh-plugin-capabilities
+description:
+  en: sh dsh plugin --profile web add dsh-plugin-capabilities
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - skills
+  - mcp
+source:
+  repository: https://github.com/qinyre/dsh-plugin-capabilities
+  repositoryNodeId: R_kgDOT6Tbmg
+  subpath: null
+  commit: 3412f8ddf0a92bdc89a3bab104b480f8745ebfc1
+creator:
+  github: qinyre
+package:
+  ecosystem: npm
+  name: dsh-plugin-capabilities
+  version: 0.3.6
+  integrity: sha512-mAKz+54pXIV56LwWxwNJ/HHTwca+kySyxMfazH8II5M0T8WHu1Ps+tzoIzrNhzG0wvZEhy86GhfEKiKL0kRWFQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:44.875Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qinyre-dsh-plugin-capabilities`
- Submission type: community curation
- Created by `qinyre` — https://github.com/qinyre
- Original source repository: https://github.com/qinyre/dsh-plugin-capabilities
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.