### PR TITLE
catalog: add wolfgenerals-ncm-player (community curation, created by @WolfGenerals)

### DIFF
--- a/catalog/plugins/wolfgenerals-ncm-player.yaml
+++ b/catalog/plugins/wolfgenerals-ncm-player.yaml
@@ -1,0 +1,64 @@
+schemaVersion: 1
+id: wolfgenerals-ncm-player
+name: "@wolfgenerals/ncm-player"
+description:
+  en: bash dsh plugin --profile web add @wolfgenerals/ncm-player
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - bash
+  - profile
+  - wolfgenerals
+  - player
+  - dsh
+source:
+  repository: https://github.com/WolfGenerals/ncm-player
+  repositoryNodeId: R_kgDOT4pF6w
+  subpath: null
+  commit: f40f982715128d2f4d7928012b6cebf86af4d40e
+creator:
+  github: WolfGenerals
+package:
+  ecosystem: npm
+  name: "@wolfgenerals/ncm-player"
+  version: 1.2.0
+  integrity: sha512-x7LPGkYEplmycg56ecO7q1jPnasCZOJ5joqUddE+xX6yUQuVL+3vUPQ38WlZ8rjbwpzz4NWaBMHvX0wdheVunw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:20.034Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WolfGenerals/ncm-player/f40f982715128d2f4d7928012b6cebf86af4d40e/doc/screenshot-1.png
+    alt: 播放
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WolfGenerals/ncm-player/f40f982715128d2f4d7928012b6cebf86af4d40e/doc/screenshot-2.png
+    alt: 歌词
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WolfGenerals/ncm-player/f40f982715128d2f4d7928012b6cebf86af4d40e/doc/screenshot-3.png
+    alt: 发现-热门
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WolfGenerals/ncm-player/f40f982715128d2f4d7928012b6cebf86af4d40e/doc/screenshot-4.png
+    alt: 发现-我的
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WolfGenerals/ncm-player/f40f982715128d2f4d7928012b6cebf86af4d40e/doc/screenshot-5.png
+    alt: 专辑内容浏览
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WolfGenerals/ncm-player/f40f982715128d2f4d7928012b6cebf86af4d40e/doc/screenshot-6.png
+    alt: 队列


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wolfgenerals-ncm-player`
- Submission type: community curation
- Created by `WolfGenerals` — https://github.com/WolfGenerals
- Original source repository: https://github.com/WolfGenerals/ncm-player
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.