### PR TITLE
catalog: add simon-world-dsh-at-file (community curation, created by @SIMON-WORLD)

### DIFF
--- a/catalog/plugins/simon-world-dsh-at-file.yaml
+++ b/catalog/plugins/simon-world-dsh-at-file.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: simon-world-dsh-at-file
+name: dsh-at-file
+description:
+  en: dsh-at-file/ ├── package.json dsh.bundle manifest ├── src/ │ ├── index.ts 插件入口（注册 composer 扩展） │ ├── file-picker.ts @ 触发 + fuzzy 搜索 │ └── inject.ts 内容注入 ├── README.md └── tests/
+  evidencePath: packages/dsh-at-file/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - at-file
+source:
+  repository: https://github.com/SIMON-WORLD/dsh-toolkit
+  repositoryNodeId: R_kgDOT7Fumw
+  subpath: packages/dsh-at-file
+  commit: 7574d611e7568d28773d49aee7fac2cad3d13a27
+creator:
+  github: SIMON-WORLD
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-at-file/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:06.947Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `simon-world-dsh-at-file`
- Submission type: community curation
- Created by `SIMON-WORLD` — https://github.com/SIMON-WORLD
- Original source repository: https://github.com/SIMON-WORLD/dsh-toolkit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.