### PR TITLE
catalog: add wode25500-dsh-k6 (community curation, created by @WODE25500)

### DIFF
--- a/catalog/plugins/wode25500-dsh-k6.yaml
+++ b/catalog/plugins/wode25500-dsh-k6.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wode25500-dsh-k6
+name: dsh-k6
+description:
+  en: "Grafana k6 load-testing integration for DeepSeek Harness: write, run and analyze performance test scripts."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - k6
+  - load-testing
+  - performance
+  - grafana
+source:
+  repository: https://github.com/WODE25500/dsh-k6
+  repositoryNodeId: R_kgDOT-CD-w
+  subpath: null
+  commit: 979c8ce347385344b01ae37eab98afad3afd9770
+creator:
+  github: WODE25500
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:24.650Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wode25500-dsh-k6`
- Submission type: community curation
- Created by `WODE25500` — https://github.com/WODE25500
- Original source repository: https://github.com/WODE25500/dsh-k6
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.