### PR TITLE
catalog: add stylelinzzz-dsh-chat-history (community curation, created by @Stylelinzzz)

### DIFF
--- a/catalog/plugins/stylelinzzz-dsh-chat-history.yaml
+++ b/catalog/plugins/stylelinzzz-dsh-chat-history.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: stylelinzzz-dsh-chat-history
+name: dsh-chat-history
+description:
+  en: "Chat history TOC: a user-message directory as a conversation view tab with click-to-jump"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - chat-history
+  - toc
+  - history
+  - navigation
+source:
+  repository: https://github.com/Stylelinzzz/dsh-chat-history
+  repositoryNodeId: R_kgDOT7brfA
+  subpath: null
+  commit: d8d4b022ddcb97ecbf7fb316218a4fb87858541c
+creator:
+  github: Stylelinzzz
+package:
+  ecosystem: npm
+  name: dsh-chat-history
+  version: 0.1.1
+  integrity: sha512-s6mLccLDdZ5jgrNQbQnZ0/bfpyiTlQlkGLksD993PzGckPu0A3IFW+qHt+XJnFb3ObxwWI0w/Z5KhJU65VMcrw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:30.236Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stylelinzzz-dsh-chat-history`
- Submission type: community curation
- Created by `Stylelinzzz` — https://github.com/Stylelinzzz
- Original source repository: https://github.com/Stylelinzzz/dsh-chat-history
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.