### PR TITLE
catalog: add sashankh-dsh-taintguard (community curation, created by @sashankh)

### DIFF
--- a/catalog/plugins/sashankh-dsh-taintguard.yaml
+++ b/catalog/plugins/sashankh-dsh-taintguard.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: sashankh-dsh-taintguard
+name: dsh-taintguard
+description:
+  en: "Indirect prompt-injection guard for DeepSeek Harness: taints tool output by origin and gates privileged tool calls that follow untrusted content"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - prompt-injection
+  - security
+  - guardrails
+  - agent-security
+source:
+  repository: https://github.com/sashankh/dsh-taintguard
+  repositoryNodeId: R_kgDOT6GOVA
+  subpath: null
+  commit: 421e6726d9d0865e36fbe00a12a263409390dc11
+creator:
+  github: sashankh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:11.702Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sashankh-dsh-taintguard`
- Submission type: community curation
- Created by `sashankh` — https://github.com/sashankh
- Original source repository: https://github.com/sashankh/dsh-taintguard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.