### PR TITLE
catalog: add superboy911-dsh-model-router (community curation, created by @superboy911)

### DIFF
--- a/catalog/plugins/superboy911-dsh-model-router.yaml
+++ b/catalog/plugins/superboy911-dsh-model-router.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: superboy911-dsh-model-router
+name: "@dsh-external/dsh-model-router"
+description:
+  en: dsh-model-router is a thin routing-policy plugin for DeepSeek Harness (DSH). DSH still owns providers, credentials, model catalogs, modalities, and retries. This plugin adds deterministic keyword routing, a default-off allowlisted model route tool, and an isolated image gen channel.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - model-router
+  - llm-gateway
+  - deepseek-harness
+source:
+  repository: https://github.com/superboy911/dsh-model-router
+  repositoryNodeId: R_kgDOT4ZVTg
+  subpath: null
+  commit: 98ca5cec34ce1f980be99c225d49bbd6fb021682
+creator:
+  github: superboy911
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:11.294Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `superboy911-dsh-model-router`
- Submission type: community curation
- Created by `superboy911` — https://github.com/superboy911
- Original source repository: https://github.com/superboy911/dsh-model-router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.