### PR TITLE
catalog: add taxueseek-taxue-dsh-artisan (community curation, created by @taxueseek)

### DIFF
--- a/catalog/plugins/taxueseek-taxue-dsh-artisan.yaml
+++ b/catalog/plugins/taxueseek-taxue-dsh-artisan.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: taxueseek-taxue-dsh-artisan
+name: taxue-dsh-artisan
+description:
+  en: <p align="center" <strong taxue-dsh-artisan</strong · taxue 画师 </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - align
+  - center
+  - strong
+  - taxue
+  - artisan
+  - dsh
+source:
+  repository: https://github.com/taxueseek/taxue-dsh-artisan
+  repositoryNodeId: R_kgDOT9rbtQ
+  subpath: null
+  commit: 811b3a1ed6c424ac1cac85a2978e004470a5d7e9
+creator:
+  github: taxueseek
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:33.156Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taxueseek-taxue-dsh-artisan`
- Submission type: community curation
- Created by `taxueseek` — https://github.com/taxueseek
- Original source repository: https://github.com/taxueseek/taxue-dsh-artisan
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.