### PR TITLE
catalog: add web0926-dsh-llm-verifier (community curation, created by @Web0926)

### DIFF
--- a/catalog/plugins/web0926-dsh-llm-verifier.yaml
+++ b/catalog/plugins/web0926-dsh-llm-verifier.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: web0926-dsh-llm-verifier
+name: dsh-llm-verifier
+description:
+  en: Best-of-3/5 orchestration and LLM-as-a-Verifier selection for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - best
+  - orchestration
+  - verifier
+  - selection
+  - dsh
+source:
+  repository: https://github.com/Web0926/dsh-llm-verifier
+  repositoryNodeId: R_kgDOT-Jhag
+  subpath: null
+  commit: ce06d928d495b865920aa0b24907a3b8d3ead669
+creator:
+  github: Web0926
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:27.641Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `web0926-dsh-llm-verifier`
- Submission type: community curation
- Created by `Web0926` — https://github.com/Web0926
- Original source repository: https://github.com/Web0926/dsh-llm-verifier
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.