### PR TITLE
catalog: add uckkk-dsh-markdown-table (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-markdown-table.yaml
+++ b/catalog/plugins/uckkk-dsh-markdown-table.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: uckkk-dsh-markdown-table
+name: dsh-markdown-table
+description:
+  en: bash dsh plugin add dsh-markdown-table 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-markdown-table" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - markdown
+  - table
+source:
+  repository: https://github.com/uckkk/dsh-markdown-table
+  repositoryNodeId: R_kgDOT6H9yg
+  subpath: null
+  commit: 4ce8301fa0b28f2c81cdf2ac1e922db467bfc672
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-markdown-table
+  version: 0.1.0
+  integrity: sha512-KeSo5cpEzmnX397XC4hfs/VdHkjmeT/TjkFzq7xvazHVZqlohmw2Dpx/4uBsKuFitov74DP0ynrkREc9YBZzrA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T15:27:05.817Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-markdown-table`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-markdown-table
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.