### PR TITLE
catalog: add s3yf1337-dsh-easyvision (community curation, created by @s3yf1337)

### DIFF
--- a/catalog/plugins/s3yf1337-dsh-easyvision.yaml
+++ b/catalog/plugins/s3yf1337-dsh-easyvision.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: s3yf1337-dsh-easyvision
+name: dsh-easyvision
+description:
+  en: A DeepSeek Harness plugin that describes images through a dedicated vision model from the dsh model list, called over the harness's own LLM runtime. The vision model is configurable in Settings → EasyVision.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - vision
+  - image
+  - multimodal
+  - settings
+source:
+  repository: https://github.com/s3yf1337/dsh-easyvision
+  repositoryNodeId: R_kgDOT5NSbQ
+  subpath: null
+  commit: 2da8550ebd74dc9ff5d6bcd35daa1e5bdeb1a23a
+creator:
+  github: s3yf1337
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:04.428Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `s3yf1337-dsh-easyvision`
- Submission type: community curation
- Created by `s3yf1337` — https://github.com/s3yf1337
- Original source repository: https://github.com/s3yf1337/dsh-easyvision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.