### PR TITLE
catalog: add spyqwer1-dsh-codex-tools (community curation, created by @SPYQWER1)

### DIFF
--- a/catalog/plugins/spyqwer1-dsh-codex-tools.yaml
+++ b/catalog/plugins/spyqwer1-dsh-codex-tools.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: spyqwer1-dsh-codex-tools
+name: dsh-codex-tools
+description:
+  en: Codex-backed web search, image generation, and image understanding tools for the DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - image-generation
+  - image-understanding
+  - web-search
+  - vision
+  - chatgpt
+  - codex
+  - openai
+  - gpt-image
+source:
+  repository: https://github.com/SPYQWER1/dsh-codex-tools
+  repositoryNodeId: R_kgDOT4Hh0w
+  subpath: null
+  commit: c19ae5b28fafd56f29a482c6d85db3ffff919444
+creator:
+  github: SPYQWER1
+package:
+  ecosystem: npm
+  name: dsh-codex-tools
+  version: 1.0.1
+  integrity: sha512-ObJcSaqhP4lxpIp4xPbP1c1DX91Pkze0D5xn/pBcnGDfEc2NzqZZdbO4wIIOwZP21Mc+1aLwswk9zqAqH4hOfQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:36.372Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `spyqwer1-dsh-codex-tools`
- Submission type: community curation
- Created by `SPYQWER1` — https://github.com/SPYQWER1
- Original source repository: https://github.com/SPYQWER1/dsh-codex-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.