### PR TITLE
catalog: add walvez-dsh-search-failover (community curation, created by @Walvez)

### DIFF
--- a/catalog/plugins/walvez-dsh-search-failover.yaml
+++ b/catalog/plugins/walvez-dsh-search-failover.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: walvez-dsh-search-failover
+name: dsh-search-failover
+description:
+  en: "Provider-level web search+fetch pool for DeepSeek Harness: bypass the official LLM search channel (0 model tokens), failover/rotate across Exa/Tavily/Jina/Firecrawl/Serper/SerpApi/SearXNG/DDG/Brave with quota-aware circuit breaking, multi-key rotation, and a GUI settings page."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - search
+  - failover
+  - circuit-breaker
+  - web-search
+source:
+  repository: https://github.com/Walvez/dsh-search-failover
+  repositoryNodeId: R_kgDOT6zdng
+  subpath: null
+  commit: 0327cf929e179998ba5469af7d38e66a15d37ffa
+creator:
+  github: Walvez
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:34.014Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Walvez/dsh-search-failover/0327cf929e179998ba5469af7d38e66a15d37ffa/docs/screenshots/settings-panel-overview.png
+    alt: DSH 搜索池设置面板
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Walvez/dsh-search-failover/0327cf929e179998ba5469af7d38e66a15d37ffa/docs/screenshots/settings-panel-scrolled.png
+    alt: DSH 搜索池引擎卡片列表


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `walvez-dsh-search-failover`
- Submission type: community curation
- Created by `Walvez` — https://github.com/Walvez
- Original source repository: https://github.com/Walvez/dsh-search-failover
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.