### PR TITLE
catalog: add vanillacreamer-dsh-plugin-visual-composer (community curation, created by @VanillaCreamer)

### DIFF
--- a/catalog/plugins/vanillacreamer-dsh-plugin-visual-composer.yaml
+++ b/catalog/plugins/vanillacreamer-dsh-plugin-visual-composer.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: vanillacreamer-dsh-plugin-visual-composer
+name: dsh-plugin-visual-composer
+description:
+  en: Visual Cordis plugin-tree composer for the DeepSeek Harness Web UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - visual-editor
+  - plugin-composer
+  - dsh
+source:
+  repository: https://github.com/VanillaCreamer/dsh-plugin-visual-composer
+  repositoryNodeId: R_kgDOT4jQBg
+  subpath: null
+  commit: 78ce825c5f5da264c709c4979b70654b1a3dac7d
+creator:
+  github: VanillaCreamer
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:28.379Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/VanillaCreamer/dsh-plugin-visual-composer/78ce825c5f5da264c709c4979b70654b1a3dac7d/demo.png
+    alt: Visual Composer 运行在 DSH Web 中


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vanillacreamer-dsh-plugin-visual-composer`
- Submission type: community curation
- Created by `VanillaCreamer` — https://github.com/VanillaCreamer
- Original source repository: https://github.com/VanillaCreamer/dsh-plugin-visual-composer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.