### PR TITLE
catalog: add tindaloskorone-dsh-cheatengine (community curation, created by @TindalosKorone)

### DIFF
--- a/catalog/plugins/tindaloskorone-dsh-cheatengine.yaml
+++ b/catalog/plugins/tindaloskorone-dsh-cheatengine.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: tindaloskorone-dsh-cheatengine
+name: "@tindalosko/dsh-cheatengine"
+description:
+  en: "Official hybrid DSH plugin: Cheat Engine dynamic debugging toolkit with host ce tools and a client floating status panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - cheat-engine
+  - debugging
+  - reverse-engineering
+  - memory-scanner
+  - game-hacking
+source:
+  repository: https://github.com/TindalosKorone/dsh-cheatengine
+  repositoryNodeId: R_kgDOT5v53g
+  subpath: null
+  commit: c3974454e310964dbd1cc2990267e8698741c2ea
+creator:
+  github: TindalosKorone
+package:
+  ecosystem: npm
+  name: "@tindalosko/dsh-cheatengine"
+  version: 0.5.2
+  integrity: sha512-Z7n/B7xpQKGiVmx5vX4TIYvaF9FLO/61TAIe4bJo8QzvfNMKl/skT/iQsvvJVMyJolUuztBE4U46fZzEhEcaLA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:35.807Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tindaloskorone-dsh-cheatengine`
- Submission type: community curation
- Created by `TindalosKorone` — https://github.com/TindalosKorone
- Original source repository: https://github.com/TindalosKorone/dsh-cheatengine
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.