### PR TITLE
catalog: add sharl210-dsh-strip-sandbox-permissions (community curation, created by @Sharl210)

### DIFF
--- a/catalog/plugins/sharl210-dsh-strip-sandbox-permissions.yaml
+++ b/catalog/plugins/sharl210-dsh-strip-sandbox-permissions.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: sharl210-dsh-strip-sandbox-permissions
+name: dsh-strip-sandbox-permissions
+description:
+  en: Strip sandbox permissions / justification from model tool-call arguments so sandbox escalation is never triggered when the session already has sufficient permission.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - sandbox
+  - permissions
+  - escalation
+source:
+  repository: https://github.com/Sharl210/dsh-strip-sandbox-permissions
+  repositoryNodeId: R_kgDOT_-SuQ
+  subpath: null
+  commit: 091d62c3dca0fcaa0cc7f26e6e470e19ef355f35
+creator:
+  github: Sharl210
+package:
+  ecosystem: npm
+  name: dsh-strip-sandbox-permissions
+  version: 0.1.0
+  integrity: sha512-eXPg189DKJtpKg9C+6a2kI9WOsG/9xOGrnpDLtAln3noMqLiBSvhKCuddi68F2pxIcOSFekO08PX1bfOxAGfDg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:55.114Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sharl210-dsh-strip-sandbox-permissions`
- Submission type: community curation
- Created by `Sharl210` — https://github.com/Sharl210
- Original source repository: https://github.com/Sharl210/dsh-strip-sandbox-permissions
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.