### PR TITLE
catalog: add wx971025-dsh-openspec (community curation, created by @wx971025)

### DIFF
--- a/catalog/plugins/wx971025-dsh-openspec.yaml
+++ b/catalog/plugins/wx971025-dsh-openspec.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: wx971025-dsh-openspec
+name: dsh-openspec
+description:
+  en: DeepSeek Harness plugin that browses, previews, edits, and saves OpenSpec change Markdown files in the Web UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - openspec
+  - dsh
+source:
+  repository: https://github.com/wx971025/dsh-openspec
+  repositoryNodeId: R_kgDOT-S7QA
+  subpath: null
+  commit: 675a3ba57eb6163fc053e2e712e4b1d94013f91e
+creator:
+  github: wx971025
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:25.928Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wx971025-dsh-openspec`
- Submission type: community curation
- Created by `wx971025` — https://github.com/wx971025
- Original source repository: https://github.com/wx971025/dsh-openspec
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.