### PR TITLE
catalog: add xtd1145-dsh-full-access-switch (community curation, created by @xtd1145)

### DIFF
--- a/catalog/plugins/xtd1145-dsh-full-access-switch.yaml
+++ b/catalog/plugins/xtd1145-dsh-full-access-switch.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: xtd1145-dsh-full-access-switch
+name: dsh-full-access-switch
+description:
+  en: powershell powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - permission
+  - full-access
+  - cordis
+source:
+  repository: https://github.com/xtd1145/dsh-full-access-switch
+  repositoryNodeId: R_kgDOUB4KPg
+  subpath: null
+  commit: 6175d10325aa4b4dd081f9168101090f2777ae7d
+creator:
+  github: xtd1145
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:34.243Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xtd1145-dsh-full-access-switch`
- Submission type: community curation
- Created by `xtd1145` — https://github.com/xtd1145
- Original source repository: https://github.com/xtd1145/dsh-full-access-switch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.