### PR TITLE
catalog: add whning0513-dsh-deepseek-protocol-doctor (community curation, created by @Whning0513)

### DIFF
--- a/catalog/plugins/whning0513-dsh-deepseek-protocol-doctor.yaml
+++ b/catalog/plugins/whning0513-dsh-deepseek-protocol-doctor.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: whning0513-dsh-deepseek-protocol-doctor
+name: dsh-deepseek-protocol-doctor
+description:
+  en: Offline DeepSeek request, tool-loop, reasoning content, and SSE diagnostics for DSH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - tool-calling
+  - reasoning-content
+  - sse
+source:
+  repository: https://github.com/Whning0513/deepseek-protocol-doctor
+  repositoryNodeId: R_kgDOT4Q3Sw
+  subpath: null
+  commit: 43f6df8cbeb4073cd83535966a47c13fb40b0e6f
+creator:
+  github: Whning0513
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:35.700Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whning0513-dsh-deepseek-protocol-doctor`
- Submission type: community curation
- Created by `Whning0513` — https://github.com/Whning0513
- Original source repository: https://github.com/Whning0513/deepseek-protocol-doctor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.