### PR TITLE
catalog: add thomasvvugt-dsh-wide-stats-footer (community curation, created by @thomasvvugt)

### DIFF
--- a/catalog/plugins/thomasvvugt-dsh-wide-stats-footer.yaml
+++ b/catalog/plugins/thomasvvugt-dsh-wide-stats-footer.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: thomasvvugt-dsh-wide-stats-footer
+name: dsh-wide-stats-footer
+description:
+  en: "Wide stats footer: removes the max-width clamp on the composer stats line (turns/steps LLM time TTFT cache hit token counts) so it spans the full composer width, centered"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - web
+  - css
+  - footer
+  - stats
+source:
+  repository: https://github.com/thomasvvugt/dsh-wide-stats-footer
+  repositoryNodeId: R_kgDOUDESSw
+  subpath: null
+  commit: 9118afeb436f234a65286b828e6446c9b43859ed
+creator:
+  github: thomasvvugt
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:51.270Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `thomasvvugt-dsh-wide-stats-footer`
- Submission type: community curation
- Created by `thomasvvugt` — https://github.com/thomasvvugt
- Original source repository: https://github.com/thomasvvugt/dsh-wide-stats-footer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.