### PR TITLE
catalog: add stormycry-dsh-auth-in-one (community curation, created by @Stormycry)

### DIFF
--- a/catalog/plugins/stormycry-dsh-auth-in-one.yaml
+++ b/catalog/plugins/stormycry-dsh-auth-in-one.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: stormycry-dsh-auth-in-one
+name: dsh-auth-in-one
+description:
+  en: Self-contained DeepSeek Harness plugin for Provider login, model switching, image fallback, usage analytics, and same-port Web restart
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - openai-codex
+  - oauth
+  - device-code
+  - provider-authentication
+  - llm-provider
+  - openai-compatible
+  - custom-api
+  - model-switching
+  - token-usage
+  - cost-tracking
+  - usage-analytics
+  - vision-fallback
+  - multimodal
+  - image-understanding
+source:
+  repository: https://github.com/Stormycry-cryp/dsh-AuthInOne
+  repositoryNodeId: R_kgDOT379Sw
+  subpath: null
+  commit: 190ecc2d834ba06da008522684e689324a9c2706
+creator:
+  github: Stormycry
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:29.225Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 105
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stormycry-dsh-auth-in-one`
- Submission type: community curation
- Created by `Stormycry` — https://github.com/Stormycry
- Original source repository: https://github.com/Stormycry-cryp/dsh-AuthInOne
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.