### PR TITLE
catalog: add rayadesune-dsh-billing (community curation, created by @rayadesune)

### DIFF
--- a/catalog/plugins/rayadesune-dsh-billing.yaml
+++ b/catalog/plugins/rayadesune-dsh-billing.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: rayadesune-dsh-billing
+name: "@rayadesu/dsh-billing"
+description:
+  en: "DeepSeek Harness billing plugin: account balance and this session's billed spend with a session-header badge."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - billing
+  - account
+  - balance
+  - session
+  - billed
+  - spend
+  - header
+  - badge
+  - dsh
+source:
+  repository: https://github.com/rayadesune/DeepSeek-Harness-chat-billing
+  repositoryNodeId: R_kgDOT7aGsQ
+  subpath: null
+  commit: 66abcbb24a4b902bc7aa816fbc31dbc93aab974c
+creator:
+  github: rayadesune
+package:
+  ecosystem: npm
+  name: "@rayadesu/dsh-billing"
+  version: 0.1.0
+  integrity: sha512-s36zIIjVxGU9cKA45WSAKVLqCtDYUY46XYEJTSa0YlqS7r0BA8gSaqhMocA/5MIHh/JoSjrFH5o5oJ0hB84Usg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:00.428Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rayadesune-dsh-billing`
- Submission type: community curation
- Created by `rayadesune` — https://github.com/rayadesune
- Original source repository: https://github.com/rayadesune/DeepSeek-Harness-chat-billing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.