### PR TITLE
catalog: add trrrrrryg-workspace-plugin (community curation, created by @trrrrrryg)

### DIFF
--- a/catalog/plugins/trrrrrryg-workspace-plugin.yaml
+++ b/catalog/plugins/trrrrrryg-workspace-plugin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: trrrrrryg-workspace-plugin
+name: "@dsh-remote/workspace-plugin"
+description:
+  en: DSH SSH Forge — secure SSH-backed remote workspaces for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - forge
+  - secure
+  - backed
+  - remote
+  - workspaces
+  - dsh
+source:
+  repository: https://github.com/trrrrrryg/dsh-ssh-forge
+  repositoryNodeId: R_kgDOUCwnTg
+  subpath: null
+  commit: e49250dae3d49292b52f45d1fac03fea9c3a3608
+creator:
+  github: trrrrrryg
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:35.401Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `trrrrrryg-workspace-plugin`
- Submission type: community curation
- Created by `trrrrrryg` — https://github.com/trrrrrryg
- Original source repository: https://github.com/trrrrrryg/dsh-ssh-forge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.