### PR TITLE
catalog: add wode25500-dsh-terraform (community curation, created by @WODE25500)

### DIFF
--- a/catalog/plugins/wode25500-dsh-terraform.yaml
+++ b/catalog/plugins/wode25500-dsh-terraform.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wode25500-dsh-terraform
+name: dsh-terraform
+description:
+  en: "Infrastructure as Code (Terraform) integration for DeepSeek Harness: plan/apply/diff, state inspection, output querying and resource listing."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - terraform
+  - iac
+  - infrastructure-as-code
+  - hashicorp
+source:
+  repository: https://github.com/WODE25500/dsh-terraform
+  repositoryNodeId: R_kgDOT-CD5Q
+  subpath: null
+  commit: fe4999ab36b81d8c4eaf6bc2566f3de7fabb5c10
+creator:
+  github: WODE25500
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:24.648Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wode25500-dsh-terraform`
- Submission type: community curation
- Created by `WODE25500` — https://github.com/WODE25500
- Original source repository: https://github.com/WODE25500/dsh-terraform
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.