### PR TITLE
catalog: add stardustlc666-dsh-code-security (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-code-security.yaml
+++ b/catalog/plugins/stardustlc666-dsh-code-security.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: stardustlc666-dsh-code-security
+name: dsh-code-security
+description:
+  en: Every agent code change passes a local security scan before delivery.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - security
+  - code-review
+  - sast
+  - secrets
+  - owasp
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-code-security
+  repositoryNodeId: R_kgDOT5kX7w
+  subpath: null
+  commit: cd38e7fd6dce10b2d0635c355407a91d87c2a7b9
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-code-security
+  version: 0.3.0
+  integrity: sha512-5D0YagOjBFBcAirZOrABxj/MRLF4YhWfbZo8dmNkoL/HwcqEPhaDzmHZesnYevbV61ceW4J10c5GyCPT6FwoCQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:50.408Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-code-security`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-code-security
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.