### PR TITLE
catalog: add airborne316-dsh-dynamic-wallpaper (community curation, created by @airborne316)

### DIFF
--- a/catalog/plugins/airborne316-dsh-dynamic-wallpaper.yaml
+++ b/catalog/plugins/airborne316-dsh-dynamic-wallpaper.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: airborne316-dsh-dynamic-wallpaper
+name: dsh-dynamic-wallpaper
+description:
+  en: "Animated wallpaper plugin for DeepSeek Harness: 8 built-in canvas backgrounds (particles, meteor shower, starfield, waves, rain, bubbles, matrix, aurora) plus custom video import, with speed/density/opacity/blur controls and durable localStorage persistence"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - wallpaper
+  - dynamic-wallpaper
+  - animated-background
+  - web-ui
+source:
+  repository: https://github.com/Willmylife/dsh-dynamic-wallpaper
+  repositoryNodeId: R_kgDOT61Flg
+  subpath: null
+  commit: 65f5215d2edef362c915799f891124990ae9c874
+creator:
+  github: airborne316
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:40.351Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `airborne316-dsh-dynamic-wallpaper`
- Submission type: community curation
- Created by `airborne316` — https://github.com/airborne316
- Original source repository: https://github.com/Willmylife/dsh-dynamic-wallpaper
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.