### PR TITLE
catalog: add stuarthu2-dsh-crew (community curation, created by @stuarthu2)

### DIFF
--- a/catalog/plugins/stuarthu2-dsh-crew.yaml
+++ b/catalog/plugins/stuarthu2-dsh-crew.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: stuarthu2-dsh-crew
+name: dsh-crew
+description:
+  en: "DeepSeek Harness (dsh) plugin: run work as a small crew of role agents (product manager, researcher, architect, engineer, test engineer, code engineer, QA, code reviewer, security reviewer, doc reviewer) that talk through files on disk, with the PM as the only voice to the user."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - cordis
+  - ai
+  - llm
+  - ai-agent
+  - agents
+  - multi-agent
+  - agent-team
+  - subagent
+  - orchestration
+  - agent-orchestration
+  - coding-agent
+  - code-review
+source:
+  repository: https://github.com/stuarthu/dsh-crew
+  repositoryNodeId: R_kgDOT706MQ
+  subpath: null
+  commit: 09c6e037ef42153d9f5f7a0d7aa9df2b6e432e21
+creator:
+  github: stuarthu2
+package:
+  ecosystem: npm
+  name: dsh-crew
+  version: 0.10.0
+  integrity: sha512-9lG7bRaiqAV+JtDS06Y85/W5gfUrcYh5XTnvYTah8Xfe8bGd48+gVyNQ8Wjh/2arxCV747+w14hh55V3+bmK+Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T11:43:33.205Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stuarthu2-dsh-crew`
- Submission type: community curation
- Created by `stuarthu2` — https://github.com/stuarthu2
- Original source repository: https://github.com/stuarthu/dsh-crew
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.