### PR TITLE
catalog: add tobycai-dsh-sessions-manager (community curation, created by @TOBYCAI)

### DIFF
--- a/catalog/plugins/tobycai-dsh-sessions-manager.yaml
+++ b/catalog/plugins/tobycai-dsh-sessions-manager.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tobycai-dsh-sessions-manager
+name: dsh-sessions-manager
+description:
+  en: "DSH session manager: archive, move, restore, and inspect sessions from Settings → 会话管理 ; mark unread, move, and delete sessions directly from the main sidebar . Deleted sessions go to the recycle bin first and can be restored or permanently purged."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh
+  - session-manager
+  - archived-sessions
+  - session
+source:
+  repository: https://github.com/TOBYCAI/dsh-sessions-manager
+  repositoryNodeId: R_kgDOT-VcJA
+  subpath: null
+  commit: 74720ecbd7a8db5a546527a3dfb55bc78ec0dec0
+creator:
+  github: TOBYCAI
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:24.923Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tobycai-dsh-sessions-manager`
- Submission type: community curation
- Created by `TOBYCAI` — https://github.com/TOBYCAI
- Original source repository: https://github.com/TOBYCAI/dsh-sessions-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.