### PR TITLE
catalog: add somnusovis-dsh-multi-workspace (community curation, created by @somnusovis)

### DIFF
--- a/catalog/plugins/somnusovis-dsh-multi-workspace.yaml
+++ b/catalog/plugins/somnusovis-dsh-multi-workspace.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: somnusovis-dsh-multi-workspace
+name: dsh-multi-workspace
+description:
+  en: "Multi-workspace sandbox for DSH: automatically grant file-write access to ALL registered workspaces — add a workspace in the UI, write to it immediately, no config needed."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - multi-workspace
+  - sandbox
+source:
+  repository: https://github.com/somnusovis/dsh-multi-workspace
+  repositoryNodeId: R_kgDOT5TIow
+  subpath: null
+  commit: 3eec3cb75910ee89236ee8950b71a03911f98267
+creator:
+  github: somnusovis
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:49.995Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `somnusovis-dsh-multi-workspace`
- Submission type: community curation
- Created by `somnusovis` — https://github.com/somnusovis
- Original source repository: https://github.com/somnusovis/dsh-multi-workspace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.