### PR TITLE
catalog: add sirilee-dsh-approval-hotkeys (community curation, created by @SiriLee)

### DIFF
--- a/catalog/plugins/sirilee-dsh-approval-hotkeys.yaml
+++ b/catalog/plugins/sirilee-dsh-approval-hotkeys.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: sirilee-dsh-approval-hotkeys
+name: dsh-approval-hotkeys
+description:
+  en: "DeepSeek Harness plugin: panel hotkeys for every interaction panel — Enter presses the confirm (primary) button, Esc presses the cancel button (approval, question/choice, plan review; Claude Code habits)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - approval
+  - hotkey
+  - keyboard
+  - ui
+source:
+  repository: https://github.com/SiriLee/dsh-approval-hotkeys
+  repositoryNodeId: R_kgDOT9NgEg
+  subpath: null
+  commit: 29fb7de42f9ff6bdbf3138574b451fad1034df29
+creator:
+  github: SiriLee
+package:
+  ecosystem: npm
+  name: dsh-approval-hotkeys
+  version: 0.1.4
+  integrity: sha512-2FFwqYPCowtu8ZtnMf1YU5BdDy8cgAaU3UsrO/r+karvDESapvVKGicuEiexTmMBG94CgdK8ywr+OFc1OZe0dg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:46.800Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sirilee-dsh-approval-hotkeys`
- Submission type: community curation
- Created by `SiriLee` — https://github.com/SiriLee
- Original source repository: https://github.com/SiriLee/dsh-approval-hotkeys
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.