### PR TITLE
catalog: add summersec-dsh-web-auth (community curation, created by @SummerSec)

### DIFF
--- a/catalog/plugins/summersec-dsh-web-auth.yaml
+++ b/catalog/plugins/summersec-dsh-web-auth.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: summersec-dsh-web-auth
+name: "@summersec/dsh-web-auth"
+description:
+  en: Transport-level authentication gate for the DeepSeek Harness Web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - authentication
+  - web
+source:
+  repository: https://github.com/SummerSec/dsh-web-auth
+  repositoryNodeId: R_kgDOT5_cNA
+  subpath: null
+  commit: b722e44a881d71fc3eb943627d654a6e293876f8
+creator:
+  github: SummerSec
+package:
+  ecosystem: npm
+  name: "@summersec/dsh-web-auth"
+  version: 0.1.3
+  integrity: sha512-9Hl2PpWKwLkfKYVKvpqHlTByS0vNfAqk3MGvpAdXD5LMYzSb/ZlDh9wmrKnqgv+GdVn7enTuizYFGnh9VofhWQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:20.600Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `summersec-dsh-web-auth`
- Submission type: community curation
- Created by `SummerSec` — https://github.com/SummerSec
- Original source repository: https://github.com/SummerSec/dsh-web-auth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.