### PR TITLE
catalog: add xwh-01-dsh-mediacrawler (community curation, created by @xwh-01)

### DIFF
--- a/catalog/plugins/xwh-01-dsh-mediacrawler.yaml
+++ b/catalog/plugins/xwh-01-dsh-mediacrawler.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: xwh-01-dsh-mediacrawler
+name: dsh-mediacrawler
+description:
+  en: Installable DeepSeek Harness profile bundle for a separately installed MediaCrawler checkout
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - mcp
+  - mediacrawler
+source:
+  repository: https://github.com/xwh-01/dsh-mediacrawler
+  repositoryNodeId: R_kgDOT3_XNQ
+  subpath: null
+  commit: 22fd327dc47ad2c40461b0d60b3f6f63f5d5446b
+creator:
+  github: xwh-01
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:23.169Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xwh-01-dsh-mediacrawler`
- Submission type: community curation
- Created by `xwh-01` — https://github.com/xwh-01
- Original source repository: https://github.com/xwh-01/dsh-mediacrawler
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.