### PR TITLE
catalog: add warmwine-dsh-memoryleak (community curation, created by @warmwine)

### DIFF
--- a/catalog/plugins/warmwine-dsh-memoryleak.yaml
+++ b/catalog/plugins/warmwine-dsh-memoryleak.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: warmwine-dsh-memoryleak
+name: dsh-memoryleak
+description:
+  en: "Notes and todos as plain Markdown in one Vault folder of your choice: /ml jots into today's journal, todos come in deadline/sleep-until/anytime flavors with auto-wakeup, /ml view fuzzy-opens any file — zero-token slash commands, notes stay plain files."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - notes
+  - todo
+  - markdown
+  - journal
+  - memory
+source:
+  repository: https://github.com/warmwine/dsh-memoryleak
+  repositoryNodeId: R_kgDOT5V_LQ
+  subpath: null
+  commit: 38e5b6af259428709283d989410bbe6f4e3b3f49
+creator:
+  github: warmwine
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:39.813Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `warmwine-dsh-memoryleak`
- Submission type: community curation
- Created by `warmwine` — https://github.com/warmwine
- Original source repository: https://github.com/warmwine/dsh-memoryleak
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.