### PR TITLE
catalog: add ratevoid-dsh-aseprite (community curation, created by @Ratevoid)

### DIFF
--- a/catalog/plugins/ratevoid-dsh-aseprite.yaml
+++ b/catalog/plugins/ratevoid-dsh-aseprite.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ratevoid-dsh-aseprite
+name: dsh-aseprite
+description:
+  en: A pixel-art and sprite-animation editor plugin for DeepSeek Harness. It is compatible with Aseprite project files and requires no Aseprite installation.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - aseprite
+  - pixel-art
+  - sprite
+  - animation
+  - web-ui
+source:
+  repository: https://github.com/Ratevoid/dsh-aseprite
+  repositoryNodeId: R_kgDOT87tJw
+  subpath: null
+  commit: e6804fe634380e63c1efe09c4c6a749cc110045b
+creator:
+  github: Ratevoid
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:43.938Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ratevoid-dsh-aseprite`
- Submission type: community curation
- Created by `Ratevoid` — https://github.com/Ratevoid
- Original source repository: https://github.com/Ratevoid/dsh-aseprite
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.