### PR TITLE
catalog: add simon-world-dsh-cost-dashboard (community curation, created by @SIMON-WORLD)

### DIFF
--- a/catalog/plugins/simon-world-dsh-cost-dashboard.yaml
+++ b/catalog/plugins/simon-world-dsh-cost-dashboard.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: simon-world-dsh-cost-dashboard
+name: dsh-cost-dashboard
+description:
+  en: bash node --test tests/cost-dashboard.test.mjs 3 个用例
+  evidencePath: packages/dsh-cost-dashboard/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - cost
+  - token
+source:
+  repository: https://github.com/SIMON-WORLD/dsh-toolkit
+  repositoryNodeId: R_kgDOT7Fumw
+  subpath: packages/dsh-cost-dashboard
+  commit: 7574d611e7568d28773d49aee7fac2cad3d13a27
+creator:
+  github: SIMON-WORLD
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-cost-dashboard/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:06.947Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `simon-world-dsh-cost-dashboard`
- Submission type: community curation
- Created by `SIMON-WORLD` — https://github.com/SIMON-WORLD
- Original source repository: https://github.com/SIMON-WORLD/dsh-toolkit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.