### PR TITLE
catalog: add uckkk-dsh-readme (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-readme.yaml
+++ b/catalog/plugins/uckkk-dsh-readme.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: uckkk-dsh-readme
+name: dsh-readme
+description:
+  en: bash dsh plugin add dsh-readme
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - documentation
+source:
+  repository: https://github.com/uckkk/dsh-readme
+  repositoryNodeId: R_kgDOT6Drhg
+  subpath: null
+  commit: 739cba851395b575805ac65a48d5b41ad6a48610
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-readme
+  version: 0.1.0
+  integrity: sha512-iALoy8h5y9eJ7m82eLc4s0hjodeLTDHagK2k8i3JLkqXdiXFcAZj3smeTuKI29p+9dP06uaRO+v6uF2eMAySng==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T17:50:59.057Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-readme`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-readme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.