### PR TITLE
catalog: add saitamahang-dsh-skill-importer (community curation, created by @saitamahang)

### DIFF
--- a/catalog/plugins/saitamahang-dsh-skill-importer.yaml
+++ b/catalog/plugins/saitamahang-dsh-skill-importer.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: saitamahang-dsh-skill-importer
+name: dsh-skill-importer
+description:
+  en: "Web UI plugin for DeepSeek Harness: import skills from local Markdown files or URLs into the skill roots the harness discovers automatically"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - skill
+  - agent
+source:
+  repository: https://github.com/saitamahang/dsh-skill-importer
+  repositoryNodeId: R_kgDOT39C_g
+  subpath: null
+  commit: 90592df4a37da99f48caee823d0335faf545ca28
+creator:
+  github: saitamahang
+package:
+  ecosystem: npm
+  name: dsh-skill-importer
+  version: 0.2.4
+  integrity: sha512-hTQXTrgAe67ktMEs+IKpnimq6B83s2rExjCCrPoAWltOL6aexSa5UMpXXQ0bnUAeR9gT7D3GlJ68It39OZU8qA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:46.334Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `saitamahang-dsh-skill-importer`
- Submission type: community curation
- Created by `saitamahang` — https://github.com/saitamahang
- Original source repository: https://github.com/saitamahang/dsh-skill-importer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.