### PR TITLE
catalog: add uckkk-dsh-random (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-random.yaml
+++ b/catalog/plugins/uckkk-dsh-random.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: uckkk-dsh-random
+name: dsh-random
+description:
+  en: bash dsh plugin add dsh-random 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-random" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - random
+source:
+  repository: https://github.com/uckkk/dsh-random
+  repositoryNodeId: R_kgDOT6JvTg
+  subpath: null
+  commit: 050db4d0566f483e2beaf7274d05c3ee9cafa319
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-random
+  version: 0.1.0
+  integrity: sha512-cC8wLea47w6SDIcXYDvcD5ZV4dKtfvtgA7H0cl6R72JH7L1mnn1YBOkpCUi8DVlNn91M59riva9GjTrls8uhrA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T17:50:57.594Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-random`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-random
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.