### PR TITLE
catalog: add tttnny-dsh-oil-sticky-prompt (community curation, created by @tttnny)

### DIFF
--- a/catalog/plugins/tttnny-dsh-oil-sticky-prompt.yaml
+++ b/catalog/plugins/tttnny-dsh-oil-sticky-prompt.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: tttnny-dsh-oil-sticky-prompt
+name: "@lynn123411/dsh-oil-sticky-prompt"
+description:
+  en: bash dsh plugin --profile web add @lynn123411/dsh-oil-sticky-prompt
+  evidencePath: plugins/dsh-oil-sticky-prompt/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - sticky
+  - prompt
+source:
+  repository: https://github.com/tttnny/my-dsh
+  repositoryNodeId: R_kgDOT91T7A
+  subpath: plugins/dsh-oil-sticky-prompt
+  commit: 933898d6021af5475fba82be2ae8bff95462cdbe
+creator:
+  github: tttnny
+package:
+  ecosystem: npm
+  name: "@lynn123411/dsh-oil-sticky-prompt"
+  version: 0.1.1
+  integrity: sha512-qSaj7xU/x823/O7OQhRJubaj3N2irpN/0+Floo94nqm09NU8+KxtnkG8V4FBpDo37ybjHKQkwNTeT1aokORvYA==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-oil-sticky-prompt/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:53.280Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tttnny-dsh-oil-sticky-prompt`
- Submission type: community curation
- Created by `tttnny` — https://github.com/tttnny
- Original source repository: https://github.com/tttnny/my-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.