### PR TITLE
catalog: add robbywang25-dsh-codex-pins (community curation, created by @robbywang25)

### DIFF
--- a/catalog/plugins/robbywang25-dsh-codex-pins.yaml
+++ b/catalog/plugins/robbywang25-dsh-codex-pins.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: robbywang25-dsh-codex-pins
+name: dsh-codex-pins
+description:
+  en: Codex-style pinned sessions for DeepSeek Harness — a Pinned pane and a Recents pane, independently scrollable.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - session-pin
+  - codex
+  - sidebar
+source:
+  repository: https://github.com/robbywang25/dsh-codex-pins
+  repositoryNodeId: R_kgDOUATP7g
+  subpath: null
+  commit: 881103f3aaa9cf5207476da948798083a801b70b
+creator:
+  github: robbywang25
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:52.440Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `robbywang25-dsh-codex-pins`
- Submission type: community curation
- Created by `robbywang25` — https://github.com/robbywang25
- Original source repository: https://github.com/robbywang25/dsh-codex-pins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.