### PR TITLE
catalog: add wiyi-dsh-web-service-manager (community curation, created by @wiyi)

### DIFF
--- a/catalog/plugins/wiyi-dsh-web-service-manager.yaml
+++ b/catalog/plugins/wiyi-dsh-web-service-manager.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wiyi-dsh-web-service-manager
+name: dsh-web-service-manager
+description:
+  en: "Manage the DSH web service from a settings panel: status, version, restart, stop, and one-click updates."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - web
+  - service-manager
+source:
+  repository: https://github.com/wiyi/dsh-web-service-manager
+  repositoryNodeId: R_kgDOT9gHlg
+  subpath: null
+  commit: 4c8af2cede6355a7ccab175af92182ab12dfe19f
+creator:
+  github: wiyi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:31.348Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wiyi/dsh-web-service-manager/4c8af2cede6355a7ccab175af92182ab12dfe19f/assets/screenshot.png
+    alt: DSH Web 服务 设置面板 | DSH web service settings panel


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wiyi-dsh-web-service-manager`
- Submission type: community curation
- Created by `wiyi` — https://github.com/wiyi
- Original source repository: https://github.com/wiyi/dsh-web-service-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.