### PR TITLE
catalog: add starsstreaming-beauticode-dsh (community curation, created by @starsstreaming)

### DIFF
--- a/catalog/plugins/starsstreaming-beauticode-dsh.yaml
+++ b/catalog/plugins/starsstreaming-beauticode-dsh.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: starsstreaming-beauticode-dsh
+name: beauticode-dsh
+description:
+  en: "Cordis plugin: image/video backgrounds for DeepSeek Harness web."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - background
+  - wallpaper
+source:
+  repository: https://github.com/starsstreaming/beautiCode
+  repositoryNodeId: R_kgDOTl5fWg
+  subpath: integrations/deepseek-harness
+  commit: 5d42fd8bca25420a95d21bbf8fa9bd140d4713a4
+creator:
+  github: starsstreaming
+package:
+  ecosystem: npm
+  name: beauticode-dsh
+  version: 1.0.22
+  integrity: sha512-b1AaItdxaSwBHvwV6BJwKa6T+T3/jSKRBg0/V+GMg8/CITVBYR3siqnt32JBQTV7QYqLN7/DkoOU7ik/l4gW/A==
+dsh:
+  profiles:
+    - web
+  evidencePath: integrations/deepseek-harness/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:23.226Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `starsstreaming-beauticode-dsh`
- Submission type: community curation
- Created by `starsstreaming` — https://github.com/starsstreaming
- Original source repository: https://github.com/starsstreaming/beautiCode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.