### PR TITLE
catalog: add sleepeggtart-dsh-code-coverage (community curation, created by @SleepEggTart)

### DIFF
--- a/catalog/plugins/sleepeggtart-dsh-code-coverage.yaml
+++ b/catalog/plugins/sleepeggtart-dsh-code-coverage.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: sleepeggtart-dsh-code-coverage
+name: dsh-code-coverage
+description:
+  en: bash npm install -g dsh-code-coverage npx dsh-code-coverage
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - code-coverage
+  - c8
+  - ai-code
+  - attribution
+  - testing
+source:
+  repository: https://github.com/SleepEggTart/dsh-code-coverage
+  repositoryNodeId: R_kgDOUFKaMg
+  subpath: null
+  commit: 77bde5d44740d0fae60bf1600a19bd09fb1d7cf6
+creator:
+  github: SleepEggTart
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:21.746Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sleepeggtart-dsh-code-coverage`
- Submission type: community curation
- Created by `SleepEggTart` — https://github.com/SleepEggTart
- Original source repository: https://github.com/SleepEggTart/dsh-code-coverage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.