### PR TITLE
catalog: add snowshadow-dsh-llm-gateway-compat (community curation, created by @snowshadow)

### DIFF
--- a/catalog/plugins/snowshadow-dsh-llm-gateway-compat.yaml
+++ b/catalog/plugins/snowshadow-dsh-llm-gateway-compat.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: snowshadow-dsh-llm-gateway-compat
+name: dsh-llm-gateway-compat
+description:
+  en: OpenAI-compatible gateway adapter and dialect fixes for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - llm
+  - openai-compatible
+  - dsh
+source:
+  repository: https://github.com/snowshadow/dsh-llm-gateway-compat
+  repositoryNodeId: R_kgDOT_ibwg
+  subpath: null
+  commit: bd09649089209bfc7bb44bccfdec540f76f3735c
+creator:
+  github: snowshadow
+package:
+  ecosystem: npm
+  name: dsh-llm-gateway-compat
+  version: 0.3.0
+  integrity: sha512-t81gi3lFDcxmR4NGF2klqfb6MaSJKJN8/H7AE2eOa1tu/dbiJ2FJlPjD4N0iy2vIkDfeq27rECy8cgtvLCdhgg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:57.724Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `snowshadow-dsh-llm-gateway-compat`
- Submission type: community curation
- Created by `snowshadow` — https://github.com/snowshadow
- Original source repository: https://github.com/snowshadow/dsh-llm-gateway-compat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.