### PR TITLE
catalog: add xiaoyuyu6420-dsh-inspect (community curation, created by @xiaoyuyu6420)

### DIFF
--- a/catalog/plugins/xiaoyuyu6420-dsh-inspect.yaml
+++ b/catalog/plugins/xiaoyuyu6420-dsh-inspect.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: xiaoyuyu6420-dsh-inspect
+name: "@dsh-external/dsh-inspect"
+description:
+  en: bash pnpm install 仅 typescript/@types/node（typecheck 用） pnpm run typecheck tsc -b，类型从 sibling deepseek-harness checkout 解析 cd plugins/dsh-inspect && node --test 回归测试
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - bash
+  - pnpm
+  - install
+  - typescript
+  - types
+  - node
+  - typecheck
+  - sibling
+  - checkout
+  - inspect
+  - test
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-inspect
+  repositoryNodeId: R_kgDOTv-JZg
+  subpath: null
+  commit: a99192eda30115dd3d4d3c5991572f5a37175996
+creator:
+  github: xiaoyuyu6420
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:45.174Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaoyuyu6420-dsh-inspect`
- Submission type: community curation
- Created by `xiaoyuyu6420` — https://github.com/xiaoyuyu6420
- Original source repository: https://github.com/omdsh-dev/dsh-inspect
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.