### PR TITLE
catalog: add stringadmin-dsh-igm-memory (community curation, created by @Stringadmin)

### DIFF
--- a/catalog/plugins/stringadmin-dsh-igm-memory.yaml
+++ b/catalog/plugins/stringadmin-dsh-igm-memory.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: stringadmin-dsh-igm-memory
+name: dsh-igm-memory
+description:
+  en: Typed, importance-gated and guarded memory tools for DeepSeek Harness with isolated current-state and optional version history
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent
+  - memory
+  - igm
+  - rag
+source:
+  repository: https://github.com/Stringadmin/dsh-igm-memory
+  repositoryNodeId: R_kgDOT9R4wg
+  subpath: null
+  commit: 4164f4a111459a3506c7bde0c5103409a5a80ea6
+creator:
+  github: Stringadmin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:44:25.749Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stringadmin-dsh-igm-memory`
- Submission type: community curation
- Created by `Stringadmin` — https://github.com/Stringadmin
- Original source repository: https://github.com/Stringadmin/dsh-igm-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.