### PR TITLE
catalog: add vibeinging-dsh-turn-navigator (community curation, created by @vibeinging)

### DIFF
--- a/catalog/plugins/vibeinging-dsh-turn-navigator.yaml
+++ b/catalog/plugins/vibeinging-dsh-turn-navigator.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: vibeinging-dsh-turn-navigator
+name: "@deepseek-ai/dsh-turn-navigator"
+description:
+  en: Compact conversation turn navigation for the DSH Web client
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - compact
+  - conversation
+  - turn
+  - navigation
+  - client
+  - dsh
+source:
+  repository: https://github.com/vibeinging/dsh-turn-navigator
+  repositoryNodeId: R_kgDOT2Sw4Q
+  subpath: null
+  commit: bcae07a2684205b3ebbd3976493c9084c2e882a1
+creator:
+  github: vibeinging
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:33.370Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/vibeinging/dsh-turn-navigator/bcae07a2684205b3ebbd3976493c9084c2e882a1/docs/assets/turn-navigator-hover.png
+    alt: The compact turn navigator highlighting the fourth turn and showing its hover preview.


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vibeinging-dsh-turn-navigator`
- Submission type: community curation
- Created by `vibeinging` — https://github.com/vibeinging
- Original source repository: https://github.com/vibeinging/dsh-turn-navigator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.