### PR TITLE
catalog: add saisenbox-dsh-prompt-manager (community curation, created by @SaiSenBox)

### DIFF
--- a/catalog/plugins/saisenbox-dsh-prompt-manager.yaml
+++ b/catalog/plugins/saisenbox-dsh-prompt-manager.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: saisenbox-dsh-prompt-manager
+name: dsh-prompt-manager
+description:
+  en: A local, bilingual prompt library with session-level system prompt injection for DeepSeek Harness Web.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - prompt-manager
+  - prompt-library
+source:
+  repository: https://github.com/SaiSenBox/dsh-prompt-manager
+  repositoryNodeId: R_kgDOT5QXkQ
+  subpath: null
+  commit: 76059cb4950b60b189aea118adee15690bad16e9
+creator:
+  github: SaiSenBox
+package:
+  ecosystem: npm
+  name: dsh-prompt-manager
+  version: 1.5.0
+  integrity: sha512-YT9+Xu8y5TvknizReA83zIlgKjNSF00rZKLpAu/RLzQZqb69Pgcj6DfxiehcLWnsBHEN90p5iaXSCp61BFKW+Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:42.055Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `saisenbox-dsh-prompt-manager`
- Submission type: community curation
- Created by `SaiSenBox` — https://github.com/SaiSenBox
- Original source repository: https://github.com/SaiSenBox/dsh-prompt-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.