### PR TITLE
catalog: add winter-and-you-gone-dsh-deep-verbs (community curation, created by @Winter-And-You-Gone)

### DIFF
--- a/catalog/plugins/winter-and-you-gone-dsh-deep-verbs.yaml
+++ b/catalog/plugins/winter-and-you-gone-dsh-deep-verbs.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: winter-and-you-gone-dsh-deep-verbs
+name: dsh-deep-verbs
+description:
+  en: Tired of the built-in status line showing Deep diving... forever? Want the model to show some personality while it thinks? Then this plugin is for you.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - status
+  - spinner
+  - emotion
+  - whale
+source:
+  repository: https://github.com/Winter-And-You-Gone/dsh-deep-verbs
+  repositoryNodeId: R_kgDOT6OrDw
+  subpath: null
+  commit: 3af25c3ee634b2a65b4bdbb194db28b6e1040d41
+creator:
+  github: Winter-And-You-Gone
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:36.262Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `winter-and-you-gone-dsh-deep-verbs`
- Submission type: community curation
- Created by `Winter-And-You-Gone` — https://github.com/Winter-And-You-Gone
- Original source repository: https://github.com/Winter-And-You-Gone/dsh-deep-verbs
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.