### PR TITLE
catalog: add huiliyi37-dsh-theme-escook (community curation, created by @huiliyi37)

### DIFF
--- a/catalog/plugins/huiliyi37-dsh-theme-escook.yaml
+++ b/catalog/plugins/huiliyi37-dsh-theme-escook.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: huiliyi37-dsh-theme-escook
+name: dsh-theme-escook
+description:
+  en: <h3 align="center" 🌸 Escook Theme for DeepSeek Harness</h3
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - theme
+  - escook
+  - escook-theme
+  - dark-theme
+source:
+  repository: https://github.com/Simon-yyy/dsh-theme-escook
+  repositoryNodeId: R_kgDOUBTW4Q
+  subpath: null
+  commit: 19f36748198c3b79fcd9d21e639f014c709b2901
+creator:
+  github: huiliyi37
+package:
+  ecosystem: npm
+  name: dsh-theme-escook
+  version: 1.0.0
+  integrity: sha512-xiGQRqd66pdpW31LbPPNzEAwdv02Dp9xWMQmZfV1HmeNTCk/TnllViHV0CwuuxfneSLIXCk4UWRKi8PYB4b1ew==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:55.999Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huiliyi37-dsh-theme-escook`
- Submission type: community curation
- Created by `huiliyi37` — https://github.com/huiliyi37
- Original source repository: https://github.com/Simon-yyy/dsh-theme-escook
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.