### PR TITLE
catalog: add tsonglew-dsh-media-preview (community curation, created by @tsonglew)

### DIFF
--- a/catalog/plugins/tsonglew-dsh-media-preview.yaml
+++ b/catalog/plugins/tsonglew-dsh-media-preview.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: tsonglew-dsh-media-preview
+name: dsh-media-preview
+description:
+  en: "Audio/video preview viewer for dsh-better-sidebar: native playback with Range-seeking served by a dedicated streaming route"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - media
+  - video
+  - audio
+  - preview
+  - better-sidebar
+source:
+  repository: https://github.com/tsonglew/dsh-media-preview
+  repositoryNodeId: R_kgDOT4ZN6A
+  subpath: null
+  commit: ef9685c9b4f0f4e3c810ebf520d3f67d099b1e39
+creator:
+  github: tsonglew
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:17.139Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tsonglew-dsh-media-preview`
- Submission type: community curation
- Created by `tsonglew` — https://github.com/tsonglew
- Original source repository: https://github.com/tsonglew/dsh-media-preview
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.