### PR TITLE
catalog: add ruiming-cn-dsh-better-at (community curation, created by @Ruiming-cn)

### DIFF
--- a/catalog/plugins/ruiming-cn-dsh-better-at.yaml
+++ b/catalog/plugins/ruiming-cn-dsh-better-at.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ruiming-cn-dsh-better-at
+name: dsh-better-at
+description:
+  en: Fast @ file/session reference caching for the DeepSeek Harness Web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - at-menu
+  - file-reference
+  - session-reference
+  - performance
+source:
+  repository: https://github.com/Ruiming-cn/dsh-better-at
+  repositoryNodeId: R_kgDOT_5qXQ
+  subpath: null
+  commit: 046bc17f42e3dfbd30da21bec2af2ce01034d59b
+creator:
+  github: Ruiming-cn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:54.812Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ruiming-cn-dsh-better-at`
- Submission type: community curation
- Created by `Ruiming-cn` — https://github.com/Ruiming-cn
- Original source repository: https://github.com/Ruiming-cn/dsh-better-at
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.