### PR TITLE
catalog: add xiaoshihou514-dsh-tui (community curation, created by @xiaoshihou514)

### DIFF
--- a/catalog/plugins/xiaoshihou514-dsh-tui.yaml
+++ b/catalog/plugins/xiaoshihou514-dsh-tui.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: xiaoshihou514-dsh-tui
+name: dsh-tui
+description:
+  en: An interactive terminal surface for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - terminal
+  - tui
+  - agent
+  - dsh
+source:
+  repository: https://github.com/xiaoshihou514/dsh-tui
+  repositoryNodeId: R_kgDOT3ewXQ
+  subpath: null
+  commit: 8b58105741f7e5400724393fcaa1b9640a31fe89
+creator:
+  github: xiaoshihou514
+package:
+  ecosystem: npm
+  name: dsh-tui
+  version: 0.1.0
+  integrity: sha512-cRw5vW54Wk/2naNosQwXsnN2Ybe4pM1Oi6ZPLxriawbLuwQcaXip9xzyGQwapzpqsgpau0GemSKqh0OYgwmgfA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:20.215Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiaoshihou514/dsh-tui/8b58105741f7e5400724393fcaa1b9640a31fe89/assets/logo.png
+    alt: dsh-tui logo


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaoshihou514-dsh-tui`
- Submission type: community curation
- Created by `xiaoshihou514` — https://github.com/xiaoshihou514
- Original source repository: https://github.com/xiaoshihou514/dsh-tui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.