### PR TITLE
catalog: add seaof0-dsh-campaign-memory (community curation, created by @SeaOf0)

### DIFF
--- a/catalog/plugins/seaof0-dsh-campaign-memory.yaml
+++ b/catalog/plugins/seaof0-dsh-campaign-memory.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: seaof0-dsh-campaign-memory
+name: "@dsh-external/dsh-campaign-memory"
+description:
+  en: "Campaign memory for the nine security presets: model-side write/search/get/list/remove tools storing raw content verbatim (credentials may be stored as-is or as pointers to existing local vaults), a marker-tagged per-workspace recall block injected into every assembly (fresh workspace starts clean; cross-workspace reca"
+  evidencePath: plugins/dsh-campaign-memory/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - campaign-memory
+  - session-scoped
+  - dsh
+source:
+  repository: https://github.com/SeaOf0/dsh-redteam-model
+  repositoryNodeId: R_kgDOT67RoQ
+  subpath: plugins/dsh-campaign-memory
+  commit: 45ba1a1cbb20043350e60ee51ec20442a7fb1fbb
+creator:
+  github: SeaOf0
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-campaign-memory/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:37.168Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `seaof0-dsh-campaign-memory`
- Submission type: community curation
- Created by `SeaOf0` — https://github.com/SeaOf0
- Original source repository: https://github.com/SeaOf0/dsh-redteam-model
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.