### PR TITLE
catalog: add rimzer-dsh-cad-plugin (community curation, created by @rimzer)

### DIFF
--- a/catalog/plugins/rimzer-dsh-cad-plugin.yaml
+++ b/catalog/plugins/rimzer-dsh-cad-plugin.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: rimzer-dsh-cad-plugin
+name: dsh-cad-plugin
+description:
+  en: DeepSeek Harness tools for inspecting, extracting and previewing CAD files.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - cad
+  - dwg
+  - dxf
+  - dsh
+source:
+  repository: https://github.com/roymina/dsh-cad
+  repositoryNodeId: R_kgDOT-uUBQ
+  subpath: null
+  commit: 749d7ca49479797a3a7797a128498645f6dbdadc
+creator:
+  github: rimzer
+package:
+  ecosystem: npm
+  name: dsh-cad-plugin
+  version: 0.1.0
+  integrity: sha512-EGd0pi7yIez6Ae3PGVEwIsAmlexGQO4ig5i0bP2BI/+8oCUl1wY6g9lBsqEKJYOHB9oSxSYfaNqI+7MonvH5YQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:10.950Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rimzer-dsh-cad-plugin`
- Submission type: community curation
- Created by `rimzer` — https://github.com/rimzer
- Original source repository: https://github.com/roymina/dsh-cad
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.