### PR TITLE
catalog: add uckkk-dsh-ux-writing (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-ux-writing.yaml
+++ b/catalog/plugins/uckkk-dsh-ux-writing.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: uckkk-dsh-ux-writing
+name: dsh-ux-writing
+description:
+  en: bash dsh plugin add dsh-ux-writing 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-ux-writing" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ux
+  - copywriting
+  - writing
+source:
+  repository: https://github.com/uckkk/dsh-ux-writing
+  repositoryNodeId: R_kgDOT6Olpg
+  subpath: null
+  commit: d87d93fa4c98f34555bf387d705b6df89f9f6773
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:32:03.620Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-ux-writing`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-ux-writing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.