### PR TITLE
catalog: add shyboy-dsh-k12-lesson-builder (community curation, created by @shyboy)

### DIFF
--- a/catalog/plugins/shyboy-dsh-k12-lesson-builder.yaml
+++ b/catalog/plugins/shyboy-dsh-k12-lesson-builder.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: shyboy-dsh-k12-lesson-builder
+name: dsh-k12-lesson-builder
+description:
+  en: DeepSeek Harness plugin for synchronized K12 English PPTX and DOCX lesson materials
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - synchronized
+  - english
+  - pptx
+  - docx
+  - lesson
+  - materials
+  - dsh
+source:
+  repository: https://github.com/shyboy/dsh-k12-lesson-builder
+  repositoryNodeId: R_kgDOT3ezOQ
+  subpath: null
+  commit: 7fd5963491f2f986385f38cfa4ebda56319c04da
+creator:
+  github: shyboy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:46.250Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shyboy-dsh-k12-lesson-builder`
- Submission type: community curation
- Created by `shyboy` — https://github.com/shyboy
- Original source repository: https://github.com/shyboy/dsh-k12-lesson-builder
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.