### PR TITLE
catalog: add szmy-haruhi-dsh-tavily (community curation, created by @SZMY-haruhi)

### DIFF
--- a/catalog/plugins/szmy-haruhi-dsh-tavily.yaml
+++ b/catalog/plugins/szmy-haruhi-dsh-tavily.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: szmy-haruhi-dsh-tavily
+name: dsh-tavily
+description:
+  en: "Tavily web search for DSH: settings toggle back to official DeepSeek, keyless by default"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - web-search
+  - tavily
+  - dsh
+source:
+  repository: https://github.com/SZMY-haruhi/dsh-tavily
+  repositoryNodeId: R_kgDOT4eIdA
+  subpath: null
+  commit: bc6609963814e19dd84e8c9e085fc42028dced39
+creator:
+  github: SZMY-haruhi
+package:
+  ecosystem: npm
+  name: dsh-tavily
+  version: 0.3.1
+  integrity: sha512-ffXb4DwLL7VAaLszotWmx3QoD/u3K4XIcWz4yYZu97aGrfORE/uZH/wuJOCbjWxrBx6bTj46k9HrbE+P5DiUyQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:13.187Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `szmy-haruhi-dsh-tavily`
- Submission type: community curation
- Created by `SZMY-haruhi` — https://github.com/SZMY-haruhi
- Original source repository: https://github.com/SZMY-haruhi/dsh-tavily
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.