### PR TITLE
catalog: add uckkk-dsh-sum-of-divisors (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-sum-of-divisors.yaml
+++ b/catalog/plugins/uckkk-dsh-sum-of-divisors.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: uckkk-dsh-sum-of-divisors
+name: dsh-sum-of-divisors
+description:
+  en: bash dsh plugin add github:uckkk/dsh-sum-of-divisors
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-sum-of-divisors
+source:
+  repository: https://github.com/uckkk/dsh-sum-of-divisors
+  repositoryNodeId: R_kgDOT9u8FA
+  subpath: null
+  commit: 172c7236536daca94d89a1299714c87e0b4d1cd4
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T19:44:14.092Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-sum-of-divisors`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-sum-of-divisors
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.