### PR TITLE
catalog: add wsz987-dsh-channels (community curation, created by @wsz987)

### DIFF
--- a/catalog/plugins/wsz987-dsh-channels.yaml
+++ b/catalog/plugins/wsz987-dsh-channels.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: wsz987-dsh-channels
+name: "@wsz987/dsh-channels"
+description:
+  en: Connect WeChat, QQ, DingTalk, Lark and Telegram to DeepSeek Harness — unified config, QR-code auth, chat with your Agent from IM
+  evidencePath: packages/channels/README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - connect
+  - wechat
+  - dingtalk
+  - lark
+  - telegram
+  - unified
+  - config
+  - code
+  - auth
+  - chat
+  - agent
+  - dsh
+source:
+  repository: https://github.com/wsz987/dsh-channels
+  repositoryNodeId: R_kgDOT3ihyg
+  subpath: packages/channels
+  commit: bb03191fd509bbbbe97fcd4d4bb1cf4308d91570
+creator:
+  github: wsz987
+package:
+  ecosystem: npm
+  name: "@wsz987/dsh-channels"
+  version: 0.4.2
+  integrity: sha512-Ew1iE2+8Rkn0fOkfKtwdNZ+XijRhPYyq66VXr7IO6gnPq50vf/ebJbBcbfVGkbQF8eZAoJq3pEeClK87PT7TdQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/channels/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:37.536Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wsz987-dsh-channels`
- Submission type: community curation
- Created by `wsz987` — https://github.com/wsz987
- Original source repository: https://github.com/wsz987/dsh-channels
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.