### PR TITLE
catalog: add radres-dsh-plugin-call-me (community curation, created by @radres)

### DIFF
--- a/catalog/plugins/radres-dsh-plugin-call-me.yaml
+++ b/catalog/plugins/radres-dsh-plugin-call-me.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: radres-dsh-plugin-call-me
+name: dsh-plugin-call-me
+description:
+  en: Your DeepSeek Harness agent rings your actual phone. It asks out loud, you answer out loud, and what you said steers the run.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - deepseek-ai
+  - cordis
+  - phone
+  - phone-call
+  - call
+  - voice
+  - notify
+  - notification
+  - notifications
+  - approval
+  - human-in-the-loop
+  - reachability
+  - iphone
+source:
+  repository: https://github.com/radres/dsh-plugin-call-me
+  repositoryNodeId: R_kgDOT4am0w
+  subpath: null
+  commit: e1845ce5315d4959a038fdc8f0dabd59d5c460b3
+creator:
+  github: radres
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:40.188Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `radres-dsh-plugin-call-me`
- Submission type: community curation
- Created by `radres` — https://github.com/radres
- Original source repository: https://github.com/radres/dsh-plugin-call-me
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.