### PR TITLE
catalog: add sxl19951101-dsh-done-sound (community curation, created by @sxl19951101)

### DIFF
--- a/catalog/plugins/sxl19951101-dsh-done-sound.yaml
+++ b/catalog/plugins/sxl19951101-dsh-done-sound.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: sxl19951101-dsh-done-sound
+name: dsh-done-sound
+description:
+  en: Play a user-chosen sound whenever a conversation finishes in the DeepSeek Harness web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - sound
+  - notification
+  - chime
+  - turn-complete
+  - done
+source:
+  repository: https://github.com/sxl19951101/dsh-done-sound
+  repositoryNodeId: R_kgDOUBU3Ag
+  subpath: null
+  commit: d6f3effc1e0533bc1cf8388f48a816a25bc36fee
+creator:
+  github: sxl19951101
+package:
+  ecosystem: npm
+  name: dsh-done-sound
+  version: 0.1.8
+  integrity: sha512-Nqzd1dmCTrPkSQcUSPq+4Qq+pBD/LWQ5YX6eXaeQFQdjlazj/xV4NDhE1x4ddvkpyU/yT2yz7LrZUbq25KMLEA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:46.895Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sxl19951101-dsh-done-sound`
- Submission type: community curation
- Created by `sxl19951101` — https://github.com/sxl19951101
- Original source repository: https://github.com/sxl19951101/dsh-done-sound
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.