### PR TITLE
catalog: add taler97-dsh-rollback (community curation, created by @Taler97)

### DIFF
--- a/catalog/plugins/taler97-dsh-rollback.yaml
+++ b/catalog/plugins/taler97-dsh-rollback.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: taler97-dsh-rollback
+name: dsh-rollback
+description:
+  en: "File-mutation rollback plugin for DeepSeek Harness — checkpoints write/edit pre-images via git blobs or snapshots and restores them on demand through a model-facing rollback files tool and a /rollback command. Opt-in bundle: capture rides the tools/result observation event, restore writes files directly (no loop change"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - rollback
+  - checkpoint
+  - undo
+source:
+  repository: https://github.com/Taler97/dsh-rollback
+  repositoryNodeId: R_kgDOT5lx7g
+  subpath: null
+  commit: 3deb80df973913da93197a3a1cf006dfc3629333
+creator:
+  github: Taler97
+package:
+  ecosystem: npm
+  name: dsh-rollback
+  version: 0.1.1
+  integrity: sha512-oMLqOejFlWKOj7JYgpaoUlPS44cailDOTrMaAkYYs7ZYBPpBr72lqgJl/2w5td/W9IXLz0kWfmwP/I4TkKuBZg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:31.397Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taler97-dsh-rollback`
- Submission type: community curation
- Created by `Taler97` — https://github.com/Taler97
- Original source repository: https://github.com/Taler97/dsh-rollback
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.