### PR TITLE
catalog: add sodazilla-zzz-dsh-liquid-glass-balance-card (community curation, created by @SoDaZilla-zzz)

### DIFF
--- a/catalog/plugins/sodazilla-zzz-dsh-liquid-glass-balance-card.yaml
+++ b/catalog/plugins/sodazilla-zzz-dsh-liquid-glass-balance-card.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: sodazilla-zzz-dsh-liquid-glass-balance-card
+name: dsh-liquid-glass-balance-card
+description:
+  en: "DeepSeek Harness (DSH) web GUI plugin: a draggable liquid-glass floating card showing DeepSeek API balance, cumulative spend and token usage in the top-right corner."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - balance
+  - quota
+  - liquid-glass
+  - draggable
+source:
+  repository: https://github.com/SoDaZilla-zzz/dsh-liquid-glass-balance-card
+  repositoryNodeId: R_kgDOT52PUA
+  subpath: null
+  commit: 3fbca87bf6d68af66f1669c592bae1e6e6ab4463
+creator:
+  github: SoDaZilla-zzz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:33.896Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sodazilla-zzz-dsh-liquid-glass-balance-card`
- Submission type: community curation
- Created by `SoDaZilla-zzz` — https://github.com/SoDaZilla-zzz
- Original source repository: https://github.com/SoDaZilla-zzz/dsh-liquid-glass-balance-card
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.