### PR TITLE
catalog: add sylkmpo-dsh-web-app-launcher (community curation, created by @sylkmpo)

### DIFF
--- a/catalog/plugins/sylkmpo-dsh-web-app-launcher.yaml
+++ b/catalog/plugins/sylkmpo-dsh-web-app-launcher.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: sylkmpo-dsh-web-app-launcher
+name: dsh-web-app-launcher
+description:
+  en: DeepSeek Harness Web app-mode launcher bundle for Windows
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - windows
+  - desktop
+  - dsh
+source:
+  repository: https://github.com/sylkmpo/dsh-web-app-launcher
+  repositoryNodeId: R_kgDOT-cVYg
+  subpath: null
+  commit: de4cd2a6449928f23bf62d340fe5968ff34bb6ee
+creator:
+  github: sylkmpo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:21.296Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sylkmpo-dsh-web-app-launcher`
- Submission type: community curation
- Created by `sylkmpo` — https://github.com/sylkmpo
- Original source repository: https://github.com/sylkmpo/dsh-web-app-launcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.