### PR TITLE
catalog: add sijie-ni-0214-dsh-subagent-error-details (community curation, created by @sijie-ni-0214)

### DIFF
--- a/catalog/plugins/sijie-ni-0214-dsh-subagent-error-details.yaml
+++ b/catalog/plugins/sijie-ni-0214-dsh-subagent-error-details.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sijie-ni-0214-dsh-subagent-error-details
+name: dsh-subagent-error-details
+description:
+  en: 'DSH plugin: deliver the real failure reason (e.g. RATE LIMIT 429) to the parent agent when a background subagent fails, instead of an empty "Its closing message:"'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - subagent
+  - diagnostics
+  - observability
+source:
+  repository: https://github.com/sijie-ni-0214/dsh-subagent-error-details
+  repositoryNodeId: R_kgDOUE1tRQ
+  subpath: null
+  commit: 0ce7bcf46c0efbfb17c60f2924ae99fc0fdac2f6
+creator:
+  github: sijie-ni-0214
+package:
+  ecosystem: npm
+  name: dsh-subagent-error-details
+  version: 0.1.0
+  integrity: sha512-9/U33zgOXMRG6BdVJvcp6hO9DxTTaDTrh338Fv70CYXZEkHslQLq606vXPAIjgk1nVNTWg2BpWbsYM+Y6NydcQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:05.117Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sijie-ni-0214-dsh-subagent-error-details`
- Submission type: community curation
- Created by `sijie-ni-0214` — https://github.com/sijie-ni-0214
- Original source repository: https://github.com/sijie-ni-0214/dsh-subagent-error-details
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.