### PR TITLE
catalog: add reatcat-l123-harness (community curation, created by @reatcat)

### DIFF
--- a/catalog/plugins/reatcat-l123-harness.yaml
+++ b/catalog/plugins/reatcat-l123-harness.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: reatcat-l123-harness
+name: l123-harness
+description:
+  en: "L1-L2-L3 three-tier memory agent harness: gate approval, zero-judgement event log, weekly distillation, TDD execution loop. Claude Code plugin and DeepSeek Harness (dsh) bundle."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - claude-code-plugin
+  - agent-memory
+  - methodology
+  - skills
+  - hooks
+  - tdd
+source:
+  repository: https://github.com/reatcat/l123-harness
+  repositoryNodeId: R_kgDOUAeSjQ
+  subpath: null
+  commit: a7ac81012f58bbc535378a684ec7482024ded742
+creator:
+  github: reatcat
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:00.918Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `reatcat-l123-harness`
- Submission type: community curation
- Created by `reatcat` — https://github.com/reatcat
- Original source repository: https://github.com/reatcat/l123-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.