### PR TITLE
catalog: add seriousz158-dsh-codex-search (community curation, created by @seriousz158)

### DIFF
--- a/catalog/plugins/seriousz158-dsh-codex-search.yaml
+++ b/catalog/plugins/seriousz158-dsh-codex-search.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: seriousz158-dsh-codex-search
+name: dsh-codex-search
+description:
+  en: Explicit, opt-in Codex search provider for DeepSeek Harness
+  evidencePath: packages/dsh-codex-search/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - explicit
+  - codex
+  - search
+  - provider
+  - dsh
+source:
+  repository: https://github.com/seriousz158/dsh-codex-use
+  repositoryNodeId: R_kgDOT_dHHQ
+  subpath: packages/dsh-codex-search
+  commit: 9b81ed3d09252cd2ce3d69a64a3412f5a56bc5ce
+creator:
+  github: seriousz158
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh-codex-search/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:40.080Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `seriousz158-dsh-codex-search`
- Submission type: community curation
- Created by `seriousz158` — https://github.com/seriousz158
- Original source repository: https://github.com/seriousz158/dsh-codex-use
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.