### PR TITLE
catalog: add usersx-dsh-automation-center (community curation, created by @usersx)

### DIFF
--- a/catalog/plugins/usersx-dsh-automation-center.yaml
+++ b/catalog/plugins/usersx-dsh-automation-center.yaml
@@ -1,0 +1,70 @@
+schemaVersion: 1
+id: usersx-dsh-automation-center
+name: dsh-automation-center
+description:
+  en: A global Automation Center with fresh, auditable scheduled Agent runs for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - automation
+  - workflow-automation
+  - scheduled-task
+  - task-scheduler
+  - ai-agent
+  - agentic-ai
+  - coding-agent
+  - typescript
+  - react
+  - desktop
+  - cordis
+source:
+  repository: https://github.com/usersx/dsh-automation-center
+  repositoryNodeId: R_kgDOT9r4zA
+  subpath: null
+  commit: e9971853cede4e8c91eb2dffde9e0f6a7ef03ed3
+creator:
+  github: usersx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:38.038Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/usersx/dsh-automation-center/e9971853cede4e8c91eb2dffde9e0f6a7ef03ed3/docs/assets/deepseek-whale-girl-automation.png
+    alt: DeepSeek 鲸鱼娘编排自动化任务
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/usersx/dsh-automation-center/e9971853cede4e8c91eb2dffde9e0f6a7ef03ed3/docs/assets/stock-rc8-conversation-mode-dark.png
+    alt: 原版 rc.8 深色皮肤中的 Session 自动化标签
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/usersx/dsh-automation-center/e9971853cede4e8c91eb2dffde9e0f6a7ef03ed3/docs/assets/automation-center-empty.png
+    alt: 原版 DeepSeek 皮肤中的 Automation Center
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/usersx/dsh-automation-center/e9971853cede4e8c91eb2dffde9e0f6a7ef03ed3/docs/assets/create-form.png
+    alt: 原版 DeepSeek 皮肤中的自动化创建表单
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/usersx/dsh-automation-center/e9971853cede4e8c91eb2dffde9e0f6a7ef03ed3/docs/assets/sidebar-expanded-fixed.png
+    alt: 原版 DeepSeek 展开侧栏中的自动化入口
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/usersx/dsh-automation-center/e9971853cede4e8c91eb2dffde9e0f6a7ef03ed3/docs/assets/sidebar-collapsed-fixed.png
+    alt: 原版 DeepSeek 折叠侧栏中的自动化入口


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `usersx-dsh-automation-center`
- Submission type: community curation
- Created by `usersx` — https://github.com/usersx
- Original source repository: https://github.com/usersx/dsh-automation-center
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.