### PR TITLE
catalog: add siberiah2o-dsh-plugin-terminal (community curation, created by @siberiah2o)

### DIFF
--- a/catalog/plugins/siberiah2o-dsh-plugin-terminal.yaml
+++ b/catalog/plugins/siberiah2o-dsh-plugin-terminal.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: siberiah2o-dsh-plugin-terminal
+name: dsh-plugin-terminal
+description:
+  en: Bottom terminal panel plugin for DeepSeek Harness Web GUI (node-pty powered, works on Windows via ConPTY)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - terminal
+  - pty
+source:
+  repository: https://github.com/siberiah2o/dsh-plugin-terminal
+  repositoryNodeId: R_kgDOT4MnkA
+  subpath: null
+  commit: e6f6bafd3898b816cb0beab73fee30fabd50169f
+creator:
+  github: siberiah2o
+package:
+  ecosystem: npm
+  name: dsh-plugin-terminal
+  version: 0.2.0
+  integrity: sha512-degRA4Azbw8ZGXcKbP/GyhIPgUOoBm+IRm+OmWjOO5LGZ1voc6YxGWLleWR7fOmCpk7cDmFcXmkH8IOQJY/65A==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:33.910Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `siberiah2o-dsh-plugin-terminal`
- Submission type: community curation
- Created by `siberiah2o` — https://github.com/siberiah2o
- Original source repository: https://github.com/siberiah2o/dsh-plugin-terminal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.