### PR TITLE
catalog: add wode25500-dsh-ssh-pro (community curation, created by @WODE25500)

### DIFF
--- a/catalog/plugins/wode25500-dsh-ssh-pro.yaml
+++ b/catalog/plugins/wode25500-dsh-ssh-pro.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wode25500-dsh-ssh-pro
+name: dsh-ssh-pro
+description:
+  en: "Enhanced SSH ops for DeepSeek Harness: adds agent tools the base dsh-ssh plugin leaves uncovered — host testing, remote ls, ~/.ssh/config import, known hosts fingerprint check and multi-host exec — on top of the shared ssh2 engine."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - ssh
+  - remote
+  - ops
+  - server
+source:
+  repository: https://github.com/WODE25500/dsh-ssh-pro
+  repositoryNodeId: R_kgDOT-B2PA
+  subpath: null
+  commit: d3785e4c8a77c9e59156a68f8794af35e24ff6e0
+creator:
+  github: WODE25500
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:29.373Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wode25500-dsh-ssh-pro`
- Submission type: community curation
- Created by `WODE25500` — https://github.com/WODE25500
- Original source repository: https://github.com/WODE25500/dsh-ssh-pro
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.