### PR TITLE
catalog: add severuszh-dsh-plugin-subagent-director (community curation, created by @SeverusZh)

### DIFF
--- a/catalog/plugins/severuszh-dsh-plugin-subagent-director.yaml
+++ b/catalog/plugins/severuszh-dsh-plugin-subagent-director.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: severuszh-dsh-plugin-subagent-director
+name: dsh-plugin-subagent-director
+description:
+  en: "Subagent Director: choose an LLM provider/model for each subagent (call args role binding plugin default inherit parent) and plan main-agent/subagent responsibilities with role templates, plus a settings UI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - subagent
+  - subagent-director
+  - llm
+  - provider
+  - model
+  - role-template
+source:
+  repository: https://github.com/SeverusZh/dsh-plugin-subagent-director
+  repositoryNodeId: R_kgDOT4VbZg
+  subpath: null
+  commit: c5c18c8fc532f455e2c6e84d1822d3271566a4d1
+creator:
+  github: SeverusZh
+package:
+  ecosystem: npm
+  name: dsh-plugin-subagent-director
+  version: 0.2.1
+  integrity: sha512-Uu8WhNlSENWEwye4XMOz+0qwvMKqnvL26kmqyd/OcNKxqmvj4ZCieJzK7DdUk5gzANONoAU1bR64Zy3uiTmViw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:37.252Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `severuszh-dsh-plugin-subagent-director`
- Submission type: community curation
- Created by `SeverusZh` — https://github.com/SeverusZh
- Original source repository: https://github.com/SeverusZh/dsh-plugin-subagent-director
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.