### PR TITLE
catalog: add uckkk-dsh-repo-health (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-repo-health.yaml
+++ b/catalog/plugins/uckkk-dsh-repo-health.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-repo-health
+name: dsh-repo-health
+description:
+  en: bash dsh plugin add dsh-repo-health
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - health
+  - best-practices
+  - repo
+source:
+  repository: https://github.com/uckkk/dsh-repo-health
+  repositoryNodeId: R_kgDOT6EkZA
+  subpath: null
+  commit: 782434c902768aa387d543da6e2a48d1644f7d1f
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-repo-health
+  version: 0.1.0
+  integrity: sha512-fLexDViGI+Tp+D21WmFSuZJYOJetjPG+uQZjVJD0l0/6e3ddzk1vI9i+fF60D/iReYcL8MPJWul9hs3VPwXLhQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T19:43:47.928Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-repo-health`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-repo-health
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.