### PR TITLE
catalog: add uckkk-dsh-html-escape (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-html-escape.yaml
+++ b/catalog/plugins/uckkk-dsh-html-escape.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: uckkk-dsh-html-escape
+name: dsh-html-escape
+description:
+  en: bash dsh plugin add dsh-html-escape 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-html-escape" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - html
+  - escape
+source:
+  repository: https://github.com/uckkk/dsh-html-escape
+  repositoryNodeId: R_kgDOT6LSOQ
+  subpath: null
+  commit: b7de1c4fad68c949d1b0a2bf6603890380d98093
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-html-escape
+  version: 0.1.0
+  integrity: sha512-sDNNsAY/2d9Ylxz8ZiAkwH0bF4/l1LmAMyeoeVMvJqtRr05VRbypL8uN45QIy4adWsdBnNICumtFWyGPCVqDtg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T14:41:54.513Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-html-escape`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-html-escape
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.