### PR TITLE
catalog: add sl82976818-dsh-gpt-bridge-manager (community curation, created by @sl82976818)

### DIFF
--- a/catalog/plugins/sl82976818-dsh-gpt-bridge-manager.yaml
+++ b/catalog/plugins/sl82976818-dsh-gpt-bridge-manager.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sl82976818-dsh-gpt-bridge-manager
+name: dsh-gpt-bridge-manager
+description:
+  en: DSH plugin-managed lifecycle and Settings status for the standalone GPT Bridge.
+  evidencePath: dsh-gpt-bridge-manager/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - deepseek-harness
+  - gpt-bridge
+  - custom-gpt
+  - cloudflared
+  - read-only
+source:
+  repository: https://github.com/sl82976818/dsh-gpt-bridge
+  repositoryNodeId: R_kgDOT5kucA
+  subpath: dsh-gpt-bridge-manager
+  commit: c8b390fb8195436bfc9a27bc791ba9d1d471d981
+creator:
+  github: sl82976818
+package:
+  ecosystem: npm
+  name: dsh-gpt-bridge-manager
+  version: 0.1.0
+  integrity: sha512-QVTWaHi2N/TQjCSaqs3fHWFmOTBy+qB9w4qoRyVFgmKhGT68QcyQDdpnxSoaGfp/y4Q/D+WOLgPhnk3l/FUJJw==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-gpt-bridge-manager/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:19.459Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sl82976818-dsh-gpt-bridge-manager`
- Submission type: community curation
- Created by `sl82976818` — https://github.com/sl82976818
- Original source repository: https://github.com/sl82976818/dsh-gpt-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.