### PR TITLE
catalog: add quophic-dsh-persona-memory (community curation, created by @Quophic)

### DIFF
--- a/catalog/plugins/quophic-dsh-persona-memory.yaml
+++ b/catalog/plugins/quophic-dsh-persona-memory.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: quophic-dsh-persona-memory
+name: dsh-persona-memory
+description:
+  en: "Persistent long-term persona memory for DeepSeek Harness: MEMORY.md/USER.md storage, memory + memory search tools, per-request context injection, secret scanning, and a WebUI memory-management settings page. Ported in spirit from pi-hermes-memory. TypeScript sources, built with tsc + esbuild."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - persistent-memory
+  - persona
+  - long-term-memory
+source:
+  repository: https://github.com/Quophic/dsh-persona-memory
+  repositoryNodeId: R_kgDOT4T4Kg
+  subpath: null
+  commit: 22e6d4cef2fdc1dc23ab4439a047e09cc4ca8b3e
+creator:
+  github: Quophic
+package:
+  ecosystem: npm
+  name: dsh-persona-memory
+  version: 0.2.0
+  integrity: sha512-sdZZXmh/Nk81CeeceA4AlGcFv2DCeZ5Rri10v2W+zug4peWREaqW6LNj5s79l9xTbP5qSLFv9S8SfDzkObWYIQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:40.208Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `quophic-dsh-persona-memory`
- Submission type: community curation
- Created by `Quophic` — https://github.com/Quophic
- Original source repository: https://github.com/Quophic/dsh-persona-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.