### PR TITLE
catalog: add taxueseek-dsh-snippets (community curation, created by @taxueseek)

### DIFF
--- a/catalog/plugins/taxueseek-dsh-snippets.yaml
+++ b/catalog/plugins/taxueseek-dsh-snippets.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: taxueseek-dsh-snippets
+name: dsh-snippets
+description:
+  en: "极简常用片段/命令工具箱 for DeepSeek Harness: JSONL-backed, five tools, no UI, no deps beyond the harness SDK. Save frequently used commands, code, URLs and prompts, then search them back in any session."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - cordis
+  - snippets
+  - commands
+source:
+  repository: https://github.com/taxueseek/dsh-snippets
+  repositoryNodeId: R_kgDOT5VP0Q
+  subpath: null
+  commit: 92c9aaa803f2c7476543aff7d098df737e1e152d
+creator:
+  github: taxueseek
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:33.158Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taxueseek-dsh-snippets`
- Submission type: community curation
- Created by `taxueseek` — https://github.com/taxueseek
- Original source repository: https://github.com/taxueseek/dsh-snippets
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.