### PR TITLE
catalog: add xiekai886-dsh-music (community curation, created by @xiekai886)

### DIFF
--- a/catalog/plugins/xiekai886-dsh-music.yaml
+++ b/catalog/plugins/xiekai886-dsh-music.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: xiekai886-dsh-music
+name: "@dsh-external/dsh-music"
+description:
+  en: An animated floating music player plugin for DeepSeek Harness Web with a collapsible/expandable draggable frosted-glass card, deep NetEase Cloud Music integration (playlist import by link/ID, search by title/artist), a multi-layer audio source resolver (Meting → outer/url) that works around browser CORS and anti-leechi
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - animated
+  - floating
+  - music
+  - player
+  - collapsible
+  - expandable
+  - draggable
+  - frosted
+  - glass
+  - card
+  - deep
+  - netease
+  - cloud
+  - integration
+  - playlist
+  - import
+source:
+  repository: https://github.com/xiekai886/dsh-MusicPlayer
+  repositoryNodeId: R_kgDOT4kl0w
+  subpath: null
+  commit: b026a1373092ba5a7993a7c63fee6611f0ebe39e
+creator:
+  github: xiekai886
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:18.787Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiekai886-dsh-music`
- Submission type: community curation
- Created by `xiekai886` — https://github.com/xiekai886
- Original source repository: https://github.com/xiekai886/dsh-MusicPlayer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.