### PR TITLE
catalog: add tikaflow-dsh-model-reasoning (community curation, created by @TikaFlow)

### DIFF
--- a/catalog/plugins/tikaflow-dsh-model-reasoning.yaml
+++ b/catalog/plugins/tikaflow-dsh-model-reasoning.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tikaflow-dsh-model-reasoning
+name: dsh-model-reasoning
+description:
+  en: bash dsh plugin --profile web add github:TikaFlow/dsh-model-reasoning
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - bash
+  - profile
+  - tikaflow
+  - model
+  - reasoning
+  - dsh
+source:
+  repository: https://github.com/TikaFlow/dsh-model-reasoning
+  repositoryNodeId: R_kgDOT5yHbA
+  subpath: null
+  commit: 840e5f10a25a5e4cfd93415267de7db2aa89a9e7
+creator:
+  github: TikaFlow
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:33.577Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tikaflow-dsh-model-reasoning`
- Submission type: community curation
- Created by `TikaFlow` — https://github.com/TikaFlow
- Original source repository: https://github.com/TikaFlow/dsh-model-reasoning
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.