### PR TITLE
catalog: add says693-dsh-log-memory (community curation, created by @says693)

### DIFF
--- a/catalog/plugins/says693-dsh-log-memory.yaml
+++ b/catalog/plugins/says693-dsh-log-memory.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: says693-dsh-log-memory
+name: dsh-log-memory
+description:
+  en: A DSH (Deepseek Harness) plugin that pops up a guardian panel for your session logs the moment you open the Web UI — back up, tune the reminder interval, and pick your backup folder, all inside the popup.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session
+  - backup
+  - reminder
+source:
+  repository: https://github.com/says693/dsh-log-memory
+  repositoryNodeId: R_kgDOT6bNQw
+  subpath: null
+  commit: 1b785f25e2f4a841bcaaa69adbe1110f220b83c0
+creator:
+  github: says693
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:42.074Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `says693-dsh-log-memory`
- Submission type: community curation
- Created by `says693` — https://github.com/says693
- Original source repository: https://github.com/says693/dsh-log-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.