### PR TITLE
catalog: add stardustlc666-dsh-slack (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-slack.yaml
+++ b/catalog/plugins/stardustlc666-dsh-slack.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: stardustlc666-dsh-slack
+name: dsh-slack
+description:
+  en: "DSH (DeepSeek Harness) community plugin: lets the agent communicate with Slack bidirectionally."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-slack
+  repositoryNodeId: R_kgDOT30TXg
+  subpath: null
+  commit: e58ea02aee6e8c5b6901e38725238ea7461c3319
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-slack
+  version: 0.3.0
+  integrity: sha512-9bPTAcAizIU6j3/v9Ija8uw/AhJepWz9nyOqe4w93qA+EZ4tdqLNKTn42C+KiXlnRl5WyZsApwzQVr+YtP0kMA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:39.061Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-slack`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-slack
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.