### PR TITLE
catalog: add sailoumili-novel-writer (community curation, created by @sailoumili)

### DIFF
--- a/catalog/plugins/sailoumili-novel-writer.yaml
+++ b/catalog/plugins/sailoumili-novel-writer.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: sailoumili-novel-writer
+name: novel-writer
+description:
+  en: "Multi-Core Collaborative Novel Writing — a DeepSeek Harness (DSH) preset plugin that installs a multi-agent novel-writing mode: one conductor plus five specialized subagents (多核协同写作模式)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - multi
+  - core
+  - collaborative
+  - novel
+  - writing
+  - preset
+  - installs
+  - agent
+  - mode
+  - conductor
+  - plus
+  - five
+  - specialized
+  - subagents
+  - dsh
+source:
+  repository: https://github.com/sailoumili/novel-writer
+  repositoryNodeId: R_kgDOT58hMQ
+  subpath: null
+  commit: 12c5e16ff0fb30e531a39e8f86e12136082b18da
+creator:
+  github: sailoumili
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:37.193Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 19
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sailoumili-novel-writer`
- Submission type: community curation
- Created by `sailoumili` — https://github.com/sailoumili
- Original source repository: https://github.com/sailoumili/novel-writer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.