### PR TITLE
catalog: add v-dev-388-dsh-usage-meter (community curation, created by @V-dev-388)

### DIFF
--- a/catalog/plugins/v-dev-388-dsh-usage-meter.yaml
+++ b/catalog/plugins/v-dev-388-dsh-usage-meter.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: v-dev-388-dsh-usage-meter
+name: dsh-usage-meter
+description:
+  en: bash dsh plugin --profile web add dsh-usage-meter
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - bundle
+  - usage
+  - token
+  - dashboard
+source:
+  repository: https://github.com/V-dev-388/dsh-usage-meter
+  repositoryNodeId: R_kgDOT44s2g
+  subpath: null
+  commit: 1a0a4f25495f5d40430b5d9809cf66e5f458432e
+creator:
+  github: V-dev-388
+package:
+  ecosystem: npm
+  name: dsh-usage-meter
+  version: 0.1.2
+  integrity: sha512-wpW7kHMX4swQWrrjgnoeleyZvuv4YmxNSDFEgk2lkARn4E8izsK+GoNHmjjR8Gkjwu7tkf9TV3Ov1+lNpamkpQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:38.490Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `v-dev-388-dsh-usage-meter`
- Submission type: community curation
- Created by `V-dev-388` — https://github.com/V-dev-388
- Original source repository: https://github.com/V-dev-388/dsh-usage-meter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.