### PR TITLE
catalog: add tonytanglab-harness-relay-mcp (community curation, created by @tonytanglab)

### DIFF
--- a/catalog/plugins/tonytanglab-harness-relay-mcp.yaml
+++ b/catalog/plugins/tonytanglab-harness-relay-mcp.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: tonytanglab-harness-relay-mcp
+name: harness-relay-mcp
+description:
+  en: Delegate and monitor DeepSeek Harness work from any MCP agent.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - mcp
+  - agent
+  - delegation
+  - monitoring
+  - dsh
+source:
+  repository: https://github.com/tonytanglab/deepseek-harness-relay-mcp
+  repositoryNodeId: R_kgDOT8kPKQ
+  subpath: null
+  commit: bcc0a86bd2c6ce68e927bf4e7e6a8ba2ecf09bfc
+creator:
+  github: tonytanglab
+package:
+  ecosystem: npm
+  name: harness-relay-mcp
+  version: 0.2.4
+  integrity: sha512-fACV6pYMrXVyy4dk2dz49yzGmL0+o154FtGMDju+XjmsQDrluKJ9y5KLNkns7p6bCHSLjm7CIlluTTQIRg35IQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:25.929Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tonytanglab-harness-relay-mcp`
- Submission type: community curation
- Created by `tonytanglab` — https://github.com/tonytanglab
- Original source repository: https://github.com/tonytanglab/deepseek-harness-relay-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.