### PR TITLE
catalog: add sugarforever-dsh-mcp-apps (community curation, created by @sugarforever)

### DIFF
--- a/catalog/plugins/sugarforever-dsh-mcp-apps.yaml
+++ b/catalog/plugins/sugarforever-dsh-mcp-apps.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: sugarforever-dsh-mcp-apps
+name: "@sugarforever/dsh-mcp-apps"
+description:
+  en: MCP Apps host plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - apps
+  - host
+  - dsh
+source:
+  repository: https://github.com/sugarforever/dsh-mcp-apps
+  repositoryNodeId: R_kgDOT4kHHw
+  subpath: null
+  commit: 5b444876f7bfb0b99909c73fd2cc2a863f7463fe
+creator:
+  github: sugarforever
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:16.050Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sugarforever-dsh-mcp-apps`
- Submission type: community curation
- Created by `sugarforever` — https://github.com/sugarforever
- Original source repository: https://github.com/sugarforever/dsh-mcp-apps
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.