### PR TITLE
catalog: add victorytianyi-dev-dsh-upload-button (community curation, created by @victorytianyi-dev)

### DIFF
--- a/catalog/plugins/victorytianyi-dev-dsh-upload-button.yaml
+++ b/catalog/plugins/victorytianyi-dev-dsh-upload-button.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: victorytianyi-dev-dsh-upload-button
+name: dsh-upload-button
+description:
+  en: Add an upload-image button beside the composer plus button. Picks local images and feeds them through the conversation draft-image drop path (DataTransfer + synthetic drop event), so describe-image rewrites the send into an image reference.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - upload
+  - image
+  - button
+  - beside
+  - composer
+  - plus
+  - picks
+  - local
+  - images
+  - feeds
+  - through
+  - conversation
+  - draft
+  - drop
+  - path
+  - datatransfer
+source:
+  repository: https://github.com/victorytianyi-dev/dsh-upload-button
+  repositoryNodeId: R_kgDOT9MXeQ
+  subpath: null
+  commit: ab6800277eece8c9086f9990bd01cdd2f7e54550
+creator:
+  github: victorytianyi-dev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:38.684Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `victorytianyi-dev-dsh-upload-button`
- Submission type: community curation
- Created by `victorytianyi-dev` — https://github.com/victorytianyi-dev
- Original source repository: https://github.com/victorytianyi-dev/dsh-upload-button
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.