### PR TITLE
catalog: add sisyphussq-dsh-session-tools (community curation, created by @SisyphusSQ)

### DIFF
--- a/catalog/plugins/sisyphussq-dsh-session-tools.yaml
+++ b/catalog/plugins/sisyphussq-dsh-session-tools.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: sisyphussq-dsh-session-tools
+name: "@suqingsq/dsh-session-tools"
+description:
+  en: Cross-session tools and Web @session mentions for DeepSeek Harness.
+  evidencePath: packages/dsh-session-tools/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - sessions
+  - agent-tools
+source:
+  repository: https://github.com/SisyphusSQ/dsh-plugins
+  repositoryNodeId: R_kgDOT4EUmw
+  subpath: packages/dsh-session-tools
+  commit: fd704d0f4813b6cdb6416d03c7215eaf4e7e0654
+creator:
+  github: SisyphusSQ
+package:
+  ecosystem: npm
+  name: "@suqingsq/dsh-session-tools"
+  version: 0.2.0
+  integrity: sha512-vVMi/o1Heep1fkoRVfS19umg8V3SLq99XaKiCS/3zslvecFxV7Fp9S53Ujq/LNrhfb1EbmQzrBxX7IKFYQSMZg==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-session-tools/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:08.190Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sisyphussq-dsh-session-tools`
- Submission type: community curation
- Created by `SisyphusSQ` — https://github.com/SisyphusSQ
- Original source repository: https://github.com/SisyphusSQ/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.