### PR TITLE
catalog: add tttpob-dsh-workspace-overlay (community curation, created by @TTTPOB)

### DIFF
--- a/catalog/plugins/tttpob-dsh-workspace-overlay.yaml
+++ b/catalog/plugins/tttpob-dsh-workspace-overlay.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: tttpob-dsh-workspace-overlay
+name: dsh-workspace-overlay
+description:
+  en: "Out-of-tree DSH plugin: canonical per-workspace Cordis scopes (workspaceCordis) with optional <workspace /.dsh/cordis.yml composition mounting and live reload on top-level config changes; rc.6-compatible MCP core (transport/tools/connection supervisor) under ./mcp."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - tree
+  - canonical
+  - workspace
+  - cordis
+  - scopes
+  - workspacecordis
+  - optional
+  - composition
+  - mounting
+  - live
+  - reload
+  - level
+  - config
+  - changes
+  - compatible
+  - core
+source:
+  repository: https://github.com/TTTPOB/dsh-workspace-overlay
+  repositoryNodeId: R_kgDOT48K0g
+  subpath: null
+  commit: 802385ee270f2dcbcc99bc831121bdb9e7925327
+creator:
+  github: TTTPOB
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:35.688Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tttpob-dsh-workspace-overlay`
- Submission type: community curation
- Created by `TTTPOB` — https://github.com/TTTPOB
- Original source repository: https://github.com/TTTPOB/dsh-workspace-overlay
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.