### PR TITLE
catalog: add w2829562572-dev-dsh-tool-squeeze (community curation, created by @w2829562572-dev)

### DIFF
--- a/catalog/plugins/w2829562572-dev-dsh-tool-squeeze.yaml
+++ b/catalog/plugins/w2829562572-dev-dsh-tool-squeeze.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: w2829562572-dev-dsh-tool-squeeze
+name: dsh-tool-squeeze
+description:
+  en: Content-aware tool output compression for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - context-engineering
+  - token-optimization
+  - ai-agent
+  - coding-agent
+source:
+  repository: https://github.com/w2829562572-dev/dsh-tool-squeeze
+  repositoryNodeId: R_kgDOT_HsWQ
+  subpath: null
+  commit: 9baf17e7bd48ae3cc0b60162de2ad816b6197c78
+creator:
+  github: w2829562572-dev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:33.421Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `w2829562572-dev-dsh-tool-squeeze`
- Submission type: community curation
- Created by `w2829562572-dev` — https://github.com/w2829562572-dev
- Original source repository: https://github.com/w2829562572-dev/dsh-tool-squeeze
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.