### PR TITLE
catalog: add qinyre-dsh-plugin-install (community curation, created by @qinyre)

### DIFF
--- a/catalog/plugins/qinyre-dsh-plugin-install.yaml
+++ b/catalog/plugins/qinyre-dsh-plugin-install.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: qinyre-dsh-plugin-install
+name: dsh-plugin-install
+description:
+  en: sh dsh plugin --profile web add dsh-plugin-install
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - plugin-manager
+  - install
+source:
+  repository: https://github.com/qinyre/dsh-plugin-install
+  repositoryNodeId: R_kgDOT6HjMw
+  subpath: null
+  commit: f629782d199e9f0394b29727dfc963984ae2f184
+creator:
+  github: qinyre
+package:
+  ecosystem: npm
+  name: dsh-plugin-install
+  version: 0.3.9
+  integrity: sha512-sLqJzC1ezkuBum0TJoddASZsKcyL7cXv3i6zXyYeqDPIly0CouKjHl7j7zintnOsv29DybuMDP945l8y/1cLBQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:04.156Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qinyre-dsh-plugin-install`
- Submission type: community curation
- Created by `qinyre` — https://github.com/qinyre
- Original source repository: https://github.com/qinyre/dsh-plugin-install
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.