### PR TITLE
catalog: add xuan666-lab-dsh-openrouter-provider-advisor (community curation, created by @xuan666-lab)

### DIFF
--- a/catalog/plugins/xuan666-lab-dsh-openrouter-provider-advisor.yaml
+++ b/catalog/plugins/xuan666-lab-dsh-openrouter-provider-advisor.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: xuan666-lab-dsh-openrouter-provider-advisor
+name: dsh-openrouter-provider-advisor
+description:
+  en: DSH web plugin that ranks OpenRouter upstream providers by quality, speed, cache-heavy price, context, and uptime, then safely switches the active route.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - openrouter
+  - provider-routing
+  - typescript
+source:
+  repository: https://github.com/xuan666-lab/dsh-openrouter-provider-advisor
+  repositoryNodeId: R_kgDOUCe_-Q
+  subpath: null
+  commit: 062b931a7256b56bacac34edccd262a4118b18cb
+creator:
+  github: xuan666-lab
+package:
+  ecosystem: npm
+  name: dsh-openrouter-provider-advisor
+  version: 0.1.3
+  integrity: sha512-IUa2TEmelUkilsIv0Qmm3buHMKDl9k8sn669ONb6YkLo+X3mr+3/7xOlZsrnHBWW91I5cnRT19DgoJLO/6kyQQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:34.442Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xuan666-lab/dsh-openrouter-provider-advisor/062b931a7256b56bacac34edccd262a4118b18cb/docs/images/provider-panel.png
+    alt: OpenRouter 供应商推荐与实时切换
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xuan666-lab/dsh-openrouter-provider-advisor/062b931a7256b56bacac34edccd262a4118b18cb/docs/images/settings-weights.png
+    alt: OpenRouter 权重设置


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xuan666-lab-dsh-openrouter-provider-advisor`
- Submission type: community curation
- Created by `xuan666-lab` — https://github.com/xuan666-lab
- Original source repository: https://github.com/xuan666-lab/dsh-openrouter-provider-advisor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.