### PR TITLE
catalog: add wingsky-1-dsh-notifier (community curation, created by @wingsky-1)

### DIFF
--- a/catalog/plugins/wingsky-1-dsh-notifier.yaml
+++ b/catalog/plugins/wingsky-1-dsh-notifier.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wingsky-1-dsh-notifier
+name: "@wingsky-1/dsh-notifier"
+description:
+  en: "Notifications for approval / completion / error events: get alerted even when you are away from the browser."
+  evidencePath: packages/dsh-notifier/README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - notification
+  - toast
+source:
+  repository: https://github.com/wingsky-1/dsh-plugin-hub
+  repositoryNodeId: R_kgDOT6Jr1Q
+  subpath: packages/dsh-notifier
+  commit: 3df534bb1114cc108b633d2bd27eb491cf756a3f
+creator:
+  github: wingsky-1
+package:
+  ecosystem: npm
+  name: "@wingsky-1/dsh-notifier"
+  version: 0.1.13
+  integrity: sha512-sSP15SHla/5yLEapOX67nsXD8keuapZOXthWAhQBLXxA2DLitSnsqMK6qsypeKn27eybytXsweZaDEzIuXpFnw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: packages/dsh-notifier/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:47.375Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wingsky-1-dsh-notifier`
- Submission type: community curation
- Created by `wingsky-1` — https://github.com/wingsky-1
- Original source repository: https://github.com/wingsky-1/dsh-plugin-hub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.