### PR TITLE
catalog: add beep879-dsh-shareone-plugin (community curation, created by @beep879)

### DIFF
--- a/catalog/plugins/beep879-dsh-shareone-plugin.yaml
+++ b/catalog/plugins/beep879-dsh-shareone-plugin.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: beep879-dsh-shareone-plugin
+name: dsh-shareone-plugin
+description:
+  en: ShareOne tools for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - shareone
+  - cordis
+  - agent-tool
+  - dsh
+source:
+  repository: https://github.com/sudoprivacy/dsh-shareone-plugin
+  repositoryNodeId: R_kgDOT77VDA
+  subpath: null
+  commit: 75218d2e85b18fc70a92a0078f73f41cceb9a4fc
+creator:
+  github: beep879
+package:
+  ecosystem: npm
+  name: dsh-shareone-plugin
+  version: 0.1.0-rc.3
+  integrity: sha512-Ps/mezBHwNomqP1qKO9KvZpvtGtO94KuOO9ww/IwG2wcGOpsklil4ulJdCpovKlcNK7Lu1qv65WOVdoNxKEYqQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:30.326Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `beep879-dsh-shareone-plugin`
- Submission type: community curation
- Created by `beep879` — https://github.com/beep879
- Original source repository: https://github.com/sudoprivacy/dsh-shareone-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.