### PR TITLE
catalog: add werifu-dsh-oai-oauth (community curation, created by @werifu)

### DIFF
--- a/catalog/plugins/werifu-dsh-oai-oauth.yaml
+++ b/catalog/plugins/werifu-dsh-oai-oauth.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: werifu-dsh-oai-oauth
+name: dsh-oai-oauth
+description:
+  en: "DSH LLM adapter plugin: use OpenAI ChatGPT subscription (GPT-5.6-Sol, GPT-5.5, ...) via OAuth — no API key. Reuses your local Codex CLI login."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - adapter
+  - openai
+  - chatgpt
+  - subscription
+  - oauth
+  - reuses
+  - local
+  - codex
+  - login
+  - dsh
+source:
+  repository: https://github.com/werifu/dsh-oai-oauth
+  repositoryNodeId: R_kgDOT4BOAA
+  subpath: null
+  commit: 75a0509a987cb4ba45dc293c0a23f2805988beb4
+creator:
+  github: werifu
+package:
+  ecosystem: npm
+  name: dsh-oai-oauth
+  version: 0.1.0
+  integrity: sha512-Vp4cQOB2hknbVX2s3UmbqWr072NF/3hREK2IYH+qE4YumpBQrJL1DnE3r7TJJdzf9OFM7ARFkA0mnWe/Y8sFEg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:40.100Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/werifu/dsh-oai-oauth/75a0509a987cb4ba45dc293c0a23f2805988beb4/usage.png
+    alt: OpenAI OAuth settings section


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `werifu-dsh-oai-oauth`
- Submission type: community curation
- Created by `werifu` — https://github.com/werifu
- Original source repository: https://github.com/werifu/dsh-oai-oauth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.