### PR TITLE
catalog: add suuuuuu-1-dsh-discord (community curation, created by @suuuuuu-1)

### DIFF
--- a/catalog/plugins/suuuuuu-1-dsh-discord.yaml
+++ b/catalog/plugins/suuuuuu-1-dsh-discord.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: suuuuuu-1-dsh-discord
+name: dsh-discord
+description:
+  en: Bidirectional Discord bridge and remote controller for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - bidirectional
+  - discord
+  - bridge
+  - remote
+  - controller
+  - dsh
+source:
+  repository: https://github.com/suuuuuu-1/dsh-discord
+  repositoryNodeId: R_kgDOT4ir2A
+  subpath: null
+  commit: 1c5a55d566fd9eefbbf04a1a81d6e4140240e98c
+creator:
+  github: suuuuuu-1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:16.045Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `suuuuuu-1-dsh-discord`
- Submission type: community curation
- Created by `suuuuuu-1` — https://github.com/suuuuuu-1
- Original source repository: https://github.com/suuuuuu-1/dsh-discord
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.