### PR TITLE
catalog: add qys0012-dsh-hotspots (community curation, created by @qys0012)

### DIFF
--- a/catalog/plugins/qys0012-dsh-hotspots.yaml
+++ b/catalog/plugins/qys0012-dsh-hotspots.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: qys0012-dsh-hotspots
+name: dsh-hotspots
+description:
+  en: bash dsh plugin --profile <profile名 add link:/path/to/dsh-hotspots
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - hotspots
+  - ai-news
+  - engineering
+  - web-ui
+  - dsh
+source:
+  repository: https://github.com/qys0012/dsh-hotspots
+  repositoryNodeId: R_kgDOUDpjOQ
+  subpath: null
+  commit: 55378b2360e13878e2a5428e87044a5aadffc5da
+creator:
+  github: qys0012
+package:
+  ecosystem: npm
+  name: dsh-hotspots
+  version: 1.1.0
+  integrity: sha512-UwIb2zl9TBF34zFikTM4mJz8YqxwogghVGITP4mjEvMwZRrBP8YOns2cQQ4oK6E2OEObVvrXmGkfmP6YJrbm3w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:58.453Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qys0012-dsh-hotspots`
- Submission type: community curation
- Created by `qys0012` — https://github.com/qys0012
- Original source repository: https://github.com/qys0012/dsh-hotspots
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.