### PR TITLE
catalog: add xianshu-virtuous-dsh-whale-companion (community curation, created by @xianshu-virtuous)

### DIFF
--- a/catalog/plugins/xianshu-virtuous-dsh-whale-companion.yaml
+++ b/catalog/plugins/xianshu-virtuous-dsh-whale-companion.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: xianshu-virtuous-dsh-whale-companion
+name: "@dsh-external/dsh-whale-companion"
+description:
+  en: Additive whale-maid persona and automatic near-limit session continuation for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - additive
+  - whale
+  - maid
+  - persona
+  - automatic
+  - near
+  - limit
+  - session
+  - continuation
+  - dsh
+source:
+  repository: https://github.com/xianshu-virtuous/dsh-whale-companion
+  repositoryNodeId: R_kgDOT5g_ow
+  subpath: null
+  commit: baaaf1a0785891e32ea984476f19c1e31e2f41ba
+creator:
+  github: xianshu-virtuous
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:31.383Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xianshu-virtuous-dsh-whale-companion`
- Submission type: community curation
- Created by `xianshu-virtuous` — https://github.com/xianshu-virtuous
- Original source repository: https://github.com/xianshu-virtuous/dsh-whale-companion
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.