### PR TITLE
catalog: add bytecii-mirage-dsh (community curation, created by @bytecii)

### DIFF
--- a/catalog/plugins/bytecii-mirage-dsh.yaml
+++ b/catalog/plugins/bytecii-mirage-dsh.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: bytecii-mirage-dsh
+name: "@struktoai/mirage-dsh"
+description:
+  en: "DeepSeek Harness (dsh) providers backed by a mirage workspace: ctx.fs and ctx.shell over mounted resources"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - providers
+  - backed
+  - mirage
+  - workspace
+  - shell
+  - over
+  - mounted
+  - resources
+  - dsh
+source:
+  repository: https://github.com/strukto-ai/mirage
+  repositoryNodeId: R_kgDOSWGiaQ
+  subpath: typescript/packages/dsh
+  commit: 2de01bdf983e948e7aa0a0c9a2831f04ef094d67
+creator:
+  github: bytecii
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: typescript/packages/dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:26.733Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bytecii-mirage-dsh`
- Submission type: community curation
- Created by `bytecii` — https://github.com/bytecii
- Original source repository: https://github.com/strukto-ai/mirage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.