### PR TITLE
catalog: add victor-770-dsh-commandcode-provider (community curation, created by @Victor-770)

### DIFF
--- a/catalog/plugins/victor-770-dsh-commandcode-provider.yaml
+++ b/catalog/plugins/victor-770-dsh-commandcode-provider.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: victor-770-dsh-commandcode-provider
+name: dsh-commandcode-provider
+description:
+  en: Command Code provider plugin for DeepSeek Harness (dsh) — works with every Command Code plan including the $1 Go plan; uses the Studio authentication API key over /alpha/generate, not the Provider API
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - commandcode
+  - provider
+  - llm
+  - dsh-plugin
+  - deepseek-harness-plugin
+source:
+  repository: https://github.com/Victor-770/dsh-commandcode-provider
+  repositoryNodeId: R_kgDOT4JeGg
+  subpath: null
+  commit: ab7ea8de054391c7bba9920e68d03dfaf8a40f21
+creator:
+  github: Victor-770
+package:
+  ecosystem: npm
+  name: dsh-commandcode-provider
+  version: 0.1.3
+  integrity: sha512-9CghEKTGTR6aHZACuPuPDstLWWtQVf7MbiqWNtQwL+VCjYYiXSPgNipv3Ma9EUoLW6cy/virg/zkcHeyhLLhlw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:24.556Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `victor-770-dsh-commandcode-provider`
- Submission type: community curation
- Created by `Victor-770` — https://github.com/Victor-770
- Original source repository: https://github.com/Victor-770/dsh-commandcode-provider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.