### PR TITLE
catalog: add vonweller-dsh-skillhub (community curation, created by @vonweller)

### DIFF
--- a/catalog/plugins/vonweller-dsh-skillhub.yaml
+++ b/catalog/plugins/vonweller-dsh-skillhub.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: vonweller-dsh-skillhub
+name: dsh-skillhub
+description:
+  en: Browse skillhub.cn skills and one-click install them into ~/.dsh/skills
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - skillhub
+  - skills
+source:
+  repository: https://github.com/vonweller/dsh-skillhub
+  repositoryNodeId: R_kgDOUCYVAg
+  subpath: null
+  commit: 2212b4ff02dd7440849f5089a6dcdb0f989e22af
+creator:
+  github: vonweller
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:27.547Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/vonweller/dsh-skillhub/2212b4ff02dd7440849f5089a6dcdb0f989e22af/docs/skill-market.png
+    alt: Settings → Skill Market browsing the skillhub.cn catalog


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vonweller-dsh-skillhub`
- Submission type: community curation
- Created by `vonweller` — https://github.com/vonweller
- Original source repository: https://github.com/vonweller/dsh-skillhub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.