### PR TITLE
catalog: add qyw233-dsh-deeplink (community curation, created by @qyw233)

### DIFF
--- a/catalog/plugins/qyw233-dsh-deeplink.yaml
+++ b/catalog/plugins/qyw233-dsh-deeplink.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: qyw233-dsh-deeplink
+name: "@dsh-community/dsh-deeplink"
+description:
+  en: A DeepSeek Harness Web UI plugin that opens a specific project conversation directly from a URL query parameter, instead of always returning to the last session.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - opens
+  - specific
+  - conversation
+  - directly
+  - query
+  - parameter
+  - instead
+  - always
+  - returning
+  - last
+  - session
+  - dsh
+source:
+  repository: https://github.com/qyw233/dsh-deeplink
+  repositoryNodeId: R_kgDOT3XJNA
+  subpath: null
+  commit: 0ec5da351b246dfcbf9a91a3d0c7b7f2699370e6
+creator:
+  github: qyw233
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:42.065Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qyw233-dsh-deeplink`
- Submission type: community curation
- Created by `qyw233` — https://github.com/qyw233
- Original source repository: https://github.com/qyw233/dsh-deeplink
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.