### PR TITLE
catalog: add sologuy-dsh-llm-bailian-kimi (community curation, created by @sologuy)

### DIFF
--- a/catalog/plugins/sologuy-dsh-llm-bailian-kimi.yaml
+++ b/catalog/plugins/sologuy-dsh-llm-bailian-kimi.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: sologuy-dsh-llm-bailian-kimi
+name: dsh-llm-bailian-kimi
+description:
+  en: sh dsh plugin --profile web add github:sologuy/dsh-llm-bailian-kimi
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - profile
+  - sologuy
+  - bailian
+  - kimi
+  - dsh
+source:
+  repository: https://github.com/sologuy/dsh-llm-bailian-kimi
+  repositoryNodeId: R_kgDOT9O2TA
+  subpath: null
+  commit: fb8540e6afd00dbda148f7c1131a04ea28f3c3d7
+creator:
+  github: sologuy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:58.037Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sologuy-dsh-llm-bailian-kimi`
- Submission type: community curation
- Created by `sologuy` — https://github.com/sologuy
- Original source repository: https://github.com/sologuy/dsh-llm-bailian-kimi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.