### PR TITLE
catalog: add uckkk-dsh-follower-goal (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-follower-goal.yaml
+++ b/catalog/plugins/uckkk-dsh-follower-goal.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: uckkk-dsh-follower-goal
+name: dsh-follower-goal
+description:
+  en: bash dsh plugin add github:uckkk/dsh-follower-goal
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-follower-goal
+source:
+  repository: https://github.com/uckkk/dsh-follower-goal
+  repositoryNodeId: R_kgDOT-tP8Q
+  subpath: null
+  commit: ec5099971e1d9a841577196104d32cbb48a5b0c4
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T14:41:40.014Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-follower-goal`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-follower-goal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.