### PR TITLE
catalog: add stephenlzc-dsh-swarm-panel (community curation, created by @stephenlzc)

### DIFF
--- a/catalog/plugins/stephenlzc-dsh-swarm-panel.yaml
+++ b/catalog/plugins/stephenlzc-dsh-swarm-panel.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: stephenlzc-dsh-swarm-panel
+name: dsh-swarm-panel
+description:
+  en: "dsh-swarm-panel: DSH Agent Swarm plugin with Conversation Flow observability, dynamic topology, cold resume, and layered HITL"
+  evidencePath: dsh-swarm-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - swarm
+  - panel
+  - agent
+  - conversation
+  - flow
+  - observability
+  - dynamic
+  - topology
+  - cold
+  - resume
+  - layered
+  - hitl
+  - dsh
+source:
+  repository: https://github.com/stephenlzc/dsh-swarm-panel
+  repositoryNodeId: R_kgDOUCtYZA
+  subpath: dsh-swarm-plugin
+  commit: 8d8b1a8bd0e9120099cdd2439932a7e0fe5df16b
+creator:
+  github: stephenlzc
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: dsh-swarm-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:25.113Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stephenlzc-dsh-swarm-panel`
- Submission type: community curation
- Created by `stephenlzc` — https://github.com/stephenlzc
- Original source repository: https://github.com/stephenlzc/dsh-swarm-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.