### PR TITLE
catalog: add thewolfwalker-dsh-coyote (community curation, created by @THEWOLFWALKER)

### DIFF
--- a/catalog/plugins/thewolfwalker-dsh-coyote.yaml
+++ b/catalog/plugins/thewolfwalker-dsh-coyote.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: thewolfwalker-dsh-coyote
+name: dsh-coyote
+description:
+  en: "Agent- and GUI-controlled DG-LAB Coyote e-stim plugin for DeepSeek Harness: safety-bounded strength, programmable waveforms, and a DSH-aligned web panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dg-lab
+  - coyote
+  - e-stim
+  - waveform
+  - dsh
+source:
+  repository: https://github.com/THEWOLFWALKER/dsh-coyote
+  repositoryNodeId: R_kgDOT5S0nw
+  subpath: null
+  commit: 6e4e5ede17aef3a4f5737652a26ed8a5199b1d1f
+creator:
+  github: THEWOLFWALKER
+package:
+  ecosystem: npm
+  name: dsh-coyote
+  version: 0.2.0
+  integrity: sha512-eNHwp/aHbZtxnfJMeEF6CxQeOx00muc7WPIcv/cCdUmT1VyZyh9xz2ZliruiH2AbUQXznHqVtZ2I8aveK+AcKQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:33.577Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `thewolfwalker-dsh-coyote`
- Submission type: community curation
- Created by `THEWOLFWALKER` — https://github.com/THEWOLFWALKER
- Original source repository: https://github.com/THEWOLFWALKER/dsh-coyote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.