### PR TITLE
catalog: add xingkong42-dsh-zh-labels (community curation, created by @Xingkong42)

### DIFF
--- a/catalog/plugins/xingkong42-dsh-zh-labels.yaml
+++ b/catalog/plugins/xingkong42-dsh-zh-labels.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: xingkong42-dsh-zh-labels
+name: dsh-zh-labels
+description:
+  en: Keep the DeepSeek Harness Web UI in Chinese — even after upgrades.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - zh
+  - chinese
+  - i18n
+  - label
+  - localization
+source:
+  repository: https://github.com/Xingkong42/dsh-zh-labels
+  repositoryNodeId: R_kgDOT_zR9w
+  subpath: null
+  commit: f18c649a5bc8b005eca24196d8d2b08a2f7c3233
+creator:
+  github: Xingkong42
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:21.701Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xingkong42-dsh-zh-labels`
- Submission type: community curation
- Created by `Xingkong42` — https://github.com/Xingkong42
- Original source repository: https://github.com/Xingkong42/dsh-zh-labels
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.