### PR TITLE
catalog: add stuarthu-dsh-chrome (community curation, created by @stuarthu)

### DIFF
--- a/catalog/plugins/stuarthu-dsh-chrome.yaml
+++ b/catalog/plugins/stuarthu-dsh-chrome.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: stuarthu-dsh-chrome
+name: dsh-chrome
+description:
+  en: "DeepSeek Harness (dsh) browser companion: a Chrome side panel that embeds the full dsh web UI and lets the dsh agent read the current page, capture HTTP traffic, and drive the browser."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - chrome
+  - chrome-extension
+  - browser
+  - browser-agent
+  - browser-automation
+source:
+  repository: https://github.com/stuarthu/dsh-chrome
+  repositoryNodeId: R_kgDOT5L-og
+  subpath: null
+  commit: 1c15b3caa4d4c2ceac74a2bf049a590186a3f88f
+creator:
+  github: stuarthu
+package:
+  ecosystem: npm
+  name: dsh-chrome
+  version: 0.1.3
+  integrity: sha512-wv+mkQ30Y2S9TWSqkTqlKK+UC2TOt1TVysAoFImtwUzZAPb+HudcxKyvY3yks0lcZIj2o7zfr2SMtdkfb7/Xfw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:39.055Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stuarthu-dsh-chrome`
- Submission type: community curation
- Created by `stuarthu` — https://github.com/stuarthu
- Original source repository: https://github.com/stuarthu/dsh-chrome
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.