### PR TITLE
catalog: add tevenfeng-dsh-plugin-omoslim (community curation, created by @tevenfeng)

### DIFF
--- a/catalog/plugins/tevenfeng-dsh-plugin-omoslim.yaml
+++ b/catalog/plugins/tevenfeng-dsh-plugin-omoslim.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: tevenfeng-dsh-plugin-omoslim
+name: dsh-plugin-omoslim
+description:
+  en: "DeepSeek Harness bundle: oh-my-opencode-slim style Orchestrator agent preset with model-pinned specialist subagents (explorer/oracle/librarian/designer/fixer/council)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-preset
+  - orchestrator
+  - subagent
+  - dsh
+source:
+  repository: https://github.com/tevenfeng/dsh-plugin-omoslim
+  repositoryNodeId: R_kgDOT5WKOw
+  subpath: null
+  commit: 29ba8e0f5fcaf50e93d8e2077f4ee1aad7b5f695
+creator:
+  github: tevenfeng
+package:
+  ecosystem: npm
+  name: dsh-plugin-omoslim
+  version: 0.5.2
+  integrity: sha512-1dua1wp54UEwOKPg1L9Eg1FaLaV/rhPEaYfe2uEEJK090VzDj6IVrU7/yVUM1+TcaTScEnYZdzyggNM6OvjvQA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:13.614Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tevenfeng-dsh-plugin-omoslim`
- Submission type: community curation
- Created by `tevenfeng` — https://github.com/tevenfeng
- Original source repository: https://github.com/tevenfeng/dsh-plugin-omoslim
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.