### PR TITLE
catalog: add r-lei2536-dsh-more-agent-presets (community curation, created by @R-LEI2536)

### DIFF
--- a/catalog/plugins/r-lei2536-dsh-more-agent-presets.yaml
+++ b/catalog/plugins/r-lei2536-dsh-more-agent-presets.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: r-lei2536-dsh-more-agent-presets
+name: dsh-more-agent-presets
+description:
+  en: Multiple selectable Agent Presets for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-preset
+  - coding-agent
+  - qwencode
+  - iflow
+source:
+  repository: https://github.com/R-LEI2536/dsh-more-agent-presets
+  repositoryNodeId: R_kgDOT76zwA
+  subpath: null
+  commit: 84b805e411d4d2d7bc21539d8b8ce437428bd53e
+creator:
+  github: R-LEI2536
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:48.895Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `r-lei2536-dsh-more-agent-presets`
- Submission type: community curation
- Created by `R-LEI2536` — https://github.com/R-LEI2536
- Original source repository: https://github.com/R-LEI2536/dsh-more-agent-presets
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.