### PR TITLE
catalog: add xxvk-dsh-cost-crystal (community curation, created by @xxvk)

### DIFF
--- a/catalog/plugins/xxvk-dsh-cost-crystal.yaml
+++ b/catalog/plugins/xxvk-dsh-cost-crystal.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: xxvk-dsh-cost-crystal
+name: dsh-cost-crystal
+description:
+  en: A cost & usage crystal ball for the DeepSeek Harness web GUI — balance, real-time rate, peak/off-peak billing, and a 🔮 next-message cost forecast, all timezone-aware.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - balance
+  - cost
+  - usage
+  - peak
+  - off-peak
+source:
+  repository: https://github.com/xxvk/dsh-cost-crystal
+  repositoryNodeId: R_kgDOT5Gw8g
+  subpath: null
+  commit: 023bed604b2a7c45a566853fcc47f0ec59bc99d1
+creator:
+  github: xxvk
+package:
+  ecosystem: npm
+  name: dsh-cost-crystal
+  version: 0.1.0
+  integrity: sha512-myiOlyHKFXWHADiFNBZNza8aJpqyRJMRYx1XZ1yvG2td4QvjuOelfyWe0GbcGdHIdG7InI4t8KXZN+YhZ4lDBQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:35.345Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xxvk/dsh-cost-crystal/023bed604b2a7c45a566853fcc47f0ec59bc99d1/docs/card.png
+    alt: dsh-cost-crystal balance card


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xxvk-dsh-cost-crystal`
- Submission type: community curation
- Created by `xxvk` — https://github.com/xxvk
- Original source repository: https://github.com/xxvk/dsh-cost-crystal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.