### PR TITLE
catalog: add sakthiveltofficial-dsh-git-bundle (community curation, created by @sakthiveltofficial)

### DIFF
--- a/catalog/plugins/sakthiveltofficial-dsh-git-bundle.yaml
+++ b/catalog/plugins/sakthiveltofficial-dsh-git-bundle.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sakthiveltofficial-dsh-git-bundle
+name: "@dsh-git/bundle"
+description:
+  en: "Profile bundle for the dsh-git plugin suite: one dsh plugin --profile <name add @dsh-git/bundle installs and wires the full git capability (local git, all hosted platforms, self-evolving memory, and the model-facing tools) into a DSH profile."
+  evidencePath: packages/git/bundle/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - git
+  - plugin-bundle
+  - source-control
+  - install
+source:
+  repository: https://github.com/sakthiveltofficial/dsh-git-plugins
+  repositoryNodeId: R_kgDOUAcLDQ
+  subpath: packages/git/bundle
+  commit: ec669e8794cf0e192e1e071c988bdd4e3312100e
+creator:
+  github: sakthiveltofficial
+package:
+  ecosystem: npm
+  name: "@dsh-git/bundle"
+  version: 0.1.2
+  integrity: sha512-TkZ+vfDkr8AQSjx7Orm4/Yk9lNiqppGkrTkSXHRBIKf5qTBv/zV8wFteusYVzFfc7El9+ALLXTI6lJxriXy/Mw==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/git/bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:54.787Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sakthiveltofficial-dsh-git-bundle`
- Submission type: community curation
- Created by `sakthiveltofficial` — https://github.com/sakthiveltofficial
- Original source repository: https://github.com/sakthiveltofficial/dsh-git-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.