### PR TITLE
catalog: add qinyu765-dsh-llm-auto-route (community curation, created by @qinyu765)

### DIFF
--- a/catalog/plugins/qinyu765-dsh-llm-auto-route.yaml
+++ b/catalog/plugins/qinyu765-dsh-llm-auto-route.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: qinyu765-dsh-llm-auto-route
+name: dsh-llm-auto-route
+description:
+  en: Provider discovery, matching, health checks, and pre-output failover for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - llm
+  - provider-routing
+  - typescript
+  - dsh
+source:
+  repository: https://github.com/qinyu765/dsh-llm-auto-route
+  repositoryNodeId: R_kgDOT4Jprg
+  subpath: null
+  commit: 4f9bdfbf936cd0e18aa2704060ce44fe384d9c52
+creator:
+  github: qinyu765
+package:
+  ecosystem: npm
+  name: dsh-llm-auto-route
+  version: 0.1.0
+  integrity: sha512-ddTpbZRLJxd5v/3UjZWqaAK2lNuxSVWQAzXl6dffmjFJ5zkHb+2CFDpV0zcrkQoG2uvSdBmBWqxRdJrLNfTdsQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:21:12.215Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qinyu765-dsh-llm-auto-route`
- Submission type: community curation
- Created by `qinyu765` — https://github.com/qinyu765
- Original source repository: https://github.com/qinyu765/dsh-llm-auto-route
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.