### PR TITLE
catalog: add ximisi-dsh-quick-attach (community curation, created by @ximisi)

### DIFF
--- a/catalog/plugins/ximisi-dsh-quick-attach.yaml
+++ b/catalog/plugins/ximisi-dsh-quick-attach.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: ximisi-dsh-quick-attach
+name: dsh-quick-attach
+description:
+  en: "Paste an image into the DSH web GUI composer: the plugin saves it into your configured directory and appends the absolute path to your message draft — when you send, the AI receives the path and can read the image with its file and vision tooling."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - attach
+  - image
+  - paste
+source:
+  repository: https://github.com/ximisi/dsh-quick-attach
+  repositoryNodeId: R_kgDOT5vHyw
+  subpath: null
+  commit: f793ebffcf0c323603c16c3952117e38178f35c1
+creator:
+  github: ximisi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:26.151Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ximisi-dsh-quick-attach`
- Submission type: community curation
- Created by `ximisi` — https://github.com/ximisi
- Original source repository: https://github.com/ximisi/dsh-quick-attach
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.