### PR TITLE
catalog: add uckkk-dsh-password (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-password.yaml
+++ b/catalog/plugins/uckkk-dsh-password.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: uckkk-dsh-password
+name: dsh-password
+description:
+  en: bash dsh plugin add dsh-password 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-password" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - password
+  - security
+source:
+  repository: https://github.com/uckkk/dsh-password-uckkk
+  repositoryNodeId: R_kgDOT6I1zQ
+  subpath: null
+  commit: a8aeb4af5575cfe13d08978f7ab066d8ffb721f6
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-password
+  version: 0.1.0
+  integrity: sha512-fAzhbTzfFokM3K+6VC6/VPxuVJ6+ibaE4en5D3/IUmrVeKboBceJNtPVccYebU9gO5m1HDp1ucqD6uFTo41PFQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T17:50:46.858Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-password`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-password-uckkk
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.