### PR TITLE
catalog: add tsingshitao-nuke-dsh-set-workspace (community curation, created by @tsingshitao-nuke)

### DIFF
--- a/catalog/plugins/tsingshitao-nuke-dsh-set-workspace.yaml
+++ b/catalog/plugins/tsingshitao-nuke-dsh-set-workspace.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: tsingshitao-nuke-dsh-set-workspace
+name: dsh-set-workspace
+description:
+  en: "DSH plugin: right-click a folder in Windows File Explorer to open it as a DSH workspace (launches DSH if needed, creates the workspace, starts a session, and switches the DSH page to it)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - right
+  - click
+  - folder
+  - windows
+  - file
+  - explorer
+  - open
+  - workspace
+  - launches
+  - needed
+  - creates
+  - starts
+  - session
+  - switches
+  - page
+  - dsh
+source:
+  repository: https://github.com/tsingshitao-nuke/dsh-set-workspace
+  repositoryNodeId: R_kgDOT6J79w
+  subpath: null
+  commit: 50b40c28e75053c1bbfa8c3f7bf22770b09335f0
+creator:
+  github: tsingshitao-nuke
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:27.452Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tsingshitao-nuke-dsh-set-workspace`
- Submission type: community curation
- Created by `tsingshitao-nuke` — https://github.com/tsingshitao-nuke
- Original source repository: https://github.com/tsingshitao-nuke/dsh-set-workspace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.