### PR TITLE
catalog: add welsione-dsh-model-router (community curation, created by @welsione)

### DIFF
--- a/catalog/plugins/welsione-dsh-model-router.yaml
+++ b/catalog/plugins/welsione-dsh-model-router.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: welsione-dsh-model-router
+name: "@welsione/dsh-model-router"
+description:
+  en: "Unified ModelID routing for DeepSeek Harness: one logical model id over multiple providers, first-token failover with cooldown, health-aware ranking, fallback reasoning efforts, purpose-based simple/complex task split, per-tier reasoning effort, and a settings-page management panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - model-router
+  - model-routing
+  - failover
+  - reasoning-effort
+  - llm
+source:
+  repository: https://github.com/welsione/dsh-model-router
+  repositoryNodeId: R_kgDOT784Nw
+  subpath: null
+  commit: 9a9c1529b6a413dfc3621b944192fb1c84c04e60
+creator:
+  github: welsione
+package:
+  ecosystem: npm
+  name: "@welsione/dsh-model-router"
+  version: 0.0.8
+  integrity: sha512-8SN3G7k+etpi09cyF5nzdRh0S7GBknNGSXuEWXzXPIVHscAHeYulqUzEgq/6/ceMn1TZ/CjBWZjfkK/3qaaxQg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:35.014Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/welsione/dsh-model-router/9a9c1529b6a413dfc3621b944192fb1c84c04e60/assets/readme/screenshot-chat-tier-picker.png
+    alt: 对话窗口档位选择器
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/welsione/dsh-model-router/9a9c1529b6a413dfc3621b944192fb1c84c04e60/assets/readme/screenshot-settings-panel.png
+    alt: 设置面板路由管理


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `welsione-dsh-model-router`
- Submission type: community curation
- Created by `welsione` — https://github.com/welsione
- Original source repository: https://github.com/welsione/dsh-model-router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.