### PR TITLE
catalog: add tussalzeus18028-dsh-conflict-checker (community curation, created by @TussalZeus18028)

### DIFF
--- a/catalog/plugins/tussalzeus18028-dsh-conflict-checker.yaml
+++ b/catalog/plugins/tussalzeus18028-dsh-conflict-checker.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tussalzeus18028-dsh-conflict-checker
+name: dsh-conflict-checker
+description:
+  en: Detect DeepSeek Harness plugin conflicts and internal issues, and manage plugins (enable / disable / uninstall) from a settings page.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - conflict
+  - diagnostics
+  - plugin-manager
+source:
+  repository: https://github.com/TussalZeus18028/dsh-conflict-checker
+  repositoryNodeId: R_kgDOUE5Q4Q
+  subpath: null
+  commit: be303fca9474d9e930239a1a6ce0cbd87e929b79
+creator:
+  github: TussalZeus18028
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:54.146Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tussalzeus18028-dsh-conflict-checker`
- Submission type: community curation
- Created by `TussalZeus18028` — https://github.com/TussalZeus18028
- Original source repository: https://github.com/TussalZeus18028/dsh-conflict-checker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.