### PR TITLE
catalog: add ruby1304-dsh-preset-anchored-standard (community curation, created by @ruby1304)

### DIFF
--- a/catalog/plugins/ruby1304-dsh-preset-anchored-standard.yaml
+++ b/catalog/plugins/ruby1304-dsh-preset-anchored-standard.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: ruby1304-dsh-preset-anchored-standard
+name: dsh-preset-anchored-standard
+description:
+  en: "Minimal-anchored agent preset for DeepSeek Harness: first request keeps the real Minimal tool pair, promotion unlocks the full Standard catalog with a one-shot background-jobs notice"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - agent-preset
+source:
+  repository: https://github.com/ruby1304/dsh-preset-anchored-standard
+  repositoryNodeId: R_kgDOT6y8DQ
+  subpath: null
+  commit: db394412fe4a5503b22ad79bc19a0ef969ba33cc
+creator:
+  github: ruby1304
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:02.916Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ruby1304-dsh-preset-anchored-standard`
- Submission type: community curation
- Created by `ruby1304` — https://github.com/ruby1304
- Original source repository: https://github.com/ruby1304/dsh-preset-anchored-standard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.