### PR TITLE
catalog: add wingsky-1-dsh-mcp-manager (community curation, created by @wingsky-1)

### DIFF
--- a/catalog/plugins/wingsky-1-dsh-mcp-manager.yaml
+++ b/catalog/plugins/wingsky-1-dsh-mcp-manager.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wingsky-1-dsh-mcp-manager
+name: "@wingsky-1/dsh-mcp-manager"
+description:
+  en: "A MCP server management plugin for DSH (DeepSeek Harness): a floating window in the top-right of the session UI + a tiered panel + quick onboarding (manual form + paste mcpServers JSON import, no servers preconfigured ). The MCP protocol client is implemented directly on top of node:child process and the global fetch —"
+  evidencePath: packages/dsh-mcp-manager/README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - mcp
+  - model-context-protocol
+source:
+  repository: https://github.com/wingsky-1/dsh-plugin-hub
+  repositoryNodeId: R_kgDOT6Jr1Q
+  subpath: packages/dsh-mcp-manager
+  commit: 3df534bb1114cc108b633d2bd27eb491cf756a3f
+creator:
+  github: wingsky-1
+package:
+  ecosystem: npm
+  name: "@wingsky-1/dsh-mcp-manager"
+  version: 0.1.13
+  integrity: sha512-la3zlWBAvh/TQtKC9IaCCJn27FBg9M5TzachlxRHLB/DBaaWOETva9ndLU+bubWfEcyt7xgMfy0hGE3DqvK6Vw==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-mcp-manager/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:47.375Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wingsky-1-dsh-mcp-manager`
- Submission type: community curation
- Created by `wingsky-1` — https://github.com/wingsky-1
- Original source repository: https://github.com/wingsky-1/dsh-plugin-hub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.