### PR TITLE
catalog: add shinjiyu-dsh-holdem (community curation, created by @shinjiyu)

### DIFF
--- a/catalog/plugins/shinjiyu-dsh-holdem.yaml
+++ b/catalog/plugins/shinjiyu-dsh-holdem.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: shinjiyu-dsh-holdem
+name: "@shinjiyu/dsh-holdem"
+description:
+  en: DeepSeek Harness tools for shinjiyu/holdem on kuroneko.chat
+  evidencePath: dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - holdem
+  - poker
+  - deepseek-harness
+  - dsh
+source:
+  repository: https://github.com/shinjiyu/holdem
+  repositoryNodeId: R_kgDOT8Mpow
+  subpath: dsh-plugin
+  commit: 4541b4d384ea48def41d8e9d9b16c8c1ff7fa0b8
+creator:
+  github: shinjiyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:02.060Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shinjiyu-dsh-holdem`
- Submission type: community curation
- Created by `shinjiyu` — https://github.com/shinjiyu
- Original source repository: https://github.com/shinjiyu/holdem
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.