### PR TITLE
catalog: add shyboy0499-dsh-git-tools (community curation, created by @Shyboy0499)

### DIFF
--- a/catalog/plugins/shyboy0499-dsh-git-tools.yaml
+++ b/catalog/plugins/shyboy0499-dsh-git-tools.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: shyboy0499-dsh-git-tools
+name: dsh-git-tools
+description:
+  en: "Local git tools for DeepSeek Harness: git status, git diff, git log, git commit"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - git
+  - agent-tools
+source:
+  repository: https://github.com/Shyboy0499/dsh-git-tools
+  repositoryNodeId: R_kgDOUE5SzA
+  subpath: null
+  commit: 7b3b0c13b48ba0c613b8092e965e6160fab9459e
+creator:
+  github: Shyboy0499
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:03.541Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shyboy0499-dsh-git-tools`
- Submission type: community curation
- Created by `Shyboy0499` — https://github.com/Shyboy0499
- Original source repository: https://github.com/Shyboy0499/dsh-git-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.