### PR TITLE
catalog: add viger1-dsh-review (community curation, created by @Viger1)

### DIFF
--- a/catalog/plugins/viger1-dsh-review.yaml
+++ b/catalog/plugins/viger1-dsh-review.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: viger1-dsh-review
+name: dsh-review
+description:
+  en: Packaged multi-agent adversarial code review for DeepSeek Harness — one finder per lens in parallel, then a verifier per finding whose task is to refute it, so only confirmed defects are reported.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - code-review
+  - subagents
+  - multi-agent
+  - static-analysis
+source:
+  repository: https://github.com/Viger1/dsh-review
+  repositoryNodeId: R_kgDOT6Nilg
+  subpath: null
+  commit: 4fa5d7fd43d929bb8f499f672bb1014067e3c15c
+creator:
+  github: Viger1
+package:
+  ecosystem: npm
+  name: dsh-review
+  version: 0.1.1
+  integrity: sha512-9CZSYertxkYbOumEav4Of/LZKXqJVpPRc3sdxtwwLdMo7FNWdxJihqZUcNeRqwqwBzRDq8gIvubtS4HmPS4B3g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:38.948Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `viger1-dsh-review`
- Submission type: community curation
- Created by `Viger1` — https://github.com/Viger1
- Original source repository: https://github.com/Viger1/dsh-review
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.