### PR TITLE
catalog: add reshuibuduo-dsh-tmcra-memory (community curation, created by @reshuibuduo)

### DIFF
--- a/catalog/plugins/reshuibuduo-dsh-tmcra-memory.yaml
+++ b/catalog/plugins/reshuibuduo-dsh-tmcra-memory.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: reshuibuduo-dsh-tmcra-memory
+name: dsh-tmcra-memory
+description:
+  en: Automatic TMCRA recall, injection, and role-separated writeback for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-memory
+  - tmcra
+  - dsh
+source:
+  repository: https://github.com/reshuibuduo/tmcra-plugin-deepseek-harness
+  repositoryNodeId: R_kgDOT39XoA
+  subpath: null
+  commit: 70bdd940b67da4e6565f4aa89fbf7ed5aed70b7c
+creator:
+  github: reshuibuduo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:01.776Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `reshuibuduo-dsh-tmcra-memory`
- Submission type: community curation
- Created by `reshuibuduo` — https://github.com/reshuibuduo
- Original source repository: https://github.com/reshuibuduo/tmcra-plugin-deepseek-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.