### PR TITLE
catalog: add xizrsams-dsh-gui-hanhua (community curation, created by @XIZRSAMS)

### DIFF
--- a/catalog/plugins/xizrsams-dsh-gui-hanhua.yaml
+++ b/catalog/plugins/xizrsams-dsh-gui-hanhua.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: xizrsams-dsh-gui-hanhua
+name: dsh-gui-hanhua
+description:
+  en: "📌 Current version: v1.1.0"
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - current
+  - version
+  - dsh
+source:
+  repository: https://github.com/XIZRSAMS/dsh-gui-hanhua
+  repositoryNodeId: R_kgDOT8UKaQ
+  subpath: null
+  commit: ac1974e90805fbf39a3cb7759490618cfd49b29b
+creator:
+  github: XIZRSAMS
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:34.231Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/XIZRSAMS/dsh-gui-hanhua/ac1974e90805fbf39a3cb7759490618cfd49b29b/assets/main.jpg
+    alt: 插件主页面
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/XIZRSAMS/dsh-gui-hanhua/ac1974e90805fbf39a3cb7759490618cfd49b29b/assets/plugin-list.png
+    alt: 插件面板汉化
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/XIZRSAMS/dsh-gui-hanhua/ac1974e90805fbf39a3cb7759490618cfd49b29b/assets/command-menu.png
+    alt: 命令面板双语
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/XIZRSAMS/dsh-gui-hanhua/ac1974e90805fbf39a3cb7759490618cfd49b29b/assets/permission.png
+    alt: 权限选择器双语
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/XIZRSAMS/dsh-gui-hanhua/ac1974e90805fbf39a3cb7759490618cfd49b29b/assets/agent-preset.png
+    alt: Agent 预设汉化


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xizrsams-dsh-gui-hanhua`
- Submission type: community curation
- Created by `XIZRSAMS` — https://github.com/XIZRSAMS
- Original source repository: https://github.com/XIZRSAMS/dsh-gui-hanhua
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.