### PR TITLE
catalog: add wjz-p-dsh-attachment (community curation, created by @WJZ-P)

### DIFF
--- a/catalog/plugins/wjz-p-dsh-attachment.yaml
+++ b/catalog/plugins/wjz-p-dsh-attachment.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: wjz-p-dsh-attachment
+name: dsh-attachment
+description:
+  en: Drag-and-drop file and folder attachments for the DeepSeek Harness Web UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - attachments
+  - drag-and-drop
+source:
+  repository: https://github.com/WJZ-P/dsh-attachments
+  repositoryNodeId: R_kgDOT6EM1Q
+  subpath: null
+  commit: c94ec8b38a126b8ab919dd3849cd88560f0063a6
+creator:
+  github: WJZ-P
+package:
+  ecosystem: npm
+  name: dsh-attachment
+  version: 1.0.1
+  integrity: sha512-cuQ3IfTBVV2LDXGCGB47GV8pkeaEnCzayJunUXvN6n2Udg+UXg0uN4v+CZhBwKmDLfnIcVfhbDp5FP0/hSXmxQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:26.282Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WJZ-P/dsh-attachments/c94ec8b38a126b8ab919dd3849cd88560f0063a6/assets/markdown/01-drag-drop-overlay.png
+    alt: 拖放附件界面
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WJZ-P/dsh-attachments/c94ec8b38a126b8ab919dd3849cd88560f0063a6/assets/markdown/02-image-conversation.png
+    alt: 图片消息与模型回复
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WJZ-P/dsh-attachments/c94ec8b38a126b8ab919dd3849cd88560f0063a6/assets/markdown/03-multiple-image-preview.png
+    alt: 多图片输入预览


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wjz-p-dsh-attachment`
- Submission type: community curation
- Created by `WJZ-P` — https://github.com/WJZ-P
- Original source repository: https://github.com/WJZ-P/dsh-attachments
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.