### PR TITLE
catalog: add uckkk-dsh-dependency-audit (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-dependency-audit.yaml
+++ b/catalog/plugins/uckkk-dsh-dependency-audit.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: uckkk-dsh-dependency-audit
+name: dsh-dependency-audit
+description:
+  en: bash dsh plugin add dsh-dependency-audit
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - security
+  - vulnerability
+  - osv
+  - audit
+source:
+  repository: https://github.com/uckkk/dsh-dependency-audit
+  repositoryNodeId: R_kgDOT59Uhg
+  subpath: null
+  commit: dd8d34601fb676bfba93010608196f9122151701
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-dependency-audit
+  version: 0.1.0
+  integrity: sha512-bGZ6t4dMZzVISAH9oLqSwyMraaDjxNCqV0mLKXxoxjftQn84FywCmlAovQpbM5jA51ZbHQIOi22n0Q0KL5Vbow==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T13:55:40.880Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-dependency-audit`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-dependency-audit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.