### PR TITLE
catalog: add thedeergod666-dsh-musage (community curation, created by @Thedeergod666)

### DIFF
--- a/catalog/plugins/thedeergod666-dsh-musage.yaml
+++ b/catalog/plugins/thedeergod666-dsh-musage.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: thedeergod666-dsh-musage
+name: dsh-musage
+description:
+  en: "Coding-plan quota and balance readout for the DSH composer toolbar: MiniMax, DeepSeek, Kimi, OpenRouter and Zhipu windows follow the selected model; API keys are reused from DSH model settings."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - cordis-plugin
+  - deepseek-harness
+  - usage
+  - quota
+  - coding-plan
+  - musage
+source:
+  repository: https://github.com/Thedeergod666/dsh-musage
+  repositoryNodeId: R_kgDOT7FQTw
+  subpath: null
+  commit: 12a3f14537b1e51c1135e8dc6e4d49512930ecd4
+creator:
+  github: Thedeergod666
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:22.615Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `thedeergod666-dsh-musage`
- Submission type: community curation
- Created by `Thedeergod666` — https://github.com/Thedeergod666
- Original source repository: https://github.com/Thedeergod666/dsh-musage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.