### PR TITLE
catalog: add runzhliu-dsh-browser-desktop (community curation, created by @runzhliu)

### DIFF
--- a/catalog/plugins/runzhliu-dsh-browser-desktop.yaml
+++ b/catalog/plugins/runzhliu-dsh-browser-desktop.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: runzhliu-dsh-browser-desktop
+name: "@runzhliu/dsh-browser-desktop"
+description:
+  en: Movable, resizable Chromium desktop embedded in the DeepSeek Harness Web UI through noVNC.
+  evidencePath: plugins/dsh-browser-desktop/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - browser-agent
+  - chromium
+  - novnc
+  - vnc
+  - webui
+  - dsh
+source:
+  repository: https://github.com/runzhliu/deepseek-harness-docker
+  repositoryNodeId: R_kgDOT3gx_w
+  subpath: plugins/dsh-browser-desktop
+  commit: 42c44a9c618ccb121e2f836856e05922b2633474
+creator:
+  github: runzhliu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-browser-desktop/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:10.858Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `runzhliu-dsh-browser-desktop`
- Submission type: community curation
- Created by `runzhliu` — https://github.com/runzhliu
- Original source repository: https://github.com/runzhliu/deepseek-harness-docker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.