### PR TITLE
catalog: add vlln-dsh-loop (community curation, created by @vlln)

### DIFF
--- a/catalog/plugins/vlln-dsh-loop.yaml
+++ b/catalog/plugins/vlln-dsh-loop.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: vlln-dsh-loop
+name: "@vlln/dsh-loop"
+description:
+  en: '<p align="center" Scheduled loop plugin: /loop command + loop tool (self-adjusting by the model) + active status bar on the chat page, with support for multiple concurrent loops</p'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - align
+  - center
+  - scheduled
+  - loop
+  - command
+  - tool
+  - self
+  - adjusting
+  - model
+  - active
+  - status
+  - chat
+  - page
+  - multiple
+  - concurrent
+  - loops
+source:
+  repository: https://github.com/vlln/dsh-loop
+  repositoryNodeId: R_kgDOT0bSyw
+  subpath: null
+  commit: 82539f9d750d79b7745e2cf7bd38d9c6db8c9fb4
+creator:
+  github: vlln
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:26.302Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vlln-dsh-loop`
- Submission type: community curation
- Created by `vlln` — https://github.com/vlln
- Original source repository: https://github.com/vlln/dsh-loop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.