### PR TITLE
catalog: add samge0-dsh-plugin-nexterm (community curation, created by @Samge0)

### DIFF
--- a/catalog/plugins/samge0-dsh-plugin-nexterm.yaml
+++ b/catalog/plugins/samge0-dsh-plugin-nexterm.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: samge0-dsh-plugin-nexterm
+name: dsh-plugin-nexterm
+description:
+  en: Nexterm fleet-maintenance plugin for DeepSeek Harness — batch SSH command execution, fleet-wide health checks and monitoring through the Nexterm REST API. Unofficial, MIT.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - nexterm
+  - ssh
+  - batch-execution
+  - server-maintenance
+  - fleet-management
+  - dsh
+source:
+  repository: https://github.com/Samge0/dsh-plugin-nexterm
+  repositoryNodeId: R_kgDOT6q99w
+  subpath: null
+  commit: f219b9e4ada0a9058dfc7f56f394efb5994ef68f
+creator:
+  github: Samge0
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:04.458Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `samge0-dsh-plugin-nexterm`
- Submission type: community curation
- Created by `Samge0` — https://github.com/Samge0
- Original source repository: https://github.com/Samge0/dsh-plugin-nexterm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.