### PR TITLE
catalog: add spookysandwich-dsh-plugin-message-edit (community curation, created by @SpookySandwich)

### DIFF
--- a/catalog/plugins/spookysandwich-dsh-plugin-message-edit.yaml
+++ b/catalog/plugins/spookysandwich-dsh-plugin-message-edit.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: spookysandwich-dsh-plugin-message-edit
+name: dsh-plugin-message-edit
+description:
+  en: "ChatGPT-style message editing for DeepSeek Harness: edit a past prompt to rewind and branch the conversation, switch versions with a counter under the bubble, and browse branches in a tree."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis-plugin
+  - message-edit
+  - edit
+  - branch
+  - version-tree
+source:
+  repository: https://github.com/SpookySandwich/dsh-plugin-message-edit
+  repositoryNodeId: R_kgDOT_wqbg
+  subpath: null
+  commit: cebadc4186d4cd5098f5a904319b019c1f1b393b
+creator:
+  github: SpookySandwich
+package:
+  ecosystem: npm
+  name: dsh-plugin-message-edit
+  version: 1.0.0
+  integrity: sha512-QewO+zmBAtK6hqsdUTwvdM90W3SBIouAuA8CDIOy2ARf94iyzqleK3OVVUSOnex/FlOjs4P62WF7TExE1SRWSw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:42.744Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `spookysandwich-dsh-plugin-message-edit`
- Submission type: community curation
- Created by `SpookySandwich` — https://github.com/SpookySandwich
- Original source repository: https://github.com/SpookySandwich/dsh-plugin-message-edit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.