### PR TITLE
catalog: add yfjz-dsh-agfs (community curation, created by @YFJZ)

### DIFF
--- a/catalog/plugins/yfjz-dsh-agfs.yaml
+++ b/catalog/plugins/yfjz-dsh-agfs.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: yfjz-dsh-agfs
+name: "@open-agfs/dsh-agfs"
+description:
+  en: Host file-browser web app over the dsh webserver with a /dsh-agfs command
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - file-browser
+  - web
+source:
+  repository: https://github.com/openAGFS/dsh-agfs
+  repositoryNodeId: R_kgDOT43b1w
+  subpath: null
+  commit: 78c3216c39ff2fe2f7915e6019854446f79228f7
+creator:
+  github: YFJZ
+package:
+  ecosystem: npm
+  name: "@open-agfs/dsh-agfs"
+  version: 0.1.9
+  integrity: sha512-Jg8U7SnWwqGV1WosXDdZJf6cCdFUWQbR5aXFOxf3+A4N1ssUvThYHGWbNz0XtElHM7TcKljWMxXbXN2Wm3KRIg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T10:20:51.894Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yfjz-dsh-agfs`
- Submission type: community curation
- Created by `YFJZ` — https://github.com/YFJZ
- Original source repository: https://github.com/openAGFS/dsh-agfs
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.