### PR TITLE
catalog: add skymecode-dsh-bgm (community curation, created by @skymecode)

### DIFF
--- a/catalog/plugins/skymecode-dsh-bgm.yaml
+++ b/catalog/plugins/skymecode-dsh-bgm.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: skymecode-dsh-bgm
+name: dsh-bgm
+description:
+  en: dsh-bgm turns system audio into rhythm-game feedback for the official DSH Web UI. It captures the default output device independently of the music player, maps bass/onset to Deep Diving, maps mid/treble changes to the latest reasoning or tool row, and keeps final-answer text readable and still.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - system-audio
+  - music-visualizer
+  - rhythm-game
+source:
+  repository: https://github.com/skymecode/dsh-bgm
+  repositoryNodeId: R_kgDOT8aiOg
+  subpath: null
+  commit: 1f177296c5f75b4fae3582f8d682cf93fb1f6d32
+creator:
+  github: skymecode
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:41.356Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `skymecode-dsh-bgm`
- Submission type: community curation
- Created by `skymecode` — https://github.com/skymecode
- Original source repository: https://github.com/skymecode/dsh-bgm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.