### PR TITLE
catalog: add rand0wn-dsh-minimal-anchor (community curation, created by @rand0wn)

### DIFF
--- a/catalog/plugins/rand0wn-dsh-minimal-anchor.yaml
+++ b/catalog/plugins/rand0wn-dsh-minimal-anchor.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: rand0wn-dsh-minimal-anchor
+name: dsh-minimal-anchor
+description:
+  en: "DeepSeek Harness (dsh) plugin: prune the tool schema and inject a structural preamble on a session's first turn only."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/rand0wn/dsh-minimal-anchor
+  repositoryNodeId: R_kgDOT7EuAg
+  subpath: null
+  commit: 782a731ce080138e3f1cf0498e8972f853da3ea9
+creator:
+  github: rand0wn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:59.120Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rand0wn-dsh-minimal-anchor`
- Submission type: community curation
- Created by `rand0wn` — https://github.com/rand0wn
- Original source repository: https://github.com/rand0wn/dsh-minimal-anchor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.