### PR TITLE
catalog: add reinocheong-dsh-session-move (community curation, created by @reinocheong)

### DIFF
--- a/catalog/plugins/reinocheong-dsh-session-move.yaml
+++ b/catalog/plugins/reinocheong-dsh-session-move.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: reinocheong-dsh-session-move
+name: dsh-session-move
+description:
+  en: "Manage DeepSeek Harness sessions from the Web UI: drag & drop or menu-move a session to another folder (workspace), permanently delete a session, and AI-rename a session by summarizing its conversation. Also exposes agent tools for each operation."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - session
+  - workspace
+  - folder
+  - rename
+  - delete
+  - move
+source:
+  repository: https://github.com/reinocheong/dsh-session-move
+  repositoryNodeId: R_kgDOT4_W6w
+  subpath: null
+  commit: 0acca8a4efcdd43487a3d38b2cbf57dd8df130fb
+creator:
+  github: reinocheong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:43.893Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `reinocheong-dsh-session-move`
- Submission type: community curation
- Created by `reinocheong` — https://github.com/reinocheong
- Original source repository: https://github.com/reinocheong/dsh-session-move
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.