### PR TITLE
catalog: add roykf-dsh-tool-weather (community curation, created by @Roykf)

### DIFF
--- a/catalog/plugins/roykf-dsh-tool-weather.yaml
+++ b/catalog/plugins/roykf-dsh-tool-weather.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: roykf-dsh-tool-weather
+name: dsh-tool-weather
+description:
+  en: Model-facing weather tool (weather) over public Open-Meteo APIs, as a DeepSeek Harness profile bundle
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - weather
+  - open-meteo
+  - forecast
+  - ui
+source:
+  repository: https://github.com/Roykf/dsh-tool-weather
+  repositoryNodeId: R_kgDOUCagFw
+  subpath: null
+  commit: 1320aedcfba6c4835f5da2969b86c4d37d2f7ac7
+creator:
+  github: Roykf
+package:
+  ecosystem: npm
+  name: dsh-tool-weather
+  version: 0.2.3
+  integrity: sha512-7yEw/byAgB/AM2erxIJYO8CGFGbh+dl3yPDa6ABSHNUdyOuakrepAOhBWw5W1yiq4FAKZow7zxDgnrzdyH2ICQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:09.630Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `roykf-dsh-tool-weather`
- Submission type: community curation
- Created by `Roykf` — https://github.com/Roykf
- Original source repository: https://github.com/Roykf/dsh-tool-weather
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.