### PR TITLE
catalog: add uckkk-dsh-file-rename (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-file-rename.yaml
+++ b/catalog/plugins/uckkk-dsh-file-rename.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: uckkk-dsh-file-rename
+name: dsh-file-rename
+description:
+  en: bash dsh plugin add dsh-file-rename 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-file-rename" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - rename
+  - batch
+source:
+  repository: https://github.com/uckkk/dsh-file-rename
+  repositoryNodeId: R_kgDOT6GOkQ
+  subpath: null
+  commit: 1c25c881d7969632672ee8899f026c7812f2066f
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-file-rename
+  version: 0.1.0
+  integrity: sha512-XHJUqMvpmVdRwbfSJiGXlxXKABqfC2SrSDKN8PSSjFpoQDXy0H5j9N4+rwXelN9/sEpS+bt4KmygDVsyPAKb3Q==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T14:41:38.435Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-file-rename`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-file-rename
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.