### PR TITLE
catalog: add shuxue6662-a11y-dsh-risk-guard (community curation, created by @shuxue6662-a11y)

### DIFF
--- a/catalog/plugins/shuxue6662-a11y-dsh-risk-guard.yaml
+++ b/catalog/plugins/shuxue6662-a11y-dsh-risk-guard.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: shuxue6662-a11y-dsh-risk-guard
+name: dsh-risk-guard
+description:
+  en: Zero-interruption audit + fuse blocking for DeepSeek Harness (dsh).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - security
+  - risk
+  - audit
+source:
+  repository: https://github.com/shuxue6662-a11y/dsh-risk-guard
+  repositoryNodeId: R_kgDOT6zGog
+  subpath: null
+  commit: 790bda59aae6ca75fac0683b3651309cf4b146d6
+creator:
+  github: shuxue6662-a11y
+package:
+  ecosystem: npm
+  name: dsh-risk-guard
+  version: 0.2.0
+  integrity: sha512-CYPbIMdd5KBYF4ZTOocGhZHmg4gU4lWvR0vNWqh+qROlgu+nLta27Z4zPW0pPQCE+G1BbgJlDtl3OP+RlfG6pQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:03.248Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shuxue6662-a11y-dsh-risk-guard`
- Submission type: community curation
- Created by `shuxue6662-a11y` — https://github.com/shuxue6662-a11y
- Original source repository: https://github.com/shuxue6662-a11y/dsh-risk-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.