### PR TITLE
catalog: add spirits001-dsh-tokensforce (community curation, created by @spirits001)

### DIFF
--- a/catalog/plugins/spirits001-dsh-tokensforce.yaml
+++ b/catalog/plugins/spirits001-dsh-tokensforce.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: spirits001-dsh-tokensforce
+name: dsh-tokensforce
+description:
+  en: "DeepSeek Harness plugin: tokensforce gateway integration — login onboarding, provider profiles, and the usage dashboard tab"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - tokensforce
+  - gateway
+  - integration
+  - login
+  - onboarding
+  - provider
+  - profiles
+  - usage
+  - dashboard
+  - dsh
+source:
+  repository: https://github.com/spirits001/dsh-tokensforce
+  repositoryNodeId: R_kgDOT445hQ
+  subpath: null
+  commit: 06fe10b5c021af17bbe08125c25dc3ac383fd488
+creator:
+  github: spirits001
+package:
+  ecosystem: npm
+  name: dsh-tokensforce
+  version: 0.5.2
+  integrity: sha512-XITGcoyYKeGwKisSRDLY4WX+MdIHNqoyU+41198jQ9MhM9faRmrDcwJiFtfv0D/fC1XcaHTSf/OxV15Qw9lpGg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:50.000Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `spirits001-dsh-tokensforce`
- Submission type: community curation
- Created by `spirits001` — https://github.com/spirits001
- Original source repository: https://github.com/spirits001/dsh-tokensforce
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.