### PR TITLE
catalog: add renji004-dsh-omni-vision (community curation, created by @Renji004)

### DIFF
--- a/catalog/plugins/renji004-dsh-omni-vision.yaml
+++ b/catalog/plugins/renji004-dsh-omni-vision.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: renji004-dsh-omni-vision
+name: dsh-omni-vision
+description:
+  en: "A canvas the agent draws on and then sees: eyes render draws text/shapes in the Web GUI, stores the PNG locally, and hands the result back to the model. Windows-only: eyes ocr reads text via the built-in Windows OCR engine (Windows.Media.Ocr)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - canvas
+  - agent
+  - draws
+  - sees
+  - eyes
+  - render
+  - text
+  - shapes
+  - stores
+  - locally
+  - hands
+  - result
+  - back
+  - model
+  - windows
+  - only
+source:
+  repository: https://github.com/Renji004/dsh-omni-vision
+  repositoryNodeId: R_kgDOT8Wvig
+  subpath: null
+  commit: 661ac80f70c9784580b7ce2edb75edb9db170f1f
+creator:
+  github: Renji004
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:01.480Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `renji004-dsh-omni-vision`
- Submission type: community curation
- Created by `Renji004` — https://github.com/Renji004
- Original source repository: https://github.com/Renji004/dsh-omni-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.