### PR TITLE
catalog: add victorzhong0110-dsh-code-reference (community curation, created by @victorzhong0110)

### DIFF
--- a/catalog/plugins/victorzhong0110-dsh-code-reference.yaml
+++ b/catalog/plugins/victorzhong0110-dsh-code-reference.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: victorzhong0110-dsh-code-reference
+name: dsh-code-reference
+description:
+  en: 'json { "allowedLicenses": ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MPL-2.0", "Unlicense", "0BSD"], "blockedLanguages": [], "requireTests": false, "minCommentRatio": 0, "reuseMode": "ask", "remoteSearch": true }'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - code-reference
+  - code-reuse
+  - reuse
+source:
+  repository: https://github.com/victorzhong0110/dsh-code-reference
+  repositoryNodeId: R_kgDOT4eSkw
+  subpath: null
+  commit: 2a2f0f1496a83034723c429866760a796720370e
+creator:
+  github: victorzhong0110
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:29.061Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `victorzhong0110-dsh-code-reference`
- Submission type: community curation
- Created by `victorzhong0110` — https://github.com/victorzhong0110
- Original source repository: https://github.com/victorzhong0110/dsh-code-reference
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.