### PR TITLE
catalog: add seaof0-dsh-stage-gate (community curation, created by @SeaOf0)

### DIFF
--- a/catalog/plugins/seaof0-dsh-stage-gate.yaml
+++ b/catalog/plugins/seaof0-dsh-stage-gate.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: seaof0-dsh-stage-gate
+name: "@dsh-external/dsh-stage-gate"
+description:
+  en: "DSH stage-gate host plugin: the stage gate / gates list model tools validate task-workspace artifacts against the nine security presets' gate schemas (structural checks, v1), append verdicts to gate-log.md, and list each mode's canonical gate files"
+  evidencePath: plugins/dsh-stage-gate/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - stage-gate
+  - model-tools
+  - dsh
+source:
+  repository: https://github.com/SeaOf0/dsh-redteam-model
+  repositoryNodeId: R_kgDOT67RoQ
+  subpath: plugins/dsh-stage-gate
+  commit: 45ba1a1cbb20043350e60ee51ec20442a7fb1fbb
+creator:
+  github: SeaOf0
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-stage-gate/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:37.168Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `seaof0-dsh-stage-gate`
- Submission type: community curation
- Created by `SeaOf0` — https://github.com/SeaOf0
- Original source repository: https://github.com/SeaOf0/dsh-redteam-model
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.