### PR TITLE
catalog: add wly10-dsh-office-com (community curation, created by @wly10)

### DIFF
--- a/catalog/plugins/wly10-dsh-office-com.yaml
+++ b/catalog/plugins/wly10-dsh-office-com.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: wly10-dsh-office-com
+name: "@eqman00003/dsh-office-com"
+description:
+  en: Excel 读写 ： excel new · excel open · excel read range · excel write range
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - office
+  - excel
+  - word
+  - com
+  - vba
+  - pivot-table
+source:
+  repository: https://github.com/wly8691-jpg/dsh-office-com
+  repositoryNodeId: R_kgDOUFBWQg
+  subpath: null
+  commit: 2b7a2051b4b10d63e5b4516b2efc50819dc54741
+creator:
+  github: wly10
+package:
+  ecosystem: npm
+  name: "@eqman00003/dsh-office-com"
+  version: 0.1.1
+  integrity: sha512-fMR6lIUAF5TCLid8rsuRH/sTjvmLtBPbGPRMN6G3dD73Z4drdNUma2invlz/Vedy9+32JO//Z7PWGLcHYWlC2A==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:54.517Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wly10-dsh-office-com`
- Submission type: community curation
- Created by `wly10` — https://github.com/wly10
- Original source repository: https://github.com/wly8691-jpg/dsh-office-com
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.