### PR TITLE
catalog: add xi-zhao-harness-web-branding (community curation, created by @xi-zhao)

### DIFF
--- a/catalog/plugins/xi-zhao-harness-web-branding.yaml
+++ b/catalog/plugins/xi-zhao-harness-web-branding.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: xi-zhao-harness-web-branding
+name: "@openquantum/harness-web-branding"
+description:
+  en: OpenQuantum branding and PWA metadata for the native DeepSeek Harness web UI
+  evidencePath: packages/openquantum-web-branding/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - openquantum
+  - quantum-computing
+  - web-ui
+  - dsh
+source:
+  repository: https://github.com/xi-zhao/OpenQuantum
+  repositoryNodeId: R_kgDOT5PL0g
+  subpath: packages/openquantum-web-branding
+  commit: 8a94635e6222a6c0b6f2cb29b1c9922107bb4005
+creator:
+  github: xi-zhao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/openquantum-web-branding/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:39.031Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xi-zhao-harness-web-branding`
- Submission type: community curation
- Created by `xi-zhao` — https://github.com/xi-zhao
- Original source repository: https://github.com/xi-zhao/OpenQuantum
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.