### PR TITLE
catalog: add xingchenyang-dsh-stats-decimal (community curation, created by @xingchenyang)

### DIFF
--- a/catalog/plugins/xingchenyang-dsh-stats-decimal.yaml
+++ b/catalog/plugins/xingchenyang-dsh-stats-decimal.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: xingchenyang-dsh-stats-decimal
+name: dsh-stats-decimal
+description:
+  en: "DSH plugin: shadows the built-in conversation stats line with a decimal cache-hit percentage, and adds a per-currency (CNY/USD) cost row via a host-side pure projection plus a browser-fetched recharge balance row."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - shadows
+  - built
+  - conversation
+  - stats
+  - line
+  - decimal
+  - cache
+  - percentage
+  - adds
+  - currency
+  - cost
+  - host
+  - side
+  - pure
+  - projection
+  - plus
+source:
+  repository: https://github.com/xingchenyang/dsh-stats-decimal
+  repositoryNodeId: R_kgDOT_a5TQ
+  subpath: null
+  commit: 6ab67e26f192ccc618e2ff09e828135c86526750
+creator:
+  github: xingchenyang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:40.178Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xingchenyang-dsh-stats-decimal`
- Submission type: community curation
- Created by `xingchenyang` — https://github.com/xingchenyang
- Original source repository: https://github.com/xingchenyang/dsh-stats-decimal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.