### PR TITLE
catalog: add wha1echai-dsh-cross-session (community curation, created by @Wha1eChai)

### DIFF
--- a/catalog/plugins/wha1echai-dsh-cross-session.yaml
+++ b/catalog/plugins/wha1echai-dsh-cross-session.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: wha1echai-dsh-cross-session
+name: "@wha1echai/dsh-cross-session"
+description:
+  en: Same-runtime cross-Session discovery and communication for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - agent
+  - multi-agent
+  - cross-session
+source:
+  repository: https://github.com/Wha1eChai/dsh-cross-session
+  repositoryNodeId: R_kgDOT3uFpA
+  subpath: null
+  commit: 23d06783867107a3bd0f2179cf621e9fad5e07b8
+creator:
+  github: Wha1eChai
+package:
+  ecosystem: npm
+  name: "@wha1echai/dsh-cross-session"
+  version: 0.1.0-rc.1
+  integrity: sha512-H0s1t5vga0mCYS9y2DSZhzE2863hwaK8oGZbN9G8seJcLMNNZYPmTs7I3Vy6PrFUj/odQ4Jx39oyFeYS/brQkg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:30.357Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Wha1eChai/dsh-cross-session/23d06783867107a3bd0f2179cf621e9fad5e07b8/docs/assets/cross-session-readme-review.png
+    alt: A calling Session lists, inspects, and messages a README review Session, then observes the claimed turn through Fleet.


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wha1echai-dsh-cross-session`
- Submission type: community curation
- Created by `Wha1eChai` — https://github.com/Wha1eChai
- Original source repository: https://github.com/Wha1eChai/dsh-cross-session
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.