### PR TITLE
fix(cli): raise the catalog file-count and byte ceilings for a 2k+ (→ 20k) catalog

### DIFF
--- a/cli/src/catalogSnapshot.ts
+++ b/cli/src/catalogSnapshot.ts
@@ -30,16 +30,29 @@ export const PUBLIC_CATALOG_RAW_ORIGIN =
 export const PUBLIC_SNAPSHOT_SITE_URL =
   "https://dsh-plugins.omniroute.online/catalog.snapshot.json";
 
+// Raised 2026-08-29 (see catalog-validation outage, #cli-catalog-ceilings): the public
+// catalog crossed 2,081 entries and tripped the old `files: 2_048` ceiling on every PR and
+// on `main` itself. These are still hostile-input safety limits, not soft targets — they are
+// widened with headroom for the growth curve (~100 entries/round, 10k+ target), not removed.
+// Measurements behind the new numbers:
+//   - Public `catalog/` checkout (2026-08-29): 2,082 files / 2,319,239 bytes (~1.11 KiB/entry).
+//   - Generated `catalog.snapshot.json` for 1,356 entries: 1,670,943 bytes (~1.23 KiB/entry).
+//   - Generated `catalog.json` for 1,356 entries: 2,450,402 bytes.
+//   - Linear extrapolation to 20,000 entries: ~24.1 MiB snapshot / ~21.3 MiB raw file bytes
+//     / ~2.0 MB git-tree listing (~100 B/entry). `files`/`directoryEntries` at 32,768 give
+//     >1.6x headroom over 20k entries with room to raise again before the next ceiling; the
+//     byte limits (128 MiB snapshot/file-bytes, 32 MiB git-tree) give >5x headroom over the
+//     20k-entry byte extrapolation above.
 export const CATALOG_SNAPSHOT_LIMITS = Object.freeze({
-  snapshotBytes: 10 * 1024 * 1024,
-  totalFileBytes: 8 * 1024 * 1024,
+  snapshotBytes: 128 * 1024 * 1024,
+  totalFileBytes: 128 * 1024 * 1024,
   fileBytes: 1024 * 1024,
-  files: 2_048,
-  directoryEntries: 4_096,
+  files: 32_768,
+  directoryEntries: 32_768,
   pathBytes: 512,
   redirects: 3,
   gitOutputBytes: 64 * 1024,
-  gitTreeBytes: 2 * 1024 * 1024,
+  gitTreeBytes: 32 * 1024 * 1024,
   pathDepth: 16,
 });
 

--- a/cli/tests/catalog-snapshot.test.ts
+++ b/cli/tests/catalog-snapshot.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   CATALOG_SNAPSHOT_FORMAT_V1,
+  CATALOG_SNAPSHOT_LIMITS,
   PUBLIC_CATALOG_RAW_ORIGIN,
   PUBLIC_SNAPSHOT_SITE_URL,
   materializeCatalog,
