### PR TITLE
catalog: add vladimir-kryshchenko-dsh-route-fence-linter (community curation, created by @Vladimir-Kryshchenko)

### DIFF
--- a/catalog/plugins/vladimir-kryshchenko-dsh-route-fence-linter.yaml
+++ b/catalog/plugins/vladimir-kryshchenko-dsh-route-fence-linter.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: vladimir-kryshchenko-dsh-route-fence-linter
+name: dsh-route-fence-linter
+description:
+  en: "Static linter: every plugin HTTP route must carry a browser-trust fence (loopback Host pin before Origin / sec-fetch-site)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - security
+  - audit
+  - static-analysis
+  - dns-rebinding
+  - csrf
+source:
+  repository: https://github.com/Vladimir-Kryshchenko/dsh-route-fence-linter
+  repositoryNodeId: R_kgDOT_qC2g
+  subpath: null
+  commit: 904339d50031181390bdb22ddd970c15876e5870
+creator:
+  github: Vladimir-Kryshchenko
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:43.474Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vladimir-kryshchenko-dsh-route-fence-linter`
- Submission type: community curation
- Created by `Vladimir-Kryshchenko` — https://github.com/Vladimir-Kryshchenko
- Original source repository: https://github.com/Vladimir-Kryshchenko/dsh-route-fence-linter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.