### PR TITLE
catalog: add v587d-capital-generation (community curation, created by @v587d)

### DIFF
--- a/catalog/plugins/v587d-capital-generation.yaml
+++ b/catalog/plugins/v587d-capital-generation.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: v587d-capital-generation
+name: capital-generation
+description:
+  en: "China A-share financial data MCP server for DeepSeek Harness: 11 fin data tools (quotes/K-lines/financials/calendar/special-data/announcements/EDB/reconcile/funds/indices) over THS (free official REST, primary) + AKShare (fallback) + Wind (authoritative/exclusive), with observable degradation and context-budget compres"
+  evidencePath: dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - finance
+  - a-share
+  - china-stock
+source:
+  repository: https://github.com/v587d/capital-generation
+  repositoryNodeId: R_kgDOT52yiw
+  subpath: dsh-plugin
+  commit: 7f4fe3df32bfbec908567b4df169380fb27f3293
+creator:
+  github: v587d
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:41.973Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `v587d-capital-generation`
- Submission type: community curation
- Created by `v587d` — https://github.com/v587d
- Original source repository: https://github.com/v587d/capital-generation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.