### PR TITLE
catalog: add qiyu166-dsh-client-ui-session-mention (community curation, created by @qiyu166)

### DIFF
--- a/catalog/plugins/qiyu166-dsh-client-ui-session-mention.yaml
+++ b/catalog/plugins/qiyu166-dsh-client-ui-session-mention.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: qiyu166-dsh-client-ui-session-mention
+name: dsh-client-ui-session-mention
+description:
+  en: Type @ in the composer to reference another conversation — pick a historical session and its compacted context is injected into the current prompt. Turn the parallel conversations in your workspace into one collaborative team.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session
+  - mention
+  - reference
+source:
+  repository: https://github.com/qiyu166/dsh-client-ui-session-mention
+  repositoryNodeId: R_kgDOUAijZQ
+  subpath: null
+  commit: a8a69f0ad10197b0491d0da3cda21bab62de2f8e
+creator:
+  github: qiyu166
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:56.714Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qiyu166-dsh-client-ui-session-mention`
- Submission type: community curation
- Created by `qiyu166` — https://github.com/qiyu166
- Original source repository: https://github.com/qiyu166/dsh-client-ui-session-mention
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.