### PR TITLE
catalog: add uckkk-dsh-valley-meter (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-valley-meter.yaml
+++ b/catalog/plugins/uckkk-dsh-valley-meter.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: uckkk-dsh-valley-meter
+name: dsh-valley-meter
+description:
+  en: "DeepSeek Harness peak/valley electricity meter: off-peak countdown, balance & spend"
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - client-plugin
+  - cost
+  - peak
+  - valley
+  - off-peak
+  - balance
+  - countdown
+source:
+  repository: https://github.com/uckkk/dsh-valley-meter
+  repositoryNodeId: R_kgDOUAqm4Q
+  subpath: null
+  commit: fc143d06984802098686f3073d998e2677b1d55f
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:31:40.672Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/uckkk/dsh-valley-meter/fc143d06984802098686f3073d998e2677b1d55f/docs/preview.png
+    alt: 卡片示意
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/uckkk/dsh-valley-meter/fc143d06984802098686f3073d998e2677b1d55f/docs/screenshots/hover.png
+    alt: 悬停态


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-valley-meter`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-valley-meter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.