### PR TITLE
catalog: add wenaixi-dsh-superpower (community curation, created by @Wenaixi)

### DIFF
--- a/catalog/plugins/wenaixi-dsh-superpower.yaml
+++ b/catalog/plugins/wenaixi-dsh-superpower.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: wenaixi-dsh-superpower
+name: "@wenaixi/dsh-superpower"
+description:
+  en: 前置 ： Node =20 、 pnpm =9 、 dsh （ npm i -g @deepseek-ai/dsh ）。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - superpowers
+  - skills
+  - agent
+  - methodology
+source:
+  repository: https://github.com/Wenaixi/dsh-superpower
+  repositoryNodeId: R_kgDOT_5Kfg
+  subpath: null
+  commit: 46d16d325b0d5a94a901242191ecf1b0fe8b55dd
+creator:
+  github: Wenaixi
+package:
+  ecosystem: npm
+  name: "@wenaixi/dsh-superpower"
+  version: 6.3.0-dsh.10
+  integrity: sha512-EKFkE1PiS5jBar7TC0I3ZThx+VjaUWov/a9UWjyc7Tu+zoQYT+UlAt9LX+/zMtbnzt7q1pZBCyox9RGEIIJ3dA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:24.683Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wenaixi-dsh-superpower`
- Submission type: community curation
- Created by `Wenaixi` — https://github.com/Wenaixi
- Original source repository: https://github.com/Wenaixi/dsh-superpower
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.