### PR TITLE
catalog: add semidia-dsh-sampling-sliders (community curation, created by @Semidia)

### DIFF
--- a/catalog/plugins/semidia-dsh-sampling-sliders.yaml
+++ b/catalog/plugins/semidia-dsh-sampling-sliders.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: semidia-dsh-sampling-sliders
+name: dsh-sampling-sliders
+description:
+  en: "DeepSeek Harness plugin: model sampling sliders (temperature / maxTokens) applied to every provider via the agent/request hook, with live settings persistence."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - model
+  - sampling
+  - sliders
+  - temperature
+  - maxtokens
+  - applied
+  - every
+  - provider
+  - agent
+  - request
+  - hook
+  - live
+  - settings
+  - persistence
+  - dsh
+source:
+  repository: https://github.com/Semidia/dsh-sampling-sliders
+  repositoryNodeId: R_kgDOT4vF9g
+  subpath: null
+  commit: 19eb0c65bd71500233e581d034894683e4dc2528
+creator:
+  github: Semidia
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:05.975Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `semidia-dsh-sampling-sliders`
- Submission type: community curation
- Created by `Semidia` — https://github.com/Semidia
- Original source repository: https://github.com/Semidia/dsh-sampling-sliders
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.