### PR TITLE
catalog: add shane-jay-dsh-self-update (community curation, created by @Shane-Jay)

### DIFF
--- a/catalog/plugins/shane-jay-dsh-self-update.yaml
+++ b/catalog/plugins/shane-jay-dsh-self-update.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: shane-jay-dsh-self-update
+name: dsh-self-update
+description:
+  en: In-app self-update for DeepSeek Harness git-source installs (check / one-click update / rollback / restart), with an optional native macOS shell.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - self-update
+  - auto-update
+  - updater
+  - cordis
+  - macos
+source:
+  repository: https://github.com/Shane-Jay/dsh-self-update
+  repositoryNodeId: R_kgDOT-2BGg
+  subpath: null
+  commit: acb32fb9a075538ca1e71ed1c2de5cf8fe54332c
+creator:
+  github: Shane-Jay
+package:
+  ecosystem: npm
+  name: dsh-self-update
+  version: 0.2.0
+  integrity: sha512-J3/J4Z63mTsGz91FCFzWIs2JTT90zynnpCvE8pfqDKWHOiDw8UQPuYIg/FCNJALrKTQiX46/Dkp7v4p3o9GOyw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:54.811Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shane-jay-dsh-self-update`
- Submission type: community curation
- Created by `Shane-Jay` — https://github.com/Shane-Jay
- Original source repository: https://github.com/Shane-Jay/dsh-self-update
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.