### PR TITLE
catalog: add uckkk-dsh-video-creator (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-video-creator.yaml
+++ b/catalog/plugins/uckkk-dsh-video-creator.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-video-creator
+name: dsh-video-creator
+description:
+  en: bash dsh plugin add dsh-video-creator
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - video
+  - short-video
+  - creator
+source:
+  repository: https://github.com/uckkk/dsh-video-creator
+  repositoryNodeId: R_kgDOT57N6g
+  subpath: null
+  commit: 09c893bfc061a018bc47a3b1567c1e852489f699
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-video-creator
+  version: 0.1.4
+  integrity: sha512-lin6KP6MbHvG+fHd4jZB0ip9OWpLnSIr28WUU5Tq33tT12TvEgQqdGeoGHWqtyGKltZamux+ELH9KsnICTWtZw==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:31:40.942Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-video-creator`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-video-creator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.