### PR TITLE
catalog: add saisenbox-dsh-boot-guard (community curation, created by @SaiSenBox)

### DIFF
--- a/catalog/plugins/saisenbox-dsh-boot-guard.yaml
+++ b/catalog/plugins/saisenbox-dsh-boot-guard.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: saisenbox-dsh-boot-guard
+name: dsh-boot-guard
+description:
+  en: A loader-independent rescue console for DeepSeek Harness when a broken plugin prevents the Web UI from starting.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-recovery
+  - safe-mode
+  - boot-guard
+source:
+  repository: https://github.com/SaiSenBox/dsh-boot-guard
+  repositoryNodeId: R_kgDOT4lddA
+  subpath: null
+  commit: 50aa4dc4e6e23f8c1f39c7c16963a89d4af5a774
+creator:
+  github: SaiSenBox
+package:
+  ecosystem: npm
+  name: dsh-boot-guard
+  version: 1.1.2
+  integrity: sha512-qkwSOtzmRzX0JPbV7gePixKAmVQLcJFbXRV0jV8ZKG3VVvP8U9lVqzbsxYEbhiKM4moDKnmvYIZSAs8LU1d+RQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:43.897Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `saisenbox-dsh-boot-guard`
- Submission type: community curation
- Created by `SaiSenBox` — https://github.com/SaiSenBox
- Original source repository: https://github.com/SaiSenBox/dsh-boot-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.