### PR TITLE
catalog: add whning0513-dsh-awesome-deepseek-skills (community curation, created by @Whning0513)

### DIFF
--- a/catalog/plugins/whning0513-dsh-awesome-deepseek-skills.yaml
+++ b/catalog/plugins/whning0513-dsh-awesome-deepseek-skills.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: whning0513-dsh-awesome-deepseek-skills
+name: dsh-awesome-deepseek-skills
+description:
+  en: Browse and install pinned Agent Skills from Awesome DeepSeek Skills in DSH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - agent-skills
+  - awesome-list
+source:
+  repository: https://github.com/Whning0513/awesome-deepseek-skills
+  repositoryNodeId: R_kgDOT4YJhw
+  subpath: null
+  commit: 11f4b482afc58f2830f0f039e2588df9a3bdffd8
+creator:
+  github: Whning0513
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:35.699Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whning0513-dsh-awesome-deepseek-skills`
- Submission type: community curation
- Created by `Whning0513` — https://github.com/Whning0513
- Original source repository: https://github.com/Whning0513/awesome-deepseek-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.