### PR TITLE
catalog: add realyujie-dsh-us-stocks (community curation, created by @Realyujie)

### DIFF
--- a/catalog/plugins/realyujie-dsh-us-stocks.yaml
+++ b/catalog/plugins/realyujie-dsh-us-stocks.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: realyujie-dsh-us-stocks
+name: dsh-us-stocks
+description:
+  en: DSH US stock market data plugin, powered by yahoo-finance2
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - stocks
+  - us-stocks
+  - yahoo-finance
+source:
+  repository: https://github.com/Realyujie/dsh-us-stocks
+  repositoryNodeId: R_kgDOT4geHA
+  subpath: null
+  commit: 13237087e59238ddbe379a82383cc82a471660b6
+creator:
+  github: Realyujie
+package:
+  ecosystem: npm
+  name: dsh-us-stocks
+  version: 0.3.0
+  integrity: sha512-kqGCmUOCrhC8XdrbjIs8lQ40hRvTkaO+KTf07kmENcca/M2LV5PC2ZFNsE6MwEc3pkCQocrXyldudg4uX4rFOA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:37.227Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `realyujie-dsh-us-stocks`
- Submission type: community curation
- Created by `Realyujie` — https://github.com/Realyujie
- Original source repository: https://github.com/Realyujie/dsh-us-stocks
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.