### PR TITLE
catalog: add scd13150-dsh-cognition (community curation, created by @scd13150)

### DIFF
--- a/catalog/plugins/scd13150-dsh-cognition.yaml
+++ b/catalog/plugins/scd13150-dsh-cognition.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: scd13150-dsh-cognition
+name: dsh-cognition
+description:
+  en: A project memory for your DeepSeek Harness agent — constrain / observe / remember / verify, built on DSH native primitives.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - memory
+  - agent
+  - constrain
+  - observe
+  - remember
+  - verify
+  - built
+  - native
+  - primitives
+  - dsh
+source:
+  repository: https://github.com/scd13150/dsh-cognition
+  repositoryNodeId: R_kgDOT5SOGA
+  subpath: null
+  commit: 500caf22b68023b3bd7d83bafa3f8e5bdb85e4af
+creator:
+  github: scd13150
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:04.458Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `scd13150-dsh-cognition`
- Submission type: community curation
- Created by `scd13150` — https://github.com/scd13150
- Original source repository: https://github.com/scd13150/dsh-cognition
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.