### PR TITLE
catalog: add reachga0-dsh-desktop-windows-launcher (community curation, created by @ReachGa0)

### DIFF
--- a/catalog/plugins/reachga0-dsh-desktop-windows-launcher.yaml
+++ b/catalog/plugins/reachga0-dsh-desktop-windows-launcher.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: reachga0-dsh-desktop-windows-launcher
+name: dsh-desktop-windows-launcher
+description:
+  en: "dsh plugin: launch the dsh-desktop Windows shell (region screenshot, tray, session manager) from the DSH conversation via a desktop launch tool."
+  evidencePath: plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - electron
+  - desktop
+source:
+  repository: https://github.com/ReachGa0/dsh-desktop
+  repositoryNodeId: R_kgDOT3_Ixg
+  subpath: plugin
+  commit: 73e0d0103aaff46a7a934c46bf61636393a0233b
+creator:
+  github: ReachGa0
+package:
+  ecosystem: npm
+  name: dsh-desktop-windows-launcher
+  version: 0.1.0
+  integrity: sha512-5oe9UFGTbe14FH6ebmUZmkooairhrYlr0Io4I1e0ZHVJmjB0ae1IOwafcWZq2CIUhAGlKsiTgX0eHvJdpgl6jA==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:09.120Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `reachga0-dsh-desktop-windows-launcher`
- Submission type: community curation
- Created by `ReachGa0` — https://github.com/ReachGa0
- Original source repository: https://github.com/ReachGa0/dsh-desktop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.