### PR TITLE
catalog: add wangbobo-coder-gitee-ai-employee (community curation, created by @wangbobo-coder)

### DIFF
--- a/catalog/plugins/wangbobo-coder-gitee-ai-employee.yaml
+++ b/catalog/plugins/wangbobo-coder-gitee-ai-employee.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: wangbobo-coder-gitee-ai-employee
+name: gitee-ai-employee
+description:
+  en: An issue-driven AI developer for DeepSeek Harness , working against Gitee (码云) and GitHub .
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - gitee
+  - bundle
+  - ai
+  - issue
+  - pull-request
+  - automation
+source:
+  repository: https://github.com/wangbobo-coder/gitee-ai-employee
+  repositoryNodeId: R_kgDOUCaIXA
+  subpath: null
+  commit: b136171588e8151b138cdc1721394dd3371c80d1
+creator:
+  github: wangbobo-coder
+package:
+  ecosystem: npm
+  name: gitee-ai-employee
+  version: 1.1.2
+  integrity: sha512-dRJ3QWir4JDGKkQhmtzZG3EEZlIH5uLEEBa3ZhEb3aEkyxacdP2A3Wrzt2ssqE6M6+fyggpE27moutYmpNdYfw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:34.225Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wangbobo-coder-gitee-ai-employee`
- Submission type: community curation
- Created by `wangbobo-coder` — https://github.com/wangbobo-coder
- Original source repository: https://github.com/wangbobo-coder/gitee-ai-employee
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.