### PR TITLE
catalog: add wode25500-dsh-kubectl (community curation, created by @WODE25500)

### DIFF
--- a/catalog/plugins/wode25500-dsh-kubectl.yaml
+++ b/catalog/plugins/wode25500-dsh-kubectl.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wode25500-dsh-kubectl
+name: dsh-kubectl
+description:
+  en: "Kubernetes (kubectl) integration for DeepSeek Harness: inspect clusters, get/describe resources, read logs, port-forward and run one-off commands — with structured JSON output that agents parse reliably."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - kubernetes
+  - kubectl
+  - k8s
+  - devops
+source:
+  repository: https://github.com/WODE25500/dsh-kubectl
+  repositoryNodeId: R_kgDOT-CD1A
+  subpath: null
+  commit: 7bb8623b7a55a997c418235b78cfae1443a23a73
+creator:
+  github: WODE25500
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T09:18:37.177Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wode25500-dsh-kubectl`
- Submission type: community curation
- Created by `WODE25500` — https://github.com/WODE25500
- Original source repository: https://github.com/WODE25500/dsh-kubectl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.