### PR TITLE
catalog: add seven282-oss-prompt-optimizer (community curation, created by @seven282)

### DIFF
--- a/catalog/plugins/seven282-oss-prompt-optimizer.yaml
+++ b/catalog/plugins/seven282-oss-prompt-optimizer.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: seven282-oss-prompt-optimizer
+name: oss-prompt-optimizer
+description:
+  en: "DeepSeek Harness plugin bundle: optimize raw instructions into professional Role / Task / Context / Format prompts through the harness llm service"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - bundle
+  - optimize
+  - instructions
+  - professional
+  - role
+  - task
+  - context
+  - format
+  - prompts
+  - through
+  - service
+  - dsh
+source:
+  repository: https://github.com/seven282/oss-prompt-optimizer
+  repositoryNodeId: R_kgDOT53CxQ
+  subpath: null
+  commit: 3166fb56f2dd46b4d8990f003bd9f64478fdaa4c
+creator:
+  github: seven282
+package:
+  ecosystem: npm
+  name: oss-prompt-optimizer
+  version: 1.8.1
+  integrity: sha512-c0JIevtVV7jY3tp7TAfjnd2k6ce8Qgn38WvX9/UxlznSB6uHeD5+P40bHtkpidepN4PYmgTBsEAKxVhpL9K8nw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:37.178Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `seven282-oss-prompt-optimizer`
- Submission type: community curation
- Created by `seven282` — https://github.com/seven282
- Original source repository: https://github.com/seven282/oss-prompt-optimizer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.