### PR TITLE
catalog: add uckkk-dsh-env-json (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-env-json.yaml
+++ b/catalog/plugins/uckkk-dsh-env-json.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: uckkk-dsh-env-json
+name: dsh-env-json
+description:
+  en: bash dsh plugin add dsh-env-json 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-env-json" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - env
+  - json
+source:
+  repository: https://github.com/uckkk/dsh-env-json
+  repositoryNodeId: R_kgDOT6NiYA
+  subpath: null
+  commit: 590d80f0ea2fe6ae4b108ee063f53b4c4e69ac8a
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-env-json
+  version: 0.1.0
+  integrity: sha512-s4XzTzw/2dEI70Ycm5k26EnTuUpWf9blLf5AvbPjOU2IC6HlqKryTF75cDuoDU9O39gOmZjZO6kFartR5FBhUw==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T14:41:36.381Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-env-json`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-env-json
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.