### PR TITLE
catalog: add wold9168-dsh-model-filter (community curation, created by @wold9168)

### DIFF
--- a/catalog/plugins/wold9168-dsh-model-filter.yaml
+++ b/catalog/plugins/wold9168-dsh-model-filter.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: wold9168-dsh-model-filter
+name: dsh-model-filter
+description:
+  en: "Model filter plugin: adds search box to model selection with fuzzy search and highlighting"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - model
+  - filter
+  - adds
+  - search
+  - selection
+  - fuzzy
+  - highlighting
+  - dsh
+source:
+  repository: https://github.com/wold9168/dsh-model-filter
+  repositoryNodeId: R_kgDOT-BM-w
+  subpath: null
+  commit: 72dac61f5373894235d369bd9349137bbcf97226
+creator:
+  github: wold9168
+package:
+  ecosystem: npm
+  name: dsh-model-filter
+  version: 0.1.0
+  integrity: sha512-IQji8KREMGzSes5107N3RAiGYGPC5U3NwDV+O2xyQfZ2MQbhqwodpVEdH/H05ExlhHflYwEZdBlapmxojq4ozA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:37.099Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wold9168-dsh-model-filter`
- Submission type: community curation
- Created by `wold9168` — https://github.com/wold9168
- Original source repository: https://github.com/wold9168/dsh-model-filter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.