### PR TITLE
catalog: add rocker2018-droid-dsh-longtask-orchestrator (community curation, created by @rocker2018-droid)

### DIFF
--- a/catalog/plugins/rocker2018-droid-dsh-longtask-orchestrator.yaml
+++ b/catalog/plugins/rocker2018-droid-dsh-longtask-orchestrator.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: rocker2018-droid-dsh-longtask-orchestrator
+name: dsh-longtask-orchestrator
+description:
+  en: sh dsh plugin --profile web add link:/绝对路径/dsh-longtask-orchestrator
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - codex
+  - kimi
+  - orchestration
+  - long-task
+source:
+  repository: https://github.com/rocker2018-droid/dsh-longtask-orchestrator
+  repositoryNodeId: R_kgDOT5Vn_Q
+  subpath: null
+  commit: d8eefcbbedf15f88dd7bc8f324fabd5df708b51a
+creator:
+  github: rocker2018-droid
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:46.079Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rocker2018-droid-dsh-longtask-orchestrator`
- Submission type: community curation
- Created by `rocker2018-droid` — https://github.com/rocker2018-droid
- Original source repository: https://github.com/rocker2018-droid/dsh-longtask-orchestrator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.