### PR TITLE
catalog: add wodongx123-dsh-qq-notify (community curation, created by @wodongx123)

### DIFF
--- a/catalog/plugins/wodongx123-dsh-qq-notify.yaml
+++ b/catalog/plugins/wodongx123-dsh-qq-notify.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wodongx123-dsh-qq-notify
+name: dsh-qq-notify
+description:
+  en: bash dsh plugin --profile web add file:<本目录
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - qq
+  - napcat
+  - notify
+  - notification
+  - onebot
+source:
+  repository: https://github.com/wodongx123/dsh-qq-notify
+  repositoryNodeId: R_kgDOT7fVZQ
+  subpath: null
+  commit: ecb83b197bb75e7fab84def9cffdf8499866663f
+creator:
+  github: wodongx123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:29.662Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wodongx123-dsh-qq-notify`
- Submission type: community curation
- Created by `wodongx123` — https://github.com/wodongx123
- Original source repository: https://github.com/wodongx123/dsh-qq-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.