### PR TITLE
catalog: add tuogusa-dsh-whale-background (community curation, created by @tuogusa)

### DIFF
--- a/catalog/plugins/tuogusa-dsh-whale-background.yaml
+++ b/catalog/plugins/tuogusa-dsh-whale-background.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tuogusa-dsh-whale-background
+name: dsh-whale-background
+description:
+  en: bash dsh plugin --profile web add github:tuogusa/dsh-whale-background
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - bash
+  - profile
+  - tuogusa
+  - whale
+  - background
+  - dsh
+source:
+  repository: https://github.com/tuogusa/dsh-whale-background
+  repositoryNodeId: R_kgDOT4pjjA
+  subpath: null
+  commit: 701b3f5e19a15ebf6c777502edd7549c956ff618
+creator:
+  github: tuogusa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:28.285Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tuogusa-dsh-whale-background`
- Submission type: community curation
- Created by `tuogusa` — https://github.com/tuogusa
- Original source repository: https://github.com/tuogusa/dsh-whale-background
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.