### PR TITLE
catalog: add radicalgitter-dsh-ui-translate (community curation, created by @RadicalGitter)

### DIFF
--- a/catalog/plugins/radicalgitter-dsh-ui-translate.yaml
+++ b/catalog/plugins/radicalgitter-dsh-ui-translate.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: radicalgitter-dsh-ui-translate
+name: dsh-ui-translate
+description:
+  en: Privacy-first browser-local Chinese UI and content translation for DeepSeek Harness Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - translation
+  - localization
+  - privacy
+  - offline
+source:
+  repository: https://github.com/RadicalGitter/dsh-ui-translate
+  repositoryNodeId: R_kgDOT-uZew
+  subpath: null
+  commit: 260083f023ec8494fbf59db7c4b9a237cf8e9648
+creator:
+  github: RadicalGitter
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:59.121Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `radicalgitter-dsh-ui-translate`
- Submission type: community curation
- Created by `RadicalGitter` — https://github.com/RadicalGitter
- Original source repository: https://github.com/RadicalGitter/dsh-ui-translate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.