### PR TITLE
catalog: add rannist-balance-dsh (community curation, created by @Rannist)

### DIFF
--- a/catalog/plugins/rannist-balance-dsh.yaml
+++ b/catalog/plugins/rannist-balance-dsh.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: rannist-balance-dsh
+name: balance-dsh
+description:
+  en: powershell cd C:\Users\<你的用户名 \.dsh\profiles\desktop pnpm add balance-dsh
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - balance
+  - usage
+  - cost
+  - token
+  - billing
+source:
+  repository: https://github.com/Rannist/balance-dsh
+  repositoryNodeId: R_kgDOUB5dHw
+  subpath: null
+  commit: 2f83039cb4517b10cf142480684d8f633d33f232
+creator:
+  github: Rannist
+package:
+  ecosystem: npm
+  name: balance-dsh
+  version: 1.0.3
+  integrity: sha512-/RIlhhIvvNVEbx/WAf/PhGPT0HWp+0+iydCubqMMwXHkVK0NlOs7cvfIvTKGu+TTJGgn6iTM5RNU8v7+/Ve5Aw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:59.805Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rannist-balance-dsh`
- Submission type: community curation
- Created by `Rannist` — https://github.com/Rannist
- Original source repository: https://github.com/Rannist/balance-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.