### PR TITLE
catalog: add sakthiveltofficial-dsh-git-plugins (community curation, created by @sakthiveltofficial)

### DIFF
--- a/catalog/plugins/sakthiveltofficial-dsh-git-plugins.yaml
+++ b/catalog/plugins/sakthiveltofficial-dsh-git-plugins.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: sakthiveltofficial-dsh-git-plugins
+name: dsh-git-plugins
+description:
+  en: "Git / source-control plugins for DeepSeek Harness: a local-git provider, a hosted-platform registry (GitHub/GitLab/Bitbucket/Azure DevOps/Gitea), and grouped model-facing tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - source
+  - control
+  - local
+  - provider
+  - hosted
+  - platform
+  - registry
+  - gitlab
+  - bitbucket
+  - azure
+  - devops
+  - gitea
+  - grouped
+  - model
+  - facing
+  - tools
+source:
+  repository: https://github.com/sakthiveltofficial/dsh-git-plugins
+  repositoryNodeId: R_kgDOUAcLDQ
+  subpath: null
+  commit: ec669e8794cf0e192e1e071c988bdd4e3312100e
+creator:
+  github: sakthiveltofficial
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:54.787Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sakthiveltofficial-dsh-git-plugins`
- Submission type: community curation
- Created by `sakthiveltofficial` — https://github.com/sakthiveltofficial
- Original source repository: https://github.com/sakthiveltofficial/dsh-git-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.