### PR TITLE
catalog: add wode25500-dsh-winget (community curation, created by @WODE25500)

### DIFF
--- a/catalog/plugins/wode25500-dsh-winget.yaml
+++ b/catalog/plugins/wode25500-dsh-winget.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wode25500-dsh-winget
+name: dsh-winget
+description:
+  en: "Windows Package Manager (winget) integration for DeepSeek Harness: search, install, upgrade, list, uninstall, export/import and pin software through native dsh tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - winget
+  - windows-package-manager
+  - package-management
+  - windows
+source:
+  repository: https://github.com/WODE25500/dsh-winget
+  repositoryNodeId: R_kgDOT-BeZA
+  subpath: null
+  commit: 65ba32fb6b9c14e7f78f801770ce0d3758ef5ce3
+creator:
+  github: WODE25500
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:24.959Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wode25500-dsh-winget`
- Submission type: community curation
- Created by `WODE25500` — https://github.com/WODE25500
- Original source repository: https://github.com/WODE25500/dsh-winget
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.