### PR TITLE
catalog: add whyzsm-dsh-clipfile (community curation, created by @whyzsm)

### DIFF
--- a/catalog/plugins/whyzsm-dsh-clipfile.yaml
+++ b/catalog/plugins/whyzsm-dsh-clipfile.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: whyzsm-dsh-clipfile
+name: dsh-clipfile
+description:
+  en: "Attach files and folders in the DSH composer: clipboard paste, native file/folder picker, @-mention path search; folders are converted to paged Markdown for the agent to read page by page"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - attach
+  - files
+  - folders
+  - composer
+  - clipboard
+  - paste
+  - native
+  - file
+  - folder
+  - picker
+  - mention
+  - path
+  - search
+  - converted
+  - paged
+  - markdown
+source:
+  repository: https://github.com/whyzsm/dsh-clipfile
+  repositoryNodeId: R_kgDOT-cqVA
+  subpath: null
+  commit: 1c23c1c77f60fb082f86a0ceac8c67847241fe85
+creator:
+  github: whyzsm
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:46.617Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whyzsm-dsh-clipfile`
- Submission type: community curation
- Created by `whyzsm` — https://github.com/whyzsm
- Original source repository: https://github.com/whyzsm/dsh-clipfile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.