### PR TITLE
catalog: add xingyingyuzhui-dsh-agent-memory (community curation, created by @xingyingyuzhui)

### DIFF
--- a/catalog/plugins/xingyingyuzhui-dsh-agent-memory.yaml
+++ b/catalog/plugins/xingyingyuzhui-dsh-agent-memory.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: xingyingyuzhui-dsh-agent-memory
+name: dsh-agent-memory
+description:
+  en: sh dsh plugin --profile web add github:xingyingyuzhui/dsh-agent-memory
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - agent
+  - memory
+source:
+  repository: https://github.com/xingyingyuzhui/dsh-agent-memory
+  repositoryNodeId: R_kgDOT8IPBw
+  subpath: null
+  commit: a225e6a461539a113f795e2481d76d551f961a32
+creator:
+  github: xingyingyuzhui
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:32.648Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xingyingyuzhui-dsh-agent-memory`
- Submission type: community curation
- Created by `xingyingyuzhui` — https://github.com/xingyingyuzhui
- Original source repository: https://github.com/xingyingyuzhui/dsh-agent-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.