### PR TITLE
catalog: add superfish058-dsh-llm-proxy (community curation, created by @superfish058)

### DIFF
--- a/catalog/plugins/superfish058-dsh-llm-proxy.yaml
+++ b/catalog/plugins/superfish058-dsh-llm-proxy.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: superfish058-dsh-llm-proxy
+name: "@superfish058/dsh-llm-proxy"
+description:
+  en: sh dsh plugin --profile web add @superfish058/dsh-llm-proxy
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - llm
+  - proxy
+  - clash
+  - undici
+  - rate-limit
+  - token-bucket
+  - cordis
+  - settings
+  - web-ui
+source:
+  repository: https://github.com/superfish058/dsh-llm-proxy
+  repositoryNodeId: R_kgDOT8QdmQ
+  subpath: null
+  commit: d0a68ca27bcc438c76f26980da0ccc749e6d9a48
+creator:
+  github: superfish058
+package:
+  ecosystem: npm
+  name: "@superfish058/dsh-llm-proxy"
+  version: 1.1.0
+  integrity: sha512-3778d9BQnxAj+SBYUvun7SMYmfAT37fAGM5h7hHewENVUSmsxqFI0jnSfVycIEaPWMfiqpPEBNtmXWFewWeL/Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:10.755Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `superfish058-dsh-llm-proxy`
- Submission type: community curation
- Created by `superfish058` — https://github.com/superfish058
- Original source repository: https://github.com/superfish058/dsh-llm-proxy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.