### PR TITLE
catalog: add sunyuhuirong-shl-session-history (community curation, created by @sunyuhuirong)

### DIFF
--- a/catalog/plugins/sunyuhuirong-shl-session-history.yaml
+++ b/catalog/plugins/sunyuhuirong-shl-session-history.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: sunyuhuirong-shl-session-history
+name: shl-session-history
+description:
+  en: sh dsh plugin --profile desktop add /path/to/shl-session-history
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - profile
+  - desktop
+  - path
+  - session
+  - history
+  - dsh
+source:
+  repository: https://github.com/sunyuhuirong/shl-session-history
+  repositoryNodeId: R_kgDOT9mcDg
+  subpath: null
+  commit: 72eaa85033cbdc1381a3eb62df42a9f48ed1f1de
+creator:
+  github: sunyuhuirong
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:16.075Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sunyuhuirong-shl-session-history`
- Submission type: community curation
- Created by `sunyuhuirong` — https://github.com/sunyuhuirong
- Original source repository: https://github.com/sunyuhuirong/shl-session-history
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.