### PR TITLE
catalog: add wodexinhaoleng-kasssa-dsh-reader (community curation, created by @Wodexinhaoleng-Kasssa)

### DIFF
--- a/catalog/plugins/wodexinhaoleng-kasssa-dsh-reader.yaml
+++ b/catalog/plugins/wodexinhaoleng-kasssa-dsh-reader.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: wodexinhaoleng-kasssa-dsh-reader
+name: "@wodexinhaoleng-kasssa/dsh-reader"
+description:
+  en: bash node scripts/test-sources.mjs 雪中悍刀行
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - bash
+  - node
+  - scripts
+  - test
+  - sources
+  - dsh
+source:
+  repository: https://github.com/Wodexinhaoleng-Kasssa/dsh-reader
+  repositoryNodeId: R_kgDOUAUa0Q
+  subpath: null
+  commit: ff8a16c4af82ed1a0dd643bf3d4bb9d88f167fa6
+creator:
+  github: Wodexinhaoleng-Kasssa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:29.429Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wodexinhaoleng-kasssa-dsh-reader`
- Submission type: community curation
- Created by `Wodexinhaoleng-Kasssa` — https://github.com/Wodexinhaoleng-Kasssa
- Original source repository: https://github.com/Wodexinhaoleng-Kasssa/dsh-reader
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.