### PR TITLE
catalog: add jiaoyangli-shadow7day-dsh-akn-plugin (community curation, created by @jiaoyangli-shadow7day)

### DIFF
--- a/catalog/plugins/jiaoyangli-shadow7day-dsh-akn-plugin.yaml
+++ b/catalog/plugins/jiaoyangli-shadow7day-dsh-akn-plugin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: jiaoyangli-shadow7day-dsh-akn-plugin
+name: dsh-akn-plugin
+description:
+  en: Installable DeepSeek Harness plugin and reference implementation for the Agent Experience Network and AEXP 0.1
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - agent
+  - experience-network
+  - aexp
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/symmetryseeker/dsh-akn-plugin
+  repositoryNodeId: R_kgDOT7-iLQ
+  subpath: null
+  commit: 1fef6c849b89d9c4e499055cb4c26713c956fe76
+creator:
+  github: jiaoyangli-shadow7day
+package:
+  ecosystem: npm
+  name: dsh-akn-plugin
+  version: 0.2.0
+  integrity: sha512-37Q9xLg6jgs6BcUoeMj9urgwddrCp1H9YWYF/VxpUqrDtAgsR5nzfB4/G0vjUA6EhuAuO3anRneCQKEQ2xc+yg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:13.186Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiaoyangli-shadow7day-dsh-akn-plugin`
- Submission type: community curation
- Created by `jiaoyangli-shadow7day` — https://github.com/jiaoyangli-shadow7day
- Original source repository: https://github.com/symmetryseeker/dsh-akn-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.