### PR TITLE
catalog: add underthestars-zhy-dsh-imessage (community curation, created by @underthestars-zhy)

### DIFF
--- a/catalog/plugins/underthestars-zhy-dsh-imessage.yaml
+++ b/catalog/plugins/underthestars-zhy-dsh-imessage.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: underthestars-zhy-dsh-imessage
+name: dsh-imessage
+description:
+  en: Photon-hosted iMessage transport and configuration UI for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - imessage
+  - photon
+  - spectrum
+source:
+  repository: https://github.com/photon-hq/dsh-imessage
+  repositoryNodeId: R_kgDOT7tHKA
+  subpath: null
+  commit: a644183adf332bff12b2fe359b3326ca1c066846
+creator:
+  github: underthestars-zhy
+package:
+  ecosystem: npm
+  name: dsh-imessage
+  version: 0.2.0
+  integrity: sha512-RRVnDE/VkRxPWePfhreIPnw9I/j5SFqCeiEri3uj53uIv1MxQlnyhe7ahnkfERhyL8oSu76GZvOcIgMNtjjy9A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:41.854Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `underthestars-zhy-dsh-imessage`
- Submission type: community curation
- Created by `underthestars-zhy` — https://github.com/underthestars-zhy
- Original source repository: https://github.com/photon-hq/dsh-imessage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.