### PR TITLE
catalog: add ruiming-cn-dsh-ask-in-sidebar (community curation, created by @Ruiming-cn)

### DIFF
--- a/catalog/plugins/ruiming-cn-dsh-ask-in-sidebar.yaml
+++ b/catalog/plugins/ruiming-cn-dsh-ask-in-sidebar.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: ruiming-cn-dsh-ask-in-sidebar
+name: dsh-ask-in-sidebar
+description:
+  en: Ask a sidebar assistant about selected assistant text using the current DeepSeek Harness conversation context, without touching the main conversation. Inspired by the MIT-licensed DSH plugin ecosystem; see README.md for credits.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - sidebar
+  - ask-in-sidebar
+  - sidebar-qa
+  - selection
+  - context
+  - ephemeral
+  - web-ui
+source:
+  repository: https://github.com/Ruiming-cn/dsh-ask-in-sidebar
+  repositoryNodeId: R_kgDOUD1e7w
+  subpath: null
+  commit: 79b1b382d75f1497cd5f3b0f1c61b4161f3aa569
+creator:
+  github: Ruiming-cn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:03.432Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ruiming-cn-dsh-ask-in-sidebar`
- Submission type: community curation
- Created by `Ruiming-cn` — https://github.com/Ruiming-cn
- Original source repository: https://github.com/Ruiming-cn/dsh-ask-in-sidebar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.