### PR TITLE
catalog: add cxyhhhhh-dsh-qqbot (community curation, created by @cxyhhhhh)

### DIFF
--- a/catalog/plugins/cxyhhhhh-dsh-qqbot.yaml
+++ b/catalog/plugins/cxyhhhhh-dsh-qqbot.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: cxyhhhhh-dsh-qqbot
+name: "@tencent-connect/dsh-qqbot"
+description:
+  en: QQ Bot IM channel plugin for deepseek-harness (dsh)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - qqbot
+  - cordis
+source:
+  repository: https://github.com/tencent-connect/dsh-qqbot
+  repositoryNodeId: R_kgDOT4bYtA
+  subpath: null
+  commit: 7bac0a9b6dd6e693cfc7532b4e7ecfb3cfcc3b13
+creator:
+  github: cxyhhhhh
+package:
+  ecosystem: npm
+  name: "@tencent-connect/dsh-qqbot"
+  version: 0.4.0
+  integrity: sha512-rFoxUsIJ/St7Hw7Iy01Jn9cpZMe+rPahzrLoNygp1bP1Hd365ONNzaKdKnMloLkCHSdCJm1mVGDnzfLJaZ618Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:06.391Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 82
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cxyhhhhh-dsh-qqbot`
- Submission type: community curation
- Created by `cxyhhhhh` — https://github.com/cxyhhhhh
- Original source repository: https://github.com/tencent-connect/dsh-qqbot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.