### PR TITLE
catalog: add xmanrui-dsh-weixin (community curation, created by @xmanrui)

### DIFF
--- a/catalog/plugins/xmanrui-dsh-weixin.yaml
+++ b/catalog/plugins/xmanrui-dsh-weixin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: xmanrui-dsh-weixin
+name: "@xmanrui/dsh-weixin"
+description:
+  en: DeepSeek Harness Weixin channel plugin with QR-code account binding
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - weixin
+  - channel
+  - code
+  - account
+  - binding
+  - dsh
+source:
+  repository: https://github.com/xmanrui/dsh-weixin
+  repositoryNodeId: R_kgDOT4tuXg
+  subpath: null
+  commit: 16ca866af80e8b95b2d73619579894e817095122
+creator:
+  github: xmanrui
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:26.361Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xmanrui-dsh-weixin`
- Submission type: community curation
- Created by `xmanrui` — https://github.com/xmanrui
- Original source repository: https://github.com/xmanrui/dsh-weixin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.