### PR TITLE
catalog: add wwumit-dsh-phone (community curation, created by @wwumit)

### DIFF
--- a/catalog/plugins/wwumit-dsh-phone.yaml
+++ b/catalog/plugins/wwumit-dsh-phone.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: wwumit-dsh-phone
+name: "@wwumit/dsh-phone"
+description:
+  en: Agent phone client plugin — phone dialer overlay in DSH web UI, consuming CHA2A phone directory
+  evidencePath: client/README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-phone
+  - cha2a
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/wwumit/dsh-phone
+  repositoryNodeId: R_kgDOT-rwYg
+  subpath: client
+  commit: 65510b4abca04fb89f7eb3bb05f293e9a807683c
+creator:
+  github: wwumit
+package:
+  ecosystem: npm
+  name: "@wwumit/dsh-phone"
+  version: 2.4.0
+  integrity: sha512-nXaXIkXI1FDXqq7OaWQ/3c6u1smkMsTzOz+mUqEjv1psnD8DF1QqHWnZu7WTw6VB1VepRr6nm2XVH2rdk60+8w==
+dsh:
+  profiles:
+    - web
+  evidencePath: client/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:38.773Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wwumit-dsh-phone`
- Submission type: community curation
- Created by `wwumit` — https://github.com/wwumit
- Original source repository: https://github.com/wwumit/dsh-phone
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.