### PR TITLE
catalog: add htommr-dsh-flowix-memory (community curation, created by @htommr)

### DIFF
--- a/catalog/plugins/htommr-dsh-flowix-memory.yaml
+++ b/catalog/plugins/htommr-dsh-flowix-memory.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: htommr-dsh-flowix-memory
+name: dsh-flowix-memory
+description:
+  en: "DeepSeek Harness bundle: expose Flowix memos and artifact tools through the local flowix-cli MCP server"
+  evidencePath: dsh-flowix-memory/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - flowix
+  - mcp
+  - notes
+  - dsh
+source:
+  repository: https://github.com/text2future/flowix
+  repositoryNodeId: R_kgDOSm7IOg
+  subpath: dsh-flowix-memory
+  commit: d2614d1e51e6f750e8c77891f630f77112e67877
+creator:
+  github: htommr
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: dsh-flowix-memory/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:49.828Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `htommr-dsh-flowix-memory`
- Submission type: community curation
- Created by `htommr` — https://github.com/htommr
- Original source repository: https://github.com/text2future/flowix
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.