### PR TITLE
catalog: add wongzexu-dsh-git-status (community curation, created by @Wongzexu)

### DIFF
--- a/catalog/plugins/wongzexu-dsh-git-status.yaml
+++ b/catalog/plugins/wongzexu-dsh-git-status.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wongzexu-dsh-git-status
+name: "@wongzexu/dsh-git-status"
+description:
+  en: sh dsh plugin --profile web add @wongzexu/dsh-git-status
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - profile
+  - wongzexu
+  - status
+  - dsh
+source:
+  repository: https://github.com/Wongzexu/dsh-git-status
+  repositoryNodeId: R_kgDOT477cA
+  subpath: null
+  commit: 2d18b6e0414829fe0a3021adfc508629845ff017
+creator:
+  github: Wongzexu
+package:
+  ecosystem: npm
+  name: "@wongzexu/dsh-git-status"
+  version: 1.0.0
+  integrity: sha512-LHFV7dlM/Sx9PyOD+jYWCnu9Zjlx9QdMW7ZEp36I7/YcSOwW9MTA7pOrlCzhmZm7aMZx3ukdi2Ss2x5lu/yoOA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:18.602Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wongzexu-dsh-git-status`
- Submission type: community curation
- Created by `Wongzexu` — https://github.com/Wongzexu
- Original source repository: https://github.com/Wongzexu/dsh-git-status
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.