### PR TITLE
catalog: add xswt442-cmd-dsh-instance-manager (community curation, created by @xswt442-cmd)

### DIFF
--- a/catalog/plugins/xswt442-cmd-dsh-instance-manager.yaml
+++ b/catalog/plugins/xswt442-cmd-dsh-instance-manager.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: xswt442-cmd-dsh-instance-manager
+name: dsh-instance-manager
+description:
+  en: DSH Web Instance Management Plugin. Uses the shared tool dock as the entry point. Lists all DSH Web instances within the local port range, with support for viewing instance details, stopping instances, and launching new ones. Once pairing is configured, remote instances can also be viewed.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - instance-manager
+  - process-manager
+source:
+  repository: https://github.com/xswt442-cmd/dsh-instance-manager
+  repositoryNodeId: R_kgDOUBpvbw
+  subpath: null
+  commit: a6b93039f1f5719ff65d3866a7631c4ac2185a3a
+creator:
+  github: xswt442-cmd
+package:
+  ecosystem: npm
+  name: dsh-instance-manager
+  version: 0.9.0
+  integrity: sha512-Fo3FwVGeKkKgw/tzVCg6g2kJFdI8es0ecl4P6+kGzbo2S46pZd9t3qBYRH0OwPHWidsJ6jXn79OxMZo9Tr45Kg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:27.676Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xswt442-cmd-dsh-instance-manager`
- Submission type: community curation
- Created by `xswt442-cmd` — https://github.com/xswt442-cmd
- Original source repository: https://github.com/xswt442-cmd/dsh-instance-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.