### PR TITLE
catalog: add liyangbing-dsh-plugin-store (community curation, created by @liyangbing)

### DIFF
--- a/catalog/plugins/liyangbing-dsh-plugin-store.yaml
+++ b/catalog/plugins/liyangbing-dsh-plugin-store.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: liyangbing-dsh-plugin-store
+name: "@sandbaseai/dsh-plugin-store"
+description:
+  en: Native DeepSeek Harness plugin marketplace for discovering, filtering, installing, and managing community DSH plugins.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-store
+  - plugin-marketplace
+  - cordis
+  - ai-agent
+  - agent-harness
+  - developer-tools
+  - sandbase
+source:
+  repository: https://github.com/sandbaseai/dsh-plugin-store
+  repositoryNodeId: R_kgDOT6zXMg
+  subpath: null
+  commit: 978770905b0467b7266810df1412a2e10b2695fb
+creator:
+  github: liyangbing
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:46.280Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liyangbing-dsh-plugin-store`
- Submission type: community curation
- Created by `liyangbing` — https://github.com/liyangbing
- Original source repository: https://github.com/sandbaseai/dsh-plugin-store
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.