### PR TITLE
catalog: add victorzhong0110-dsh-outcome-loop (community curation, created by @victorzhong0110)

### DIFF
--- a/catalog/plugins/victorzhong0110-dsh-outcome-loop.yaml
+++ b/catalog/plugins/victorzhong0110-dsh-outcome-loop.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: victorzhong0110-dsh-outcome-loop
+name: dsh-outcome-loop
+description:
+  en: Know whether a task was actually completed — with near-zero extra tokens and mechanically re-checkable evidence — and keep the result as a portable, user-owned record.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - outcome
+  - verification
+  - acceptance
+  - task-ledger
+  - evidence
+source:
+  repository: https://github.com/victorzhong0110/dsh-outcome-loop
+  repositoryNodeId: R_kgDOT7kDOA
+  subpath: null
+  commit: 4953d8cc4ee6da45753658a49ae91e9cd02b5e4c
+creator:
+  github: victorzhong0110
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:29.369Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `victorzhong0110-dsh-outcome-loop`
- Submission type: community curation
- Created by `victorzhong0110` — https://github.com/victorzhong0110
- Original source repository: https://github.com/victorzhong0110/dsh-outcome-loop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.