### PR TITLE
catalog: add stardustlc666-dsh-email (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-email.yaml
+++ b/catalog/plugins/stardustlc666-dsh-email.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: stardustlc666-dsh-email
+name: dsh-email
+description:
+  en: "IMAP/SMTP email tools for DeepSeek Harness: list, read, search and send mail, with QQ/163/126/Sina/Aliyun/Gmail/Outlook/iCloud presets."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - email
+  - imap
+  - smtp
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-email
+  repositoryNodeId: R_kgDOT3vK5Q
+  subpath: null
+  commit: 3c679a514633244d75a3660ef88f80b356febf82
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-email
+  version: 0.8.0
+  integrity: sha512-PiQSunrt8ILCVgUQKE0pSSBbxFYPD3sAoyN6n6cj+UPwFfgcyjhfvlkRL1F+F4CiZe2rF9rOEGF6Nm/wCbRAeg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:27.669Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-email`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-email
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.