### PR TITLE
catalog: add xsoc1-math-research-dsh (community curation, created by @xsoc1)

### DIFF
--- a/catalog/plugins/xsoc1-math-research-dsh.yaml
+++ b/catalog/plugins/xsoc1-math-research-dsh.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: xsoc1-math-research-dsh
+name: math-research-dsh
+description:
+  en: "Rigorous open mathematics research suite for DeepSeek Harness: four agent skills (rigorous-open-math-research, manage-math-research-program, math-research-workflow, lean-verify) with CI-verified tests, mechanical upstream sync, and a DSH environment doctor."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - cordis
+  - skill
+  - mathematics
+  - research
+  - proof
+  - lean
+source:
+  repository: https://github.com/xsoc1/math-research-dsh
+  repositoryNodeId: R_kgDOT36uTg
+  subpath: null
+  commit: 1c761240dc923c53fc2d0bbff7260a824a2bf35f
+creator:
+  github: xsoc1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:27.635Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xsoc1-math-research-dsh`
- Submission type: community curation
- Created by `xsoc1` — https://github.com/xsoc1
- Original source repository: https://github.com/xsoc1/math-research-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.