### PR TITLE
catalog: add quinn2006-dsh-guise (community curation, created by @Quinn2006)

### DIFF
--- a/catalog/plugins/quinn2006-dsh-guise.yaml
+++ b/catalog/plugins/quinn2006-dsh-guise.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: quinn2006-dsh-guise
+name: dsh-guise
+description:
+  en: bash dsh plugin --profile web add github:Quinn2006/dsh-guise
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - bash
+  - profile
+  - quinn2006
+  - guise
+  - dsh
+source:
+  repository: https://github.com/Quinn2006/dsh-guise
+  repositoryNodeId: R_kgDOT7Eh5Q
+  subpath: null
+  commit: f4504916a4715bd83161f1923d34112b0ec190d3
+creator:
+  github: Quinn2006
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:57.449Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `quinn2006-dsh-guise`
- Submission type: community curation
- Created by `Quinn2006` — https://github.com/Quinn2006
- Original source repository: https://github.com/Quinn2006/dsh-guise
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.