### PR TITLE
catalog: add wldxiaobai-dsh-project-mcp-manager (community curation, created by @wldxiaobai)

### DIFF
--- a/catalog/plugins/wldxiaobai-dsh-project-mcp-manager.yaml
+++ b/catalog/plugins/wldxiaobai-dsh-project-mcp-manager.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wldxiaobai-dsh-project-mcp-manager
+name: dsh-project-mcp-manager
+description:
+  en: "dsh-project-mcp-manager: per-project MCP server loading for DSH. Reads <projectRoot /.dsh/mcp.yml, mounts each server as an @deepseek-ai/dsh-mcp-client instance, hot-reloads on file change, and scopes tool visibility per session."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - mcp
+  - cordis
+source:
+  repository: https://github.com/wldxiaobai/dsh-project-mcp-manager
+  repositoryNodeId: R_kgDOUA_BUw
+  subpath: null
+  commit: 4405735acd0bb7e4fb0e3271f0c51ee0a12f96bd
+creator:
+  github: wldxiaobai
+package:
+  ecosystem: npm
+  name: dsh-project-mcp-manager
+  version: 0.1.1
+  integrity: sha512-MCq8WckovS8LuKOUHUI4pMoEn5zftDCkF4xgTBoF0wYCfMSHCPpleBxZjC5YD+Y/JmZvKSx7p7PdkceuZ+OP9g==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:41.382Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wldxiaobai-dsh-project-mcp-manager`
- Submission type: community curation
- Created by `wldxiaobai` — https://github.com/wldxiaobai
- Original source repository: https://github.com/wldxiaobai/dsh-project-mcp-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.