### PR TITLE
catalog: add tecfancy-dsh-mobile (community curation, created by @TecFancy)

### DIFF
--- a/catalog/plugins/tecfancy-dsh-mobile.yaml
+++ b/catalog/plugins/tecfancy-dsh-mobile.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: tecfancy-dsh-mobile
+name: "@tecfancy/dsh-mobile"
+description:
+  en: "A mobile adapter for the DeepSeek Harness (DSH) web shell. The stock shell is desktop-first: below 1024px the sidebar only collapses to a rail, and on phones the expanded drawer squeezes the main column to ~110px, composer buttons overlap, and the settings dialog shrinks to a sliver. dsh-mobile adds the missing phone t"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - mobile
+  - responsive
+  - layout
+  - web
+source:
+  repository: https://github.com/TecFancy/dsh-mobile
+  repositoryNodeId: R_kgDOT51MEg
+  subpath: null
+  commit: aa5908a0b68689c1f6946666143b4b60f8b21601
+creator:
+  github: TecFancy
+package:
+  ecosystem: npm
+  name: "@tecfancy/dsh-mobile"
+  version: 0.1.7
+  integrity: sha512-f5yrARX9Ej/ehyAXK+jHs5u0PTGg6c56OddOWhnJs09I4jtcti2dGRetVnkJb1B8csF4mSDKuYqmK/ZEzFh9dw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:33.156Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tecfancy-dsh-mobile`
- Submission type: community curation
- Created by `TecFancy` — https://github.com/TecFancy
- Original source repository: https://github.com/TecFancy/dsh-mobile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.