### PR TITLE
catalog: add snowamberx-dsh-role-router (community curation, created by @SnowAmberX)

### DIFF
--- a/catalog/plugins/snowamberx-dsh-role-router.yaml
+++ b/catalog/plugins/snowamberx-dsh-role-router.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: snowamberx-dsh-role-router
+name: "@snowamberx/dsh-role-router"
+description:
+  en: "Route DeepSeek Harness agent requests by role: planner model in plan mode, default model otherwise, subagent model for subagents."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - bundle
+  - model-routing
+source:
+  repository: https://github.com/SnowAmberX/dsh-role-router
+  repositoryNodeId: R_kgDOT4FcUQ
+  subpath: null
+  commit: a4b67633e314dd9a1975c9c5272946930cfd39fd
+creator:
+  github: SnowAmberX
+package:
+  ecosystem: npm
+  name: "@snowamberx/dsh-role-router"
+  version: 0.2.2
+  integrity: sha512-lyLWEKMn5x4CMtzpLWWtml6WWK3KCMMVSQ04xxYYlaillnNcZrnTMjqNABTeFaATKZfPRNUfO81aArHShBTiOg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:36.861Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `snowamberx-dsh-role-router`
- Submission type: community curation
- Created by `SnowAmberX` — https://github.com/SnowAmberX
- Original source repository: https://github.com/SnowAmberX/dsh-role-router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.