### PR TITLE
catalog: add tiantianlaolao-dsh-astock-research (community curation, created by @tiantianlaolao)

### DIFF
--- a/catalog/plugins/tiantianlaolao-dsh-astock-research.yaml
+++ b/catalog/plugins/tiantianlaolao-dsh-astock-research.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: tiantianlaolao-dsh-astock-research
+name: dsh-astock-research
+description:
+  en: A-share (China) stock research assistant — a DeepSeek Harness (dsh) plugin.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - astock
+  - stock
+  - china-a-share
+  - dsh
+source:
+  repository: https://github.com/tiantianlaolao/dsh-astock-research
+  repositoryNodeId: R_kgDOT9HHag
+  subpath: null
+  commit: 1767eb6ad3c96c144d08d0c779a1377c0d204b94
+creator:
+  github: tiantianlaolao
+package:
+  ecosystem: npm
+  name: dsh-astock-research
+  version: 0.1.1
+  integrity: sha512-W7Hg5db9VqRQMTChOMsF/OElt/xdC1GzqyCHSJLWwYZhcuFw3RzRScz0Opxml3CgdYJjH3y26s/Xi+MrSLe86w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:24.682Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tiantianlaolao-dsh-astock-research`
- Submission type: community curation
- Created by `tiantianlaolao` — https://github.com/tiantianlaolao
- Original source repository: https://github.com/tiantianlaolao/dsh-astock-research
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.