### PR TITLE
catalog: add stardustlc666-dsh-remotion (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-remotion.yaml
+++ b/catalog/plugins/stardustlc666-dsh-remotion.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: stardustlc666-dsh-remotion
+name: dsh-remotion
+description:
+  en: "DSH (DeepSeek Harness) video-creation skill plugin: installing it registers the official Remotion skill into DSH (programmatic video with React: animation, audio, captions, 3D, charts, fonts, and 38 rule files)."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - skills
+  - video
+  - dsh-plugin
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-remotion
+  repositoryNodeId: R_kgDOT4uvmA
+  subpath: null
+  commit: 19a174ec01cf779a5aca620f258e13162357cfe5
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-remotion
+  version: 0.2.0
+  integrity: sha512-aBSs/tv6aA5ehjlgE60Jfzc0KnS7OdaAclQN2XdXNsjx6EndJIzDIk5QMEK7KtbKt1AHJQXKN4+zn/CsmeW+tw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:28.950Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-remotion`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-remotion
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.