### PR TITLE
catalog: add rogerdigital-dsh-searxng (community curation, created by @rogerdigital)

### DIFF
--- a/catalog/plugins/rogerdigital-dsh-searxng.yaml
+++ b/catalog/plugins/rogerdigital-dsh-searxng.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: rogerdigital-dsh-searxng
+name: dsh-searxng
+description:
+  en: SearXNG-backed search provider for the DeepSeek Harness web capability seam (ctx.web)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - searxng
+  - search
+  - metasearch
+  - agent
+source:
+  repository: https://github.com/rogerdigital/dsh-searxng
+  repositoryNodeId: R_kgDOT5v-Gw
+  subpath: null
+  commit: c071ff26737b85ff5d194363f8b1f89785444a5a
+creator:
+  github: rogerdigital
+package:
+  ecosystem: npm
+  name: dsh-searxng
+  version: 0.1.1
+  integrity: sha512-8MV0faiTR4q/Gx2yrs66xQANZoGY1U1xm9KDVgN0uoGwisxJxMS2L8oOWYeT1cdFo4ludKcNQSlYRpUHeCvcrg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:46.153Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rogerdigital-dsh-searxng`
- Submission type: community curation
- Created by `rogerdigital` — https://github.com/rogerdigital
- Original source repository: https://github.com/rogerdigital/dsh-searxng
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.