### PR TITLE
catalog: add ruisenbai-dsh-annotation (community curation, created by @ruisenbai)

### DIFF
--- a/catalog/plugins/ruisenbai-dsh-annotation.yaml
+++ b/catalog/plugins/ruisenbai-dsh-annotation.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ruisenbai-dsh-annotation
+name: dsh-annotation
+description:
+  en: Selection annotations for DeepSeek Harness assistant replies, sent through the official composer
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugins
+  - cordis
+  - annotation
+  - review
+source:
+  repository: https://github.com/ruisenbai/dsh-annotation
+  repositoryNodeId: R_kgDOT6520A
+  subpath: null
+  commit: 19c8a5a3b50d32cabac04bc24269c8f58f1f9698
+creator:
+  github: ruisenbai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:54.837Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ruisenbai-dsh-annotation`
- Submission type: community curation
- Created by `ruisenbai` — https://github.com/ruisenbai
- Original source repository: https://github.com/ruisenbai/dsh-annotation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.