### PR TITLE
catalog: add uckkk-dsh-composition (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-composition.yaml
+++ b/catalog/plugins/uckkk-dsh-composition.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-composition
+name: dsh-composition
+description:
+  en: bash dsh plugin add dsh-composition 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-composition" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - composition
+  - layout
+  - design
+source:
+  repository: https://github.com/uckkk/dsh-composition
+  repositoryNodeId: R_kgDOT6Ok3A
+  subpath: null
+  commit: 091549527b65f937130edcb20d43b444ae2ee03b
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-composition
+  version: 0.1.0
+  integrity: sha512-I9ChaicjWkBElZ7D3ZAKn3or+mqd3peUdlmazy1/ymxm+Lpus0hhf6e93cepiZv8954lYOuyZWYHHHRPZjSX2g==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T13:55:30.700Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-composition`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-composition
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.