### PR TITLE
catalog: add roarpeng-graphflow (community curation, created by @Roarpeng)

### DIFF
--- a/catalog/plugins/roarpeng-graphflow.yaml
+++ b/catalog/plugins/roarpeng-graphflow.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: roarpeng-graphflow
+name: "@roarpeng/graphflow"
+description:
+  en: A Context-Aware Multi-Agent Orchestration Engine
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - multi-agent
+  - orchestration
+  - mcp
+  - context-engine
+  - agent-plugins
+  - cursor
+  - claude-code
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+source:
+  repository: https://github.com/Roarpeng/GraphFlow
+  repositoryNodeId: R_kgDOSpFukg
+  subpath: null
+  commit: 74b4cf5bd769db70443ad288d1a33203f5872888
+creator:
+  github: Roarpeng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:40.253Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `roarpeng-graphflow`
- Submission type: community curation
- Created by `Roarpeng` — https://github.com/Roarpeng
- Original source repository: https://github.com/Roarpeng/GraphFlow
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.