### PR TITLE
catalog: add sucriss-dsh-version-update (community curation, created by @SuCriss)

### DIFF
--- a/catalog/plugins/sucriss-dsh-version-update.yaml
+++ b/catalog/plugins/sucriss-dsh-version-update.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: sucriss-dsh-version-update
+name: dsh-version-update
+description:
+  en: "Version management for the dsh Web GUI settings panel: inspect the installed @deepseek-ai/dsh against every npm channel or version line, install or downgrade with one click, roll back instantly from local snapshots, automate the whole cycle with a policy engine (silent auto-update, execution windows, daily checks), and"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - settings
+  - update
+  - self-update
+  - rollback
+source:
+  repository: https://github.com/SuCriss/dsh-version-update
+  repositoryNodeId: R_kgDOT-dZbg
+  subpath: null
+  commit: 0805410a5db07836a1c85ea1c714c6430d36f95a
+creator:
+  github: SuCriss
+package:
+  ecosystem: npm
+  name: dsh-version-update
+  version: 1.0.6
+  integrity: sha512-ePmIuvKT0GItwScuRwSZ/9/uQ7yU0oTv7X9GBouADaonISGsmGlwGu9bZA64m7Kn62JgAyVJ9aj9fa3HTqijsw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:19.081Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sucriss-dsh-version-update`
- Submission type: community curation
- Created by `SuCriss` — https://github.com/SuCriss
- Original source repository: https://github.com/SuCriss/dsh-version-update
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.