### PR TITLE
catalog: add xiaxingtianxia2-glitch-dsh-chime (community curation, created by @xiaxingtianxia2-glitch)

### DIFF
--- a/catalog/plugins/xiaxingtianxia2-glitch-dsh-chime.yaml
+++ b/catalog/plugins/xiaxingtianxia2-glitch-dsh-chime.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: xiaxingtianxia2-glitch-dsh-chime
+name: dsh-chime
+description:
+  en: <p align="center" <sub <i Independently built with the dsh creation mode + Deepseek-V4-Flash0731</i </sub </p
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - chime
+  - sound
+  - notification
+source:
+  repository: https://github.com/xiaxingtianxia2-glitch/dsh-chime
+  repositoryNodeId: R_kgDOT9GnbQ
+  subpath: null
+  commit: 3d13e52902b0e2e70cbfa4d170d682801d0ed612
+creator:
+  github: xiaxingtianxia2-glitch
+package:
+  ecosystem: npm
+  name: dsh-chime
+  version: 0.1.3
+  integrity: sha512-UpQLNV02+5TnB0rW+3VtiRMfaMZlhDXIFQKkhkn/NdaB2QO0xswRDIAPALzVIF9rff56XBUEBHGQGA+Pgr+N0w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:21.531Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaxingtianxia2-glitch-dsh-chime`
- Submission type: community curation
- Created by `xiaxingtianxia2-glitch` — https://github.com/xiaxingtianxia2-glitch
- Original source repository: https://github.com/xiaxingtianxia2-glitch/dsh-chime
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.