### PR TITLE
catalog: add xiyuepcl-dsh-translator (community curation, created by @xiyuepcl)

### DIFF
--- a/catalog/plugins/xiyuepcl-dsh-translator.yaml
+++ b/catalog/plugins/xiyuepcl-dsh-translator.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: xiyuepcl-dsh-translator
+name: dsh-translator
+description:
+  en: sh npx -y @deepseek-ai/dsh plugin --profile web-desktop add https://github.com/xiyuepcl/dsh-approval-translator/releases/download/v0.1.3/dsh-translator-0.1.3.tgz
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - translation
+  - approval
+  - hanhua
+source:
+  repository: https://github.com/xiyuepcl/dsh-approval-translator
+  repositoryNodeId: R_kgDOT6qTVg
+  subpath: null
+  commit: 2279a497b82029384c5126f9318a9b83141788cd
+creator:
+  github: xiyuepcl
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:33.841Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiyuepcl-dsh-translator`
- Submission type: community curation
- Created by `xiyuepcl` — https://github.com/xiyuepcl
- Original source repository: https://github.com/xiyuepcl/dsh-approval-translator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.