### PR TITLE
catalog: add wode25500-dsh-wsl (community curation, created by @WODE25500)

### DIFF
--- a/catalog/plugins/wode25500-dsh-wsl.yaml
+++ b/catalog/plugins/wode25500-dsh-wsl.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wode25500-dsh-wsl
+name: dsh-wsl
+description:
+  en: "WSL (Windows Subsystem for Linux) bridge for DeepSeek Harness: run Linux commands, manage distros, and move files between Windows and WSL through native dsh tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - wsl
+  - windows-subsystem-for-linux
+  - linux
+  - bridge
+source:
+  repository: https://github.com/WODE25500/dsh-wsl
+  repositoryNodeId: R_kgDOT-BlFg
+  subpath: null
+  commit: 91d581e0a60ff9dd01392673b6ba393d6f8a42d9
+creator:
+  github: WODE25500
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:36.958Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wode25500-dsh-wsl`
- Submission type: community curation
- Created by `WODE25500` — https://github.com/WODE25500
- Original source repository: https://github.com/WODE25500/dsh-wsl
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.