### PR TITLE
catalog: add uckkk-dsh-json-query (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-json-query.yaml
+++ b/catalog/plugins/uckkk-dsh-json-query.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: uckkk-dsh-json-query
+name: dsh-json-query
+description:
+  en: bash dsh plugin add dsh-json-query 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-json-query" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - json
+  - path
+source:
+  repository: https://github.com/uckkk/dsh-json-query
+  repositoryNodeId: R_kgDOT6M-Jw
+  subpath: null
+  commit: 7fef7cf511a3862b09e664ec13c010bec80b9365
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T15:27:14.033Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-json-query`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-json-query
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.