### PR TITLE
catalog: add signalight-dsh-codex-pet (community curation, created by @Signalight)

### DIFF
--- a/catalog/plugins/signalight-dsh-codex-pet.yaml
+++ b/catalog/plugins/signalight-dsh-codex-pet.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: signalight-dsh-codex-pet
+name: "@signalight/dsh-codex-pet"
+description:
+  en: "DSH web-GUI pet runtime: renders Codex spritesheet-atlas pets (v1/v2) with drag/wave/jump, live activity poses and progress bubbles. 把 Codex 桌宠图集渲染为 DSH 网页桌宠的运行时插件。"
+  evidencePath: packages/dsh-codex-pet/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - runtime
+  - renders
+  - codex
+  - spritesheet
+  - atlas
+  - pets
+  - drag
+  - wave
+  - jump
+  - live
+  - activity
+  - poses
+  - progress
+  - bubbles
+  - dsh
+source:
+  repository: https://github.com/Signalight/codex-to-dsh-pet
+  repositoryNodeId: R_kgDOT5aHmg
+  subpath: packages/dsh-codex-pet
+  commit: e786fba25affa45ec2adee43d40755c4ba8dc223
+creator:
+  github: Signalight
+package:
+  ecosystem: npm
+  name: "@signalight/dsh-codex-pet"
+  version: 0.3.0
+  integrity: sha512-lYjsC/7GX162Y8YMnP+y3NZWFs6zUPd8IMRPy5Vv5SvQXxgJz/pzLCXjbaAw22Q1r5WDvIcKoi0Prjjz+9roQQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-codex-pet/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:05.444Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `signalight-dsh-codex-pet`
- Submission type: community curation
- Created by `Signalight` — https://github.com/Signalight
- Original source repository: https://github.com/Signalight/codex-to-dsh-pet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.