### PR TITLE
catalog: add ql-isaac-dsh-ui-font (community curation, created by @ql-isaac)

### DIFF
--- a/catalog/plugins/ql-isaac-dsh-ui-font.yaml
+++ b/catalog/plugins/ql-isaac-dsh-ui-font.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: ql-isaac-dsh-ui-font
+name: dsh-ui-font
+description:
+  en: "DSH Web GUI font engine + settings page: runtime discovery of every client plugin's styles, declaration-point pick-to-tune selector (design tokens / per-rule px), configurable hotkeys (picker / font size ±1), system font enumeration via sfnt name-table parsing, DSH settings.yaml persistence (with localStorage fallback "
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - font
+  - font-size
+  - ui
+  - settings
+source:
+  repository: https://github.com/warmwine/dsh-ui-font
+  repositoryNodeId: R_kgDOT48enQ
+  subpath: null
+  commit: 3d986759e4d8b083016959f982a2cb0b3fc30880
+creator:
+  github: ql-isaac
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:24.576Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/warmwine/dsh-ui-font/3d986759e4d8b083016959f982a2cb0b3fc30880/images/before.png
+    alt: 安装前
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/warmwine/dsh-ui-font/3d986759e4d8b083016959f982a2cb0b3fc30880/images/after.png
+    alt: 安装后
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/warmwine/dsh-ui-font/3d986759e4d8b083016959f982a2cb0b3fc30880/images/setting.png
+    alt: 设置界面


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ql-isaac-dsh-ui-font`
- Submission type: community curation
- Created by `ql-isaac` — https://github.com/ql-isaac
- Original source repository: https://github.com/warmwine/dsh-ui-font
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.