### PR TITLE
catalog: add uckkk-dsh-validator (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-validator.yaml
+++ b/catalog/plugins/uckkk-dsh-validator.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: uckkk-dsh-validator
+name: dsh-validator
+description:
+  en: bash dsh plugin add dsh-validator 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-validator" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - validate
+  - email
+  - phone
+source:
+  repository: https://github.com/uckkk/dsh-validator
+  repositoryNodeId: R_kgDOT6Mtzg
+  subpath: null
+  commit: 48356b2cc785b0d39418c625a7509f27ab5b626a
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:32:04.511Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-validator`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-validator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.