### PR TITLE
catalog: add snow-the-dsh-session-handoff (community curation, created by @snow-The)

### DIFF
--- a/catalog/plugins/snow-the-dsh-session-handoff.yaml
+++ b/catalog/plugins/snow-the-dsh-session-handoff.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: snow-the-dsh-session-handoff
+name: "@snow-the/dsh-session-handoff"
+description:
+  en: "Session handoff & context management for DeepSeek Harness: structured handoff documents (export/resume/status), active context pruning (acp tools + pressure banner), session management (trash/restore/purge), model routes for one model across vendors/plans, and optional OpenViking memory / archify diagram integration. C"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session
+  - handoff
+  - context
+  - compaction
+  - memory
+  - model-routes
+source:
+  repository: https://github.com/snow-The/dsh-session-handoff
+  repositoryNodeId: R_kgDOT8x3xA
+  subpath: null
+  commit: 663dbdc7cd7de72e1e60beca6b04ff9b5660e7e8
+creator:
+  github: snow-The
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:57.732Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `snow-the-dsh-session-handoff`
- Submission type: community curation
- Created by `snow-The` — https://github.com/snow-The
- Original source repository: https://github.com/snow-The/dsh-session-handoff
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.