### PR TITLE
catalog: add stfq-dsh-session-showcase (community curation, created by @STFQ)

### DIFF
--- a/catalog/plugins/stfq-dsh-session-showcase.yaml
+++ b/catalog/plugins/stfq-dsh-session-showcase.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: stfq-dsh-session-showcase
+name: dsh-session-showcase
+description:
+  en: Turn DeepSeek Harness sessions into redacted, README-ready animated demos — as a local CLI or DSH plugin.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-plugin-demo
+  - ai-agent
+  - agent-session
+  - session-replay
+  - demo-generator
+  - agent-demo
+  - session-to-video
+  - animated-webp
+  - animated-gif
+  - github-readme
+  - redaction
+  - offline
+  - zero-token
+source:
+  repository: https://github.com/STFQ/dsh-showcase
+  repositoryNodeId: R_kgDOT9yTaw
+  subpath: null
+  commit: b2793049cc179500f0218f027ceb2130ad89a8ba
+creator:
+  github: STFQ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:59.171Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stfq-dsh-session-showcase`
- Submission type: community curation
- Created by `STFQ` — https://github.com/STFQ
- Original source repository: https://github.com/STFQ/dsh-showcase
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.