### PR TITLE
catalog: add stvli-dsh-ros2-profile (community curation, created by @StvLi)

### DIFF
--- a/catalog/plugins/stvli-dsh-ros2-profile.yaml
+++ b/catalog/plugins/stvli-dsh-ros2-profile.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: stvli-dsh-ros2-profile
+name: dsh-ros2-profile
+description:
+  en: "dsh-ros2 robot profile: body registration, load, communication-topology knowledge base (snapshot/learn/show/search/diagnose) and zero-pose calibration (4 tools) + robot-registration/robot-retrieval skills. Cordis bundle."
+  evidencePath: packages/profile/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ros2
+source:
+  repository: https://github.com/StvLi/dsh-ros2
+  repositoryNodeId: R_kgDOT7EbTQ
+  subpath: packages/profile
+  commit: a7309851ee6a5b5b11bbbffdefd88be1ebe742bc
+creator:
+  github: StvLi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/profile/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:39.681Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stvli-dsh-ros2-profile`
- Submission type: community curation
- Created by `StvLi` — https://github.com/StvLi
- Original source repository: https://github.com/StvLi/dsh-ros2
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.