### PR TITLE
catalog: add tisitan-dsh-live2d-companion (community curation, created by @Tisitan)

### DIFF
--- a/catalog/plugins/tisitan-dsh-live2d-companion.yaml
+++ b/catalog/plugins/tisitan-dsh-live2d-companion.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tisitan-dsh-live2d-companion
+name: dsh-live2d-companion
+description:
+  en: "Live2D companion for DeepSeek Harness: 8-state AI status lamp, web widget, and always-on-top desktop pet with expressions, motions and bubbles"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - live2d
+  - desktop-pet
+  - widget
+  - web-ui
+source:
+  repository: https://github.com/Tisitan/dsh-live2d-companion
+  repositoryNodeId: R_kgDOT5e8Vg
+  subpath: null
+  commit: 48d9b3af7cfcee1e54137fe01a64e58d912bb78a
+creator:
+  github: Tisitan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:06.388Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tisitan-dsh-live2d-companion`
- Submission type: community curation
- Created by `Tisitan` — https://github.com/Tisitan
- Original source repository: https://github.com/Tisitan/dsh-live2d-companion
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.