### PR TITLE
catalog: add shizuku-keop-dsh-compat-guard (community curation, created by @Shizuku-keop)

### DIFF
--- a/catalog/plugins/shizuku-keop-dsh-compat-guard.yaml
+++ b/catalog/plugins/shizuku-keop-dsh-compat-guard.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: shizuku-keop-dsh-compat-guard
+name: dsh-compat-guard
+description:
+  en: "Compatibility governance for DeepSeek Harness: upgrade pre-flight gate, storage-format fingerprinting, $DSH HOME backup, session migration, per-profile lockfile with rollback, and a machine-readable plugin x DSH compatibility matrix + CI workflow."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - compatibility
+  - upgrade
+  - lockfile
+  - migration
+  - backup
+source:
+  repository: https://github.com/Shizuku-keop/dsh-compat-guard
+  repositoryNodeId: R_kgDOUDfT6g
+  subpath: null
+  commit: d418f04c0a5e6f45ca961fdec64273a46dd66ec6
+creator:
+  github: Shizuku-keop
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:55.999Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shizuku-keop-dsh-compat-guard`
- Submission type: community curation
- Created by `Shizuku-keop` — https://github.com/Shizuku-keop
- Original source repository: https://github.com/Shizuku-keop/dsh-compat-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.