### PR TITLE
catalog: add tuogusa-dsh-word-complete (community curation, created by @tuogusa)

### DIFF
--- a/catalog/plugins/tuogusa-dsh-word-complete.yaml
+++ b/catalog/plugins/tuogusa-dsh-word-complete.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tuogusa-dsh-word-complete
+name: dsh-word-complete
+description:
+  en: bash dsh plugin --profile web add github:tuogusa/dsh-word-complete
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - bash
+  - profile
+  - tuogusa
+  - word
+  - complete
+  - dsh
+source:
+  repository: https://github.com/tuogusa/dsh-word-complete
+  repositoryNodeId: R_kgDOT77BvA
+  subpath: null
+  commit: ee8ff1a9df708f8ff64193429ce281324f097ca7
+creator:
+  github: tuogusa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:28.904Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tuogusa-dsh-word-complete`
- Submission type: community curation
- Created by `tuogusa` — https://github.com/tuogusa
- Original source repository: https://github.com/tuogusa/dsh-word-complete
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.