### PR TITLE
catalog: add xsoc1-dsh-image-vision (community curation, created by @xsoc1)

### DIFF
--- a/catalog/plugins/xsoc1-dsh-image-vision.yaml
+++ b/catalog/plugins/xsoc1-dsh-image-vision.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: xsoc1-dsh-image-vision
+name: "@dsh-external/dsh-image-vision"
+description:
+  en: "Eyes for text-only DeepSeek: view image tool (any OpenAI-compatible VLM, local Ollama or cloud) + chat image-attachment bridge that rewrites pasted/dropped images into view image path markers"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - vision
+  - image
+  - ocr
+  - multimodal
+  - vlm
+  - ollama
+source:
+  repository: https://github.com/xsoc1/dsh-image-vision
+  repositoryNodeId: R_kgDOT5bTxQ
+  subpath: null
+  commit: dbe64b429289ab8da1ed6940fefd8395bdc167f0
+creator:
+  github: xsoc1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:27.923Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xsoc1-dsh-image-vision`
- Submission type: community curation
- Created by `xsoc1` — https://github.com/xsoc1
- Original source repository: https://github.com/xsoc1/dsh-image-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.