### PR TITLE
catalog: add uriekang1211-bot-dsh-ssq-plugin (community curation, created by @uriekang1211-bot)

### DIFF
--- a/catalog/plugins/uriekang1211-bot-dsh-ssq-plugin.yaml
+++ b/catalog/plugins/uriekang1211-bot-dsh-ssq-plugin.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: uriekang1211-bot-dsh-ssq-plugin
+name: dsh-ssq-plugin
+description:
+  en: sh dsh plugin --profile web remove dsh-ssq-plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - ssq
+  - lottery
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/uriekang1211-bot/dsh-ssq-plugin
+  repositoryNodeId: R_kgDOT8L6rQ
+  subpath: null
+  commit: 08a3281ab8ff2c168f7cde9a56af0887c6d56bd6
+creator:
+  github: uriekang1211-bot
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-29T20:31:36.355Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uriekang1211-bot-dsh-ssq-plugin`
- Submission type: community curation
- Created by `uriekang1211-bot` — https://github.com/uriekang1211-bot
- Original source repository: https://github.com/uriekang1211-bot/dsh-ssq-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.