### PR TITLE
catalog: add stardustlc666-dsh-flakefinder (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-flakefinder.yaml
+++ b/catalog/plugins/stardustlc666-dsh-flakefinder.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: stardustlc666-dsh-flakefinder
+name: dsh-flakefinder
+description:
+  en: Teach agents the difference between broken code and a flaky test.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - testing
+  - flaky-test
+  - quality
+  - dsh-plugin
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-flakefinder
+  repositoryNodeId: R_kgDOT5e9PQ
+  subpath: null
+  commit: fa23dac5ebb18baf6d8e8ce8691fa2276984cfc5
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-flakefinder
+  version: 0.3.0
+  integrity: sha512-se/XPonJdiBxjN0QiVaWXMVH2svJ6TIFUXYDtDOlehvjssqsLxVlXZpBfkRXXeQIr6e6cZlVSQGrjj5YDVil9Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:51.984Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-flakefinder`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-flakefinder
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.