### PR TITLE
catalog: add wenzetan-dsh-quota-panel (community curation, created by @wenzetan)

### DIFF
--- a/catalog/plugins/wenzetan-dsh-quota-panel.yaml
+++ b/catalog/plugins/wenzetan-dsh-quota-panel.yaml
@@ -1,0 +1,66 @@
+schemaVersion: 1
+id: wenzetan-dsh-quota-panel
+name: dsh-quota-panel
+description:
+  en: "Provider quota/balance widget for the dsh web surface: collapsed glanceable capsule expanding into a Harness-native card with a settings panel (provider visibility / refresh interval / warn thresholds), fed by a loopback Connection RPC channel whose host half proxies each provider with credentials that never reach the "
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - quota
+  - balance
+  - usage
+  - opencode
+source:
+  repository: https://github.com/wenzetan/dsh-quota-panel
+  repositoryNodeId: R_kgDOT4iLjA
+  subpath: null
+  commit: 8f916973ab06eee7498de4e4fff56e5556ffe61b
+creator:
+  github: wenzetan
+package:
+  ecosystem: npm
+  name: dsh-quota-panel
+  version: 0.9.1-rc.1
+  integrity: sha512-z88d/Qjmwr9Cw4XoxKMLRymsRaZYmxlWWkgjpKS7s9JPbRWsUzFrYENdezlqZozKIMbh89ItT4MSSEGDdDSvfQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:24.826Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wenzetan/dsh-quota-panel/8f916973ab06eee7498de4e4fff56e5556ffe61b/docs/screenshot-light.png
+    alt: capsule (light)
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wenzetan/dsh-quota-panel/8f916973ab06eee7498de4e4fff56e5556ffe61b/docs/screenshot-light-expanded.png
+    alt: expanded (light)
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wenzetan/dsh-quota-panel/8f916973ab06eee7498de4e4fff56e5556ffe61b/docs/screenshot-light-settings.png
+    alt: settings (light)
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wenzetan/dsh-quota-panel/8f916973ab06eee7498de4e4fff56e5556ffe61b/docs/screenshot-dark.png
+    alt: capsule (dark)
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wenzetan/dsh-quota-panel/8f916973ab06eee7498de4e4fff56e5556ffe61b/docs/screenshot-dark-expanded.png
+    alt: expanded (dark)
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wenzetan/dsh-quota-panel/8f916973ab06eee7498de4e4fff56e5556ffe61b/docs/screenshot-dark-settings.png
+    alt: settings (dark)


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wenzetan-dsh-quota-panel`
- Submission type: community curation
- Created by `wenzetan` — https://github.com/wenzetan
- Original source repository: https://github.com/wenzetan/dsh-quota-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.