### PR TITLE
catalog: add sev7een-dsh-plugin-ds-api-usage (community curation, created by @Sev7een)

### DIFF
--- a/catalog/plugins/sev7een-dsh-plugin-ds-api-usage.yaml
+++ b/catalog/plugins/sev7een-dsh-plugin-ds-api-usage.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: sev7een-dsh-plugin-ds-api-usage
+name: dsh-plugin-ds-api-usage
+description:
+  en: "DeepSeek Harness plugin: real-time DeepSeek API balance and usage timeline (cost / tokens / request count), rendered in a settings page."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - api-usage
+  - balance
+source:
+  repository: https://github.com/Sev7een/ds-api-usage
+  repositoryNodeId: R_kgDOT3fw1g
+  subpath: null
+  commit: d7644200ed0530f60794a1b081b7176cb3ac93fd
+creator:
+  github: Sev7een
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:40.209Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sev7een-dsh-plugin-ds-api-usage`
- Submission type: community curation
- Created by `Sev7een` — https://github.com/Sev7een
- Original source repository: https://github.com/Sev7een/ds-api-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.