### PR TITLE
catalog: add sisyphussq-dsh-openai-codex-oauth (community curation, created by @SisyphusSQ)

### DIFF
--- a/catalog/plugins/sisyphussq-dsh-openai-codex-oauth.yaml
+++ b/catalog/plugins/sisyphussq-dsh-openai-codex-oauth.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sisyphussq-dsh-openai-codex-oauth
+name: "@suqingsq/dsh-openai-codex-oauth"
+description:
+  en: ChatGPT subscription OAuth for DeepSeek Harness openai-codex, including silent browser login for dock and Settings.
+  evidencePath: packages/dsh-openai-codex-oauth/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - openai-codex
+  - oauth
+source:
+  repository: https://github.com/SisyphusSQ/dsh-plugins
+  repositoryNodeId: R_kgDOT4EUmw
+  subpath: packages/dsh-openai-codex-oauth
+  commit: fd704d0f4813b6cdb6416d03c7215eaf4e7e0654
+creator:
+  github: SisyphusSQ
+package:
+  ecosystem: npm
+  name: "@suqingsq/dsh-openai-codex-oauth"
+  version: 0.2.0
+  integrity: sha512-SzoZg9kiCL1D5GybzCV40dTeZ9i0h7ileQEctnGpYa+yRGnhVWvY5lw0zMwo+irvGJGnmkda9rxU2ng049JfjQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: packages/dsh-openai-codex-oauth/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:08.190Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sisyphussq-dsh-openai-codex-oauth`
- Submission type: community curation
- Created by `SisyphusSQ` — https://github.com/SisyphusSQ
- Original source repository: https://github.com/SisyphusSQ/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.