### PR TITLE
catalog: add wr-web-dsh-context-tree (community curation, created by @wr-web)

### DIFF
--- a/catalog/plugins/wr-web-dsh-context-tree.yaml
+++ b/catalog/plugins/wr-web-dsh-context-tree.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: wr-web-dsh-context-tree
+name: dsh-context-tree
+description:
+  en: Reusable trajectory-tree context, exact-turn forks, and bounded cross-session recall for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - dsh-plugin
+  - agent-context
+  - context-tree
+  - session-memory
+  - session-visualization
+  - coding-agent
+  - dsh
+source:
+  repository: https://github.com/wr-web/dsh-context-tree
+  repositoryNodeId: R_kgDOUFLGYw
+  subpath: null
+  commit: 6f3cf9287937ea5acee8e118ac02af5cde067928
+creator:
+  github: wr-web
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:37.236Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wr-web-dsh-context-tree`
- Submission type: community curation
- Created by `wr-web` — https://github.com/wr-web
- Original source repository: https://github.com/wr-web/dsh-context-tree
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.