### PR TITLE
catalog: add aiad-dsh-swarm-router (community curation, created by @Aiad)

### DIFF
--- a/catalog/plugins/aiad-dsh-swarm-router.yaml
+++ b/catalog/plugins/aiad-dsh-swarm-router.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: aiad-dsh-swarm-router
+name: dsh-swarm-router
+description:
+  en: "DSH plugin platform: sub-agent matrix swarm + model aggregation registry (PR flow) + plugin extension point (ctx.swarmRouter) + real-task feedback/ranking + token-consumption stats (cfgpu highlighted). Routes heterogeneous tasks to the most suitable model (OpenRouter-like + cfgpu.com/llm/square), dispatches via in-proc"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - subagent
+  - swarm
+  - model-router
+  - cfgpu
+  - openrouter
+  - llm-routing
+source:
+  repository: https://github.com/r600a-code/dsh-swarm-router
+  repositoryNodeId: R_kgDOT5dnAQ
+  subpath: null
+  commit: fc051ea2ad05fc27ad7271630b7e0bd7ebb24bb9
+creator:
+  github: Aiad
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:51.542Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aiad-dsh-swarm-router`
- Submission type: community curation
- Created by `Aiad` — https://github.com/Aiad
- Original source repository: https://github.com/r600a-code/dsh-swarm-router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.