### PR TITLE
catalog: add wjnct55555-dsh-achievements-bundle (community curation, created by @WJNCT55555)

### DIFF
--- a/catalog/plugins/wjnct55555-dsh-achievements-bundle.yaml
+++ b/catalog/plugins/wjnct55555-dsh-achievements-bundle.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: wjnct55555-dsh-achievements-bundle
+name: "@wjnct55555/dsh-achievements-bundle"
+description:
+  en: "Achievements for DeepSeek Harness Web: gallery, toasts, trophy, dock, and crossover achievements — installable bundle"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - achievements
+  - gamification
+source:
+  repository: https://github.com/WJNCT55555/dsh-achievements
+  repositoryNodeId: R_kgDOT5pfDw
+  subpath: null
+  commit: ce6ceb3f3231648565cadcd598edbe50e41eda26
+creator:
+  github: WJNCT55555
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:28.087Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WJNCT55555/dsh-achievements/ce6ceb3f3231648565cadcd598edbe50e41eda26/assets/gallery.png
+    alt: 成就画廊


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wjnct55555-dsh-achievements-bundle`
- Submission type: community curation
- Created by `WJNCT55555` — https://github.com/WJNCT55555
- Original source repository: https://github.com/WJNCT55555/dsh-achievements
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.