### PR TITLE
catalog: add wilianyichen-dsh-deepseek-web (community curation, created by @wilianyichen)

### DIFF
--- a/catalog/plugins/wilianyichen-dsh-deepseek-web.yaml
+++ b/catalog/plugins/wilianyichen-dsh-deepseek-web.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: wilianyichen-dsh-deepseek-web
+name: "@yichenwilian/dsh-deepseek-web"
+description:
+  en: "Operate chat.deepseek.com as a programmable agent from inside DeepSeek Harness: list/get/search/chat sessions, shares, digest. Wraps the battle-tested deepseek-ops python client. 把 DeepSeek 网页版当作可编程 Agent 的 DSH 插件"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - chat-deepseek-com
+  - web
+  - share
+  - llm
+  - cordis
+source:
+  repository: https://github.com/wilianyichen/dsh-deepseek-web
+  repositoryNodeId: R_kgDOT_u3rQ
+  subpath: null
+  commit: daa6df3c0098b96138b63a03d915c8455ff16cfd
+creator:
+  github: wilianyichen
+package:
+  ecosystem: npm
+  name: "@yichenwilian/dsh-deepseek-web"
+  version: 0.1.0
+  integrity: sha512-D27Ul5eFCSR4NarQ2LYdmj6ozJkyT7vhX6fF2HWc8lnAVG3pdEJARy13+GMFns/tAiAgqBvoQcXRzrdQ5FvfAQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:40.309Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wilianyichen-dsh-deepseek-web`
- Submission type: community curation
- Created by `wilianyichen` — https://github.com/wilianyichen
- Original source repository: https://github.com/wilianyichen/dsh-deepseek-web
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.