### PR TITLE
catalog: add wjnct55555-dsh-web-preview-float (community curation, created by @WJNCT55555)

### DIFF
--- a/catalog/plugins/wjnct55555-dsh-web-preview-float.yaml
+++ b/catalog/plugins/wjnct55555-dsh-web-preview-float.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: wjnct55555-dsh-web-preview-float
+name: "@dsh-external/dsh-web-preview-float"
+description:
+  en: "yaml - id: dsh-web-preview-float name: '@dsh-external/dsh-web-preview-float'"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - yaml
+  - preview
+  - float
+  - name
+  - external
+  - dsh
+source:
+  repository: https://github.com/WJNCT55555/dsh-web-preview-float
+  repositoryNodeId: R_kgDOT4YfuA
+  subpath: null
+  commit: c3289448f4e2c3aa3d59041e65c22f675234cb15
+creator:
+  github: WJNCT55555
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:36.343Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wjnct55555-dsh-web-preview-float`
- Submission type: community curation
- Created by `WJNCT55555` — https://github.com/WJNCT55555
- Original source repository: https://github.com/WJNCT55555/dsh-web-preview-float
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.