### PR TITLE
catalog: add siruignaw-sys-dsh-tool-bandit-search (community curation, created by @siruignaw-sys)

### DIFF
--- a/catalog/plugins/siruignaw-sys-dsh-tool-bandit-search.yaml
+++ b/catalog/plugins/siruignaw-sys-dsh-tool-bandit-search.yaml
@@ -1,0 +1,39 @@
+schemaVersion: 1
+id: siruignaw-sys-dsh-tool-bandit-search
+name: dsh-tool-bandit-search
+description:
+  en: A search tool for DeepSeek Harness that learns to pick between quick and thorough search strategies using a contextual bandit (Thompson sampling).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - dsh
+source:
+  repository: https://github.com/siruignaw-sys/dsh-tool-bandit-search
+  repositoryNodeId: R_kgDOT5sQVg
+  subpath: null
+  commit: 089dd0d3e5b2b1686e66363905b8a393caa1d387
+creator:
+  github: siruignaw-sys
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:47.091Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `siruignaw-sys-dsh-tool-bandit-search`
- Submission type: community curation
- Created by `siruignaw-sys` — https://github.com/siruignaw-sys
- Original source repository: https://github.com/siruignaw-sys/dsh-tool-bandit-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.