### PR TITLE
catalog: add small-tailqwq-dsh-client-ui-skin-deep-whale-manager (community curation, created by @Small-tailqwq)

### DIFF
--- a/catalog/plugins/small-tailqwq-dsh-client-ui-skin-deep-whale-manager.yaml
+++ b/catalog/plugins/small-tailqwq-dsh-client-ui-skin-deep-whale-manager.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: small-tailqwq-dsh-client-ui-skin-deep-whale-manager
+name: "@dsh-external/dsh-client-ui-skin-deep-whale-manager"
+description:
+  en: Settings-integrated discovery, activation, and skin-owned customization for DSH Web skins
+  evidencePath: skin-manager/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - settings
+  - integrated
+  - discovery
+  - activation
+  - skin
+  - owned
+  - customization
+  - skins
+  - dsh
+source:
+  repository: https://github.com/Small-tailqwq/dsh-deep-whale
+  repositoryNodeId: R_kgDOT3XawA
+  subpath: skin-manager
+  commit: af20f8e8634fbb4490ec6737593da7dbd9046963
+creator:
+  github: Small-tailqwq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: skin-manager/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:21.902Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `small-tailqwq-dsh-client-ui-skin-deep-whale-manager`
- Submission type: community curation
- Created by `Small-tailqwq` — https://github.com/Small-tailqwq
- Original source repository: https://github.com/Small-tailqwq/dsh-deep-whale
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.