### PR TITLE
catalog: add userinner-dsh-academic-research (community curation, created by @userInner)

### DIFF
--- a/catalog/plugins/userinner-dsh-academic-research.yaml
+++ b/catalog/plugins/userinner-dsh-academic-research.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: userinner-dsh-academic-research
+name: "@onpeople/dsh-academic-research"
+description:
+  en: Evidence-grounded bilingual research tools and workflows for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - academic-research
+  - literature-review
+  - research-paper
+  - dsh
+source:
+  repository: https://github.com/userInner/dsh-academic-research
+  repositoryNodeId: R_kgDOT35ukQ
+  subpath: null
+  commit: 41650f0b52c593867dc352116204a0ad8f067498
+creator:
+  github: userInner
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:37.750Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `userinner-dsh-academic-research`
- Submission type: community curation
- Created by `userInner` — https://github.com/userInner
- Original source repository: https://github.com/userInner/dsh-academic-research
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.