### PR TITLE
catalog: add tongy1n-dsh-client-ui-muyu (community curation, created by @TongY1n)

### DIFF
--- a/catalog/plugins/tongy1n-dsh-client-ui-muyu.yaml
+++ b/catalog/plugins/tongy1n-dsh-client-ui-muyu.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: tongy1n-dsh-client-ui-muyu
+name: "@deepseek-ai/dsh-client-ui-muyu"
+description:
+  en: A cyber wooden fish — a small floating widget in the web window. Tap it during work breaks to rack up some "merit".
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - cyber
+  - wooden
+  - fish
+  - small
+  - floating
+  - widget
+  - window
+  - during
+  - work
+  - breaks
+  - rack
+  - some
+  - merit
+  - dsh
+source:
+  repository: https://github.com/TongY1n/ui-muyu
+  repositoryNodeId: R_kgDOT7nHkg
+  subpath: null
+  commit: ef96072b8b2663b4bf87f7cc01adb5cb30612e71
+creator:
+  github: TongY1n
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:35.757Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tongy1n-dsh-client-ui-muyu`
- Submission type: community curation
- Created by `TongY1n` — https://github.com/TongY1n
- Original source repository: https://github.com/TongY1n/ui-muyu
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.