### PR TITLE
catalog: add relethe-dsh-brief-session-title (community curation, created by @Relethe)

### DIFF
--- a/catalog/plugins/relethe-dsh-brief-session-title.yaml
+++ b/catalog/plugins/relethe-dsh-brief-session-title.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: relethe-dsh-brief-session-title
+name: dsh-brief-session-title
+description:
+  en: A DeepSeek Harness (DSH) session-title plugin that condenses a full sentence into a single word for easier recall.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - session
+  - title
+  - condenses
+  - full
+  - sentence
+  - single
+  - word
+  - easier
+  - recall
+  - dsh
+source:
+  repository: https://github.com/Relethe/dsh-brief-session-title
+  repositoryNodeId: R_kgDOT8gjfg
+  subpath: null
+  commit: d0b4a8507739ce2f0fff24b9683e9b634894c60b
+creator:
+  github: Relethe
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:01.278Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `relethe-dsh-brief-session-title`
- Submission type: community curation
- Created by `Relethe` — https://github.com/Relethe
- Original source repository: https://github.com/Relethe/dsh-brief-session-title
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.