### PR TITLE
catalog: add songoao25-dsh-chatgpt-subscription (community curation, created by @songoao25)

### DIFF
--- a/catalog/plugins/songoao25-dsh-chatgpt-subscription.yaml
+++ b/catalog/plugins/songoao25-dsh-chatgpt-subscription.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: songoao25-dsh-chatgpt-subscription
+name: dsh-chatgpt-subscription
+description:
+  en: A DeepSeek Harness plugin that lets you sign in with your ChatGPT account using the official OAuth flow and chat with ChatGPT models inside DSH, consuming your ChatGPT Plus / Pro subscription quota.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - chatgpt
+  - codex
+  - subscription
+  - oauth
+source:
+  repository: https://github.com/songoao25/dsh-chatgpt-subscription
+  repositoryNodeId: R_kgDOT5bdgA
+  subpath: null
+  commit: 4d447e4c3e0b8380af946acb79e05731677f5840
+creator:
+  github: songoao25
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:41.668Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `songoao25-dsh-chatgpt-subscription`
- Submission type: community curation
- Created by `songoao25` — https://github.com/songoao25
- Original source repository: https://github.com/songoao25/dsh-chatgpt-subscription
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.