### PR TITLE
catalog: add nicoloboschi-hindsight-coding-agents (community curation, created by @nicoloboschi)

### DIFF
--- a/catalog/plugins/nicoloboschi-hindsight-coding-agents.yaml
+++ b/catalog/plugins/nicoloboschi-hindsight-coding-agents.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: nicoloboschi-hindsight-coding-agents
+name: "@vectorize-io/hindsight-coding-agents"
+description:
+  en: "Reflect-only Hindsight long-term memory for coding agents (harness-pluggable: opencode, …), with automatic background ingestion (no setup CLI)."
+  evidencePath: hindsight-integrations/coding-agents/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - reflect
+  - only
+  - hindsight
+  - long
+  - term
+  - memory
+  - coding
+  - agents
+  - pluggable
+  - opencode
+  - automatic
+  - background
+  - ingestion
+  - setup
+  - dsh
+source:
+  repository: https://github.com/vectorize-io/hindsight
+  repositoryNodeId: R_kgDOQMFwdQ
+  subpath: hindsight-integrations/coding-agents
+  commit: d2e8fa7286b37012b7e45de8f1b10dc333274918
+creator:
+  github: nicoloboschi
+package:
+  ecosystem: npm
+  name: "@vectorize-io/hindsight-coding-agents"
+  version: 0.4.3
+  integrity: sha512-Vdw2tiv17lB5SW7qNmT6PKJHC7eDTBBcW8QBBJH7QpiIsEFgPkCg5TvR+Gt1clgYmViKqpWxzR8OJh9l6YVkRQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: hindsight-integrations/coding-agents/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:44.789Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nicoloboschi-hindsight-coding-agents`
- Submission type: community curation
- Created by `nicoloboschi` — https://github.com/nicoloboschi
- Original source repository: https://github.com/vectorize-io/hindsight
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.