### PR TITLE
catalog: add qswwltn-dsh-ue-uasset-operator (community curation, created by @QSWWLTN)

### DIFF
--- a/catalog/plugins/qswwltn-dsh-ue-uasset-operator.yaml
+++ b/catalog/plugins/qswwltn-dsh-ue-uasset-operator.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: qswwltn-dsh-ue-uasset-operator
+name: "@deepseek-dsh-desktop/dsh-ue-uasset-operator"
+description:
+  en: Native DSH tools for Unreal Engine uasset inspection and the Blueprint node edits exposed by built-in UE Python
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - unreal-engine
+  - blueprint
+  - uasset
+  - dsh-plugin
+source:
+  repository: https://github.com/QSWWLTN/dsh-UEAssetsOperator
+  repositoryNodeId: R_kgDOT4FfFg
+  subpath: null
+  commit: 2dbb6833c9b7e556131dbbe05b070a7e0f535576
+creator:
+  github: QSWWLTN
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:48.889Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qswwltn-dsh-ue-uasset-operator`
- Submission type: community curation
- Created by `QSWWLTN` — https://github.com/QSWWLTN
- Original source repository: https://github.com/QSWWLTN/dsh-UEAssetsOperator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.