### PR TITLE
catalog: add songoao25-dsh-virtual-product-team (community curation, created by @songoao25)

### DIFF
--- a/catalog/plugins/songoao25-dsh-virtual-product-team.yaml
+++ b/catalog/plugins/songoao25-dsh-virtual-product-team.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: songoao25-dsh-virtual-product-team
+name: dsh-virtual-product-team
+description:
+  en: A DeepSeek Harness agent mode that walks you through the full product pipeline — from idea validation to release, promotion, and iteration — by saying "I have an idea".
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - agent-preset
+  - product-management
+  - ai-agent
+  - virtual-team
+  - product-team
+source:
+  repository: https://github.com/songoao25/dsh-virtual-product-team
+  repositoryNodeId: R_kgDOT5AQeA
+  subpath: null
+  commit: 1c49f53f88737dca59c4081bbb4eb62b36ebae09
+creator:
+  github: songoao25
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:33.905Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `songoao25-dsh-virtual-product-team`
- Submission type: community curation
- Created by `songoao25` — https://github.com/songoao25
- Original source repository: https://github.com/songoao25/dsh-virtual-product-team
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.