### PR TITLE
catalog: add skyhancloud-dsh-client-ui-quote (community curation, created by @skyhancloud)

### DIFF
--- a/catalog/plugins/skyhancloud-dsh-client-ui-quote.yaml
+++ b/catalog/plugins/skyhancloud-dsh-client-ui-quote.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: skyhancloud-dsh-client-ui-quote
+name: dsh-client-ui-quote
+description:
+  en: "Selection quoting for the dsh web GUI: a toolbar over selected assistant text that attaches the selection to the composer as a removable quote banner, prepended to the outgoing message at send"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - selection
+  - quoting
+  - toolbar
+  - over
+  - selected
+  - assistant
+  - text
+  - attaches
+  - composer
+  - removable
+  - quote
+  - banner
+  - prepended
+  - outgoing
+  - message
+  - send
+source:
+  repository: https://github.com/skyhancloud/dsh-client-ui-quote
+  repositoryNodeId: R_kgDOT564SA
+  subpath: null
+  commit: 627bc2f7739241c60295e46fd62aa9f10109cc69
+creator:
+  github: skyhancloud
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:47.653Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `skyhancloud-dsh-client-ui-quote`
- Submission type: community curation
- Created by `skyhancloud` — https://github.com/skyhancloud
- Original source repository: https://github.com/skyhancloud/dsh-client-ui-quote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.