### PR TITLE
catalog: add woosh2010-dsh-client-ui-usage (community curation, created by @woosh2010)

### DIFF
--- a/catalog/plugins/woosh2010-dsh-client-ui-usage.yaml
+++ b/catalog/plugins/woosh2010-dsh-client-ui-usage.yaml
@@ -1,0 +1,67 @@
+schemaVersion: 1
+id: woosh2010-dsh-client-ui-usage
+name: "@deepseek-ai/dsh-client-ui-usage"
+description:
+  en: "Usage dashboard for the conversation composer dock: peak/valley pricing with period progress, live DeepSeek balance, cross-session usage history and analysis charts"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - usage
+  - dashboard
+  - conversation
+  - composer
+  - dock
+  - peak
+  - valley
+  - pricing
+  - period
+  - progress
+  - live
+  - balance
+  - cross
+  - session
+  - history
+  - analysis
+source:
+  repository: https://github.com/woosh2010/dsh-usage-dashboard
+  repositoryNodeId: R_kgDOT_zfOw
+  subpath: null
+  commit: 4d2be914f937880704198353f8a77f31dc07eda2
+creator:
+  github: woosh2010
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:30.807Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/woosh2010/dsh-usage-dashboard/4d2be914f937880704198353f8a77f31dc07eda2/docs/demo.gif
+    alt: 演示
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/woosh2010/dsh-usage-dashboard/4d2be914f937880704198353f8a77f31dc07eda2/docs/screenshots/dashboard.png
+    alt: 用量分析仪表盘
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/woosh2010/dsh-usage-dashboard/4d2be914f937880704198353f8a77f31dc07eda2/docs/screenshots/dock.png
+    alt: 折叠坞
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/woosh2010/dsh-usage-dashboard/4d2be914f937880704198353f8a77f31dc07eda2/docs/screenshots/recent.png
+    alt: 最近记录


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `woosh2010-dsh-client-ui-usage`
- Submission type: community curation
- Created by `woosh2010` — https://github.com/woosh2010
- Original source repository: https://github.com/woosh2010/dsh-usage-dashboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.