### PR TITLE
catalog: add wulun811-dsh-malong-bridge (community curation, created by @wulun811)

### DIFF
--- a/catalog/plugins/wulun811-dsh-malong-bridge.yaml
+++ b/catalog/plugins/wulun811-dsh-malong-bridge.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: wulun811-dsh-malong-bridge
+name: "@jieai/dsh-malong-bridge"
+description:
+  en: LiuHe (Six Harmonies) tool suite as a DeepSeek Harness (dsh) plugin bundle — 44 MCP tools with dynamic workspace injection
+  evidencePath: malong/dsh/bundle/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - mcp
+  - malong
+  - liuhe
+  - code-index
+  - tools
+source:
+  repository: https://github.com/wulun811/LiuHe
+  repositoryNodeId: R_kgDOTquRmw
+  subpath: malong/dsh/bundle
+  commit: aeacf13b6450eaab5e97ddecf880c094abe1801d
+creator:
+  github: wulun811
+package:
+  ecosystem: npm
+  name: "@jieai/dsh-malong-bridge"
+  version: 0.4.7
+  integrity: sha512-UqCIR+rxCyCjB+5hcV3HPRpdpSXBbOd1fz18p6HV7hMOAYQRGV932BOCuVRbprQHwzhAtNvdletGdKApEiEl0w==
+dsh:
+  profiles:
+    - web
+  evidencePath: malong/dsh/bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:38.547Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wulun811-dsh-malong-bridge`
- Submission type: community curation
- Created by `wulun811` — https://github.com/wulun811
- Original source repository: https://github.com/wulun811/LiuHe
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.