### PR TITLE
catalog: add westwind2022-dsh-stock-jt (community curation, created by @westwind2022)

### DIFF
--- a/catalog/plugins/westwind2022-dsh-stock-jt.yaml
+++ b/catalog/plugins/westwind2022-dsh-stock-jt.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: westwind2022-dsh-stock-jt
+name: dsh-stock-jt
+description:
+  en: sh dsh plugin --profile web add github:westwind2022/dsh-stock-jt dsh plugin --profile web add /path/to/dsh-stock-jt dsh plugin --profile web remove dsh-stock-jt
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - profile
+  - westwind2022
+  - stock
+  - path
+  - remove
+  - dsh
+source:
+  repository: https://github.com/westwind2022/dsh-stock-jt
+  repositoryNodeId: R_kgDOUBVwCQ
+  subpath: null
+  commit: 6e7cbcd7bf79fc6f328ab51415678a70b31b4d0a
+creator:
+  github: westwind2022
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:35.690Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `westwind2022-dsh-stock-jt`
- Submission type: community curation
- Created by `westwind2022` — https://github.com/westwind2022
- Original source repository: https://github.com/westwind2022/dsh-stock-jt
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.