### PR TITLE
catalog: add taxueseek-dsh-files (community curation, created by @taxueseek)

### DIFF
--- a/catalog/plugins/taxueseek-dsh-files.yaml
+++ b/catalog/plugins/taxueseek-dsh-files.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: taxueseek-dsh-files
+name: dsh-files
+description:
+  en: "DeepSeek Harness dual-face plugin: a composer file-upload button (paperclip + folder + drag-drop, @ dual-source candidates) with session-isolated storage, TTL sweep and sha256 dedup; native image support that hands JPEG/PNG/WebP/GIF to any image-capable model via the core attachment pipeline; plus a read document tool "
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - cordis
+  - upload
+  - attachment
+  - pdf
+  - docx
+  - xlsx
+source:
+  repository: https://github.com/taxueseek/dsh-files
+  repositoryNodeId: R_kgDOT36jHA
+  subpath: null
+  commit: 93552711542e628ab311c74a5ea175a703792a2d
+creator:
+  github: taxueseek
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:06.394Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 28
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taxueseek-dsh-files`
- Submission type: community curation
- Created by `taxueseek` — https://github.com/taxueseek
- Original source repository: https://github.com/taxueseek/dsh-files
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.