### PR TITLE
catalog: add suiyideali-dsh-selection-toolbar (community curation, created by @suiyideali)

### DIFF
--- a/catalog/plugins/suiyideali-dsh-selection-toolbar.yaml
+++ b/catalog/plugins/suiyideali-dsh-selection-toolbar.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: suiyideali-dsh-selection-toolbar
+name: dsh-selection-toolbar
+description:
+  en: "Select text in a conversation to get a floating toolbar: copy, quote-reply, ask/explain/translate/summarize, and a custom-prompt input. All AI actions reuse the current session."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - selection
+  - toolbar
+  - quote
+  - translate
+  - summarize
+source:
+  repository: https://github.com/suiyideali/dsh-selection-toolbar
+  repositoryNodeId: R_kgDOT8HEsQ
+  subpath: null
+  commit: 7adedb12537aa4bf1e25be660a5d384bee4f79a4
+creator:
+  github: suiyideali
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:20.602Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `suiyideali-dsh-selection-toolbar`
- Submission type: community curation
- Created by `suiyideali` — https://github.com/suiyideali
- Original source repository: https://github.com/suiyideali/dsh-selection-toolbar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.