### PR TITLE
catalog: add rand0wn-dsh-wrapped (community curation, created by @rand0wn)

### DIFF
--- a/catalog/plugins/rand0wn-dsh-wrapped.yaml
+++ b/catalog/plugins/rand0wn-dsh-wrapped.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: rand0wn-dsh-wrapped
+name: dsh-wrapped
+description:
+  en: "DeepSeek Harness (dsh) plugin: /wrapped generates a shareable SVG summary card for the current session."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/rand0wn/dsh-wrapped
+  repositoryNodeId: R_kgDOT-TjIg
+  subpath: null
+  commit: aa4a3d1de500827b96373f653452d39c101e565a
+creator:
+  github: rand0wn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:59.683Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rand0wn-dsh-wrapped`
- Submission type: community curation
- Created by `rand0wn` — https://github.com/rand0wn
- Original source repository: https://github.com/rand0wn/dsh-wrapped
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.