### PR TITLE
catalog: add shuguang1994-project-blueprint (community curation, created by @shuguang1994)

### DIFF
--- a/catalog/plugins/shuguang1994-project-blueprint.yaml
+++ b/catalog/plugins/shuguang1994-project-blueprint.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: shuguang1994-project-blueprint
+name: project-blueprint
+description:
+  en: DSH (DeepSeek Harness) plugin packaging of the Project Blueprint skill — one-command AI coding conventions (AGENTS.md, docs skeleton, CI/CD, git rules, testing policy) with an autonomous discovery engine (7 languages, 15 frameworks, 70+ components, web fallback).
+  evidencePath: dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - agent-skills
+  - skills
+  - project-blueprint
+  - coding-conventions
+  - scaffolding
+  - ai-agents
+source:
+  repository: https://github.com/shuguang1994/project-blueprint
+  repositoryNodeId: R_kgDOTcJb4A
+  subpath: dsh-plugin
+  commit: f227ce5c61703e041ec56b6e27b2af550d585fb2
+creator:
+  github: shuguang1994
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:02.532Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shuguang1994-project-blueprint`
- Submission type: community curation
- Created by `shuguang1994` — https://github.com/shuguang1994
- Original source repository: https://github.com/shuguang1994/project-blueprint
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.