### PR TITLE
catalog: add taxueseek-argo-dsh (community curation, created by @taxueseek)

### DIFF
--- a/catalog/plugins/taxueseek-argo-dsh.yaml
+++ b/catalog/plugins/taxueseek-argo-dsh.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: taxueseek-argo-dsh
+name: "@taxueseek/argo-dsh"
+description:
+  en: <p align="center" <a href=" what-it-is" Intro</a · <a href=" why-its-stronger-than-built-in-search--ai-search--metasearch" Compare</a · <a href=" query-shaped-routing" Proof</a · <a href=" how-it-works" How it works</a · <a href=" quick-start" Quick start</a · <a href=" capabilities" Capabilities</a · <a href=" install
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - align
+  - center
+  - href
+  - what
+  - intro
+  - stronger
+  - built
+  - search
+  - metasearch
+  - compare
+  - query
+  - shaped
+  - routing
+  - proof
+  - works
+  - quick
+source:
+  repository: https://github.com/taxueseek/argo
+  repositoryNodeId: R_kgDOTciv2w
+  subpath: packages/dsh-plugin
+  commit: dc943d43066f0cdece8ab2ddc867dbc0eef69109
+creator:
+  github: taxueseek
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:06.441Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taxueseek-argo-dsh`
- Submission type: community curation
- Created by `taxueseek` — https://github.com/taxueseek
- Original source repository: https://github.com/taxueseek/argo
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.