### PR TITLE
catalog: add uckkk-dsh-watering-schedule (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-watering-schedule.yaml
+++ b/catalog/plugins/uckkk-dsh-watering-schedule.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: uckkk-dsh-watering-schedule
+name: dsh-watering-schedule
+description:
+  en: bash dsh plugin add github:uckkk/dsh-watering-schedule
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-watering-schedule
+source:
+  repository: https://github.com/uckkk/dsh-watering-schedule
+  repositoryNodeId: R_kgDOT-r6_w
+  subpath: null
+  commit: c73ac1afa0829285168b127464d61c1c57712cac
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:32:08.428Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-watering-schedule`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-watering-schedule
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.