### PR TITLE
catalog: add vesna-strivozha-dsh-llm-wiki (community curation, created by @Vesna-Strivozha)

### DIFF
--- a/catalog/plugins/vesna-strivozha-dsh-llm-wiki.yaml
+++ b/catalog/plugins/vesna-strivozha-dsh-llm-wiki.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: vesna-strivozha-dsh-llm-wiki
+name: "@vesna-strivozha-2026/dsh-llm-wiki"
+description:
+  en: "LLM Wiki host engine: RPC for the wiki panel, ingest/search/graph/lint, the wiki query tool, and a prompt section (Karpathy Wiki methodology)"
+  evidencePath: packages/dsh-llm-wiki/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - wiki
+  - host
+  - engine
+  - panel
+  - ingest
+  - search
+  - graph
+  - lint
+  - query
+  - tool
+  - prompt
+  - section
+  - karpathy
+  - methodology
+  - dsh
+source:
+  repository: https://github.com/Vesna-Strivozha/DSH-LLM-wiki-plugin
+  repositoryNodeId: R_kgDOUBcq5g
+  subpath: packages/dsh-llm-wiki
+  commit: 084e7f5a1ec60e63245ce95e00a5bb4c77bbed85
+creator:
+  github: Vesna-Strivozha
+package:
+  ecosystem: npm
+  name: "@vesna-strivozha-2026/dsh-llm-wiki"
+  version: 1.0.6
+  integrity: sha512-/v4RG58jGQTo1pdajbnNP/PRspYomB7SPlgoty3W07CBEkpnsx9LgwPkCfo4Y+r8Hi3N0gmags0Rxslh9K0c5w==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-llm-wiki/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:42.995Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vesna-strivozha-dsh-llm-wiki`
- Submission type: community curation
- Created by `Vesna-Strivozha` — https://github.com/Vesna-Strivozha
- Original source repository: https://github.com/Vesna-Strivozha/DSH-LLM-wiki-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.