### PR TITLE
catalog: add uckkk-dsh-log-analyzer (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-log-analyzer.yaml
+++ b/catalog/plugins/uckkk-dsh-log-analyzer.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-log-analyzer
+name: dsh-log-analyzer
+description:
+  en: bash dsh plugin add dsh-log-analyzer
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - log
+  - analyzer
+  - debug
+source:
+  repository: https://github.com/uckkk/dsh-log-analyzer
+  repositoryNodeId: R_kgDOT6EGyg
+  subpath: null
+  commit: 571c49484afc18203a68c7d4f3b5d5d4f3b0606f
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-log-analyzer
+  version: 0.1.0
+  integrity: sha512-TGz0+/VKdjSHwRv69mDkrVJlswdHNsjIHV3qXZ21KtdSfZN2PIDVBBYjOEax8JXhS2m8h0aAQ64p16RMrQU6ww==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T15:27:05.787Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-log-analyzer`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-log-analyzer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.