### PR TITLE
catalog: add wjz-p-dsh-model-capability (community curation, created by @WJZ-P)

### DIFF
--- a/catalog/plugins/wjz-p-dsh-model-capability.yaml
+++ b/catalog/plugins/wjz-p-dsh-model-capability.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: wjz-p-dsh-model-capability
+name: dsh-model-capability
+description:
+  en: Explicit model input-modality selection for the DeepSeek Harness Web UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - models
+  - multimodal
+source:
+  repository: https://github.com/WJZ-P/dsh-model-capabilities
+  repositoryNodeId: R_kgDOT6EQrQ
+  subpath: null
+  commit: 4b351a8890170caa85c9b5c4e6ed4ad0dd6599e8
+creator:
+  github: WJZ-P
+package:
+  ecosystem: npm
+  name: dsh-model-capability
+  version: 1.0.1
+  integrity: sha512-G5413jd85ELcdpu3+3PQQrzVOBKywj3lasETq3RWqDFgdTVn4w21AP5psGv+evLIL6CegXG1vbuiVJyHVKHIcQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:31.774Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WJZ-P/dsh-model-capabilities/4b351a8890170caa85c9b5c4e6ed4ad0dd6599e8/assets/screenshots/01-model-input-selector.png
+    alt: 模型输入类型选择为文本和图片


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wjz-p-dsh-model-capability`
- Submission type: community curation
- Created by `WJZ-P` — https://github.com/WJZ-P
- Original source repository: https://github.com/WJZ-P/dsh-model-capabilities
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.