### PR TITLE
catalog: add simon300000-dsh-auto (community curation, created by @simon300000)

### DIFF
--- a/catalog/plugins/simon300000-dsh-auto.yaml
+++ b/catalog/plugins/simon300000-dsh-auto.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: simon300000-dsh-auto
+name: dsh-auto
+description:
+  en: Model-reviewed Auto Approve permission preset for the DeepSeek Harness Web UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - approval
+  - webui
+  - dsh
+source:
+  repository: https://github.com/simon300000/dsh-auto
+  repositoryNodeId: R_kgDOT3li6Q
+  subpath: null
+  commit: eb409400843e195886edb45d9a75d2188120a2b6
+creator:
+  github: simon300000
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:33.895Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `simon300000-dsh-auto`
- Submission type: community curation
- Created by `simon300000` — https://github.com/simon300000
- Original source repository: https://github.com/simon300000/dsh-auto
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.