### PR TITLE
catalog: add wanbinyu-dsh-provider-probe (community curation, created by @Wanbinyu)

### DIFF
--- a/catalog/plugins/wanbinyu-dsh-provider-probe.yaml
+++ b/catalog/plugins/wanbinyu-dsh-provider-probe.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wanbinyu-dsh-provider-probe
+name: dsh-provider-probe
+description:
+  en: Safe, explicit provider connectivity and latency checks for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - provider
+  - diagnostics
+  - latency
+source:
+  repository: https://github.com/Wanbinyu/dsh-provider-probe
+  repositoryNodeId: R_kgDOT9GDpg
+  subpath: null
+  commit: ea035f77793420fb451e5c977093a335cf4a304e
+creator:
+  github: Wanbinyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:34.235Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Wanbinyu/dsh-provider-probe/ea035f77793420fb451e5c977093a335cf4a304e/docs/images/dsh-provider-probe.png
+    alt: dsh-provider-probe 的供应商检测页面


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wanbinyu-dsh-provider-probe`
- Submission type: community curation
- Created by `Wanbinyu` — https://github.com/Wanbinyu
- Original source repository: https://github.com/Wanbinyu/dsh-provider-probe
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.