### PR TITLE
catalog: add uckkk-dsh-api-mock (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-api-mock.yaml
+++ b/catalog/plugins/uckkk-dsh-api-mock.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-api-mock
+name: dsh-api-mock
+description:
+  en: bash dsh plugin add dsh-api-mock
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - openapi
+  - mock
+  - mock-server
+source:
+  repository: https://github.com/uckkk/dsh-api-mock
+  repositoryNodeId: R_kgDOT5815Q
+  subpath: null
+  commit: 5040c93f84965d56f45ba00c8189dbb657bd4a05
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-api-mock
+  version: 0.1.0
+  integrity: sha512-YGE6vEa1MzXrecpbd2iCdQyGNZy8pmed0NszxACgO5qptRvHITUAXPC/5L74hnmP7uPvRsmc7HUw2atBBPyWzA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T13:13:26.506Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-api-mock`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-api-mock
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.