### PR TITLE
catalog: add untr-untr-dsh-marketplace (community curation, created by @UntR)

### DIFF
--- a/catalog/plugins/untr-untr-dsh-marketplace.yaml
+++ b/catalog/plugins/untr-untr-dsh-marketplace.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: untr-untr-dsh-marketplace
+name: untr-dsh-marketplace
+description:
+  en: Registry-backed plugin marketplace and profile plugin manager for DeepSeek Harness
+  evidencePath: dsh-marketplace/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - marketplace
+source:
+  repository: https://github.com/UntR/dsh-plugin-marketplace
+  repositoryNodeId: R_kgDOT4Us7Q
+  subpath: dsh-marketplace
+  commit: 2dfd22e4ff4ec635a7856a88262bebd92458ce8f
+creator:
+  github: UntR
+package:
+  ecosystem: npm
+  name: untr-dsh-marketplace
+  version: 0.1.4
+  integrity: sha512-IAoZvIGn17RROkcw7iXQVb8emJ1HfK5TWvXa8+T5kFLgOmq7F50N66jkBspGIygVmRvrFVcnc9QB8qpRoGqF1A==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-marketplace/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:32:16.491Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `untr-untr-dsh-marketplace`
- Submission type: community curation
- Created by `UntR` — https://github.com/UntR
- Original source repository: https://github.com/UntR/dsh-plugin-marketplace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.