### PR TITLE
catalog: add siweina-dsh-novel-writer (community curation, created by @siweina)

### DIFF
--- a/catalog/plugins/siweina-dsh-novel-writer.yaml
+++ b/catalog/plugins/siweina-dsh-novel-writer.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: siweina-dsh-novel-writer
+name: dsh-novel-writer
+description:
+  en: "A novel-writing assistant plugin for DeepSeek Harness (DSH) : chapter library management, sentence-pattern analysis, emotion purification & quantification, 12-axis vibe spectrum , style portrait report , six-dimension style baseline band , writing sentinels (bridge/OOC/outline drift) , plot & settings management, local"
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - novel-writing
+  - chinese-novel
+  - writing-assistant
+  - creative-writing
+  - fiction
+  - webnovel
+  - ai-writing
+  - text-analysis
+  - semantic-search
+  - style-analysis
+  - sentence-analysis
+  - emotion-analysis
+  - vibe
+source:
+  repository: https://github.com/siweina/dsh-novel-writer
+  repositoryNodeId: R_kgDOT593cA
+  subpath: null
+  commit: 62825959ccc00823b9212188d6178eae05f00ab6
+creator:
+  github: siweina
+package:
+  ecosystem: npm
+  name: dsh-novel-writer
+  version: 3.7.0
+  integrity: sha512-5U5OGo5Rd7dLFelySpgmnjw+gzw7vsmQOGv33ux6OXXxlwUoyqR8kwEUebbAx4Hon847HpR2M20QvCE2agkRVg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:29.394Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 12
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `siweina-dsh-novel-writer`
- Submission type: community curation
- Created by `siweina` — https://github.com/siweina
- Original source repository: https://github.com/siweina/dsh-novel-writer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.