### PR TITLE
catalog: add sanqi-normal-dsh-model-picker (community curation, created by @Sanqi-normal)

### DIFF
--- a/catalog/plugins/sanqi-normal-dsh-model-picker.yaml
+++ b/catalog/plugins/sanqi-normal-dsh-model-picker.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sanqi-normal-dsh-model-picker
+name: dsh-model-picker
+description:
+  en: "Enhanced model picker for the dsh web GUI: provider-tabbed left column with model list on the right, both independently scrollable, plus cross-provider search"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - agent-harness
+  - model
+  - picker
+  - web
+  - ui
+source:
+  repository: https://github.com/Sanqi-normal/dsh-model-picker
+  repositoryNodeId: R_kgDOT5B13Q
+  subpath: null
+  commit: 0c02710f9fd704ce5fba9cc65082330876d1f83f
+creator:
+  github: Sanqi-normal
+package:
+  ecosystem: npm
+  name: dsh-model-picker
+  version: 1.0.2
+  integrity: sha512-6BEuD1rfOb7q1DubSUC72p5l6po7yfQ5l9IwcNh/JJ9gtNujE0FS41n1qMKeyp5Ftt2ImRb3RY5k8iWuhgn2pw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:43.928Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sanqi-normal-dsh-model-picker`
- Submission type: community curation
- Created by `Sanqi-normal` — https://github.com/Sanqi-normal
- Original source repository: https://github.com/Sanqi-normal/dsh-model-picker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.