### PR TITLE
catalog: add taiyakioffical-claude-style-skin (community curation, created by @TaiyakiOffical)

### DIFF
--- a/catalog/plugins/taiyakioffical-claude-style-skin.yaml
+++ b/catalog/plugins/taiyakioffical-claude-style-skin.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: taiyakioffical-claude-style-skin
+name: claude-style-skin
+description:
+  en: Claude Style — Anthropic warm-editorial skin for the dsh web GUI, distilled from anthropic.com
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - web-ui
+  - skin
+  - theme
+  - claude
+  - anthropic
+  - warm
+  - editorial
+  - ivory
+  - clay
+source:
+  repository: https://github.com/TaiyakiOffical/claude-style-skin
+  repositoryNodeId: R_kgDOT_8suw
+  subpath: null
+  commit: 09cfe36237b7fa0c4e57141b364b8bf50f084d37
+creator:
+  github: TaiyakiOffical
+package:
+  ecosystem: npm
+  name: claude-style-skin
+  version: 0.1.1
+  integrity: sha512-NFpLT73ku2kerPTq2KRa43uEp6GnlIyC7evYXBGMgpIN1E0MvQTzyxtqDyyRwF4f9DVAjbCAMgcg0RFrAhRlzw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:48.054Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taiyakioffical-claude-style-skin`
- Submission type: community curation
- Created by `TaiyakiOffical` — https://github.com/TaiyakiOffical
- Original source repository: https://github.com/TaiyakiOffical/claude-style-skin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.