### PR TITLE
catalog: add wuxiangru915-dsh-session-navigator (community curation, created by @wuxiangru915)

### DIFF
--- a/catalog/plugins/wuxiangru915-dsh-session-navigator.yaml
+++ b/catalog/plugins/wuxiangru915-dsh-session-navigator.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: wuxiangru915-dsh-session-navigator
+name: "@dsh-plugin/dsh-session-navigator"
+description:
+  en: Session navigation minimap & outline for DeepSeek Harness web UI (Google AI Studio style side navigation) · DSH 会话导航插件：仿 Google AI Studio 侧边 Minimap、问题刻度与悬浮预览
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - session-navigator
+  - minimap
+  - ai-studio
+source:
+  repository: https://github.com/wuxiangru915/dsh-session-navigator
+  repositoryNodeId: R_kgDOT_kVBA
+  subpath: null
+  commit: d3710670fa97c2e957ccbf7957408b8e8ce8eeff
+creator:
+  github: wuxiangru915
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:38.608Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wuxiangru915/dsh-session-navigator/d3710670fa97c2e957ccbf7957408b8e8ce8eeff/assets/session-navigator.png
+    alt: Session navigator


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wuxiangru915-dsh-session-navigator`
- Submission type: community curation
- Created by `wuxiangru915` — https://github.com/wuxiangru915
- Original source repository: https://github.com/wuxiangru915/dsh-session-navigator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.