### PR TITLE
catalog: add slin-code-dsh-task-notice-board (community curation, created by @SLin-code)

### DIFF
--- a/catalog/plugins/slin-code-dsh-task-notice-board.yaml
+++ b/catalog/plugins/slin-code-dsh-task-notice-board.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: slin-code-dsh-task-notice-board
+name: dsh-task-notice-board
+description:
+  en: Workspace-to-Task-to-Session collaboration control center for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - workspace
+  - task
+  - session
+  - collaboration
+  - control
+  - center
+  - dsh
+source:
+  repository: https://github.com/SLin-code/dsh-task-notice-board
+  repositoryNodeId: R_kgDOT8GJbA
+  subpath: null
+  commit: 60c98a7dfe799d9528973401694f258d6cc3d2b0
+creator:
+  github: SLin-code
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:41.464Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `slin-code-dsh-task-notice-board`
- Submission type: community curation
- Created by `SLin-code` — https://github.com/SLin-code
- Original source repository: https://github.com/SLin-code/dsh-task-notice-board
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.