@@ -272,6 +273,49 @@ describe("catalog snapshot materialization", () => {
     expect(materialized.revision).toBe(REVISION_A);
     expect(materialized.root).toBe(await realpath(materialized.root));
     await materialized.cleanup();
+  });
+
+  it("accepts a snapshot at the current public file-count ceiling (2,100 entries, above the old 2,048 cap)", async () => {
+    // Regression guard for the 2026-08-29 catalog-validation outage: the public catalog
+    // crossed 2,081 entries and the old `files: 2_048` ceiling started rejecting every PR
+    // and `main` itself. 2,100 stays comfortably clear of that retired cap while staying
+    // far below the current `CATALOG_SNAPSHOT_LIMITS.files` ceiling.
+    const entryCount = 2_100;
+    expect(entryCount).toBeGreaterThan(2_048);
+    expect(entryCount).toBeLessThan(CATALOG_SNAPSHOT_LIMITS.files);
+
+    const files: Record<string, string> = {};
+    for (let index = 0; index < entryCount; index += 1) {
+      files[`catalog/plugins/plugin-${index}.yaml`] = `schemaVersion: 1\nid: plugin-${index}\n`;
+    }
+    const sourceRoot = await temporaryRoot("dsh-catalog-file-many-");
+    const sourcePath = join(sourceRoot, "catalog.snapshot.json");
+    await writeFile(sourcePath, snapshot(files));
+
+    const materialized = await materializeCatalog({ kind: "snapshot-file", path: sourcePath });
+    if (materialized.kind !== "snapshot") throw new Error("expected snapshot result");
+    expect(
+      await readFile(join(materialized.root, "catalog/plugins/plugin-0.yaml"), "utf8"),
+    ).toBe("schemaVersion: 1\nid: plugin-0\n");
+    await materialized.cleanup();
+  });
+
+  it("still rejects a snapshot one entry above the current public file-count ceiling", async () => {
+    const entryCount = CATALOG_SNAPSHOT_LIMITS.files + 1;
+    const files: Record<string, string> = {};
+    for (let index = 0; index < entryCount; index += 1) {
+      files[`catalog/plugins/plugin-${index}.yaml`] = `schemaVersion: 1\nid: plugin-${index}\n`;
+    }
+    const sourceRoot = await temporaryRoot("dsh-catalog-file-toomany-");
+    const sourcePath = join(sourceRoot, "catalog.snapshot.json");
+    await writeFile(sourcePath, snapshot(files));
+
+    await expect(
+      materializeCatalog({ kind: "snapshot-file", path: sourcePath }),
+    ).rejects.toMatchObject({
+      name: "CliSafetyError",
+      message: "catalog snapshot exceeds the public file count limit",
+    });
   });
 
   it("fetches only a pinned public raw snapshot without credentials", async () => {


### PR DESCRIPTION
## Summary

- `catalog validate` (and the snapshot parser) hardcoded `CATALOG_SNAPSHOT_LIMITS.files = 2_048` as a hostile-input safety ceiling. The public catalog crossed 2,081 entries on 2026-08-29, so `catalog-validation` started failing on every PR and on `main`.
- Raises the count/byte ceilings with measured headroom for the growth curve (~100 entries/round, 10k+ target) — these stay as safety limits against a hostile/oversized snapshot or local tree, they are widened, not removed.

## Measurements (2026-08-29, recorded as a comment on the constant)

- Public `catalog/` checkout: 2,082 files / 2,319,239 bytes (~1.11 KiB/entry).
- Generated `catalog.snapshot.json` for 1,356 entries: 1,670,943 bytes (~1.23 KiB/entry).
- Generated `catalog.json` for 1,356 entries: 2,450,402 bytes.
- Linear extrapolation to 20,000 entries: ~24.1 MiB snapshot / ~21.3 MiB raw file bytes / ~2.0 MB git-tree listing.

## New values

| Limit | Old | New |
|---|---|---|
| `files` | 2,048 | 32,768 |
| `directoryEntries` | 4,096 | 32,768 |
| `totalFileBytes` | 8 MiB | 128 MiB |
| `snapshotBytes` | 10 MiB | 128 MiB |
| `gitTreeBytes` | 2 MiB | 32 MiB |
| `fileBytes`, `pathBytes`, `pathDepth`, `redirects`, `gitOutputBytes` | unchanged | unchanged |

## Test plan

- [x] TDD: added `cli/tests/catalog-snapshot.test.ts` cases — a synthetic 2,100-entry snapshot (above the old 2,048 cap) now materializes cleanly; a snapshot one entry above the *current* `files` ceiling is still rejected with `catalog snapshot exceeds the public file count limit`. Confirmed red against the old `2_048`/`4_096` values before applying the new ones.
- [x] `npm run build && npx vitest run` in `cli/` — all `catalog-snapshot.test.ts` (31) and `catalog-id-conventions.test.ts` pass; `package-contents.test.ts` fails locally with a pre-existing npm 12 issue unrelated to this change.
- [x] `node cli/dist/bin.js catalog validate --catalog .` from the worktree root → `2081 entries valid`.