### PR TITLE
catalog: add revive-dsh-git-credentials (community curation, created by @revive)

### DIFF
--- a/catalog/plugins/revive-dsh-git-credentials.yaml
+++ b/catalog/plugins/revive-dsh-git-credentials.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: revive-dsh-git-credentials
+name: dsh-git-credentials
+description:
+  en: "Out-of-tree dsh plugin: GitLab, GitHub, Gitee, Gitea, and Bitbucket tokens stay out of the model context, stored encrypted (AES-256-GCM) in a plugin-owned file; the model calls forge API tools on demand, and the web settings page manages sites and tokens."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - gitlab
+  - gitee
+  - gitea
+  - bitbucket
+  - credentials
+source:
+  repository: https://github.com/revive/dsh-git-credentials
+  repositoryNodeId: R_kgDOT4F7gg
+  subpath: null
+  commit: f1812bdeaad92dff12c0a7a46f85d07c931176a8
+creator:
+  github: revive
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:52.477Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `revive-dsh-git-credentials`
- Submission type: community curation
- Created by `revive` — https://github.com/revive
- Original source repository: https://github.com/revive/dsh-git-credentials
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.