### PR TITLE
catalog: add qkycir-123-dsh-run2skill (community curation, created by @qkycir-123)

### DIFF
--- a/catalog/plugins/qkycir-123-dsh-run2skill.yaml
+++ b/catalog/plugins/qkycir-123-dsh-run2skill.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: qkycir-123-dsh-run2skill
+name: dsh-run2skill
+description:
+  en: Turn explicit DSH session experience into reviewable native Skills
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-skills
+  - local-first
+  - human-in-the-loop
+source:
+  repository: https://github.com/qkycir-123/dsh-run2skill
+  repositoryNodeId: R_kgDOT9RbjA
+  subpath: null
+  commit: 18c37f3783454b16e20697591c0f2ecee597c735
+creator:
+  github: qkycir-123
+package:
+  ecosystem: npm
+  name: dsh-run2skill
+  version: 0.3.0
+  integrity: sha512-I1GDKgiwmcUVB/btJI/EhJFKWUdXZJuU+3Ytop/V7V+yVnl3o+zcntRdaQBGFy0UA1InCl92620sVGAyW3vn/g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:37.292Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 13
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qkycir-123-dsh-run2skill`
- Submission type: community curation
- Created by `qkycir-123` — https://github.com/qkycir-123
- Original source repository: https://github.com/qkycir-123/dsh-run2skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.