### PR TITLE
catalog: add wine-red-dsh-prompt-stash (community curation, created by @Wine-Red)

### DIFF
--- a/catalog/plugins/wine-red-dsh-prompt-stash.yaml
+++ b/catalog/plugins/wine-red-dsh-prompt-stash.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: wine-red-dsh-prompt-stash
+name: dsh-prompt-stash
+description:
+  en: Local, per-session prompt stash for DeepSeek Harness Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - web-ui
+  - local-first
+  - prompt
+  - stash
+source:
+  repository: https://github.com/Wine-Red/dsh-prompt-stash
+  repositoryNodeId: R_kgDOT3w8jA
+  subpath: null
+  commit: 770467287c0577af1d74220d77eda8a0cb5097f4
+creator:
+  github: Wine-Red
+package:
+  ecosystem: npm
+  name: dsh-prompt-stash
+  version: 0.2.5
+  integrity: sha512-pHIw+LHAvQsGW61dcN+S9qKDxczRK6g8H5+qx9XwqcNRRvcjcwK/yO55IGELFkVtpbov26V1J/fUakhWTUjtDA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:31.091Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Wine-Red/dsh-prompt-stash/770467287c0577af1d74220d77eda8a0cb5097f4/docs/assets/dsh-prompt-stash-cover.jpg
+    alt: dsh-prompt-stash — Save the thought. Ask the detour.
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Wine-Red/dsh-prompt-stash/770467287c0577af1d74220d77eda8a0cb5097f4/docs/assets/dsh-prompt-stash-demo.png
+    alt: 暂存消息与 DSH 原生排队消息组合显示


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wine-red-dsh-prompt-stash`
- Submission type: community curation
- Created by `Wine-Red` — https://github.com/Wine-Red
- Original source repository: https://github.com/Wine-Red/dsh-prompt-stash
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.