### PR TITLE
catalog: add stardustlc666-dsh-sql (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-sql.yaml
+++ b/catalog/plugins/stardustlc666-dsh-sql.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: stardustlc666-dsh-sql
+name: dsh-sql
+description:
+  en: "Your agent can query databases now : SQLite / MySQL / PostgreSQL engines, read-only whitelist + write approval gate."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - deepseek-harness
+  - sql
+  - sqlite
+  - mysql
+  - postgresql
+  - database
+  - dsh-plugin
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-sql
+  repositoryNodeId: R_kgDOT4wbtw
+  subpath: null
+  commit: ab058bc3cc97c42140b95a269032f8e6d516404e
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-sql
+  version: 0.4.0
+  integrity: sha512-832YO5zH1uRyxc+FL1dvJxaAsvM1uz2LHXokqR/XC/BHo3sKHgcxvQkLZ8piFfe7X6nATLPD4l68OKFFdCz4qg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:36.865Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-sql`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-sql
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.