### PR TITLE
catalog: add yejiming-dsh-auto-chess (community curation, created by @yejiming)

### DIFF
--- a/catalog/plugins/yejiming-dsh-auto-chess.yaml
+++ b/catalog/plugins/yejiming-dsh-auto-chess.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: yejiming-dsh-auto-chess
+name: "@deepseek-ai/dsh-auto-chess"
+description:
+  en: "Minimal auto chess for the dsh web GUI: AI action routes, model catalog, and default prompt (node half) plus the conversation-view tab with the boards (browser half)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - minimal
+  - auto
+  - chess
+  - action
+  - routes
+  - model
+  - catalog
+  - default
+  - prompt
+  - node
+  - half
+  - plus
+  - conversation
+  - view
+  - boards
+  - browser
+source:
+  repository: https://github.com/omdsh-dev/dsh-auto-chess
+  repositoryNodeId: R_kgDOT0LPJQ
+  subpath: null
+  commit: cc0728d808cb9c9b563cc6be95e5bf60ae2a5025
+creator:
+  github: yejiming
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:50.462Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yejiming-dsh-auto-chess`
- Submission type: community curation
- Created by `yejiming` — https://github.com/yejiming
- Original source repository: https://github.com/omdsh-dev/dsh-auto-chess
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.