### PR TITLE
catalog: add studyzy-dsh-suggest-prompt (community curation, created by @studyzy)

### DIFF
--- a/catalog/plugins/studyzy-dsh-suggest-prompt.yaml
+++ b/catalog/plugins/studyzy-dsh-suggest-prompt.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: studyzy-dsh-suggest-prompt
+name: "@studyzy/dsh-suggest-prompt"
+description:
+  en: sh dsh plugin --profile web add git@github.com:studyzy/dsh-suggest-prompt.git
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - profile
+  - studyzy
+  - suggest
+  - prompt
+  - dsh
+source:
+  repository: https://github.com/studyzy/dsh-suggest-prompt
+  repositoryNodeId: R_kgDOT3j-8A
+  subpath: null
+  commit: 14d4f3abfb784812ce5fe63d55689f3f8ea6edb0
+creator:
+  github: studyzy
+package:
+  ecosystem: npm
+  name: "@studyzy/dsh-suggest-prompt"
+  version: 1.0.1
+  integrity: sha512-scV7/SFo5Iaon0NJyxGluxtijhi6OAcnQmqZZiL/k6QjY7mpLJuzJhAo5YyGHZ+zizRfUYrxzxNN4uC0KzrOpA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:14.852Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `studyzy-dsh-suggest-prompt`
- Submission type: community curation
- Created by `studyzy` — https://github.com/studyzy
- Original source repository: https://github.com/studyzy/dsh-suggest-prompt
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.