### PR TITLE
catalog: add xfgong-dsh-omni-reader (community curation, created by @xfgong)

### DIFF
--- a/catalog/plugins/xfgong-dsh-omni-reader.yaml
+++ b/catalog/plugins/xfgong-dsh-omni-reader.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: xfgong-dsh-omni-reader
+name: "@cueai/dsh-omni-reader"
+description:
+  en: "DSH bundle: registers the audited Cue Omni Reader MCP server so its tools surface as mcp omni in any DeepSeek Harness profile."
+  evidencePath: dsh/cue-omni-reader/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - mcp
+  - omni-reader
+  - cue
+source:
+  repository: https://github.com/sensedeal/cue-skills
+  repositoryNodeId: R_kgDOSigUuw
+  subpath: dsh/cue-omni-reader
+  commit: cfecbf74d3d46320e4a997bc5c0397d1ca52c45d
+creator:
+  github: xfgong
+package:
+  ecosystem: npm
+  name: "@cueai/dsh-omni-reader"
+  version: 0.1.1
+  integrity: sha512-oc8S+bCjy38VLhfmzAdFFuYh13F849qOcmlxyFaiQwnOkKhl918/3ml5uw+rSZSR53fhohOBqXV059bFKK8SAQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh/cue-omni-reader/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:01:39.683Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xfgong-dsh-omni-reader`
- Submission type: community curation
- Created by `xfgong` — https://github.com/xfgong
- Original source repository: https://github.com/sensedeal/cue-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.