### PR TITLE
catalog: add xxiaoxiong-dsh-prometheus (community curation, created by @xxiaoxiong)

### DIFF
--- a/catalog/plugins/xxiaoxiong-dsh-prometheus.yaml
+++ b/catalog/plugins/xxiaoxiong-dsh-prometheus.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: xxiaoxiong-dsh-prometheus
+name: dsh-prometheus
+description:
+  en: Privacy-conscious Prometheus metrics and a Grafana dashboard for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - prometheus
+  - grafana
+  - monitoring
+  - observability
+source:
+  repository: https://github.com/xxiaoxiong/dsh-prometheus
+  repositoryNodeId: R_kgDOT4_6EQ
+  subpath: null
+  commit: 2ce4d945b06f40be8101976df359f98a8bfede8e
+creator:
+  github: xxiaoxiong
+package:
+  ecosystem: npm
+  name: dsh-prometheus
+  version: 0.1.0
+  integrity: sha512-/svdchsy4VpGzveGCvVQ0E+z5rilDwzc0b/Dgi/xyBwxXjPhApfH6LkRmzIWE+f2O3AjS2HwIQhhzPOr3U2XhA==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:27.937Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xxiaoxiong-dsh-prometheus`
- Submission type: community curation
- Created by `xxiaoxiong` — https://github.com/xxiaoxiong
- Original source repository: https://github.com/xxiaoxiong/dsh-prometheus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.