### PR TITLE
catalog: add jiaoyangli-shadow7day-dsh-plugin (community curation, created by @jiaoyangli-shadow7day)

### DIFF
--- a/catalog/plugins/jiaoyangli-shadow7day-dsh-plugin.yaml
+++ b/catalog/plugins/jiaoyangli-shadow7day-dsh-plugin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jiaoyangli-shadow7day-dsh-plugin
+name: "@aen/dsh-plugin"
+description:
+  en: DeepSeek Harness Cordis plugin for low-frequency AEN live manifests
+  evidencePath: packages/dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - cordis
+  - frequency
+  - live
+  - manifests
+  - dsh
+source:
+  repository: https://github.com/symmetryseeker/dsh-akn-plugin
+  repositoryNodeId: R_kgDOT7-iLQ
+  subpath: packages/dsh-plugin
+  commit: 1fef6c849b89d9c4e499055cb4c26713c956fe76
+creator:
+  github: jiaoyangli-shadow7day
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: packages/dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:13.186Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jiaoyangli-shadow7day-dsh-plugin`
- Submission type: community curation
- Created by `jiaoyangli-shadow7day` — https://github.com/jiaoyangli-shadow7day
- Original source repository: https://github.com/symmetryseeker/dsh-akn-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.