### PR TITLE
catalog: add toukaiteio-dsh-plugin-installer (community curation, created by @Toukaiteio)

### DIFF
--- a/catalog/plugins/toukaiteio-dsh-plugin-installer.yaml
+++ b/catalog/plugins/toukaiteio-dsh-plugin-installer.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: toukaiteio-dsh-plugin-installer
+name: dsh-plugin-installer
+description:
+  en: A Web UI marketplace and profile switcher for DeepSeek Harness plugins.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-marketplace
+source:
+  repository: https://github.com/Toukaiteio/dsh-plugin-installer
+  repositoryNodeId: R_kgDOT3lGHw
+  subpath: null
+  commit: 5ea0ec73b461a5d2cbb1562329abf85c2b161324
+creator:
+  github: Toukaiteio
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:06.400Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `toukaiteio-dsh-plugin-installer`
- Submission type: community curation
- Created by `Toukaiteio` — https://github.com/Toukaiteio
- Original source repository: https://github.com/Toukaiteio/dsh-plugin-installer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.