### PR TITLE
catalog: add tipoli5890-dsh-file-mention (community curation, created by @tipoLi5890)

### DIFF
--- a/catalog/plugins/tipoli5890-dsh-file-mention.yaml
+++ b/catalog/plugins/tipoli5890-dsh-file-mention.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tipoli5890-dsh-file-mention
+name: dsh-file-mention
+description:
+  en: Secure, session-scoped DSH Web @file/@folder mentions with Git-aware indexing, validated path markers, and drag-drop uploads
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - mention
+  - file
+  - composer
+  - input-trigger
+source:
+  repository: https://github.com/tipoLi5890/dsh-file-mention
+  repositoryNodeId: R_kgDOT7-p4g
+  subpath: null
+  commit: d9e37e1255d9443cabfddc307daba8eb380068aa
+creator:
+  github: tipoLi5890
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:16.261Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tipoli5890-dsh-file-mention`
- Submission type: community curation
- Created by `tipoLi5890` — https://github.com/tipoLi5890
- Original source repository: https://github.com/tipoLi5890/dsh-file-mention
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.