### PR TITLE
catalog: add wqx-txdsyl-dsh-ds-attach (community curation, created by @wqx-txdsyl)

### DIFF
--- a/catalog/plugins/wqx-txdsyl-dsh-ds-attach.yaml
+++ b/catalog/plugins/wqx-txdsyl-dsh-ds-attach.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wqx-txdsyl-dsh-ds-attach
+name: dsh-ds-attach
+description:
+  en: "chat.deepseek.com-style attachments for DeepSeek Harness: official upload icon, DS-style file cards (240x64, 16px radius), drag-drop, text extraction (PDF/DOCX/XLSX/TXT) injected into the message"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - chat
+  - style
+  - attachments
+  - official
+  - upload
+  - icon
+  - file
+  - cards
+  - 240x64
+  - 16px
+  - radius
+  - drag
+  - drop
+  - text
+  - extraction
+  - docx
+source:
+  repository: https://github.com/wqx-txdsyl/dsh-ds-attach
+  repositoryNodeId: R_kgDOT5rnLg
+  subpath: null
+  commit: 7b11a471e731253b74d6f41a34e15dabaa715244
+creator:
+  github: wqx-txdsyl
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:20.189Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wqx-txdsyl-dsh-ds-attach`
- Submission type: community curation
- Created by `wqx-txdsyl` — https://github.com/wqx-txdsyl
- Original source repository: https://github.com/wqx-txdsyl/dsh-ds-attach
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.