### PR TITLE
catalog: add xohmai-dsh-cpa-status (community curation, created by @xohmai)

### DIFF
--- a/catalog/plugins/xohmai-dsh-cpa-status.yaml
+++ b/catalog/plugins/xohmai-dsh-cpa-status.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: xohmai-dsh-cpa-status
+name: dsh-cpa-status
+description:
+  en: "CPA account-pool status panel for DeepSeek Harness: sidebar health light, quota bars, success-rate ticks, and gateway key endings"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cliproxyapi
+  - cpa
+  - status-panel
+source:
+  repository: https://github.com/xohmai/dsh-cpa-status
+  repositoryNodeId: R_kgDOT8Otxw
+  subpath: null
+  commit: f54a2ac4a06006b866ee2953a114d3b87342aba2
+creator:
+  github: xohmai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:21.749Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xohmai/dsh-cpa-status/f54a2ac4a06006b866ee2953a114d3b87342aba2/docs/images/panel.png
+    alt: 状态面板
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xohmai/dsh-cpa-status/f54a2ac4a06006b866ee2953a114d3b87342aba2/docs/images/collapsed.png
+    alt: 侧栏底部收起态


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xohmai-dsh-cpa-status`
- Submission type: community curation
- Created by `xohmai` — https://github.com/xohmai
- Original source repository: https://github.com/xohmai/dsh-cpa-status
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.