### PR TITLE
catalog: add uknowmyface-dsh-tool-screenshot-ocr (community curation, created by @uknowmyface)

### DIFF
--- a/catalog/plugins/uknowmyface-dsh-tool-screenshot-ocr.yaml
+++ b/catalog/plugins/uknowmyface-dsh-tool-screenshot-ocr.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: uknowmyface-dsh-tool-screenshot-ocr
+name: "@locallens/dsh-tool-screenshot-ocr"
+description:
+  en: "macOS Vision OCR tool plugin for DeepSeek Harness: read text from screen capture, clipboard images, or image files (zh-Hans + en-US). Unofficial community project."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - ocr
+  - macos
+  - vision
+  - dsh
+source:
+  repository: https://github.com/uknowmyface/locallens
+  repositoryNodeId: R_kgDOT4qjZg
+  subpath: null
+  commit: 22099c5ccee08c002e8c55e771e9e87632ba5222
+creator:
+  github: uknowmyface
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:31:36.444Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/uknowmyface/locallens/22099c5ccee08c002e8c55e771e9e87632ba5222/docs/demo.gif
+    alt: Screenshot a region, ask in the chat box, get the text back


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uknowmyface-dsh-tool-screenshot-ocr`
- Submission type: community curation
- Created by `uknowmyface` — https://github.com/uknowmyface
- Original source repository: https://github.com/uknowmyface/locallens
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.