### PR TITLE
catalog: add stvli-dsh-ros2-vision (community curation, created by @StvLi)

### DIFF
--- a/catalog/plugins/stvli-dsh-ros2-vision.yaml
+++ b/catalog/plugins/stvli-dsh-ros2-vision.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: stvli-dsh-ros2-vision
+name: dsh-ros2-vision
+description:
+  en: "dsh-ros2 realtime vision: image-topic acquisition, parallel VLM analysis, vision pipeline tools + vision provider service (5 tools) + the vlm/ and offscreen/ ROS2 packages (published) + robot-state-vision-analysis skill. Cordis bundle."
+  evidencePath: packages/vision/README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ros2
+source:
+  repository: https://github.com/StvLi/dsh-ros2
+  repositoryNodeId: R_kgDOT7EbTQ
+  subpath: packages/vision
+  commit: a7309851ee6a5b5b11bbbffdefd88be1ebe742bc
+creator:
+  github: StvLi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/vision/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:39.681Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stvli-dsh-ros2-vision`
- Submission type: community curation
- Created by `StvLi` — https://github.com/StvLi
- Original source repository: https://github.com/StvLi/dsh-ros2
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.