### PR TITLE
catalog: add jeffw1527-dsh-remote-sandbox (community curation, created by @jeffw1527)

### DIFF
--- a/catalog/plugins/jeffw1527-dsh-remote-sandbox.yaml
+++ b/catalog/plugins/jeffw1527-dsh-remote-sandbox.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: jeffw1527-dsh-remote-sandbox
+name: dsh-remote-sandbox
+description:
+  en: One-line DeepSeek Harness bundle that moves the execution world into a crash-resilient, heartbeat-kept, workspace-synced E2B sandbox.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - dsh-bundle
+  - deepseek-harness
+  - sandbox
+  - e2b
+  - dsh
+source:
+  repository: https://github.com/weijiafu14/dsh-remote-sandbox
+  repositoryNodeId: R_kgDOT3sTnQ
+  subpath: packages/bundle
+  commit: 4da3dfd7bde2309c335a6d1383ce037c5f6d8e3f
+creator:
+  github: jeffw1527
+package:
+  ecosystem: npm
+  name: dsh-remote-sandbox
+  version: 0.1.0
+  integrity: sha512-XgGpWX0i9VocbDAZB/PqfZZg21Wkiorm1DPktREUNh+96fMWHpJjMNe1CK09obPIEnWS7X2fiMbIFzircq6R6w==
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:45.643Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jeffw1527-dsh-remote-sandbox`
- Submission type: community curation
- Created by `jeffw1527` — https://github.com/jeffw1527
- Original source repository: https://github.com/weijiafu14/dsh-remote-sandbox
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.