### PR TITLE
catalog: add tianyazty-dsh-client-ui-subagent-dashboard (community curation, created by @tianyaZTY)

### DIFF
--- a/catalog/plugins/tianyazty-dsh-client-ui-subagent-dashboard.yaml
+++ b/catalog/plugins/tianyazty-dsh-client-ui-subagent-dashboard.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: tianyazty-dsh-client-ui-subagent-dashboard
+name: dsh-client-ui-subagent-dashboard
+description:
+  en: "Subagent dashboard for DeepSeek Harness Web: a right-column panel listing all subagents with live status, expandable details, background jobs, and one-click open of the child session transcript."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - subagent
+  - dashboard
+  - client-plugin
+source:
+  repository: https://github.com/tianyaZTY/dsh-hot-plugin-host
+  repositoryNodeId: R_kgDOT4nnyg
+  subpath: packages/dsh-client-ui-subagent-dashboard
+  commit: 369985a7722ff16425576b31fadd667ca94c61d0
+creator:
+  github: tianyaZTY
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-client-ui-subagent-dashboard/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:24.688Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tianyazty-dsh-client-ui-subagent-dashboard`
- Submission type: community curation
- Created by `tianyaZTY` — https://github.com/tianyaZTY
- Original source repository: https://github.com/tianyaZTY/dsh-hot-plugin-host
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.