### PR TITLE
catalog: add wode25500-dsh-skillopt (community curation, created by @WODE25500)

### DIFF
--- a/catalog/plugins/wode25500-dsh-skillopt.yaml
+++ b/catalog/plugins/wode25500-dsh-skillopt.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wode25500-dsh-skillopt
+name: dsh-skillopt
+description:
+  en: "Microsoft SkillOpt-Sleep integration for DeepSeek Harness: give your dsh agent a nightly sleep cycle that harvests past sessions, replays recurring tasks, and consolidates validated skills behind a held-out gate."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - skillopt
+  - skill-optimization
+  - self-improvement
+  - memory-consolidation
+  - sleep
+source:
+  repository: https://github.com/WODE25500/dsh-skillopt
+  repositoryNodeId: R_kgDOT9_AAA
+  subpath: null
+  commit: 654f6eb386f7d766dd8d571dba7ba9454e649a2d
+creator:
+  github: WODE25500
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:20.030Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wode25500-dsh-skillopt`
- Submission type: community curation
- Created by `WODE25500` — https://github.com/WODE25500
- Original source repository: https://github.com/WODE25500/dsh-skillopt
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.