### PR TITLE
catalog: add timedomain1-dsh-mermaid-renderer (community curation, created by @timedomain1)

### DIFF
--- a/catalog/plugins/timedomain1-dsh-mermaid-renderer.yaml
+++ b/catalog/plugins/timedomain1-dsh-mermaid-renderer.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: timedomain1-dsh-mermaid-renderer
+name: dsh-mermaid-renderer
+description:
+  en: A DeepSeek Harness (dsh) web plugin that renders Mermaid code blocks in the chat as diagram cards. Supports flowchart / graph / sequenceDiagram / classDiagram / stateDiagram / erDiagram / journey / gantt / pie / mindmap / timeline / C4Context / gitGraph and more.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - mermaid
+  - diagram
+  - flowchart
+source:
+  repository: https://github.com/timedomain1/dsh-mermaid-renderer
+  repositoryNodeId: R_kgDOT-bRwg
+  subpath: null
+  commit: f9002b72b4a28ef510802001438d044c9bd59b25
+creator:
+  github: timedomain1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:33.860Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `timedomain1-dsh-mermaid-renderer`
- Submission type: community curation
- Created by `timedomain1` — https://github.com/timedomain1
- Original source repository: https://github.com/timedomain1/dsh-mermaid-renderer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.