### PR TITLE
catalog: add stardustlc666-dsh-ffmpeg (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-ffmpeg.yaml
+++ b/catalog/plugins/stardustlc666-dsh-ffmpeg.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: stardustlc666-dsh-ffmpeg
+name: dsh-ffmpeg
+description:
+  en: "DSH (DeepSeek Harness) video-processing plugin: seven tools covering probing, cutting, concatenation, transcoding, subtitles, extraction and GIF creation — all powered by ffmpeg/ffprobe."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - ffmpeg
+  - video
+  - media
+  - dsh-plugin
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-ffmpeg
+  repositoryNodeId: R_kgDOT4se0w
+  subpath: null
+  commit: 2370802ad88d5977d77ec4b54e0f2d90ae62682a
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-ffmpeg
+  version: 0.3.0
+  integrity: sha512-Md/DXP3pvMp92pgULb5XMc8Temx4yAZVYhVW+m2sQfOmSVaNhCP9ybdKLSHbFPJoA6PEvxFW4PuXTgqwaHOM4g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:38.752Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-ffmpeg`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-ffmpeg
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.