### PR TITLE
catalog: add swell05-dsh-whale-tank (community curation, created by @swell05)

### DIFF
--- a/catalog/plugins/swell05-dsh-whale-tank.yaml
+++ b/catalog/plugins/swell05-dsh-whale-tank.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: swell05-dsh-whale-tank
+name: "@swell05/dsh-whale-tank"
+description:
+  en: powershell dsh plugin --profile web add @swell05/dsh-whale-tank
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - powershell
+  - profile
+  - swell05
+  - whale
+  - tank
+  - dsh
+source:
+  repository: https://github.com/swell05/dsh-whale-tank
+  repositoryNodeId: R_kgDOT-m1IQ
+  subpath: null
+  commit: c7142649010f28f506e79018c6243655ebc97653
+creator:
+  github: swell05
+package:
+  ecosystem: npm
+  name: "@swell05/dsh-whale-tank"
+  version: 0.1.7
+  integrity: sha512-SZt60BdaSqa4gabv0vdEoEOulXwJcoyOvbALz/z8IUSGb3NIxROdDIjowA9zysK5ITy357MB893fUgoEWDZA0g==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:06.386Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `swell05-dsh-whale-tank`
- Submission type: community curation
- Created by `swell05` — https://github.com/swell05
- Original source repository: https://github.com/swell05/dsh-whale-tank
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.