### PR TITLE
catalog: add s3yf1337-dsh-desktop-shell (community curation, created by @s3yf1337)

### DIFF
--- a/catalog/plugins/s3yf1337-dsh-desktop-shell.yaml
+++ b/catalog/plugins/s3yf1337-dsh-desktop-shell.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: s3yf1337-dsh-desktop-shell
+name: dsh-desktop-shell
+description:
+  en: "The dsh desktop profile bundle: opens the native Tauri render client on the served web surface and adds the dsh-desktop settings tab to the web UI."
+  evidencePath: bundle/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - desktop
+  - profile
+  - bundle
+  - opens
+  - native
+  - tauri
+  - render
+  - client
+  - served
+  - surface
+  - adds
+  - settings
+  - dsh
+source:
+  repository: https://github.com/s3yf1337/dsh-desktop
+  repositoryNodeId: R_kgDOT3_UVA
+  subpath: bundle
+  commit: 896237b2d10a8f8da19e04d2a1670d043b102131
+creator:
+  github: s3yf1337
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:11.418Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `s3yf1337-dsh-desktop-shell`
- Submission type: community curation
- Created by `s3yf1337` — https://github.com/s3yf1337
- Original source repository: https://github.com/s3yf1337/dsh-desktop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.