### PR TITLE
catalog: add uckkk-dsh-date-calc (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-date-calc.yaml
+++ b/catalog/plugins/uckkk-dsh-date-calc.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: uckkk-dsh-date-calc
+name: dsh-date-calc
+description:
+  en: bash dsh plugin add dsh-date-calc 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-date-calc" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - date
+source:
+  repository: https://github.com/uckkk/dsh-date-calc
+  repositoryNodeId: R_kgDOT6LzXw
+  subpath: null
+  commit: b948c27367755c7fdfc388854b401d3f3d19e7a0
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T13:55:37.378Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-date-calc`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-date-calc
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.