### PR TITLE
catalog: add stardustlc666-dsh-voice (community curation, created by @STARDUSTLC666)

### DIFF
--- a/catalog/plugins/stardustlc666-dsh-voice.yaml
+++ b/catalog/plugins/stardustlc666-dsh-voice.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: stardustlc666-dsh-voice
+name: dsh-voice
+description:
+  en: "DSH (DeepSeek Harness) voice plugin pair: let the agent speak and listen ."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - tts
+  - stt
+  - whisper
+  - voice
+  - dsh-plugin
+source:
+  repository: https://github.com/STARDUSTLC666/dsh-voice
+  repositoryNodeId: R_kgDOT4uQQQ
+  subpath: null
+  commit: e8a90d4917cd28897727df6bea33cc0568a95f38
+creator:
+  github: STARDUSTLC666
+package:
+  ecosystem: npm
+  name: dsh-voice
+  version: 0.3.0
+  integrity: sha512-5a42P6/RI0e8o1jwcOwVA5LtyJhrpMggQZgAYS8zAUbMlm2VDcAWuFLnmA8LWPjUz2wsKdz+iBzLJMJOoi6U6A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:44.118Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stardustlc666-dsh-voice`
- Submission type: community curation
- Created by `STARDUSTLC666` — https://github.com/STARDUSTLC666
- Original source repository: https://github.com/STARDUSTLC666/dsh-voice
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.