### PR TITLE
catalog: add wangcong1137-dsh-geoserver (community curation, created by @wangcong1137)

### DIFF
--- a/catalog/plugins/wangcong1137-dsh-geoserver.yaml
+++ b/catalog/plugins/wangcong1137-dsh-geoserver.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: wangcong1137-dsh-geoserver
+name: dsh-geoserver
+description:
+  en: Read GeoServer WMS services and render map images in the dsh web GUI, with a configuration card in the settings page.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - geoserver
+  - wms
+  - gis
+  - map
+source:
+  repository: https://github.com/wangcong1137-hash/dsh-geoserver
+  repositoryNodeId: R_kgDOT9MuMA
+  subpath: null
+  commit: c320f01d5cbef0ccb8d0bfe64a34e061b57d0c3f
+creator:
+  github: wangcong1137
+package:
+  ecosystem: npm
+  name: dsh-geoserver
+  version: 0.2.4
+  integrity: sha512-ZmEwYssP4Q7SVgTXOH+k1dYkXSK/knLHUpD2ZnnDolP4dYp6bB371Nry+JU9T7oQVJLzQALuXKQZ4mU9W7YBaQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:34.372Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wangcong1137-dsh-geoserver`
- Submission type: community curation
- Created by `wangcong1137` — https://github.com/wangcong1137
- Original source repository: https://github.com/wangcong1137-hash/dsh-geoserver
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.