### PR TITLE
catalog: add swaylq-dsh-wildmon (community curation, created by @swaylq)

### DIFF
--- a/catalog/plugins/swaylq-dsh-wildmon.yaml
+++ b/catalog/plugins/swaylq-dsh-wildmon.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: swaylq-dsh-wildmon
+name: dsh-wildmon
+description:
+  en: "A collect-em-all safari for DeepSeek Harness: your real work is the tall grass. Turns, tool calls and errors roll wild encounters; throw balls, fill a 28-slot dex, build a team of six. Zero tokens, zero tools, the model never knows."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - cordis
+  - ai-agents
+  - monster-collecting
+  - pokemon-like
+source:
+  repository: https://github.com/swaylq/dsh-wildmon
+  repositoryNodeId: R_kgDOT5TPXA
+  subpath: null
+  commit: a2c7df00b27c2de9f2b0915d3bd5f1acc4d02c68
+creator:
+  github: swaylq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:21.281Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `swaylq-dsh-wildmon`
- Submission type: community curation
- Created by `swaylq` — https://github.com/swaylq
- Original source repository: https://github.com/swaylq/dsh-wildmon
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.