### PR TITLE
catalog: add sivan757-dsh-agent-plugins-market (community curation, created by @Sivan757)

### DIFF
--- a/catalog/plugins/sivan757-dsh-agent-plugins-market.yaml
+++ b/catalog/plugins/sivan757-dsh-agent-plugins-market.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: sivan757-dsh-agent-plugins-market
+name: dsh-agent-plugins-market
+description:
+  en: The standard way to install Claude Code / Codex / Cursor / Kimi plugin marketplace suites in DeepSeek Harness (DSH) — zero conversion, zero file copying. Skills, MCP servers, hooks and slash commands are injected into your dsh sessions at runtime.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-plugins
+  - dsh-marketplace
+  - dsh-plugin-marketplace
+  - deepseek-plugin
+  - deepseek-plugins
+  - agent-plugins
+  - agent-plugin
+  - plugin-marketplace
+  - marketplace
+  - claude-code
+  - claude-code-plugins
+  - claude-code-plugin-marketplace
+  - claude
+source:
+  repository: https://github.com/Sivan757/dsh-agent-plugins-market
+  repositoryNodeId: R_kgDOT8motA
+  subpath: null
+  commit: c7991363aac7762c836dd374bbeaa4b9d075cc4f
+creator:
+  github: Sivan757
+package:
+  ecosystem: npm
+  name: dsh-agent-plugins-market
+  version: 0.5.2
+  integrity: sha512-IkjWXfiKFsc5Orhy79neWNTlwe1aFhfFGW/j3RtgC6FMmbJP5TEgezsxnDqnZV1dKUH9FHF0e3fo6VQzYGIp4g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:33.905Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sivan757-dsh-agent-plugins-market`
- Submission type: community curation
- Created by `Sivan757` — https://github.com/Sivan757
- Original source repository: https://github.com/Sivan757/dsh-agent-plugins-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.