### PR TITLE
catalog: add tsdfy-dsh-skin-switcher (community curation, created by @tsdfy)

### DIFF
--- a/catalog/plugins/tsdfy-dsh-skin-switcher.yaml
+++ b/catalog/plugins/tsdfy-dsh-skin-switcher.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: tsdfy-dsh-skin-switcher
+name: dsh-skin-switcher
+description:
+  en: "Skin switcher for DeepSeek Harness web UI: one-click theme switching with auto-discovery of community skins"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+  - switcher
+  - web-ui
+source:
+  repository: https://github.com/tsdfy/dsh-skin-switcher
+  repositoryNodeId: R_kgDOT9Av9Q
+  subpath: null
+  commit: ac55cf9b974859efc5f7d43eacf6a274a1fc6497
+creator:
+  github: tsdfy
+package:
+  ecosystem: npm
+  name: dsh-skin-switcher
+  version: 0.2.1
+  integrity: sha512-wMQCY6LKQQMP9eQnV+EhZNF1824AgFcAnopYnR7mbKrzv5M1zuP1y1yF2asggyY/GJU7y79ON+hFJ+TvUfxvng==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:25.919Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tsdfy-dsh-skin-switcher`
- Submission type: community curation
- Created by `tsdfy` — https://github.com/tsdfy
- Original source repository: https://github.com/tsdfy/dsh-skin-switcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.