### PR TITLE
catalog: add sharewiner-dsh-model-management (community curation, created by @sharewiner)

### DIFF
--- a/catalog/plugins/sharewiner-dsh-model-management.yaml
+++ b/catalog/plugins/sharewiner-dsh-model-management.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sharewiner-dsh-model-management
+name: "@sharewiner/dsh-model-management"
+description:
+  en: DSH model management, synchronized model visibility, and OpenAI Responses web search.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - model-management
+  - openai
+  - web-search
+  - dsh
+source:
+  repository: https://github.com/sharewiner/dsh-model-management
+  repositoryNodeId: R_kgDOUDfIOA
+  subpath: null
+  commit: 09db30228b428c3a2cb5e1cf40b9037f0e991ccb
+creator:
+  github: sharewiner
+package:
+  ecosystem: npm
+  name: "@sharewiner/dsh-model-management"
+  version: 0.2.3
+  integrity: sha512-ENCbnzgcY7GfyV7Fad0X78hV/1l6sVzMCiU5hbJ8Axxs5ryiIw9LELUoyxHvzmht/EMcfvASq3nYA7NlQDKQOw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:00.979Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sharewiner-dsh-model-management`
- Submission type: community curation
- Created by `sharewiner` — https://github.com/sharewiner
- Original source repository: https://github.com/sharewiner/dsh-model-management
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.