### PR TITLE
catalog: add uckkk-dsh-test-coverage (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-test-coverage.yaml
+++ b/catalog/plugins/uckkk-dsh-test-coverage.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: uckkk-dsh-test-coverage
+name: dsh-test-coverage
+description:
+  en: bash dsh plugin add dsh-test-coverage
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - coverage
+  - test
+source:
+  repository: https://github.com/uckkk/dsh-test-coverage
+  repositoryNodeId: R_kgDOT57NKg
+  subpath: null
+  commit: a4d90387696bbe25376c92237054e8da552316b1
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-test-coverage
+  version: 0.1.0
+  integrity: sha512-1aaXjw0QPlSNSmLqhEdrhKMI0LD3Nr6X30pmFtVYjx0ZqIaXftgMnxcJC8I9KRSBvtDbW/EzXBl9dTYVm/Wcwg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:31:40.595Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-test-coverage`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-test-coverage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.