### PR TITLE
docs: license policy — copyleft-network licenses are held, not listed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,9 @@ Provide all of the following in the pull request:
 - A bounded English description and its evidence path at that pinned commit.
 - The artifact `kind`, primary category and tags selected from
   [docs/CATEGORIES.md](docs/CATEGORIES.md).
-- The complete upstream SPDX license expression evidenced at the pinned commit.
+- The complete upstream SPDX license expression evidenced at the pinned commit. See
+  [docs/LICENSE-POLICY.md](docs/LICENSE-POLICY.md) for which licenses qualify and how a
+  copyleft-network (AGPL-3.0 and variants) submission is handled.
 - A canonical install descriptor pinned to an exact npm version, or to the source repository,
   full commit and subpath. The descriptor is data, never a shell command.
 - Native DSH integration evidence and its path at the pinned commit.

--- a/docs/LICENSE-POLICY.md
+++ b/docs/LICENSE-POLICY.md
@@ -1,0 +1,7 @@
+# License policy
+
+Entries are listed only when the pinned commit carries an OSI-approved license the CLI can
+install without imposing obligations on the installer's own code. Copyleft-network licenses
+(AGPL-3.0 and variants) are **held**: not listed, not rejected on merit. A creator may ask for
+review by relicensing or by opening a direct PR explaining the terms; the owner rules case by case.
+Held entries are visible to the curators only.


### PR DESCRIPTION
## Summary
- Add `docs/LICENSE-POLICY.md`: entries are listed only when the pinned commit carries an OSI-approved license the CLI can install without imposing obligations on the installer's own code. Copyleft-network licenses (AGPL-3.0 and variants) are held — not listed, not rejected on merit. A creator may ask for review by relicensing or by opening a direct PR explaining the terms; the owner rules case by case. Held entries are visible to curators only.
- Link the policy from the "complete upstream SPDX license expression" bullet in `CONTRIBUTING.md` → Required evidence.

## Test plan
- [x] `node cli/dist/bin.js catalog docs-check . --skip-count` → `Catalog documentation checks passed for 2151 entries.`
- Not touched: `README.md`, `docs/CATEGORIES.md` structured tables (kept schema/category parity intact), and no `docs/i18n/*` translation files (the new doc is not in `i18nFreshness.mjs`'s `TRANSLATED_DOCUMENTS` list, so it stays English-only by design).