### PR TITLE
catalog: add winditer-dsh-elf (community curation, created by @winditer)

### DIFF
--- a/catalog/plugins/winditer-dsh-elf.yaml
+++ b/catalog/plugins/winditer-dsh-elf.yaml
@@ -1,0 +1,63 @@
+schemaVersion: 1
+id: winditer-dsh-elf
+name: dsh-elf
+description:
+  en: A DeepSeek whale elf that lives on your DSH page. A translucent, slowly drifting whale (rendered from the official DeepSeek favicon path, tinted blue → purple → green) hovers at the edge of the viewport; click it to open a lightweight, draggable chat window that never touches your session history.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - whale
+  - lives
+  - page
+  - translucent
+  - slowly
+  - drifting
+  - rendered
+  - official
+  - favicon
+  - path
+  - tinted
+  - blue
+  - purple
+  - green
+  - hovers
+  - edge
+source:
+  repository: https://github.com/winditer/dsh-elf
+  repositoryNodeId: R_kgDOT8Ue6w
+  subpath: null
+  commit: 14b3748d9bd70959c3c1161051db2590d14fd99e
+creator:
+  github: winditer
+package:
+  ecosystem: npm
+  name: dsh-elf
+  version: 2.2.1
+  integrity: sha512-TIZmbfs9Y8WOs+RQJj4+44C+7dJ1N/aTF3wDenUJF37sdKDC+lxwesixPBJcGoS0OBWr6zhTWCU9ze2coykXOw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:40.723Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/winditer/dsh-elf/14b3748d9bd70959c3c1161051db2590d14fd99e/assets/screenshot-elf.png
+    alt: The whale elf hovering at the corner of the page
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/winditer/dsh-elf/14b3748d9bd70959c3c1161051db2590d14fd99e/assets/screenshot-chat.png
+    alt: The temporary chat window opened by clicking the elf


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `winditer-dsh-elf`
- Submission type: community curation
- Created by `winditer` — https://github.com/winditer
- Original source repository: https://github.com/winditer/dsh-elf
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.