### PR TITLE
catalog: add uckkk-dsh-typography (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-typography.yaml
+++ b/catalog/plugins/uckkk-dsh-typography.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: uckkk-dsh-typography
+name: dsh-typography
+description:
+  en: bash dsh plugin add dsh-typography 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-typography" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - typography
+  - font
+  - design
+source:
+  repository: https://github.com/uckkk/dsh-typography
+  repositoryNodeId: R_kgDOT6OkAQ
+  subpath: null
+  commit: 36ea7c74175c4151a11ef02403696db7168fed0d
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:31:58.550Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-typography`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-typography
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.