### PR TITLE
catalog: add stardustlc666-dsh-hyperframes (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-hyperframes.yaml
+++ b/catalog/plugins/stardustlc666-dsh-hyperframes.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: stardustlc666-dsh-hyperframes
+name: dsh-hyperframes
+description:
+  en: "DSH (DeepSeek Harness) video-creation skill plugin: installing it registers the five official HyperFrames by HeyGen skills into DSH (video from HTML: compositions, GSAP animation, captions, voiceovers, audio-reactive visuals, website-to-video)."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - skills
+  - video
+  - dsh-plugin
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-hyperframes
+  repositoryNodeId: R_kgDOT4uv7g
+  subpath: null
+  commit: 646a9489015d622b1b3f10c984fb5879794a6d70
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-hyperframes
+  version: 0.2.0
+  integrity: sha512-+JJIEqxO595Z0IRD2R+9sJTc8KBKPACXhE5lyPGPddUkCG4C3oCIhgexBZck1fe6KR3wLMGTuGd1XYrt2a4faQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:36.363Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-hyperframes`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-hyperframes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.