### PR TITLE
catalog: add xingyingyuzhui-dsh-agent-policy (community curation, created by @xingyingyuzhui)

### DIFF
--- a/catalog/plugins/xingyingyuzhui-dsh-agent-policy.yaml
+++ b/catalog/plugins/xingyingyuzhui-dsh-agent-policy.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: xingyingyuzhui-dsh-agent-policy
+name: dsh-agent-policy
+description:
+  en: sh dsh plugin --profile web add github:xingyingyuzhui/dsh-agent-policy
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - agent
+  - policy
+source:
+  repository: https://github.com/xingyingyuzhui/dsh-agent-policy
+  repositoryNodeId: R_kgDOT8INFg
+  subpath: null
+  commit: f4983d2870553c0ac06f847f3fc69ed1430690e3
+creator:
+  github: xingyingyuzhui
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:32.938Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xingyingyuzhui-dsh-agent-policy`
- Submission type: community curation
- Created by `xingyingyuzhui` — https://github.com/xingyingyuzhui
- Original source repository: https://github.com/xingyingyuzhui/dsh-agent-policy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.