### PR TITLE
catalog: add xiaweiliang060035-dsh-opencode-go-usage (community curation, created by @xiaweiliang060035)

### DIFF
--- a/catalog/plugins/xiaweiliang060035-dsh-opencode-go-usage.yaml
+++ b/catalog/plugins/xiaweiliang060035-dsh-opencode-go-usage.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: xiaweiliang060035-dsh-opencode-go-usage
+name: "@xiaweiliang060035/dsh-opencode-go-usage"
+description:
+  en: DSH (DeepSeek Harness) web plugin — floating widget showing real-time OpenCode Go subscription usage (rolling / weekly / monthly) for every API key. 悬浮实时展示 opencode-go 各 key 用量。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - opencode
+  - opencode-go
+  - usage
+  - quota
+source:
+  repository: https://github.com/xiaweiliang060035/dsh-opencode-go-usage
+  repositoryNodeId: R_kgDOT5IG6A
+  subpath: null
+  commit: ad2586d30d4dd7274cb151a01ea9db07abbe595e
+creator:
+  github: xiaweiliang060035
+package:
+  ecosystem: npm
+  name: "@xiaweiliang060035/dsh-opencode-go-usage"
+  version: 0.3.0
+  integrity: sha512-sYFwfRWUlBLQoXQJRRaOs+91orD88NqiaHt4RsE32vKDOopp4rk6OgGuAX22BoJJe7XV7nXoWEToi3shBxNeuA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:21.464Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiaweiliang060035/dsh-opencode-go-usage/ad2586d30d4dd7274cb151a01ea9db07abbe595e/docs/screenshot.png
+    alt: floating widget


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaweiliang060035-dsh-opencode-go-usage`
- Submission type: community curation
- Created by `xiaweiliang060035` — https://github.com/xiaweiliang060035
- Original source repository: https://github.com/xiaweiliang060035/dsh-opencode-go-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.