### PR TITLE
catalog: add small-tailqwq-dsh-client-ui-skin-orca-link (community curation, created by @Small-tailqwq)

### DIFF
--- a/catalog/plugins/small-tailqwq-dsh-client-ui-skin-orca-link.yaml
+++ b/catalog/plugins/small-tailqwq-dsh-client-ui-skin-orca-link.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: small-tailqwq-dsh-client-ui-skin-orca-link
+name: "@dsh-external/dsh-client-ui-skin-orca-link"
+description:
+  en: "Hot-pluggable ORCA LINK skin for the dsh web GUI: pearl-white technical glass, graphite mechanics, and electric-blue signal accents"
+  evidencePath: orca-link/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - pluggable
+  - orca
+  - link
+  - skin
+  - pearl
+  - white
+  - technical
+  - glass
+  - graphite
+  - mechanics
+  - electric
+  - blue
+  - signal
+  - accents
+  - dsh
+source:
+  repository: https://github.com/Small-tailqwq/dsh-deep-whale
+  repositoryNodeId: R_kgDOT3XawA
+  subpath: orca-link
+  commit: af20f8e8634fbb4490ec6737593da7dbd9046963
+creator:
+  github: Small-tailqwq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: orca-link/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: CC-BY-NC-SA-4.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:21.902Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `small-tailqwq-dsh-client-ui-skin-orca-link`
- Submission type: community curation
- Created by `Small-tailqwq` — https://github.com/Small-tailqwq
- Original source repository: https://github.com/Small-tailqwq/dsh-deep-whale
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.