### PR TITLE
catalog: add uckkk-dsh-secret-scan (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-secret-scan.yaml
+++ b/catalog/plugins/uckkk-dsh-secret-scan.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-secret-scan
+name: dsh-secret-scan
+description:
+  en: bash dsh plugin add dsh-secret-scan
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - security
+  - secret
+  - scan
+source:
+  repository: https://github.com/uckkk/dsh-secret-scan
+  repositoryNodeId: R_kgDOT58_1Q
+  subpath: null
+  commit: 0150f91aff85f779afa69bcbddbe84486e2b2820
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-secret-scan
+  version: 0.1.0
+  integrity: sha512-4po2Bog+VPC0pd2BjXD+Oje5+YY0jwLGxsBRriMHkniDsdQNPfVPGRAOZWE83zaKS03m/gS+O5TmtLlOlUfp7A==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T19:43:57.578Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-secret-scan`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-secret-scan
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.