### PR TITLE
catalog: add xohmai-dsh-session-delete (community curation, created by @xohmai)

### DIFF
--- a/catalog/plugins/xohmai-dsh-session-delete.yaml
+++ b/catalog/plugins/xohmai-dsh-session-delete.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: xohmai-dsh-session-delete
+name: dsh-session-delete
+description:
+  en: "Real session deletion for DeepSeek Harness: settings-page manager with trash & restore, archived-session cleanup, and batch delete"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - session-management
+source:
+  repository: https://github.com/xohmai/dsh-session-delete
+  repositoryNodeId: R_kgDOT8RaWQ
+  subpath: null
+  commit: 8c8ad2ce3122caef7fb3c83d5666157fc4b2f5bb
+creator:
+  github: xohmai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:14.936Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xohmai-dsh-session-delete`
- Submission type: community curation
- Created by `xohmai` — https://github.com/xohmai
- Original source repository: https://github.com/xohmai/dsh-session-delete
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.