### PR TITLE
catalog: add tiantyu-dsh-skin-toggle (community curation, created by @tiantyu)

### DIFF
--- a/catalog/plugins/tiantyu-dsh-skin-toggle.yaml
+++ b/catalog/plugins/tiantyu-dsh-skin-toggle.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tiantyu-dsh-skin-toggle
+name: dsh-skin-toggle
+description:
+  en: "Skin manager for the DeepSeek Harness (DSH) web GUI: a floating 🐋 button — left-click restores the default look, right-click lists every installed skin and switches between them (mutually exclusive). Pure client-side presentation utility."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - skin
+  - theme
+  - maid-atelier
+source:
+  repository: https://github.com/tiantyu/dsh-skin-toggle
+  repositoryNodeId: R_kgDOT5QEqg
+  subpath: null
+  commit: 781fd4605756503f9635d6083686e079b5a8944f
+creator:
+  github: tiantyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:13.884Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tiantyu-dsh-skin-toggle`
- Submission type: community curation
- Created by `tiantyu` — https://github.com/tiantyu
- Original source repository: https://github.com/tiantyu/dsh-skin-toggle
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.