### PR TITLE
catalog: add spookysandwich-dsh-plugin-rollout-scout (community curation, created by @SpookySandwich)

### DIFF
--- a/catalog/plugins/spookysandwich-dsh-plugin-rollout-scout.yaml
+++ b/catalog/plugins/spookysandwich-dsh-plugin-rollout-scout.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: spookysandwich-dsh-plugin-rollout-scout
+name: dsh-plugin-rollout-scout
+description:
+  en: "Detect which conversation model your DeepSeek Harness account is served: score probe conversations' live chain-of-thought, cancel old-model probes in seconds, keep confident catches."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis-plugin
+  - rollout
+  - ab-test
+  - model-detection
+source:
+  repository: https://github.com/SpookySandwich/dsh-plugin-rollout-scout
+  repositoryNodeId: R_kgDOT-uzLA
+  subpath: null
+  commit: a56c1b0dd8ad0299e8f9dc537fd3191384d160b8
+creator:
+  github: SpookySandwich
+package:
+  ecosystem: npm
+  name: dsh-plugin-rollout-scout
+  version: 1.4.0
+  integrity: sha512-ZuL4lXdCEhbbf6vkgcUsR95p1ngNIf1toiNp9Bb6QULmo14eNEq0QkdkfokoxqJqY/eEQEaaLiGwnSML8k9LuA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:44.120Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `spookysandwich-dsh-plugin-rollout-scout`
- Submission type: community curation
- Created by `SpookySandwich` — https://github.com/SpookySandwich
- Original source repository: https://github.com/SpookySandwich/dsh-plugin-rollout-scout
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.