### PR TITLE
catalog: add wpc0323-deepseek-web-import (community curation, created by @wpc0323)

### DIFF
--- a/catalog/plugins/wpc0323-deepseek-web-import.yaml
+++ b/catalog/plugins/wpc0323-deepseek-web-import.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: wpc0323-deepseek-web-import
+name: deepseek-web-import
+description:
+  en: Import chat.deepseek.com conversations into DeepSeek Harness as resumable sessions, from a settings-page UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web-ui
+  - import
+  - conversations
+  - session
+source:
+  repository: https://github.com/wpc0323/deepseek-web-import
+  repositoryNodeId: R_kgDOT6A5jg
+  subpath: null
+  commit: 8780b8c80addf9f6519a02106f6a28d2ebaedb99
+creator:
+  github: wpc0323
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:18.787Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wpc0323-deepseek-web-import`
- Submission type: community curation
- Created by `wpc0323` — https://github.com/wpc0323
- Original source repository: https://github.com/wpc0323/deepseek-web-import
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.