### PR TITLE
catalog: add wayne036-dsh-plugin-login-gate (community curation, created by @Wayne036)

### DIFF
--- a/catalog/plugins/wayne036-dsh-plugin-login-gate.yaml
+++ b/catalog/plugins/wayne036-dsh-plugin-login-gate.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: wayne036-dsh-plugin-login-gate
+name: dsh-plugin-login-gate
+description:
+  en: sh git clone https://github.com/<你的用户名 /dsh-plugin-login-gate.git
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - login
+  - auth
+  - reverse-proxy
+  - lan
+  - local-network
+  - loopback
+  - settings
+source:
+  repository: https://github.com/Wayne036/dsh-plugin-login-gate
+  repositoryNodeId: R_kgDOT9vT3g
+  subpath: null
+  commit: 7c8b958fd55f9da83fecc949503c36893e5b87d1
+creator:
+  github: Wayne036
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:39.940Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wayne036-dsh-plugin-login-gate`
- Submission type: community curation
- Created by `Wayne036` — https://github.com/Wayne036
- Original source repository: https://github.com/Wayne036/dsh-plugin-login-gate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.