### PR TITLE
catalog: add swaylq-dsh-digipet (community curation, created by @swaylq)

### DIFF
--- a/catalog/plugins/swaylq-dsh-digipet.yaml
+++ b/catalog/plugins/swaylq-dsh-digipet.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: swaylq-dsh-digipet
+name: dsh-digipet
+description:
+  en: Hatch a digital creature in your DeepSeek Harness. It feeds on your real work — turns, tool calls, even your errors — and evolves along branching lines shaped by how you actually work. Zero tokens, zero tools, the model never knows.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - cordis
+  - ai-agents
+  - digital-pet
+  - tamagotchi-like
+source:
+  repository: https://github.com/swaylq/dsh-digipet
+  repositoryNodeId: R_kgDOT5GYVg
+  subpath: null
+  commit: 1558da9e58c765041c95d061f6e49397b914d086
+creator:
+  github: swaylq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:11.065Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `swaylq-dsh-digipet`
- Submission type: community curation
- Created by `swaylq` — https://github.com/swaylq
- Original source repository: https://github.com/swaylq/dsh-digipet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.