### PR TITLE
catalog: add tomsawyerhu-dsh-tui-contrib (community curation, created by @Tomsawyerhu)

### DIFF
--- a/catalog/plugins/tomsawyerhu-dsh-tui-contrib.yaml
+++ b/catalog/plugins/tomsawyerhu-dsh-tui-contrib.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: tomsawyerhu-dsh-tui-contrib
+name: "@deepseek-ai/dsh-tui-contrib"
+description:
+  en: Non-invasive terminal conversation surface for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - invasive
+  - terminal
+  - conversation
+  - surface
+  - dsh
+source:
+  repository: https://github.com/Tomsawyerhu/deepseek-harness-cli
+  repositoryNodeId: R_kgDOT3jXfw
+  subpath: null
+  commit: afbecbce0b6610d9a2858d06a091d0759da284ea
+creator:
+  github: Tomsawyerhu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:25.905Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tomsawyerhu-dsh-tui-contrib`
- Submission type: community curation
- Created by `Tomsawyerhu` — https://github.com/Tomsawyerhu
- Original source repository: https://github.com/Tomsawyerhu/deepseek-harness-cli
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.