### PR TITLE
catalog: add xiaxingtianxia2-glitch-dsh-auto-exit (community curation, created by @xiaxingtianxia2-glitch)

### DIFF
--- a/catalog/plugins/xiaxingtianxia2-glitch-dsh-auto-exit.yaml
+++ b/catalog/plugins/xiaxingtianxia2-glitch-dsh-auto-exit.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: xiaxingtianxia2-glitch-dsh-auto-exit
+name: dsh-auto-exit
+description:
+  en: "Exit the DSH CLI process automatically when the Web UI closes (equivalent to Ctrl+C). DSH plugin: 关闭 Web UI 自动退出 CLI 进程."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - exit
+  - process
+  - automatically
+  - closes
+  - equivalent
+  - ctrl
+  - dsh
+source:
+  repository: https://github.com/xiaxingtianxia2-glitch/dsh-auto-exit
+  repositoryNodeId: R_kgDOT7QTGA
+  subpath: null
+  commit: 7eebd9b2806b28c5a3bc9bff7f8c5d4a88dabc50
+creator:
+  github: xiaxingtianxia2-glitch
+package:
+  ecosystem: npm
+  name: dsh-auto-exit
+  version: 0.0.4
+  integrity: sha512-krOOFkyvIOtwSstSrzkX2Dd3Ts+2SrNPIVPqbj0RGOqZDtIE6NXe6aU6v93SXjGZjdHMInVeWrTPNnwBTvgMXQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:26.581Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaxingtianxia2-glitch-dsh-auto-exit`
- Submission type: community curation
- Created by `xiaxingtianxia2-glitch` — https://github.com/xiaxingtianxia2-glitch
- Original source repository: https://github.com/xiaxingtianxia2-glitch/dsh-auto-exit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.