### PR TITLE
catalog: add wintrygrass-dsh-multi-candidate (community curation, created by @WintryGrass)

### DIFF
--- a/catalog/plugins/wintrygrass-dsh-multi-candidate.yaml
+++ b/catalog/plugins/wintrygrass-dsh-multi-candidate.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: wintrygrass-dsh-multi-candidate
+name: dsh-multi-candidate
+description:
+  en: bash dsh plugin --profile web add dsh-multi-candidate
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - multi-candidate
+  - test-time-scaling
+  - llm-as-a-verifier
+source:
+  repository: https://github.com/WintryGrass/dsh-multi-candidate
+  repositoryNodeId: R_kgDOT-lsug
+  subpath: null
+  commit: c034cd62d2b3f82cd29148cb0d41b8731bfd5dac
+creator:
+  github: WintryGrass
+package:
+  ecosystem: npm
+  name: dsh-multi-candidate
+  version: 1.1.2
+  integrity: sha512-d7RvGoLmDvJYGAsoutRRJl6V/RTvPwko9eMS1Lwfl/+g+nxHfyLO3CaKZSfGEqYtMNLVjOkDr69kjoD1IE8sWA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:31.306Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wintrygrass-dsh-multi-candidate`
- Submission type: community curation
- Created by `WintryGrass` — https://github.com/WintryGrass
- Original source repository: https://github.com/WintryGrass/dsh-multi-candidate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.