### PR TITLE
catalog: add ttmouse-dsh-taskboard (community curation, created by @ttmouse)

### DIFF
--- a/catalog/plugins/ttmouse-dsh-taskboard.yaml
+++ b/catalog/plugins/ttmouse-dsh-taskboard.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: ttmouse-dsh-taskboard
+name: "@ttmouse/dsh-taskboard"
+description:
+  en: sh npm run build cd plugin && npm install && npm run build
+  evidencePath: plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - taskboard
+  - kanban
+  - issue-tracker
+  - project-management
+  - cordis
+  - sqlite
+  - ai-agent
+source:
+  repository: https://github.com/ttmouse/dsh-taskboard
+  repositoryNodeId: R_kgDOT7xWHw
+  subpath: plugin
+  commit: 446e6286e3b3ca9fde366f11225079b0a58f1da5
+creator:
+  github: ttmouse
+package:
+  ecosystem: npm
+  name: "@ttmouse/dsh-taskboard"
+  version: 0.5.0
+  integrity: sha512-0g3HZ5QXv6N0IWQwO7EpaV6Wy32vVTIOmN32rhJZSJEXgaUn/KNNG4ovTNQFmYdhcLph0dKeUJog8jtZ/kqP/g==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:53.278Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ttmouse-dsh-taskboard`
- Submission type: community curation
- Created by `ttmouse` — https://github.com/ttmouse
- Original source repository: https://github.com/ttmouse/dsh-taskboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.