### PR TITLE
catalog: add sdoygb-geometry-knowledge (community curation, created by @sdoygb)

### DIFF
--- a/catalog/plugins/sdoygb-geometry-knowledge.yaml
+++ b/catalog/plugins/sdoygb-geometry-knowledge.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: sdoygb-geometry-knowledge
+name: geometry-knowledge
+description:
+  en: sh npm i geometry-knowledge
+  evidencePath: dsh-geometry-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - cordis
+  - geometry
+  - knowledge-base
+  - bm25
+  - dsh
+source:
+  repository: https://github.com/sdoygb/conjugate-spectral-geometry
+  repositoryNodeId: R_kgDOTp9PUQ
+  subpath: dsh-geometry-plugin
+  commit: b3267eadeaad98ca20fe14a74efd8b14e9df6938
+creator:
+  github: sdoygb
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-geometry-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:12.921Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sdoygb-geometry-knowledge`
- Submission type: community curation
- Created by `sdoygb` — https://github.com/sdoygb
- Original source repository: https://github.com/sdoygb/conjugate-spectral-geometry
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.