### PR TITLE
docs(categories): add finance-trading

### DIFF
--- a/docs/CATEGORIES.md
+++ b/docs/CATEGORIES.md
@@ -48,6 +48,7 @@ contradictory classification pairs.
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Finance, trading and bookkeeping |
 
 Choose the category that best represents the plugin's primary job, not the category most likely
 to increase visibility.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -85,12 +85,13 @@ Meanings and ranking consequences are defined in [docs/CATEGORIES.md](CATEGORIES
 
 ### `primaryCategory`
 
-One of the thirteen capability categories:
+One of the fourteen capability categories:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` ·
+`finance-trading`
 
 Display labels and selection guidance are in [docs/CATEGORIES.md](CATEGORIES.md).
 

--- a/docs/i18n/ar/CATEGORIES.md
+++ b/docs/i18n/ar/CATEGORIES.md
@@ -49,6 +49,7 @@
 | `messaging-notifications` | المراسلة والإشعارات |
 | `data-external-services` | البيانات والخدمات الخارجية |
 | `entertainment-customization` | الترفيه والتخصيص |
+| `finance-trading` | التمويل والتداول ومسك الدفاتر |
 
 اختر الفئة التي تمثّل أفضل تمثيل المهمة الأساسية للإضافة، لا الفئة الأكثر احتمالًا لزيادة
 الظهور.
@@ -65,4 +66,4 @@ kebab-case بأحرف صغيرة عندما تصف دليلًا مرئيًا ف�
 عندما تكون الإضافة مسارًا فرعيًا أو حزمة داخل مشروع أوسع. يجب أن يستخدم إدخال المستودع الأحادي
 `popularity.starsPolicy: undefined-parent-repository` و `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/ar/SCHEMA.md
+++ b/docs/i18n/ar/SCHEMA.md
@@ -71,12 +71,12 @@
 
 ### `primaryCategory`
 
-واحدة من الفئات الثلاث عشرة للقدرة:
+واحدة من الفئات الأربع عشرة للقدرة:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 توجد تسميات العرض وإرشادات الاختيار في [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -197,4 +197,4 @@
 
 المخطط محلي وبنيوي عمدًا. وهو لا يتحقق من وجود المستودع، أو تطابق معرّف العقدة مع عنوان URL، أو وجود مسارات الأدلة عند الالتزام المثبَّت، أو دقة عدد النجوم، أو ملكية المنشئ للمصدر. تنتمي تلك الفحوصات إلى بوابات مراجعة المشرفين الموصوفة في [CONTRIBUTING.md](../../CONTRIBUTING.md) و[docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/az/CATEGORIES.md
+++ b/docs/i18n/az/CATEGORIES.md
@@ -50,6 +50,7 @@ layihə deməkdir. Bu, ziddiyyətli təsnifat cütlərinin qarşısını alır.
 | `messaging-notifications` | Mesajlaşma və bildirişlər |
 | `data-external-services` | Məlumat və xarici xidmətlər |
 | `entertainment-customization` | Əyləncə və fərdiləşdirmə |
+| `finance-trading` | Maliyyə, treyding və mühasibatlıq |
 
 Əlavənin əsas işini ən yaxşı təmsil edən kateqoriyanı seçin, görünmə ehtimalını artıracaq
 kateqoriyanı deyil.
@@ -67,4 +68,4 @@ olduqda. Əlavə daha geniş layihənin içində alt yol və ya paket olduqda `m
 edin. Monorepo qeydi `popularity.starsPolicy: undefined-parent-repository` və
 `popularity.stars: null` istifadə etməlidir.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/az/SCHEMA.md
+++ b/docs/i18n/az/SCHEMA.md
@@ -87,12 +87,12 @@ müəyyən edilib.
 
 ### `primaryCategory`
 
-On üç imkan kateqoriyasından biri:
+On dörd imkan kateqoriyasından biri:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Görünən etiketlər və seçım təlimatları [docs/CATEGORIES.md](../../docs/CATEGORIES.md)
 sənədindədir.
@@ -233,4 +233,4 @@ olduğunu və ya yaradıcının mənbəyə sahib olduğunu yoxla**mır**. Bu yox
 [CONTRIBUTING.md](../../CONTRIBUTING.md) və [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)
 sənədlərində təsvir edilən baxıcı baxış qapılarına aiddir.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/bg/CATEGORIES.md
+++ b/docs/i18n/bg/CATEGORIES.md
@@ -50,6 +50,7 @@ DSH интеграция. Това предотвратява противоре
 | `messaging-notifications` | Съобщения и известия |
 | `data-external-services` | Данни и външни услуги |
 | `entertainment-customization` | Развлечения и персонализация |
+| `finance-trading` | Финанси, търговия и счетоводство |
 
 Изберете категорията, която най-добре представя основната работа на плъгина, а не категорията,
 която най-вероятно би увеличила видимостта.
@@ -68,4 +69,4 @@ DSH интеграция. Това предотвратява противоре
 Запис в monorepo трябва да използва `popularity.starsPolicy: undefined-parent-repository` и
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/bg/SCHEMA.md
+++ b/docs/i18n/bg/SCHEMA.md
@@ -89,12 +89,12 @@
 
 ### `primaryCategory`
 
-Една от тринадесетте категории на възможностите:
+Една от четиринадесетте категории на възможностите:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Етикетите за показване и насоките за избор са в
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -236,4 +236,4 @@ commit, дали броят на звездите е точен, или дали
 принадлежат на gate-овете за рецензия на поддръжниците, описани в
 [CONTRIBUTING.md](../../CONTRIBUTING.md) и [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/bn/CATEGORIES.md
+++ b/docs/i18n/bn/CATEGORIES.md
@@ -49,6 +49,7 @@
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | অর্থ, ট্রেডিং এবং হিসাবরক্ষণ |
 
 সেই ক্যাটাগরিটি বেছে নিন যা প্লাগইনের প্রাথমিক কাজকে সর্বোত্তমভাবে প্রতিনিধিত্ব করে, দৃশ্যমানতা বাড়ানোর
 সম্ভাবনা সবচেয়ে বেশি এমন ক্যাটাগরি নয়।
@@ -66,4 +67,4 @@
 এন্ট্রিকে অবশ্যই `popularity.starsPolicy: undefined-parent-repository` এবং
 `popularity.stars: null` ব্যবহার করতে হবে।
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/bn/SCHEMA.md
+++ b/docs/i18n/bn/SCHEMA.md
@@ -84,12 +84,12 @@
 
 ### `primaryCategory`
 
-তেরোটি সক্ষমতা ক্যাটাগরির মধ্যে একটি:
+চৌদ্দটি সক্ষমতা ক্যাটাগরির মধ্যে একটি:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 প্রদর্শন লেবেল এবং নির্বাচন নির্দেশিকা [docs/CATEGORIES.md](../../docs/CATEGORIES.md)-এ রয়েছে।
 
@@ -224,4 +224,4 @@
 যাচাই করে **না**। সেই চেকগুলি [CONTRIBUTING.md](../../CONTRIBUTING.md) এবং
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)-এ বর্ণিত মেইনটেইনার পর্যালোচনা গেটের অন্তর্গত।
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/cs/CATEGORIES.md
+++ b/docs/i18n/cs/CATEGORIES.md
@@ -49,6 +49,7 @@ integrace: `plugin` již znamená nativní balíček DSH, zatímco `ecosystem-pr
 | `messaging-notifications` | Zprávy a oznámení |
 | `data-external-services` | Data a externí služby |
 | `entertainment-customization` | Zábava a přizpůsobení |
+| `finance-trading` | Finance, obchodování a účetnictví |
 
 Zvolte kategorii, která nejlépe vystihuje hlavní funkci pluginu, nikoli kategorii, která by
 nejspíše zvýšila viditelnost.
@@ -66,4 +67,4 @@ pluginu. `monorepo` použijte, pokud je plugin podcestou nebo balíčkem uvnitř
 Záznam z monorepa musí používat `popularity.starsPolicy: undefined-parent-repository` a
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/cs/SCHEMA.md
+++ b/docs/i18n/cs/SCHEMA.md
@@ -86,12 +86,12 @@ Významy a důsledky pro žebříček jsou definovány v
 
 ### `primaryCategory`
 
-Jedna ze třinácti kategorií schopností:
+Jedna ze čtrnácti kategorií schopností:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Zobrazované popisky a pokyny pro výběr jsou v
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -232,4 +232,4 @@ přesný, ani zda tvůrce vlastní zdroj. Tyto kontroly patří k bránám posou
 popsaným v [CONTRIBUTING.md](../../CONTRIBUTING.md) a
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/da/CATEGORIES.md
+++ b/docs/i18n/da/CATEGORIES.md
@@ -53,6 +53,7 @@ modsigende klassifikationspar.
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Finans, handel og bogføring |
 
 Vælg den kategori, der bedst repræsenterer pluginnets primære funktion, ikke den kategori, der med
 størst sandsynlighed øger synligheden.
@@ -71,4 +72,4 @@ Brug kun `dedicated`, når repository-stjernerne tilhører det præcise katalogi
 monorepo-post skal bruge `popularity.starsPolicy: undefined-parent-repository` og
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/da/SCHEMA.md
+++ b/docs/i18n/da/SCHEMA.md
@@ -84,12 +84,12 @@ Betydninger og rangeringskonsekvenser er defineret i [docs/CATEGORIES.md](../../
 
 ### `primaryCategory`
 
-En af de tretten kapacitetskategorier:
+En af de fjorten kapacitetskategorier:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Visningsnavne og valgvejledning findes i [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -228,4 +228,4 @@ korrekt, eller at skaberen ejer kilden. Disse kontroller tilhører de vedligehol
 der er beskrevet i [CONTRIBUTING.md](../../CONTRIBUTING.md) og
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/de/CATEGORIES.md
+++ b/docs/i18n/de/CATEGORIES.md
@@ -54,6 +54,7 @@ widersprüchliche Klassifizierungspaare.
 | `messaging-notifications` | Messaging und Benachrichtigungen |
 | `data-external-services` | Daten und externe Dienste |
 | `entertainment-customization` | Entertainment und Anpassung |
+| `finance-trading` | Finanzen, Handel und Buchhaltung |
 
 Wähle die Kategorie, die die primäre Aufgabe des Plugins am besten repräsentiert — nicht die
 Kategorie, die die Sichtbarkeit am wahrscheinlichsten erhöht.
@@ -72,4 +73,4 @@ Plugin gehören. Verwende `monorepo`, wenn das Plugin ein Unterpfad oder Paket i
 breiteren Projekts ist. Ein Monorepo-Eintrag muss
 `popularity.starsPolicy: undefined-parent-repository` und `popularity.stars: null` verwenden.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/de/SCHEMA.md
+++ b/docs/i18n/de/SCHEMA.md
@@ -90,12 +90,12 @@ definiert.
 
 ### `primaryCategory`
 
-Eine der dreizehn Fähigkeitskategorien:
+Eine der vierzehn Fähigkeitskategorien:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Anzeigebeschriftungen und Auswahlhinweise stehen in [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -239,4 +239,4 @@ existieren, ob die Sternezahl korrekt ist, oder ob der Ersteller die Quelle besi
 Prüfungen gehören zu den Maintainer-Review-Gates, beschrieben in
 [CONTRIBUTING.md](../../CONTRIBUTING.md) und [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/es/CATEGORIES.md
+++ b/docs/i18n/es/CATEGORIES.md
@@ -53,6 +53,7 @@ pares de clasificación contradictorios.
 | `messaging-notifications` | Mensajería y notificaciones |
 | `data-external-services` | Datos y servicios externos |
 | `entertainment-customization` | Entretenimiento y personalización |
+| `finance-trading` | Finanzas, trading y contabilidad |
 
 Elija la categoría que mejor represente el trabajo principal del plugin, no la categoría que más
 probablemente aumente la visibilidad.
@@ -71,4 +72,4 @@ catalogado. Use `monorepo` cuando el plugin sea una subruta o un paquete dentro 
 más amplio. Una entrada de monorepo debe usar `popularity.starsPolicy:
 undefined-parent-repository` y `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/es/SCHEMA.md
+++ b/docs/i18n/es/SCHEMA.md
@@ -88,12 +88,12 @@ Los significados y las consecuencias en el ranking se definen en
 
 ### `primaryCategory`
 
-Una de las trece categorías de capacidad:
+Una de las catorce categorías de capacidad:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Las etiquetas de visualización y la guía de selección están en
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -235,4 +235,4 @@ conteo de estrellas sea preciso, ni que el creador sea dueño de la fuente. Esas
 pertenecen a los gates de revisión de los mantenedores descritos en
 [CONTRIBUTING.md](../../CONTRIBUTING.md) y [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/fa/CATEGORIES.md
+++ b/docs/i18n/fa/CATEGORIES.md
@@ -49,6 +49,7 @@
 | `messaging-notifications` | پیام‌رسانی و اعلان‌ها |
 | `data-external-services` | داده و سرویس‌های خارجی |
 | `entertainment-customization` | سرگرمی و سفارشی‌سازی |
+| `finance-trading` | مالی، معاملات و دفترداری |
 
 دسته‌ای را انتخاب کنید که بهترین بازتاب‌دهندهٔ کار اصلی افزونه باشد، نه دسته‌ای که بیشترین
 احتمال افزایش دیده‌شدن را دارد.
@@ -66,4 +67,4 @@ kebab-case با حروف کوچک وقتی شاهد قابل‌مشاهده در
 کنید. یک ورودی مونوریپو باید از `popularity.starsPolicy: undefined-parent-repository` و
 `popularity.stars: null` استفاده کند.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/fa/SCHEMA.md
+++ b/docs/i18n/fa/SCHEMA.md
@@ -85,12 +85,12 @@ JSON Schema عمومی (پیش‌نویس 2020-12) که هر فایل زیر `ca
 
 ### `primaryCategory`
 
-یکی از سیزده دستهٔ قابلیت:
+یکی از چهارده دستهٔ قابلیت:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 برچسب‌های نمایشی و راهنمای انتخاب در [docs/CATEGORIES.md](../../docs/CATEGORIES.md) هستند.
 
@@ -229,4 +229,4 @@ URL پروفایل عمومی همیشه به‌صورت `https://github.com/<ha
 [CONTRIBUTING.md](../../CONTRIBUTING.md) و [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)
 توصیف شده‌اند.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/fi/CATEGORIES.md
+++ b/docs/i18n/fi/CATEGORIES.md
@@ -52,6 +52,7 @@ projektia, jolla on DSH-integraatio. Tämä estää ristiriitaiset luokittelupar
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Talous, kaupankäynti ja kirjanpito |
 
 Valitse kategoria, joka kuvaa parhaiten liitännäisen päätehtävää, ei sitä kategoriaa, joka
 todennäköisimmin lisää näkyvyyttä.
@@ -70,4 +71,4 @@ Käytä `dedicated` vain, kun repositorion tähdet kuuluvat juuri katalogoituun 
 Monorepo-merkinnän on käytettävä arvoja `popularity.starsPolicy: undefined-parent-repository` ja
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/fi/SCHEMA.md
+++ b/docs/i18n/fi/SCHEMA.md
@@ -87,12 +87,12 @@ Merkitykset ja järjestysvaikutukset määritellään tiedostossa
 
 ### `primaryCategory`
 
-Yksi kolmestatoista ominaisuuskategoriasta:
+Yksi neljästätoista ominaisuuskategoriasta:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Näyttönimet ja valintaohjeet ovat tiedostossa [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -234,4 +234,4 @@ commitissa, että tähtimäärä on oikea tai että luoja omistaa lähteen. Näm
 ylläpitäjien tarkastusporteille, jotka kuvataan tiedostoissa
 [CONTRIBUTING.md](../../CONTRIBUTING.md) ja [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/fr/CATEGORIES.md
+++ b/docs/i18n/fr/CATEGORIES.md
@@ -54,6 +54,7 @@ paires de classification contradictoires.
 | `messaging-notifications` | Messagerie et notifications |
 | `data-external-services` | Données et services externes |
 | `entertainment-customization` | Divertissement et personnalisation |
+| `finance-trading` | Finance, trading et comptabilité |
 
 Choisissez la catégorie qui représente le mieux la fonction principale du plugin, pas la
 catégorie la plus susceptible d'augmenter sa visibilité.
@@ -72,4 +73,4 @@ exact. Utilisez `monorepo` lorsque le plugin est un sous-chemin ou un paquet dan
 large. Une entrée de monorepo doit utiliser `popularity.starsPolicy: undefined-parent-repository`
 et `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/fr/SCHEMA.md
+++ b/docs/i18n/fr/SCHEMA.md
@@ -88,12 +88,12 @@ Les significations et les conséquences sur le classement sont définies dans
 
 ### `primaryCategory`
 
-Une des treize catégories de capacité :
+Une des quatorze catégories de capacité :
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Les libellés d'affichage et les recommandations de sélection sont dans
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -236,4 +236,4 @@ que le nombre d'étoiles est exact, ou que le créateur possède la source. Ces 
 des contrôles de révision des mainteneurs décrits dans [CONTRIBUTING.md](../../CONTRIBUTING.md) et
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/gu/CATEGORIES.md
+++ b/docs/i18n/gu/CATEGORIES.md
@@ -50,6 +50,7 @@
 | `messaging-notifications` | મેસેજિંગ અને નોટિફિકેશન્સ |
 | `data-external-services` | ડેટા અને એક્સટર્નલ સર્વિસીઝ |
 | `entertainment-customization` | એન્ટરટેઇનમેન્ટ અને કસ્ટમાઇઝેશન |
+| `finance-trading` | નાણાં, ટ્રેડિંગ અને હિસાબકિતાબ |
 
 એવી શ્રેણી પસંદ કરો જે પ્લગિનના પ્રાથમિક કામને શ્રેષ્ઠ રજૂ કરે, દૃશ્યતા વધારવાની
 સૌથી વધુ શક્યતા ધરાવતી શ્રેણી નહીં.
@@ -66,4 +67,4 @@ kebab-case ક્ષમતા ટૅગ્સની મંજૂરી છે �
 `monorepo` ત્યારે વાપરો જ્યારે પ્લગિન વ્યાપક પ્રોજેક્ટની અંદર સબપાથ કે પેકેજ હોય. મોનોરેપો એન્ટ્રીએ
 `popularity.starsPolicy: undefined-parent-repository` અને `popularity.stars: null` વાપરવું જ પડે.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/gu/SCHEMA.md
+++ b/docs/i18n/gu/SCHEMA.md
@@ -85,12 +85,12 @@
 
 ### `primaryCategory`
 
-તેર ક્ષમતા શ્રેણીઓમાંનું એક:
+ચૌદ ક્ષમતા શ્રેણીઓમાંનું એક:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 ડિસ્પ્લે લેબલ્સ અને પસંદગી માર્ગદર્શન [docs/CATEGORIES.md](../../docs/CATEGORIES.md) માં છે.
 
@@ -228,4 +228,4 @@ URL સાથે મેચ થાય છે કે નહીં, પિન ક�
 [CONTRIBUTING.md](../../CONTRIBUTING.md) અને [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) માં
 વર્ણવેલા મેન્ટેનર રિવ્યૂ ગેટ્સની જવાબદારી છે.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/he/CATEGORIES.md
+++ b/docs/i18n/he/CATEGORIES.md
@@ -48,6 +48,7 @@
 | `messaging-notifications` | הודעות והתראות |
 | `data-external-services` | נתונים ושירותים חיצוניים |
 | `entertainment-customization` | בידור והתאמה אישית |
+| `finance-trading` | פיננסים, מסחר והנהלת חשבונות |
 
 בחרו את הקטגוריה המייצגת בצורה הטובה ביותר את התפקיד הראשי של התוסף, לא את הקטגוריה
 הסבירה ביותר להגביר חשיפה.
@@ -64,4 +65,4 @@
 כאשר התוסף הוא תת-נתיב או חבילה בתוך פרויקט רחב יותר. רשומת מונו-ריפו חייבת להשתמש
 ב-`popularity.starsPolicy: undefined-parent-repository` וב-`popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/he/SCHEMA.md
+++ b/docs/i18n/he/SCHEMA.md
@@ -82,12 +82,12 @@ SemVer מדויק עבור גרסאות, SHA-512 SRI עבור ערכי שלמו�
 
 ### `primaryCategory`
 
-אחת משלוש-עשרה קטגוריות היכולת:
+אחת מארבע-עשרה קטגוריות היכולת:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 תוויות תצוגה והנחיות בחירה נמצאות ב-[docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -223,4 +223,4 @@ smoke test הניתנת לבדיקה משתמשות ב-`status: eligible` וב-`
 בדיקות אלו שייכות לשערי הבדיקה של המתחזקים המתוארים ב-[CONTRIBUTING.md](../../CONTRIBUTING.md)
 וב-[docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/hi/CATEGORIES.md
+++ b/docs/i18n/hi/CATEGORIES.md
@@ -47,6 +47,7 @@
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | वित्त, ट्रेडिंग और बहीखाता |
 
 वह श्रेणी चुनें जो प्लगइन के प्राथमिक काम का सबसे अच्छा प्रतिनिधित्व करे, न कि वह श्रेणी जो दृश्यता बढ़ाने की
 सबसे अधिक संभावना रखे।
@@ -63,4 +64,4 @@
 उपयोग तब करें जब प्लगइन किसी व्यापक प्रोजेक्ट के अंदर एक subpath या package हो। एक monorepo एंट्री को
 `popularity.starsPolicy: undefined-parent-repository` और `popularity.stars: null` का उपयोग करना होगा।
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/hi/SCHEMA.md
+++ b/docs/i18n/hi/SCHEMA.md
@@ -82,12 +82,12 @@
 
 ### `primaryCategory`
 
-तेरह क्षमता श्रेणियों में से एक:
+चौदह क्षमता श्रेणियों में से एक:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 प्रदर्शन लेबल और चयन मार्गदर्शन [docs/CATEGORIES.md](../../docs/CATEGORIES.md) में हैं।
 
@@ -222,4 +222,4 @@
 [CONTRIBUTING.md](../../CONTRIBUTING.md) और [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) में वर्णित मेंटेनर समीक्षा
 गेट्स से संबंधित हैं।
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/hu/CATEGORIES.md
+++ b/docs/i18n/hu/CATEGORIES.md
@@ -49,6 +49,7 @@ DSH-integrációval. Ez megakadályozza az ellentmondásos besorolási párokat.
 | `messaging-notifications` | Üzenetküldés és értesítések |
 | `data-external-services` | Adat és külső szolgáltatások |
 | `entertainment-customization` | Szórakozás és testreszabás |
+| `finance-trading` | Pénzügy, kereskedés és könyvelés |
 
 Válaszd azt a kategóriát, amely a legjobban képviseli a bővítmény elsődleges feladatát, nem azt,
 amely valószínűleg a legnagyobb láthatóságot adja.
@@ -67,4 +68,4 @@ csomag egy szélesebb projekten belül. Egy monorepo-bejegyzésnek a
 `popularity.starsPolicy: undefined-parent-repository` és a `popularity.stars: null` értéket kell
 használnia.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/hu/SCHEMA.md
+++ b/docs/i18n/hu/SCHEMA.md
@@ -89,12 +89,12 @@ határozza meg.
 
 ### `primaryCategory`
 
-A tizenhárom képességkategória egyike:
+A tizennégy képességkategória egyike:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 A megjelenítendő címkék és a kiválasztási útmutató a [docs/CATEGORIES.md](../../docs/CATEGORIES.md)
 fájlban találhatók.
@@ -238,4 +238,4 @@ a csillagszám pontos-e, vagy hogy az alkotó a forrás tulajdonosa-e. Ezek az e
 [CONTRIBUTING.md](../../CONTRIBUTING.md) és a [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)
 fájlban leírt karbantartói átvizsgálási kapukhoz tartoznak.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/id/CATEGORIES.md
+++ b/docs/i18n/id/CATEGORIES.md
@@ -54,6 +54,7 @@ bertentangan.
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Keuangan, trading, dan pembukuan |
 
 Pilih kategori yang paling merepresentasikan fungsi utama plugin, bukan kategori yang paling
 mungkin meningkatkan visibilitas.
@@ -71,4 +72,4 @@ Gunakan `monorepo` ketika plugin adalah subpath atau paket di dalam proyek yang 
 Entri monorepo harus menggunakan `popularity.starsPolicy: undefined-parent-repository` dan
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/id/SCHEMA.md
+++ b/docs/i18n/id/SCHEMA.md
@@ -87,12 +87,12 @@ Makna dan konsekuensi peringkatnya didefinisikan di
 
 ### `primaryCategory`
 
-Salah satu dari tiga belas kategori kapabilitas:
+Salah satu dari empat belas kategori kapabilitas:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Label tampilan dan panduan pemilihan ada di
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -235,4 +235,4 @@ yang dipatok, bahwa jumlah bintang akurat, atau bahwa kreator memiliki sumber te
 Pemeriksaan tersebut menjadi bagian gerbang tinjauan maintainer yang dijelaskan di
 [CONTRIBUTING.md](../../CONTRIBUTING.md) dan [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/in/CATEGORIES.md
+++ b/docs/i18n/in/CATEGORIES.md
@@ -50,6 +50,7 @@ yang lebih luas dengan integrasi DSH. Ini mencegah pasangan klasifikasi yang kon
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Keuangan, trading, dan pembukuan |
 
 Pilih kategori yang paling merepresentasikan pekerjaan utama plugin, bukan kategori yang paling
 mungkin meningkatkan visibilitas.
@@ -68,4 +69,4 @@ tersebut. Gunakan `monorepo` ketika plugin adalah subpath atau paket di dalam pr
 luas. Entri monorepo harus menggunakan `popularity.starsPolicy: undefined-parent-repository`
 dan `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/in/SCHEMA.md
+++ b/docs/i18n/in/SCHEMA.md
@@ -86,12 +86,12 @@ Arti dan konsekuensi peringkatnya didefinisikan di [docs/CATEGORIES.md](../../do
 
 ### `primaryCategory`
 
-Salah satu dari tiga belas kategori kapabilitas:
+Salah satu dari empat belas kategori kapabilitas:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Label tampilan dan panduan pemilihannya ada di [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -232,4 +232,4 @@ jumlah bintang akurat, atau bahwa kreator memiliki sumber tersebut. Pemeriksaan 
 milik gerbang tinjauan maintainer yang dijelaskan di [CONTRIBUTING.md](../../CONTRIBUTING.md)
 dan [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/it/CATEGORIES.md
+++ b/docs/i18n/it/CATEGORIES.md
@@ -51,6 +51,7 @@ classificazione contraddittorie.
 | `messaging-notifications` | Messaggistica e notifiche |
 | `data-external-services` | Dati e servizi esterni |
 | `entertainment-customization` | Intrattenimento e personalizzazione |
+| `finance-trading` | Finanza, trading e contabilità |
 
 Scegli la categoria che meglio rappresenta il compito primario del plugin, non la categoria più
 probabile ad aumentarne la visibilità.
@@ -69,4 +70,4 @@ Usa `monorepo` quando il plugin è un subpath o un pacchetto all'interno di un p
 ampio. Una voce di monorepo deve usare `popularity.starsPolicy: undefined-parent-repository` e
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/it/SCHEMA.md
+++ b/docs/i18n/it/SCHEMA.md
@@ -89,12 +89,12 @@ I significati e le conseguenze sulla classifica sono definiti in
 
 ### `primaryCategory`
 
-Una delle tredici categorie di capacità:
+Una delle quattordici categorie di capacità:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Le etichette visualizzate e le indicazioni per la scelta sono in
 [docs/CATEGORIES.md](CATEGORIES.md).
@@ -235,4 +235,4 @@ conteggio delle stelle sia accurato, o che il creatore possieda la sorgente. Que
 appartengono ai gate di revisione dei maintainer descritti in
 [CONTRIBUTING.md](../../CONTRIBUTING.md) e [docs/GOVERNANCE.md](GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/ja/CATEGORIES.md
+++ b/docs/i18n/ja/CATEGORIES.md
@@ -49,6 +49,7 @@
 | `messaging-notifications` | メッセージングと通知 |
 | `data-external-services` | データと外部サービス |
 | `entertainment-customization` | エンターテインメントとカスタマイズ |
+| `finance-trading` | 金融・トレーディング・記帳 |
 
 視認性を高める可能性が最も高いカテゴリではなく、プラグインの主な役割を最もよく表すカテゴリを選択してくだ
 さい。
@@ -66,4 +67,4 @@
 てください。モノレポのエントリは、`popularity.starsPolicy: undefined-parent-repository` と
 `popularity.stars: null` を使用しなければなりません。
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/ja/SCHEMA.md
+++ b/docs/i18n/ja/SCHEMA.md
@@ -85,12 +85,12 @@
 
 ### `primaryCategory`
 
-13の機能カテゴリのいずれか:
+14の機能カテゴリのいずれか:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 表示ラベルと選択のガイダンスは [docs/CATEGORIES.md](../../docs/CATEGORIES.md) にあります。
 
@@ -230,4 +230,4 @@
 [CONTRIBUTING.md](../../CONTRIBUTING.md) と [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) に記載され
 ている、メンテナーのレビューゲートに属します。
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/ko/CATEGORIES.md
+++ b/docs/i18n/ko/CATEGORIES.md
@@ -49,6 +49,7 @@
 | `messaging-notifications` | 메시징과 알림 |
 | `data-external-services` | 데이터와 외부 서비스 |
 | `entertainment-customization` | 엔터테인먼트와 커스터마이징 |
+| `finance-trading` | 금융, 트레이딩 및 부기 |
 
 가시성을 가장 많이 높일 것 같은 카테고리가 아니라, 플러그인의 주요 역할을 가장 잘 나타내는
 카테고리를 선택하세요.
@@ -66,4 +67,4 @@
 `popularity.starsPolicy: undefined-parent-repository`와 `popularity.stars: null`을 사용해야
 합니다.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/ko/SCHEMA.md
+++ b/docs/i18n/ko/SCHEMA.md
@@ -83,12 +83,12 @@ SPDX 표현식 파싱, 그리고 중복 키 거부. 값이 스키마 패턴과 �
 
 ### `primaryCategory`
 
-13개의 기능 카테고리 중 하나:
+14개의 기능 카테고리 중 하나:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 표시 라벨과 선택 가이드는 [docs/CATEGORIES.md](../../docs/CATEGORIES.md)에 있습니다.
 
@@ -226,4 +226,4 @@ SPDX 표현식 파싱, 그리고 중복 키 거부. 값이 스키마 패턴과 �
 [CONTRIBUTING.md](../../CONTRIBUTING.md)와 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)에
 설명된 메인테이너 검토 게이트에 속합니다.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/mr/CATEGORIES.md
+++ b/docs/i18n/mr/CATEGORIES.md
@@ -50,6 +50,7 @@
 | `messaging-notifications` | संदेशन आणि सूचना |
 | `data-external-services` | डेटा आणि बाह्य सेवा |
 | `entertainment-customization` | मनोरंजन आणि सानुकूलन |
+| `finance-trading` | वित्त, ट्रेडिंग आणि हिशोबनीस |
 
 प्लगइनचे प्राथमिक काम सर्वोत्तम प्रकारे दर्शवणारी श्रेणी निवडा, दृश्यमानता वाढवण्याची
 सर्वाधिक शक्यता असलेली श्रेणी नाही.
@@ -66,4 +67,4 @@
 प्लगइन मोठ्या प्रकल्पाच्या आत सबपाथ किंवा पॅकेज असल्यास `monorepo` वापरा. मोनोरेपो एंट्रीने
 `popularity.starsPolicy: undefined-parent-repository` आणि `popularity.stars: null` वापरलेच पाहिजे.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/mr/SCHEMA.md
+++ b/docs/i18n/mr/SCHEMA.md
@@ -85,12 +85,12 @@
 
 ### `primaryCategory`
 
-तेरा क्षमता श्रेणींपैकी एक:
+चौदा क्षमता श्रेणींपैकी एक:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 प्रदर्शन लेबल्स आणि निवड मार्गदर्शन [docs/CATEGORIES.md](../../docs/CATEGORIES.md) मध्ये आहे.
 
@@ -228,4 +228,4 @@ URL शी जुळतो का, निश्चित केलेल्य�
 [CONTRIBUTING.md](../../CONTRIBUTING.md) आणि [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) मध्ये
 वर्णन केलेल्या मेंटेनर पुनरावलोकन गेट्सच्या अधिकारक्षेत्रातील आहेत.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/ms/CATEGORIES.md
+++ b/docs/i18n/ms/CATEGORIES.md
@@ -54,6 +54,7 @@ klasifikasi yang bercanggah.
 | `messaging-notifications` | Pemesejan dan pemberitahuan |
 | `data-external-services` | Data dan perkhidmatan luaran |
 | `entertainment-customization` | Hiburan dan penyesuaian |
+| `finance-trading` | Kewangan, dagangan dan perakaunan |
 
 Pilih kategori yang paling mewakili tugas utama pemalam itu, bukan kategori yang paling
 mungkin meningkatkan keterlihatan.
@@ -72,4 +73,4 @@ tepat itu. Gunakan `monorepo` apabila pemalam itu adalah subpath atau pakej dala
 yang lebih luas. Entri monorepo mesti menggunakan
 `popularity.starsPolicy: undefined-parent-repository` dan `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/ms/SCHEMA.md
+++ b/docs/i18n/ms/SCHEMA.md
@@ -89,12 +89,12 @@ Makna dan akibat kedudukan ditakrifkan di [docs/CATEGORIES.md](../../docs/CATEGO
 
 ### `primaryCategory`
 
-Salah satu daripada tiga belas kategori keupayaan:
+Salah satu daripada empat belas kategori keupayaan:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Label paparan dan panduan pemilihan terdapat di [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -237,4 +237,4 @@ tergolong dalam pintu gerbang semakan penyelenggara yang diterangkan di
 [CONTRIBUTING.md](../../CONTRIBUTING.md) dan
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/nl/CATEGORIES.md
+++ b/docs/i18n/nl/CATEGORIES.md
@@ -50,6 +50,7 @@ breder project met DSH-integratie betekent. Dit voorkomt tegenstrijdige classifi
 | `messaging-notifications` | Berichten en meldingen |
 | `data-external-services` | Data en externe diensten |
 | `entertainment-customization` | Entertainment en aanpassing |
+| `finance-trading` | Financiën, trading en boekhouding |
 
 Kies de categorie die de primaire taak van de plugin het beste weergeeft, niet de categorie die
 de zichtbaarheid het meest waarschijnlijk vergroot.
@@ -68,4 +69,4 @@ behoren. Gebruik `monorepo` wanneer de plugin een subpad of package is binnen ee
 project. Een monorepo-invoer moet `popularity.starsPolicy: undefined-parent-repository` en
 `popularity.stars: null` gebruiken.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/nl/SCHEMA.md
+++ b/docs/i18n/nl/SCHEMA.md
@@ -88,12 +88,12 @@ Betekenissen en gevolgen voor de ranglijst zijn gedefinieerd in [docs/CATEGORIES
 
 ### `primaryCategory`
 
-Eén van de dertien capaciteitscategorieën:
+Eén van de veertien capaciteitscategorieën:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Weergavelabels en selectierichtlijnen staan in [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -235,4 +235,4 @@ sterrenaantal accuraat is, of dat de maker eigenaar is van de bron. Die controle
 beoordelingscontroles van beheerders die zijn beschreven in [CONTRIBUTING.md](../../CONTRIBUTING.md) en
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/no/CATEGORIES.md
+++ b/docs/i18n/no/CATEGORIES.md
@@ -50,6 +50,7 @@ klassifiseringspar.
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Finans, trading og bokføring |
 
 Velg kategorien som best representerer pluginens primære jobb, ikke kategorien som mest
 sannsynlig øker synligheten.
@@ -68,4 +69,4 @@ Bruk `monorepo` når pluginen er en understi eller pakke inne i et bredere prosj
 monorepo-oppføring må bruke `popularity.starsPolicy: undefined-parent-repository` og
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/no/SCHEMA.md
+++ b/docs/i18n/no/SCHEMA.md
@@ -86,12 +86,12 @@ Betydninger og rangeringskonsekvenser er definert i [docs/CATEGORIES.md](../../d
 
 ### `primaryCategory`
 
-Én av de tretten kapasitetskategoriene:
+Én av de fjorten kapasitetskategoriene:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Visningsetiketter og veiledning for valg finnes i [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -231,4 +231,4 @@ stjernetallet er nøyaktig, eller at skaperen eier kilden. Disse sjekkene tilhø
 vedlikeholdernes gjennomgangsporter beskrevet i [CONTRIBUTING.md](../../CONTRIBUTING.md) og
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/phi/CATEGORIES.md
+++ b/docs/i18n/phi/CATEGORIES.md
@@ -52,6 +52,7 @@ Pinipigilan nito ang mga magkasalungat na pares ng klasipikasyon.
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Pananalapi, pangangalakal at bookkeeping |
 
 Piliin ang kategoryang pinakakumakatawan sa pangunahing trabaho ng plugin, hindi ang
 kategoryang pinakamalamang magpapataas ng visibility.
@@ -70,4 +71,4 @@ kinakatalogong plugin. Gamitin ang `monorepo` kapag ang plugin ay isang subpath 
 loob ng mas malawak na proyekto. Ang monorepo entry ay dapat gumamit ng
 `popularity.starsPolicy: undefined-parent-repository` at `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/phi/SCHEMA.md
+++ b/docs/i18n/phi/SCHEMA.md
@@ -92,12 +92,12 @@ Ang mga kahulugan at kahihinatnan sa ranggo ay tinukoy sa
 
 ### `primaryCategory`
 
-Isa sa labintatlong kategorya ng kakayahan:
+Isa sa labing-apat na kategorya ng kakayahan:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Ang mga label na ipinapakita at patnubay sa pagpili ay nasa
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -243,4 +243,4 @@ commit, na tama ang bilang ng bituin, o na pag-aari ng lumikha ang source. Ang m
 iyon ay nabibilang sa mga review gate ng maintainer na inilarawan sa
 [CONTRIBUTING.md](../../CONTRIBUTING.md) at [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/pl/CATEGORIES.md
+++ b/docs/i18n/pl/CATEGORIES.md
@@ -50,6 +50,7 @@ szerszy projekt z integracją DSH. Zapobiega to sprzecznym parom klasyfikacji.
 | `messaging-notifications` | Wiadomości i powiadomienia |
 | `data-external-services` | Dane i usługi zewnętrzne |
 | `entertainment-customization` | Rozrywka i personalizacja |
+| `finance-trading` | Finanse, trading i księgowość |
 
 Wybierz kategorię, która najlepiej odzwierciedla główne zadanie wtyczki, a nie kategorię
 najprawdopodobniej zwiększającą widoczność.
@@ -68,4 +69,4 @@ wtyczki. Używaj `monorepo`, gdy wtyczka jest podścieżką lub pakietem wewnąt
 Wpis monorepo musi używać `popularity.starsPolicy: undefined-parent-repository` oraz
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/pl/SCHEMA.md
+++ b/docs/i18n/pl/SCHEMA.md
@@ -71,12 +71,12 @@ Znaczenia i konsekwencje dla rankingu są zdefiniowane w [docs/CATEGORIES.md](..
 
 ### `primaryCategory`
 
-Jedna z trzynastu kategorii możliwości:
+Jedna z czternastu kategorii możliwości:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Etykiety wyświetlane i wskazówki dotyczące wyboru znajdują się w [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -197,4 +197,4 @@ Publiczne linki pochodzenia, każdy jako URI lub `null`:
 
 Schemat jest celowo lokalny i strukturalny. **Nie** weryfikuje, czy repozytorium istnieje, czy node ID pasuje do URL, czy ścieżki dowodowe istnieją w przypiętym commicie, czy liczba gwiazdek jest dokładna, ani czy twórca jest właścicielem źródła. Te sprawdzenia należą do bramek recenzji maintainerów opisanych w [CONTRIBUTING.md](../../CONTRIBUTING.md) i [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/pt-BR/CATEGORIES.md
+++ b/docs/i18n/pt-BR/CATEGORIES.md
@@ -50,6 +50,7 @@ contraditórios.
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Finanças, trading e contabilidade |
 
 Escolha a categoria que melhor representa a função primária do plugin, não a categoria com maior
 probabilidade de aumentar a visibilidade.
@@ -67,4 +68,4 @@ catalogado. Use `monorepo` quando o plugin for um subcaminho ou pacote dentro de
 amplo. Uma entrada de monorepo deve usar `popularity.starsPolicy: undefined-parent-repository` e
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/pt-BR/SCHEMA.md
+++ b/docs/i18n/pt-BR/SCHEMA.md
@@ -88,12 +88,12 @@ Os significados e as consequências para o ranking são definidos em
 
 ### `primaryCategory`
 
-Uma das treze categorias de capacidade:
+Uma das catorze categorias de capacidade:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Os rótulos de exibição e a orientação de seleção estão em
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -234,4 +234,4 @@ de estrelas é precisa, ou se o criador é dono da fonte. Essas checagens perten
 revisão dos mantenedores descritos em [CONTRIBUTING.md](../../CONTRIBUTING.md) e
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/pt/CATEGORIES.md
+++ b/docs/i18n/pt/CATEGORIES.md
@@ -50,6 +50,7 @@ contraditórios.
 | `messaging-notifications` | Mensagens e notificações |
 | `data-external-services` | Dados e serviços externos |
 | `entertainment-customization` | Entretenimento e personalização |
+| `finance-trading` | Finanças, trading e contabilidade |
 
 Escolha a categoria que melhor representa a função principal do plugin, não a categoria mais
 provável de aumentar a visibilidade.
@@ -68,4 +69,4 @@ catalogado. Use `monorepo` quando o plugin é um subcaminho ou pacote dentro de 
 amplo. Uma entrada de monorepo tem de usar `popularity.starsPolicy:
 undefined-parent-repository` e `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/pt/SCHEMA.md
+++ b/docs/i18n/pt/SCHEMA.md
@@ -88,12 +88,12 @@ Os significados e as consequências na classificação estão definidos em
 
 ### `primaryCategory`
 
-Uma das treze categorias de capacidade:
+Uma das catorze categorias de capacidade:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 As etiquetas de exibição e as orientações de seleção estão em
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -234,4 +234,4 @@ estrelas é exata, nem se o criador é dono da fonte. Essas verificações perte
 revisão dos mantenedores descritos em [CONTRIBUTING.md](../../CONTRIBUTING.md) e
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/ro/CATEGORIES.md
+++ b/docs/i18n/ro/CATEGORIES.md
@@ -51,6 +51,7 @@ clasificare.
 | `messaging-notifications` | Mesagerie și notificări |
 | `data-external-services` | Date și servicii externe |
 | `entertainment-customization` | Divertisment și personalizare |
+| `finance-trading` | Finanțe, tranzacționare și contabilitate |
 
 Alege categoria care reprezintă cel mai bine funcția principală a pluginului, nu categoria cu cele
 mai mari șanse de a crește vizibilitatea.
@@ -68,4 +69,4 @@ Folosește `monorepo` când pluginul este un subpath sau un pachet într-un proi
 intrare de monorepo trebuie să folosească `popularity.starsPolicy: undefined-parent-repository` și
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/ro/SCHEMA.md
+++ b/docs/i18n/ro/SCHEMA.md
@@ -87,12 +87,12 @@ Semnificațiile și consecințele pentru clasament sunt definite în
 
 ### `primaryCategory`
 
-Una dintre cele treisprezece categorii de capabilitate:
+Una dintre cele paisprezece categorii de capabilitate:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Etichetele de afișare și ghidajul de alegere sunt în [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -232,4 +232,4 @@ stele este exact sau că creatorul deține sursa. Acele verificări aparțin por
 întreținătorilor, descrise în [CONTRIBUTING.md](../../CONTRIBUTING.md) și
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/ru/CATEGORIES.md
+++ b/docs/i18n/ru/CATEGORIES.md
@@ -50,6 +50,7 @@
 | `messaging-notifications` | Сообщения и уведомления |
 | `data-external-services` | Данные и внешние сервисы |
 | `entertainment-customization` | Развлечения и кастомизация |
+| `finance-trading` | Финансы, трейдинг и бухгалтерия |
 
 Выбирайте категорию, которая лучше всего отражает основную задачу плагина, а не категорию,
 которая с наибольшей вероятностью повысит видимость.
@@ -68,4 +69,4 @@
 внутри более широкого проекта. Запись monorepo должна использовать
 `popularity.starsPolicy: undefined-parent-repository` и `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/ru/SCHEMA.md
+++ b/docs/i18n/ru/SCHEMA.md
@@ -86,12 +86,12 @@
 
 ### `primaryCategory`
 
-Одна из тринадцати категорий возможностей:
+Одна из четырнадцати категорий возможностей:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Отображаемые метки и рекомендации по выбору — в [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -230,4 +230,4 @@ URL публичного профиля всегда выводится как `
 описанным в [CONTRIBUTING.md](../../CONTRIBUTING.md) и
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/sk/CATEGORIES.md
+++ b/docs/i18n/sk/CATEGORIES.md
@@ -49,6 +49,7 @@ s DSH integráciou. Tým sa predchádza rozporným dvojiciam zaradenia.
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Financie, obchodovanie a účtovníctvo |
 
 Vyberte kategóriu, ktorá najlepšie vystihuje hlavnú funkciu pluginu, nie kategóriu, ktorá by
 najpravdepodobnejšie zvýšila viditeľnosť.
@@ -65,4 +66,4 @@ písmenami sú povolené, ak opisujú dôkaz viditeľný v pripnutom pôvodnom z
 `monorepo` použite, keď je plugin podcestou alebo balíkom v širšom projekte. Záznam v monorepe musí
 používať `popularity.starsPolicy: undefined-parent-repository` a `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/sk/SCHEMA.md
+++ b/docs/i18n/sk/SCHEMA.md
@@ -84,12 +84,12 @@ Významy a dôsledky pre rebríček sú definované v [docs/CATEGORIES.md](../..
 
 ### `primaryCategory`
 
-Jedna z trinástich kategórií schopností:
+Jedna zo štrnástich kategórií schopností:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Zobrazované označenia a usmernenie pre výber sú v [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -226,4 +226,4 @@ zhoduje s URL, že cesty dôkazov existujú na pripnutom commite, že počet hvi
 že tvorca vlastní zdroj. Tieto kontroly patria do brán posúdenia správcov popísaných v
 [CONTRIBUTING.md](../../CONTRIBUTING.md) a [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/sv/CATEGORIES.md
+++ b/docs/i18n/sv/CATEGORIES.md
@@ -53,6 +53,7 @@ motsägelsefulla klassificeringspar.
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Finans, trading och bokföring |
 
 Välj den kategori som bäst representerar pluginets huvuduppgift, inte den kategori som med störst
 sannolikhet ökar synligheten.
@@ -70,4 +71,4 @@ Använd `monorepo` när pluginet är en understig eller ett paket inuti ett bred
 monorepo-post måste använda `popularity.starsPolicy: undefined-parent-repository` och
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/sv/SCHEMA.md
+++ b/docs/i18n/sv/SCHEMA.md
@@ -86,12 +86,12 @@ Betydelser och rankningskonsekvenser definieras i
 
 ### `primaryCategory`
 
-En av de tretton förmågekategorierna:
+En av de fjorton förmågekategorierna:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Visningsetiketter och vägledning för val finns i
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
@@ -230,4 +230,4 @@ korrekt eller att skaparen äger källan. Dessa kontroller tillhör de
 underhållargranskningsgrindar som beskrivs i [CONTRIBUTING.md](../../CONTRIBUTING.md) och
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/sw/CATEGORIES.md
+++ b/docs/i18n/sw/CATEGORIES.md
@@ -49,6 +49,7 @@ pana zaidi wenye muunganisho wa DSH. Hii huzuia jozi za uainishaji zinazopingana
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Fedha, biashara ya hisa na uhasibu |
 
 Chagua jamii inayowakilisha vizuri zaidi kazi kuu ya programu-jalizi, si jamii ambayo huenda
 ikaongeza mwonekano.
@@ -66,4 +67,4 @@ Tumia `dedicated` tu wakati nyota za hazina ni za programu-jalizi halisi iliyoka
 monorepo lazima kitumie `popularity.starsPolicy: undefined-parent-repository` na
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/sw/SCHEMA.md
+++ b/docs/i18n/sw/SCHEMA.md
@@ -84,12 +84,12 @@ Maana na matokeo ya upangaji yamefafanuliwa katika [docs/CATEGORIES.md](../../do
 
 ### `primaryCategory`
 
-Moja ya jamii kumi na tatu za uwezo:
+Moja ya jamii kumi na nne za uwezo:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Lebo za kuonyesha na mwongozo wa uchaguzi ziko katika [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -226,4 +226,4 @@ inalingana na URL, kwamba njia za ushahidi zipo kwenye commit iliyobandikwa, kwa
 sahihi, au kwamba muumba ndiye mmiliki wa chanzo. Ukaguzi huo ni wa malango ya ukaguzi ya wasimamizi
 yaliyoelezwa katika [CONTRIBUTING.md](../../CONTRIBUTING.md) na [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/ta/CATEGORIES.md
+++ b/docs/i18n/ta/CATEGORIES.md
@@ -51,6 +51,7 @@
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | நிதி, வர்த்தகம் மற்றும் கணக்கியல் |
 
 செருகுநிரலின் முதன்மைப் பணியைச் சிறப்பாகப் பிரதிநிதித்துவப்படுத்தும் வகையைத் தேர்ந்தெடுக்கவும்,
 தென்படும் தன்மையை அதிகரிக்கக்கூடிய வகையை அல்ல.
@@ -70,4 +71,4 @@
 `popularity.starsPolicy: undefined-parent-repository` மற்றும் `popularity.stars: null`
 பயன்படுத்த வேண்டும்.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/ta/SCHEMA.md
+++ b/docs/i18n/ta/SCHEMA.md
@@ -89,12 +89,12 @@
 
 ### `primaryCategory`
 
-பதிமூன்று திறன் வகைகளில் ஒன்று:
+பதினான்கு திறன் வகைகளில் ஒன்று:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 காட்சி பெயரிடல்களும் தேர்வு வழிகாட்டுதலும்
 [docs/CATEGORIES.md](../../docs/CATEGORIES.md)-இல் உள்ளன.
@@ -240,4 +240,4 @@ URL-உடன் பொருந்துகிறதா, ஆதாரப் ப
 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)-இல் விவரிக்கப்பட்ட பராமரிப்பாளர் மதிப்பாய்வு
 நுழைவாயில்களுக்குரியவை.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/te/CATEGORIES.md
+++ b/docs/i18n/te/CATEGORIES.md
@@ -49,6 +49,7 @@
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | ఆర్థిక, ట్రేడింగ్ మరియు బుక్‌కీపింగ్ |
 
 ప్లగిన్ యొక్క ప్రాథమిక పనిని ఉత్తమంగా సూచించే వర్గాన్ని ఎంచుకోండి, కనిపించే అవకాశాన్ని పెంచే అవకాశం
 ఉన్న వర్గాన్ని కాదు.
@@ -66,4 +67,4 @@
 తప్పనిసరిగా `popularity.starsPolicy: undefined-parent-repository` మరియు
 `popularity.stars: null` ఉపయోగించాలి.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/te/SCHEMA.md
+++ b/docs/i18n/te/SCHEMA.md
@@ -84,12 +84,12 @@
 
 ### `primaryCategory`
 
-పదమూడు సామర్థ్య వర్గాలలో ఒకటి:
+పద్నాలుగు సామర్థ్య వర్గాలలో ఒకటి:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 డిస్‌ప్లే లేబుల్స్ మరియు ఎంపిక మార్గదర్శకత్వం [docs/CATEGORIES.md](../../docs/CATEGORIES.md)లో ఉన్నాయి.
 
@@ -225,4 +225,4 @@
 లేదో, లేదా సృష్టికర్త సోర్స్‌కు యజమానో లేదో ధృవీకరించ**దు**. ఆ తనిఖీలు [CONTRIBUTING.md](../../CONTRIBUTING.md)
 మరియు [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)లో వివరించిన మెయింటైనర్ సమీక్ష గేట్‌లకు చెందుతాయి.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/th/CATEGORIES.md
+++ b/docs/i18n/th/CATEGORIES.md
@@ -50,6 +50,7 @@
 | `messaging-notifications` | การส่งข้อความและการแจ้งเตือน |
 | `data-external-services` | ข้อมูลและบริการภายนอก |
 | `entertainment-customization` | ความบันเทิงและการปรับแต่ง |
+| `finance-trading` | การเงิน การเทรด และการทำบัญชี |
 
 เลือกหมวดหมู่ที่สื่อถึงหน้าที่หลักของปลั๊กอินได้ดีที่สุด ไม่ใช่หมวดหมู่ที่มีแนวโน้มจะเพิ่มการมองเห็นมากที่สุด
 
@@ -65,4 +66,4 @@
 เป็น subpath หรือแพ็กเกจภายในโปรเจกต์ที่ใหญ่กว่า รายการใน monorepo ต้องใช้
 `popularity.starsPolicy: undefined-parent-repository` และ `popularity.stars: null`
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/th/SCHEMA.md
+++ b/docs/i18n/th/SCHEMA.md
@@ -82,12 +82,12 @@ SemVer ที่แน่นอนสำหรับเวอร์ชัน, SH
 
 ### `primaryCategory`
 
-หนึ่งในสิบสามหมวดหมู่ความสามารถ:
+หนึ่งในสิบสี่หมวดหมู่ความสามารถ:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 ป้ายชื่อที่แสดงผลและแนวทางการเลือกอยู่ใน [docs/CATEGORIES.md](../../docs/CATEGORIES.md)
 
@@ -222,4 +222,4 @@ node ID ตรงกับ URL ว่าเส้นทางหลักฐา�
 ซอร์สจริง การตรวจสอบเหล่านั้นเป็นหน้าที่ของด่านตรวจรีวิวของผู้ดูแลที่อธิบายไว้ใน
 [CONTRIBUTING.md](../../CONTRIBUTING.md) และ [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/tr/CATEGORIES.md
+++ b/docs/i18n/tr/CATEGORIES.md
@@ -49,6 +49,7 @@ daha geniş bir proje anlamına gelir. Bu, çelişkili sınıflandırma çiftler
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | Finans, alım satım ve muhasebe |
 
 Görünürlüğü artırma olasılığı en yüksek kategoriyi değil, eklentinin birincil işini en iyi
 temsil eden kategoriyi seçin.
@@ -66,4 +67,4 @@ Eklenti daha geniş bir projenin içinde bir alt yol veya paket olduğunda `mono
 monorepo kaydı `popularity.starsPolicy: undefined-parent-repository` ve
 `popularity.stars: null` kullanmalıdır.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/tr/SCHEMA.md
+++ b/docs/i18n/tr/SCHEMA.md
@@ -85,12 +85,12 @@ Anlamları ve sıralama sonuçları [docs/CATEGORIES.md](CATEGORIES.md) içinde 
 
 ### `primaryCategory`
 
-On üç yetenek kategorisinden biri:
+On dört yetenek kategorisinden biri:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Görüntü etiketleri ve seçim rehberliği [docs/CATEGORIES.md](CATEGORIES.md) içindedir.
 
@@ -228,4 +228,4 @@ olduğunu veya üreticinin kaynağa sahip olduğunu **doğrulamaz**. Bu denetiml
 [CONTRIBUTING.md](../../CONTRIBUTING.md) ve [docs/GOVERNANCE.md](GOVERNANCE.md) içinde
 açıklanan sürdürücü inceleme kapılarına aittir.
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/uk-UA/CATEGORIES.md
+++ b/docs/i18n/uk-UA/CATEGORIES.md
@@ -50,6 +50,7 @@
 | `messaging-notifications` | Обмін повідомленнями та сповіщення |
 | `data-external-services` | Дані та зовнішні сервіси |
 | `entertainment-customization` | Розваги та персоналізація |
+| `finance-trading` | Фінанси, трейдинг і бухгалтерія |
 
 Обирайте категорію, яка найкраще відображає основне призначення плагіна, а не категорію, яка з
 найбільшою ймовірністю підвищить помітність.
@@ -67,4 +68,4 @@
 із монорепозиторію має використовувати `popularity.starsPolicy: undefined-parent-repository` і
 `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/uk-UA/SCHEMA.md
+++ b/docs/i18n/uk-UA/SCHEMA.md
@@ -84,12 +84,12 @@
 
 ### `primaryCategory`
 
-Одна з тринадцяти категорій можливостей:
+Одна з чотирнадцяти категорій можливостей:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Мітки для відображення та поради щодо вибору — у [docs/CATEGORIES.md](../../docs/CATEGORIES.md).
 
@@ -227,4 +227,4 @@ ID відповідає URL, що шляхи доказів існують на 
 що автор володіє джерелом. Ці перевірки належать до перевіркових шлюзів мейнтейнерів, описаних у
 [CONTRIBUTING.md](../../CONTRIBUTING.md) і [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/ur/CATEGORIES.md
+++ b/docs/i18n/ur/CATEGORIES.md
@@ -40,6 +40,7 @@
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | مالیات، ٹریڈنگ اور بک کیپنگ |
 
 وہ زمرہ منتخب کریں جو پلگ ان کے بنیادی کام کی بہترین نمائندگی کرے، نہ کہ وہ زمرہ جس سے سب سے زیادہ نمائش بڑھنے کا امکان ہو۔
 
@@ -51,4 +52,4 @@
 
 `dedicated` صرف اس وقت استعمال کریں جب ریپوزٹری کے ستارے عین کیٹلاگ کردہ پلگ ان سے تعلق رکھتے ہوں۔ `monorepo` اس وقت استعمال کریں جب پلگ ان کسی وسیع تر پروجیکٹ کے اندر ایک subpath یا پیکج ہو۔ ایک مونوریپو اندراج کو لازمی طور پر `popularity.starsPolicy: undefined-parent-repository` اور `popularity.stars: null` استعمال کرنا چاہیے۔
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/ur/SCHEMA.md
+++ b/docs/i18n/ur/SCHEMA.md
@@ -71,12 +71,12 @@
 
 ### `primaryCategory`
 
-تیرہ صلاحیت زمروں میں سے ایک:
+چودہ صلاحیت زمروں میں سے ایک:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 نمائشی labels اور انتخاب کی رہنمائی [docs/CATEGORIES.md](../../docs/CATEGORIES.md) میں ہے۔
 
@@ -197,4 +197,4 @@
 
 اسکیما جان بوجھ کر مقامی اور ساختی ہے۔ یہ تصدیق **نہیں** کرتی کہ ریپوزٹری موجود ہے، node ID URL سے مطابقت رکھتا ہے، ثبوت کے راستے پن شدہ کمٹ پر موجود ہیں، ستاروں کی تعداد درست ہے، یا تخلیق کار سورس کا مالک ہے۔ وہ چیکس [CONTRIBUTING.md](../../CONTRIBUTING.md) اور [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) میں بیان کردہ مینٹینر جائزہ گیٹس سے تعلق رکھتی ہیں۔
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/vi/CATEGORIES.md
+++ b/docs/i18n/vi/CATEGORIES.md
@@ -47,6 +47,7 @@ các cặp phân loại mâu thuẫn nhau.
 | `messaging-notifications` | Nhắn tin và thông báo |
 | `data-external-services` | Dữ liệu và dịch vụ bên ngoài |
 | `entertainment-customization` | Giải trí và tùy biến |
+| `finance-trading` | Tài chính, giao dịch và sổ sách kế toán |
 
 Hãy chọn danh mục đại diện tốt nhất cho công việc chính của plugin, không phải danh mục có khả năng tăng lượt xem
 nhiều nhất.
@@ -63,4 +64,4 @@ Chỉ dùng `dedicated` khi số sao repository thuộc về đúng plugin đư�
 một subpath hoặc gói bên trong một dự án lớn hơn. Một mục trong monorepo phải dùng
 `popularity.starsPolicy: undefined-parent-repository` và `popularity.stars: null`.
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/vi/SCHEMA.md
+++ b/docs/i18n/vi/SCHEMA.md
@@ -84,12 +84,12 @@ Bộ phân biệt **duy nhất** cho loại sản phẩm (không tồn tại tr�
 
 ### `primaryCategory`
 
-Một trong mười ba danh mục năng lực:
+Một trong mười bốn danh mục năng lực:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 Nhãn hiển thị và hướng dẫn lựa chọn nằm tại [docs/CATEGORIES.md](CATEGORIES.md).
 
@@ -225,4 +225,4 @@ hay không, hay nhà phát triển có thực sự sở hữu nguồn hay không
 duyệt của người bảo trì được mô tả tại [CONTRIBUTING.md](../../CONTRIBUTING.md) và
 [docs/GOVERNANCE.md](GOVERNANCE.md).
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/zh-CN/CATEGORIES.md
+++ b/docs/i18n/zh-CN/CATEGORIES.md
@@ -45,6 +45,7 @@
 | `messaging-notifications` | Messaging and notifications |
 | `data-external-services` | Data and external services |
 | `entertainment-customization` | Entertainment and customization |
+| `finance-trading` | 金融、交易与记账 |
 
 选择最能代表插件主要功能的分类,而不是最有可能提升曝光度的分类。
 
@@ -60,4 +61,4 @@
 软件包时,使用 `monorepo`。单体仓库条目必须使用 `popularity.starsPolicy:
 undefined-parent-repository` 和 `popularity.stars: null`。
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/zh-CN/SCHEMA.md
+++ b/docs/i18n/zh-CN/SCHEMA.md
@@ -81,12 +81,12 @@
 
 ### `primaryCategory`
 
-十三个能力分类之一:
+十四个能力分类之一:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 显示标签和选择指南参见 [docs/CATEGORIES.md](../../docs/CATEGORIES.md)。
 
@@ -220,4 +220,4 @@ source 描述符刻意不存储其他任何内容:仓库、提交和子路径均
 [CONTRIBUTING.md](../../CONTRIBUTING.md) 和 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) 中所述的
 维护者审查门禁。
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/docs/i18n/zh-TW/CATEGORIES.md
+++ b/docs/i18n/zh-TW/CATEGORIES.md
@@ -47,6 +47,7 @@
 | `messaging-notifications` | 訊息與通知 |
 | `data-external-services` | 資料與外部服務 |
 | `entertainment-customization` | 娛樂與客製化 |
+| `finance-trading` | 金融、交易與記帳 |
 
 請選擇最能代表該外掛主要功能的分類,而不是最有可能提高曝光度的分類。
 
@@ -62,4 +63,4 @@
 中的子路徑或套件,則使用 `monorepo`。monorepo 條目必須使用
 `popularity.starsPolicy: undefined-parent-repository` 與 `popularity.stars: null`。
 
-<!-- i18n-source-hash: 7b8e3dc5e30c5a9227179fe0caa70415b18a29014362c6b2a6fa4f7db37f82b4 -->
+<!-- i18n-source-hash: e0cd5f70656160d1f893d746d2c6f246ee986ef69e2b50281d0864aa77fd98f7 -->

--- a/docs/i18n/zh-TW/SCHEMA.md
+++ b/docs/i18n/zh-TW/SCHEMA.md
@@ -82,12 +82,12 @@ SemVer,完整性(integrity)值要求 SHA-512 SRI,授權要求 SPDX 表達式剖�
 
 ### `primaryCategory`
 
-十三個能力分類之一:
+十四個能力分類之一:
 
 `user-interface-dashboards` · `memory-rag` · `search-research` · `coding-developer-tools` ·
 `browser-automation` · `vision-audio-multimodal` · `sessions-productivity` ·
 `security-permissions-approvals` · `diagnostics-observability` · `models-providers-routing` ·
-`messaging-notifications` · `data-external-services` · `entertainment-customization`
+`messaging-notifications` · `data-external-services` · `entertainment-customization` · `finance-trading`
 
 顯示標籤與選擇指引參見 [docs/CATEGORIES.md](../../docs/CATEGORIES.md)。
 
@@ -222,4 +222,4 @@ source 描述子刻意不儲存其他任何內容:儲存庫、提交與子路徑
 屬於 [CONTRIBUTING.md](../../CONTRIBUTING.md) 與 [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md)
 中所述的維護者審查關卡。
 
-<!-- i18n-source-hash: d1232382b38d13680fc8bbadf837b3f7c51c0aae9f5b5ec10118d8dfa84b62a0 -->
+<!-- i18n-source-hash: 284a877b347e1fbe1238fab6eb1e0f3b17ab01c1499ee61430f2cc31fc46a62f -->

--- a/schemas/plugin.schema.yaml
+++ b/schemas/plugin.schema.yaml
@@ -75,6 +75,7 @@ properties:
       - messaging-notifications
       - data-external-services
       - entertainment-customization
+      - finance-trading
   tags:
     type: array
     uniqueItems: true


### PR DESCRIPTION
## Summary
- Nine published plugins (crypto portfolio tracking, invoicing, bookkeeping, quant trading, prediction markets) had no matching primary capability category and were falling into the private classifier's `taxonomyGap` bucket.
- Adds `finance-trading` as the 14th primary capability category: `docs/CATEGORIES.md` table row, `schemas/plugin.schema.yaml` `primaryCategory` enum, and the `docs/SCHEMA.md` prose list.
- Updates and re-stamps all 42 `docs/i18n/<locale>/{CATEGORIES,SCHEMA}.md` translations so the i18n freshness gate stays 420 current / 0 stale.

## Test plan
- [x] `node cli/dist/bin.js catalog validate --catalog .` → `1892 entries valid`
- [x] `node cli/dist/bin.js catalog docs-check . --skip-count` → `Catalog documentation checks passed for 1892 entries.`
- [x] i18n freshness inspect (private repo `scripts/i18nFreshness.mjs`) → `{current: 420, stale: 0, unstamped: 0, missing: 0}`
- [x] `cli` typecheck + `npm test` (34/35 suites pass; the pre-existing `package-contents.test.ts` npm-pack-dry-run failure is unrelated to this change — no `cli/` source files were touched)