### PR TITLE
catalog: add socfeng-dsh-query-jump (community curation, created by @SocFeng)

### DIFF
--- a/catalog/plugins/socfeng-dsh-query-jump.yaml
+++ b/catalog/plugins/socfeng-dsh-query-jump.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: socfeng-dsh-query-jump
+name: dsh-query-jump
+description:
+  en: bash dsh plugin --profile web remove dsh-query-jump dsh plugin --profile web add github:SocFeng/dsh-query-jump
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - query-jump
+  - navigation
+source:
+  repository: https://github.com/SocFeng/dsh-query-jump
+  repositoryNodeId: R_kgDOT7C7WQ
+  subpath: null
+  commit: d255937a0ac4b167bd761ae08c01263ceef9d328
+creator:
+  github: SocFeng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:49.722Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `socfeng-dsh-query-jump`
- Submission type: community curation
- Created by `SocFeng` — https://github.com/SocFeng
- Original source repository: https://github.com/SocFeng/dsh-query-jump
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.