### PR TITLE
catalog: add uckkk-dsh-minify (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-minify.yaml
+++ b/catalog/plugins/uckkk-dsh-minify.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: uckkk-dsh-minify
+name: dsh-minify
+description:
+  en: bash dsh plugin add dsh-minify 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-minify" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - minify
+  - uglify
+  - compress
+source:
+  repository: https://github.com/uckkk/dsh-minify
+  repositoryNodeId: R_kgDOT9sA9w
+  subpath: null
+  commit: 7aff6e6646be4034cf717b989bc5ed4d66c4d741
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T15:27:30.543Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-minify`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-minify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.