### PR TITLE
catalog: add whale-zhang-dsh-complete-chime (community curation, created by @Whale-Zhang)

### DIFF
--- a/catalog/plugins/whale-zhang-dsh-complete-chime.yaml
+++ b/catalog/plugins/whale-zhang-dsh-complete-chime.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: whale-zhang-dsh-complete-chime
+name: "@dsh-external/dsh-complete-chime"
+description:
+  en: Play a short chime when any conversation turn finishes. Built-in tones plus one custom upload, configured in Settings → Plugins.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - notification
+  - sound
+  - chime
+source:
+  repository: https://github.com/Whale-Zhang/dsh-complete-chime
+  repositoryNodeId: R_kgDOUBFfNA
+  subpath: null
+  commit: 9536566e14e61c676adfd155a9c3b7497ab75ee1
+creator:
+  github: Whale-Zhang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:30.506Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Whale-Zhang/dsh-complete-chime/9536566e14e61c676adfd155a9c3b7497ab75ee1/docs/settings-card.png
+    alt: Settings → Plugins → Plugin configuration


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whale-zhang-dsh-complete-chime`
- Submission type: community curation
- Created by `Whale-Zhang` — https://github.com/Whale-Zhang
- Original source repository: https://github.com/Whale-Zhang/dsh-complete-chime
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.