### PR TITLE
catalog: add uckkk-dsh-mite-removal (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-mite-removal.yaml
+++ b/catalog/plugins/uckkk-dsh-mite-removal.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: uckkk-dsh-mite-removal
+name: dsh-mite-removal
+description:
+  en: bash dsh plugin add github:uckkk/dsh-mite-removal
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-mite-removal
+source:
+  repository: https://github.com/uckkk/dsh-mite-removal
+  repositoryNodeId: R_kgDOT-wRCA
+  subpath: null
+  commit: 9acfc47a9012a96cbd6fd98aaaaf4697402c6eb9
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T15:27:31.912Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-mite-removal`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-mite-removal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.