### PR TITLE
catalog: add chengzeyi-wavespeed-dsh-skill (community curation, created by @chengzeyi)

### DIFF
--- a/catalog/plugins/chengzeyi-wavespeed-dsh-skill.yaml
+++ b/catalog/plugins/chengzeyi-wavespeed-dsh-skill.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: chengzeyi-wavespeed-dsh-skill
+name: wavespeed-dsh-skill
+description:
+  en: "WaveSpeed skill for DeepSeek Harness (dsh): generate and edit AI media (image, video, audio, 3D) via the open-source wavespeed CLI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - wavespeed
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - skill
+  - ai-image-generation
+  - ai-video-generation
+source:
+  repository: https://github.com/WaveSpeedAI/wavespeed-dsh-skill
+  repositoryNodeId: R_kgDOT8785A
+  subpath: null
+  commit: cef794e54dce0582a008486f152540c9e56081e7
+creator:
+  github: chengzeyi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:34.735Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chengzeyi-wavespeed-dsh-skill`
- Submission type: community curation
- Created by `chengzeyi` — https://github.com/chengzeyi
- Original source repository: https://github.com/WaveSpeedAI/wavespeed-dsh-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.