### PR TITLE
catalog: add vibeinging-dsh-trace (community curation, created by @vibeinging)

### DIFF
--- a/catalog/plugins/vibeinging-dsh-trace.yaml
+++ b/catalog/plugins/vibeinging-dsh-trace.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: vibeinging-dsh-trace
+name: "@deepseek-ai/dsh-trace"
+description:
+  en: Embedded yiTrace plugin for DeepSeek Harness turns, model steps, and tool calls
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - embedded
+  - yitrace
+  - turns
+  - model
+  - steps
+  - tool
+  - calls
+  - dsh
+source:
+  repository: https://github.com/vibeinging/dsh-trace
+  repositoryNodeId: R_kgDOT1C92w
+  subpath: null
+  commit: caadf1b831ae2643bd25a365cc1356c2100e7a05
+creator:
+  github: vibeinging
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:32.949Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vibeinging-dsh-trace`
- Submission type: community curation
- Created by `vibeinging` — https://github.com/vibeinging
- Original source repository: https://github.com/vibeinging/dsh-trace
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.