### PR TITLE
catalog: add taltara-dsh-blueprint (community curation, created by @taltara)

### DIFF
--- a/catalog/plugins/taltara-dsh-blueprint.yaml
+++ b/catalog/plugins/taltara-dsh-blueprint.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: taltara-dsh-blueprint
+name: dsh-blueprint
+description:
+  en: Read the config your harness actually booted, and validate an overlay before you apply it. A Blueprint tab for the DSH web client.
+  evidencePath: packages/blueprint/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - cordis
+  - gui
+source:
+  repository: https://github.com/taltara/mddl-harness
+  repositoryNodeId: R_kgDOT9syFA
+  subpath: packages/blueprint
+  commit: 93579d8e7d6cde56203d6d9a0f101d1ac6825efb
+creator:
+  github: taltara
+package:
+  ecosystem: npm
+  name: dsh-blueprint
+  version: 0.6.0
+  integrity: sha512-MPZAiiptkzUtzp3T1Yo8fFvRSKcoc2jrcRglPADZAbw1z5YEn0kL6aal6fVz4kMuPn44aSUOdBf5Hf4xV8Yheg==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/blueprint/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:48.982Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taltara-dsh-blueprint`
- Submission type: community curation
- Created by `taltara` — https://github.com/taltara
- Original source repository: https://github.com/taltara/mddl-harness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.