### PR TITLE
catalog: add tussalzeus18028-dsh-open-folder (community curation, created by @TussalZeus18028)

### DIFF
--- a/catalog/plugins/tussalzeus18028-dsh-open-folder.yaml
+++ b/catalog/plugins/tussalzeus18028-dsh-open-folder.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tussalzeus18028-dsh-open-folder
+name: dsh-open-folder
+description:
+  en: Add an "Open folder" entry to the workspace session row overflow (⋯) menu; opens the session's workspace folder with the host OS.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - workspace
+  - open-folder
+  - file-explorer
+source:
+  repository: https://github.com/TussalZeus18028/dsh-open-folder
+  repositoryNodeId: R_kgDOUEgN8Q
+  subpath: null
+  commit: 4aa92f92971740bf80cbef8abaf1198753effad8
+creator:
+  github: TussalZeus18028
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T12:33:54.231Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tussalzeus18028-dsh-open-folder`
- Submission type: community curation
- Created by `TussalZeus18028` — https://github.com/TussalZeus18028
- Original source repository: https://github.com/TussalZeus18028/dsh-open-folder
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.