### PR TITLE
catalog: add wode25500-dsh-maf (community curation, created by @WODE25500)

### DIFF
--- a/catalog/plugins/wode25500-dsh-maf.yaml
+++ b/catalog/plugins/wode25500-dsh-maf.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wode25500-dsh-maf
+name: dsh-maf
+description:
+  en: "Microsoft Agent Framework (MAF) integration for DeepSeek Harness: validate, run and scaffold declarative agents and workflows defined in YAML, through native dsh tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - microsoft-agent-framework
+  - maf
+  - semantic-kernel
+  - agents
+  - yaml
+source:
+  repository: https://github.com/WODE25500/dsh-maf
+  repositoryNodeId: R_kgDOT-osvQ
+  subpath: null
+  commit: 84077ac812f24d7a0334f73efed97912c8b3f97d
+creator:
+  github: WODE25500
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:29.367Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wode25500-dsh-maf`
- Submission type: community curation
- Created by `WODE25500` — https://github.com/WODE25500
- Original source repository: https://github.com/WODE25500/dsh-maf
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.