### PR TITLE
catalog: add semidia-dsh-session-manager (community curation, created by @Semidia)

### DIFF
--- a/catalog/plugins/semidia-dsh-session-manager.yaml
+++ b/catalog/plugins/semidia-dsh-session-manager.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: semidia-dsh-session-manager
+name: "@dsh-external/dsh-session-manager"
+description:
+  en: "Right-click session menu + sidebar session manager for DeepSeek Harness web: pin, rename, archive, continue, export, copy cwd/id/deep-link, open in explorer or a new window."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session
+  - sidebar
+  - context-menu
+source:
+  repository: https://github.com/Semidia/dsh-session-manager
+  repositoryNodeId: R_kgDOT4uSAQ
+  subpath: null
+  commit: d4f6f857e79b042b33ee6b2882e368b996fa14a8
+creator:
+  github: Semidia
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:48.486Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `semidia-dsh-session-manager`
- Submission type: community curation
- Created by `Semidia` — https://github.com/Semidia
- Original source repository: https://github.com/Semidia/dsh-session-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.