### PR TITLE
catalog: add yuanyi-github-redfox-community-dsh (community curation, created by @yuanyi-github)

### DIFF
--- a/catalog/plugins/yuanyi-github-redfox-community-dsh.yaml
+++ b/catalog/plugins/yuanyi-github-redfox-community-dsh.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yuanyi-github-redfox-community-dsh
+name: redfox-community-dsh
+description:
+  en: "RedFox community skills for DeepSeek Harness: 100+ social-media data skills (Douyin, Xiaohongshu, Kuaishou, Bilibili, WeChat, Weibo, YouTube, TikTok and more), mirrored one-way from the redfox-community hub repo."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - cordis
+  - skill
+  - redfox
+  - douyin
+  - xiaohongshu
+  - kuaishou
+  - bilibili
+  - wechat
+  - weibo
+source:
+  repository: https://github.com/redfox-data/redfox-community-dsh
+  repositoryNodeId: R_kgDOT6_H-w
+  subpath: null
+  commit: 092fdd8939447e6359cda28dfa161d2160592596
+creator:
+  github: yuanyi-github
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:00:41.087Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yuanyi-github-redfox-community-dsh`
- Submission type: community curation
- Created by `yuanyi-github` — https://github.com/yuanyi-github
- Original source repository: https://github.com/redfox-data/redfox-community-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.