### PR TITLE
catalog: add qlzqqlzq-dsh-dual-agent-presets (community curation, created by @QlzqQlzq)

### DIFF
--- a/catalog/plugins/qlzqqlzq-dsh-dual-agent-presets.yaml
+++ b/catalog/plugins/qlzqqlzq-dsh-dual-agent-presets.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: qlzqqlzq-dsh-dual-agent-presets
+name: dsh-dual-agent-presets
+description:
+  en: General-purpose and coding-focused agent presets for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-preset
+  - coding-agent
+source:
+  repository: https://github.com/QlzqQlzq/dsh-dual-agent-presets
+  repositoryNodeId: R_kgDOT5PBMg
+  subpath: null
+  commit: 46c4cbf21d13815fd706ca1aa2217e45d9fb4400
+creator:
+  github: QlzqQlzq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:57.014Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qlzqqlzq-dsh-dual-agent-presets`
- Submission type: community curation
- Created by `QlzqQlzq` — https://github.com/QlzqQlzq
- Original source repository: https://github.com/QlzqQlzq/dsh-dual-agent-presets
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.