### PR TITLE
catalog: add xiaoso456-dsh-run-config (community curation, created by @xiaoso456)

### DIFF
--- a/catalog/plugins/xiaoso456-dsh-run-config.yaml
+++ b/catalog/plugins/xiaoso456-dsh-run-config.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: xiaoso456-dsh-run-config
+name: "@xiaoso/dsh-run-config"
+description:
+  en: "VS Code / IDEA-style run control for the DeepSeek Harness web GUI: run buttons, task run configurations (LLM prompt / background command), configuration CRUD, and an LLM-exposed configuration tool with an on-demand usage skill"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - task-runner
+  - run-configuration
+  - conversation
+source:
+  repository: https://github.com/xiaoso456/dsh-run-config
+  repositoryNodeId: R_kgDOUBth5Q
+  subpath: null
+  commit: 8deedae0eaf2b3421a1ef46802cc0ac701667f88
+creator:
+  github: xiaoso456
+package:
+  ecosystem: npm
+  name: "@xiaoso/dsh-run-config"
+  version: 0.1.3
+  integrity: sha512-PLgr9ymT0J8zIfwdla68d8e3AdGKK38j2mv8POPq1xq6qSTaj6FtTNzv6EAmps7+BAZFBT1xdhR/Nt9AE34wmQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:32.017Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiaoso456/dsh-run-config/8deedae0eaf2b3421a1ef46802cc0ac701667f88/docs/images/hero.png
+    alt: image-20260823222328727
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiaoso456/dsh-run-config/8deedae0eaf2b3421a1ef46802cc0ac701667f88/docs/images/dialog.png
+    alt: image-20260823222318093
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiaoso456/dsh-run-config/8deedae0eaf2b3421a1ef46802cc0ac701667f88/docs/images/llm-create.png
+    alt: image-20260823222125260


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaoso456-dsh-run-config`
- Submission type: community curation
- Created by `xiaoso456` — https://github.com/xiaoso456
- Original source repository: https://github.com/xiaoso456/dsh-run-config
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.