### PR TITLE
catalog: add skymecode-dsh-deep-dive-skins (community curation, created by @skymecode)

### DIFF
--- a/catalog/plugins/skymecode-dsh-deep-dive-skins.yaml
+++ b/catalog/plugins/skymecode-dsh-deep-dive-skins.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: skymecode-dsh-deep-dive-skins
+name: dsh-deep-dive-skins
+description:
+  en: "Pre-deep-dive ornaments for the DSH Web GUI turn-status row: swap the spouting whale for anime skins (whale-girl variant, cat-girl, mermaid) with a surface-prepare then dive choreography. Official cordis bundle: host half registers the settings namespace, browser half patches the 'Deep diving...' status row."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - whale
+  - deep-dive
+  - skin
+  - web-ui
+source:
+  repository: https://github.com/skymecode/dsh-deep-diving
+  repositoryNodeId: R_kgDOT-qa4g
+  subpath: null
+  commit: c5a5916aa9894dbdfb0516e6977451bff610504b
+creator:
+  github: skymecode
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:41.578Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `skymecode-dsh-deep-dive-skins`
- Submission type: community curation
- Created by `skymecode` — https://github.com/skymecode
- Original source repository: https://github.com/skymecode/dsh-deep-diving
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.