### PR TITLE
catalog: add xinchen03-dsh-plugin (community curation, created by @xinchen03)

### DIFF
--- a/catalog/plugins/xinchen03-dsh-plugin.yaml
+++ b/catalog/plugins/xinchen03-dsh-plugin.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: xinchen03-dsh-plugin
+name: "@xxinchen/dsh-plugin"
+description:
+  en: Minta for DeepSeek Harness — bundles the MCP wiring, a real Cordis plugin (runtime skill + session-start prewarm), and the minta agent preset (per-turn preflight/postflight protocol) over the Minta memory engine.
+  evidencePath: dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - minta
+  - bundles
+  - wiring
+  - real
+  - cordis
+  - runtime
+  - skill
+  - session
+  - start
+  - prewarm
+  - agent
+  - preset
+  - turn
+  - preflight
+  - postflight
+  - protocol
+source:
+  repository: https://github.com/xinchen03/minta
+  repositoryNodeId: R_kgDOSs8i6Q
+  subpath: dsh-plugin
+  commit: 2f5020c6e2a80985cc567c360b14998b8997682f
+creator:
+  github: xinchen03
+package:
+  ecosystem: npm
+  name: "@xxinchen/dsh-plugin"
+  version: 0.2.0
+  integrity: sha512-jsM5uZAET9D7KXVBVfsa48IMXzdfeB9tGNuc5oxhudEDJu7ktp5GtxQmrY1wd40EBQpp9gARgB/dHw7IRQTijA==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:40.078Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xinchen03-dsh-plugin`
- Submission type: community curation
- Created by `xinchen03` — https://github.com/xinchen03
- Original source repository: https://github.com/xinchen03/minta
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.