### PR TITLE
catalog: add simon-world-dsh-journal-monitor (community curation, created by @SIMON-WORLD)

### DIFF
--- a/catalog/plugins/simon-world-dsh-journal-monitor.yaml
+++ b/catalog/plugins/simon-world-dsh-journal-monitor.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: simon-world-dsh-journal-monitor
+name: dsh-journal-monitor
+description:
+  en: sh dsh plugin --profile web add git+https://github.com/SIMON-WORLD/dsh-journal-monitor.git
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - journal
+  - rss
+  - monitor
+  - economics
+source:
+  repository: https://github.com/SIMON-WORLD/dsh-journal-monitor
+  repositoryNodeId: R_kgDOT7RJDw
+  subpath: null
+  commit: 5e701342e14db5711f193ac16d66f3407da23b38
+creator:
+  github: SIMON-WORLD
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:55.999Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `simon-world-dsh-journal-monitor`
- Submission type: community curation
- Created by `SIMON-WORLD` — https://github.com/SIMON-WORLD
- Original source repository: https://github.com/SIMON-WORLD/dsh-journal-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.