### PR TITLE
catalog: add weien666-dsh-conversation-density-map (community curation, created by @weien666)

### DIFF
--- a/catalog/plugins/weien666-dsh-conversation-density-map.yaml
+++ b/catalog/plugins/weien666-dsh-conversation-density-map.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: weien666-dsh-conversation-density-map
+name: dsh-conversation-density-map
+description:
+  en: 安装： dsh plugin --profile web add github:weien666/dsh-conversation-density-map
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - profile
+  - weien666
+  - conversation
+  - density
+  - dsh
+source:
+  repository: https://github.com/weien666/dsh-conversation-density-map
+  repositoryNodeId: R_kgDOT9FCNQ
+  subpath: null
+  commit: b860585efc441ee9f8f252c591f1969318e92d0a
+creator:
+  github: weien666
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:28.075Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/weien666/dsh-conversation-density-map/b860585efc441ee9f8f252c591f1969318e92d0a/docs/demo-main.gif
+    alt: 主界面总览
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/weien666/dsh-conversation-density-map/b860585efc441ee9f8f252c591f1969318e92d0a/docs/demo-window-length.gif
+    alt: 常规与最大化切换
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/weien666/dsh-conversation-density-map/b860585efc441ee9f8f252c591f1969318e92d0a/docs/demo-spread-regular.gif
+    alt: 常规窗口疏散
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/weien666/dsh-conversation-density-map/b860585efc441ee9f8f252c591f1969318e92d0a/docs/demo-spread-maximized.gif
+    alt: 最大化窗口疏散


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `weien666-dsh-conversation-density-map`
- Submission type: community curation
- Created by `weien666` — https://github.com/weien666
- Original source repository: https://github.com/weien666/dsh-conversation-density-map
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.