### PR TITLE
catalog: add uckkk-dsh-duration (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-duration.yaml
+++ b/catalog/plugins/uckkk-dsh-duration.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: uckkk-dsh-duration
+name: dsh-duration
+description:
+  en: bash dsh plugin add dsh-duration 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-duration" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - duration
+source:
+  repository: https://github.com/uckkk/dsh-duration
+  repositoryNodeId: R_kgDOT6NnNA
+  subpath: null
+  commit: 643ad704962f57d061acbbb50c084729da36d803
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-duration
+  version: 0.1.0
+  integrity: sha512-QdoV5iWWihKuxzFiVhAWXCICeJnYCRDUdha6/kurlFXYhyWS1EudJFjxtws6Uqgn+BmHuCf1UwI6lY6xthPTpQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T14:41:33.322Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-duration`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-duration
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.