### PR TITLE
catalog: add uckkk-dsh-voltage-drop (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-voltage-drop.yaml
+++ b/catalog/plugins/uckkk-dsh-voltage-drop.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: uckkk-dsh-voltage-drop
+name: dsh-voltage-drop
+description:
+  en: bash dsh plugin add github:uckkk/dsh-voltage-drop
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-voltage-drop
+source:
+  repository: https://github.com/uckkk/dsh-voltage-drop
+  repositoryNodeId: R_kgDOT-s7nw
+  subpath: null
+  commit: c554def40b2b129641118feb734cbd16f16f2d4e
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:32:07.051Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-voltage-drop`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-voltage-drop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.