### PR TITLE
catalog: add ringoage-dsh-subagent-model-picker (community curation, created by @ringoage)

### DIFF
--- a/catalog/plugins/ringoage-dsh-subagent-model-picker.yaml
+++ b/catalog/plugins/ringoage-dsh-subagent-model-picker.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: ringoage-dsh-subagent-model-picker
+name: dsh-subagent-model-picker
+description:
+  en: "DSH web plugin: the visual, manual subagent-model picker beside the main model seat — predictable per-session routing with global coverage of every in-process subagent path, complementary to auto-routing plugins."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - subagent
+  - model-picker
+  - web-plugin
+source:
+  repository: https://github.com/ringoage/dsh-subagent-model-picker
+  repositoryNodeId: R_kgDOT5xVMw
+  subpath: null
+  commit: 771082e64f3a1a8a1ab8b2f4e44d073b3d27ea2b
+creator:
+  github: ringoage
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:02.912Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ringoage-dsh-subagent-model-picker`
- Submission type: community curation
- Created by `ringoage` — https://github.com/ringoage
- Original source repository: https://github.com/ringoage/dsh-subagent-model-picker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.