### PR TITLE
catalog: add xiaozhe7772222-dsh-api-key-pool (community curation, created by @xiaozhe7772222)

### DIFF
--- a/catalog/plugins/xiaozhe7772222-dsh-api-key-pool.yaml
+++ b/catalog/plugins/xiaozhe7772222-dsh-api-key-pool.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: xiaozhe7772222-dsh-api-key-pool
+name: dsh-api-key-pool
+description:
+  en: "API Key rotation pool for DeepSeek Harness: multiple keys per provider, weighted round-robin selection, automatic failover on 401/429/403, cooldown and recovery probing, usage statistics."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - rotation
+  - pool
+  - multiple
+  - keys
+  - provider
+  - weighted
+  - round
+  - robin
+  - selection
+  - automatic
+  - failover
+  - cooldown
+  - recovery
+  - probing
+  - usage
+  - statistics
+source:
+  repository: https://github.com/xiaozhe7772222/dsh-api-key-pool
+  repositoryNodeId: R_kgDOT5EmEg
+  subpath: null
+  commit: ce5fbe534d0e7e95c960eddc29e527dd2fd5256c
+creator:
+  github: xiaozhe7772222
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:16.758Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaozhe7772222-dsh-api-key-pool`
- Submission type: community curation
- Created by `xiaozhe7772222` — https://github.com/xiaozhe7772222
- Original source repository: https://github.com/xiaozhe7772222/dsh-api-key-pool
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.