### PR TITLE
catalog: add xiaoyuink-dsh-image-create (community curation, created by @xiaoyuink)

### DIFF
--- a/catalog/plugins/xiaoyuink-dsh-image-create.yaml
+++ b/catalog/plugins/xiaoyuink-dsh-image-create.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: xiaoyuink-dsh-image-create
+name: "@xiaoyuink/dsh-image-create"
+description:
+  en: "AI 生图 (image generation) plugin for the dsh web GUI: text-to-image and image-to-image through a configurable OpenAI-compatible endpoint, with multi-provider support, model discovery, and agent tool registration. 与 @xiaoyuink/dsh-image-vision 同系列的图像插件。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - image
+  - generation
+  - text
+  - through
+  - configurable
+  - openai
+  - compatible
+  - endpoint
+  - multi
+  - provider
+  - model
+  - discovery
+  - agent
+  - tool
+  - registration
+  - xiaoyuink
+source:
+  repository: https://github.com/xiaoyuink/dsh-image-create
+  repositoryNodeId: R_kgDOT94CZg
+  subpath: null
+  commit: 8e83a779ea559623fe8ea44bfa810886defc83c6
+creator:
+  github: xiaoyuink
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:26.011Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaoyuink-dsh-image-create`
- Submission type: community curation
- Created by `xiaoyuink` — https://github.com/xiaoyuink
- Original source repository: https://github.com/xiaoyuink/dsh-image-create
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.