### PR TITLE
catalog: add vvlife-whalehub-market (community curation, created by @vvlife)

### DIFF
--- a/catalog/plugins/vvlife-whalehub-market.yaml
+++ b/catalog/plugins/vvlife-whalehub-market.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: vvlife-whalehub-market
+name: whalehub-market
+description:
+  en: sh dsh plugin --profile web add "github:vvlife/whalehub-dsh main&path:/plugin"
+  evidencePath: plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - profile
+  - vvlife
+  - whalehub
+  - main
+  - path
+  - dsh
+source:
+  repository: https://github.com/vvlife/whalehub-dsh
+  repositoryNodeId: R_kgDOT3jamA
+  subpath: plugin
+  commit: fa68a91128e588265df8322bcfeffb2f95fe4a49
+creator:
+  github: vvlife
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:44.175Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/vvlife/whalehub-dsh/fa68a91128e588265df8322bcfeffb2f95fe4a49/docs/screenshots/08-dsh-web-market.png
+    alt: 在 DSH Web 中使用 WhaleHub


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vvlife-whalehub-market`
- Submission type: community curation
- Created by `vvlife` — https://github.com/vvlife
- Original source repository: https://github.com/vvlife/whalehub-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.