### PR TITLE
catalog: add uckkk-dsh-env-manager (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-env-manager.yaml
+++ b/catalog/plugins/uckkk-dsh-env-manager.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-env-manager
+name: dsh-env-manager
+description:
+  en: bash dsh plugin add dsh-env-manager
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - env
+  - environment
+  - dotenv
+source:
+  repository: https://github.com/uckkk/dsh-env-manager
+  repositoryNodeId: R_kgDOT6EdGA
+  subpath: null
+  commit: 19d0e37768395c63ca9fa182548a22dc335b7b77
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-env-manager
+  version: 0.1.0
+  integrity: sha512-BdM/2C0euHjtKDT2m29dG1wODOx9rW90gschQwOpBl8LiYOwg6hAMgny55Ez89aGy7IqpC3acANxJylkeupZeg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T14:41:36.678Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-env-manager`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-env-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.