### PR TITLE
catalog: add simon314620-dsh-turn-index (community curation, created by @Simon314620)

### DIFF
--- a/catalog/plugins/simon314620-dsh-turn-index.yaml
+++ b/catalog/plugins/simon314620-dsh-turn-index.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: simon314620-dsh-turn-index
+name: dsh-turn-index
+description:
+  en: "A turn-index sidebar for the DeepSeek Harness web GUI: one entry per user turn, click to jump, scroll-spy keeps the current turn highlighted."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - client-plugin
+  - conversation
+  - turn-index
+  - navigation
+  - sidebar
+source:
+  repository: https://github.com/Simon314620/dsh-turn-index
+  repositoryNodeId: R_kgDOT3qeLA
+  subpath: null
+  commit: a324ecde201a219448c23c1c8bbd872bdab512b4
+creator:
+  github: Simon314620
+package:
+  ecosystem: npm
+  name: dsh-turn-index
+  version: 0.1.1
+  integrity: sha512-6WN7SojM9j81qm27XgV4lw/6R1PPBMWH9+al/kDSWUYgaKFtnIxwp3d8kzWZaWL8RiVxzUNE71mODlj8YAjz0Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:39.649Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `simon314620-dsh-turn-index`
- Submission type: community curation
- Created by `Simon314620` — https://github.com/Simon314620
- Original source repository: https://github.com/Simon314620/dsh-turn-index
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.