### PR TITLE
catalog: add uckkk-dsh-db-migration (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-db-migration.yaml
+++ b/catalog/plugins/uckkk-dsh-db-migration.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: uckkk-dsh-db-migration
+name: dsh-db-migration
+description:
+  en: bash dsh plugin add dsh-db-migration
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - database
+  - migration
+  - ddl
+  - schema
+source:
+  repository: https://github.com/uckkk/dsh-db-migration
+  repositoryNodeId: R_kgDOT59fwA
+  subpath: null
+  commit: 9a0d56ade7852407bd42c8fa07f70f45057e7c77
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-db-migration
+  version: 0.1.0
+  integrity: sha512-lynnu6t2kqnc56hwO8n+8OOI6+SSU/nmeC+KH2ZSOk9oDsSyUV3xcjfau1Bk6f4xcreKrIBH/nLsuzpuL6BG+w==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T13:55:38.372Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-db-migration`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-db-migration
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.