### PR TITLE
catalog: add spookysandwich-dsh-plugin-no-workspace (community curation, created by @SpookySandwich)

### DIFF
--- a/catalog/plugins/spookysandwich-dsh-plugin-no-workspace.yaml
+++ b/catalog/plugins/spookysandwich-dsh-plugin-no-workspace.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: spookysandwich-dsh-plugin-no-workspace
+name: dsh-plugin-no-workspace
+description:
+  en: Start and detach standalone chats without a mandatory workspace in DeepSeek Harness while preserving the native workspace UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis-plugin
+  - no-workspace
+  - workspace-free
+  - direct-chat
+  - standalone-chat
+source:
+  repository: https://github.com/SpookySandwich/dsh-plugin-no-workspace
+  repositoryNodeId: R_kgDOUA5ceQ
+  subpath: null
+  commit: 28a3daaab62058191e01d1141afb820033395842
+creator:
+  github: SpookySandwich
+package:
+  ecosystem: npm
+  name: dsh-plugin-no-workspace
+  version: 1.0.0
+  integrity: sha512-+AXQ2ASrzH6eiAhpRPLUZ6NiY2VaUM71SEBAxiKCUve/VmsUke+OjdrOFQXKlQwnXIhznp4U2WJOFULSzBFJ3Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:58.058Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `spookysandwich-dsh-plugin-no-workspace`
- Submission type: community curation
- Created by `SpookySandwich` — https://github.com/SpookySandwich
- Original source repository: https://github.com/SpookySandwich/dsh-plugin-no-workspace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.