### PR TITLE
catalog: add openqht-dsh-llm-as-a-verifier (community curation, created by @openqht)

### DIFF
--- a/catalog/plugins/openqht-dsh-llm-as-a-verifier.yaml
+++ b/catalog/plugins/openqht-dsh-llm-as-a-verifier.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: openqht-dsh-llm-as-a-verifier
+name: dsh-llm-as-a-verifier
+description:
+  en: "LLM-as-a-Verifier for DeepSeek Harness: fine-grained reward, Probabilistic Pivot Tournament best-of-N selection, and per-step progress tracking as agent tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - llm-verifier
+  - verification
+  - reward-model
+  - best-of-n
+  - cordis
+source:
+  repository: https://github.com/TaurenMountain/dsh-llm-as-a-verifier
+  repositoryNodeId: R_kgDOT-cAuQ
+  subpath: null
+  commit: 4d69526bea516583658f53b42ada25d8efa70796
+creator:
+  github: openqht
+package:
+  ecosystem: npm
+  name: dsh-llm-as-a-verifier
+  version: 0.1.1
+  integrity: sha512-Fm5V2KaoeSjDFovkMKQbXxjpwsCHD7SrJ9ywvEVr2WFLCv85IOCuBPQevQE8ghCgrs7D8cOjJiDimxHwaZ/xMA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:13.501Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `openqht-dsh-llm-as-a-verifier`
- Submission type: community curation
- Created by `openqht` — https://github.com/openqht
- Original source repository: https://github.com/TaurenMountain/dsh-llm-as-a-verifier
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.