### PR TITLE
catalog: add stardustlc666-dsh-rss (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-rss.yaml
+++ b/catalog/plugins/stardustlc666-dsh-rss.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: stardustlc666-dsh-rss
+name: dsh-rss
+description:
+  en: "DSH (DeepSeek Harness) plugin for RSS/Atom subscriptions: manage feeds, fetch and parse RSS 0.9x / 1.0 / 2.0 and Atom, with OPML bulk import/export, exposing seven model-facing tools."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - rss
+  - atom
+  - feed
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-rss
+  repositoryNodeId: R_kgDOT4OFYg
+  subpath: null
+  commit: 9c3e0a7c4416840079e8315302e1dd73e48a7c96
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-rss
+  version: 0.3.0
+  integrity: sha512-studOVg3pprFUHTG+dilh4gBK9mgtLtazR8/lSxm/pOds1oRYs5dUshZyRlWx5rBVxojENsFgPwewDak7K3UWw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:39.091Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-rss`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-rss
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.