### PR TITLE
catalog: add vibeinging-dsh-tool-search (community curation, created by @vibeinging)

### DIFF
--- a/catalog/plugins/vibeinging-dsh-tool-search.yaml
+++ b/catalog/plugins/vibeinging-dsh-tool-search.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: vibeinging-dsh-tool-search
+name: "@deepseek-ai/dsh-tool-search"
+description:
+  en: Experimental per-agent tool discovery and progressive schema disclosure
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - experimental
+  - agent
+  - tool
+  - discovery
+  - progressive
+  - schema
+  - disclosure
+  - dsh
+source:
+  repository: https://github.com/vibeinging/dsh-tool-search
+  repositoryNodeId: R_kgDOT09-qw
+  subpath: null
+  commit: 265ce76eda21b211dc4a4c8f30d73a6826f035ca
+creator:
+  github: vibeinging
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:28.997Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vibeinging-dsh-tool-search`
- Submission type: community curation
- Created by `vibeinging` — https://github.com/vibeinging
- Original source repository: https://github.com/vibeinging/dsh-tool-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.