### PR TITLE
catalog: add uckkk-dsh-number-format (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-number-format.yaml
+++ b/catalog/plugins/uckkk-dsh-number-format.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: uckkk-dsh-number-format
+name: dsh-number-format
+description:
+  en: bash dsh plugin add dsh-number-format 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-number-format" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - number
+  - format
+source:
+  repository: https://github.com/uckkk/dsh-number-format
+  repositoryNodeId: R_kgDOT6LVVQ
+  subpath: null
+  commit: efc48e58616c26b9cda2b0e5bf1250bb73795695
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-number-format
+  version: 0.1.0
+  integrity: sha512-Cj36Akuq6RP6U7ItldgHCPuhVreaPIP4NNGUfJEtHoTq10nq/fxHuHeQI8eaex9PM/YfEdnaATCeBEnQUzkH3Q==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T17:50:41.309Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-number-format`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-number-format
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.