### PR TITLE
catalog: add windrover-dsh-long-term-memory (community curation, created by @windrover)

### DIFF
--- a/catalog/plugins/windrover-dsh-long-term-memory.yaml
+++ b/catalog/plugins/windrover-dsh-long-term-memory.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: windrover-dsh-long-term-memory
+name: dsh-long-term-memory
+description:
+  en: "Layered deterministic long-term memory for DeepSeek Harness: CJK-aware BM25 recall, JSONL storage, per-assembly context injection, and an optional write-approval gate."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - layered
+  - deterministic
+  - long
+  - term
+  - memory
+  - aware
+  - bm25
+  - recall
+  - jsonl
+  - storage
+  - assembly
+  - context
+  - injection
+  - optional
+  - write
+  - approval
+source:
+  repository: https://github.com/windrover/dsh-long-term-memory
+  repositoryNodeId: R_kgDOUDsvmA
+  subpath: null
+  commit: 3740ba890cfe97a593ab0a74cbd56010622edc3e
+creator:
+  github: windrover
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: archived
+  checkedAt: 2026-08-30T09:18:46.555Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `windrover-dsh-long-term-memory`
- Submission type: community curation
- Created by `windrover` — https://github.com/windrover
- Original source repository: https://github.com/windrover/dsh-long-term-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.