### PR TITLE
catalog: add uckkk-dsh-color (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-color.yaml
+++ b/catalog/plugins/uckkk-dsh-color.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: uckkk-dsh-color
+name: dsh-color
+description:
+  en: bash dsh plugin add dsh-color 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-color" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - color
+  - hex
+  - rgb
+  - hsl
+source:
+  repository: https://github.com/uckkk/dsh-color
+  repositoryNodeId: R_kgDOT6GiyQ
+  subpath: null
+  commit: 9d9c72c1ad37a30b67e28942f7b454c3c6303215
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T13:55:27.880Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-color`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-color
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.