### PR TITLE
catalog: add schumchanvi-dsh-voice-input-cn (community curation, created by @Schumchanvi)

### DIFF
--- a/catalog/plugins/schumchanvi-dsh-voice-input-cn.yaml
+++ b/catalog/plugins/schumchanvi-dsh-voice-input-cn.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: schumchanvi-dsh-voice-input-cn
+name: dsh-voice-input-cn
+description:
+  en: "Voice input plugin for DeepSeek Harness web (China-ready): Alibaba Cloud DashScope ASR via a local bridge. Mic button in the composer, streaming recognition, cursor-aware insertion, silence auto-stop."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - voice
+  - asr
+  - speech
+  - dashscope
+  - aliyun
+source:
+  repository: https://github.com/Schumchanvi/dsh-voice-input-cn
+  repositoryNodeId: R_kgDOT9ffnw
+  subpath: null
+  commit: f87eb135d6f3e85e4d1ea385ada8335eddf4211f
+creator:
+  github: Schumchanvi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:05.986Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `schumchanvi-dsh-voice-input-cn`
- Submission type: community curation
- Created by `Schumchanvi` — https://github.com/Schumchanvi
- Original source repository: https://github.com/Schumchanvi/dsh-voice-input-cn
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.