### PR TITLE
catalog: add wowyuarm-dsh-agent-team (community curation, created by @wowyuarm)

### DIFF
--- a/catalog/plugins/wowyuarm-dsh-agent-team.yaml
+++ b/catalog/plugins/wowyuarm-dsh-agent-team.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wowyuarm-dsh-agent-team
+name: "@wowyuarm/dsh-agent-team"
+description:
+  en: Help humans organize tasks and let agents collaborate - a Team plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-team
+  - multi-agent
+  - ai-agents
+source:
+  repository: https://github.com/wowyuarm/dsh-agent-team
+  repositoryNodeId: R_kgDOUBsSUw
+  subpath: null
+  commit: c6872196c368154bffc241fe602be8f413567142
+creator:
+  github: wowyuarm
+package:
+  ecosystem: npm
+  name: "@wowyuarm/dsh-agent-team"
+  version: 0.1.3
+  integrity: sha512-AM8JZ3Kz2JJITqgxPo9HzNU8PrTZKFhKkYcOCwKzIi63GLz29dzd159u2lzP9tuhOm4DpYqvNMK+KKUgS41jQA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:16.878Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wowyuarm/dsh-agent-team/c6872196c368154bffc241fe602be8f413567142/assets/readme/team-mode.png
+    alt: "Team mode in the DSH Web UI: Channels and seven online Agents in the sidebar; the Main Channel shows Task references and"
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wowyuarm/dsh-agent-team/c6872196c368154bffc241fe602be8f413567142/assets/readme/task-thread.png
+    alt: "Completed Task Thread in the DSH Web UI: a Claim, Agent handoffs, Human acceptance activity, and the reply composer"


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wowyuarm-dsh-agent-team`
- Submission type: community curation
- Created by `wowyuarm` — https://github.com/wowyuarm
- Original source repository: https://github.com/wowyuarm/dsh-agent-team
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.