### PR TITLE
catalog: add uckkk-dsh-color-contrast (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-color-contrast.yaml
+++ b/catalog/plugins/uckkk-dsh-color-contrast.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: uckkk-dsh-color-contrast
+name: dsh-color-contrast
+description:
+  en: bash dsh plugin add dsh-color-contrast 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-color-contrast" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - contrast
+  - wcag
+  - a11y
+  - color
+source:
+  repository: https://github.com/uckkk/dsh-color-contrast
+  repositoryNodeId: R_kgDOT6O75w
+  subpath: null
+  commit: 3fcd67f904987310a1963561298bf991157fe0f8
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-color-contrast
+  version: 0.1.0
+  integrity: sha512-EBzAQMdfbBVvS7GSJiU3N5THIGmV3O4TeruMkwVYK4S2YhXYVVVm37vXhjyl2vmEwd3VVeHfStwJFAcYV2DpfQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T13:55:28.801Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-color-contrast`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-color-contrast
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.