### PR TITLE
catalog: add uckkk-dsh-license-guard (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-license-guard.yaml
+++ b/catalog/plugins/uckkk-dsh-license-guard.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-license-guard
+name: dsh-license-guard
+description:
+  en: bash dsh plugin add dsh-license-guard
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - license
+  - spdx
+  - compliance
+source:
+  repository: https://github.com/uckkk/dsh-license-guard
+  repositoryNodeId: R_kgDOT57Nqg
+  subpath: null
+  commit: 60a50881744efd3bf09d1e1ef6f344df4bb3bc3f
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-license-guard
+  version: 0.1.0
+  integrity: sha512-DtwP3D+2eZpJwq9eQNWxZx+EtXj+37aQgOvtHNJCaNdVKLGU4keQxJhG3XTrw3a0ljLgM1Z61/dGRC7wmHgmOw==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T15:27:05.982Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-license-guard`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-license-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.