### PR TITLE
catalog: add yabolee-kkk-dsh-streaming-mcp-bridge (community curation, created by @yabolee-kkk)

### DIFF
--- a/catalog/plugins/yabolee-kkk-dsh-streaming-mcp-bridge.yaml
+++ b/catalog/plugins/yabolee-kkk-dsh-streaming-mcp-bridge.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: yabolee-kkk-dsh-streaming-mcp-bridge
+name: dsh-streaming-mcp-bridge
+description:
+  en: "DeepSeek Harness streaming MCP bridge: expose live session events as MCP progress and stream ACP updates to cc-connect/Feishu."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - acp
+  - streaming
+  - feishu
+  - cc-connect
+source:
+  repository: https://github.com/yabolee-kkk/dsh-streaming-mcp-bridge
+  repositoryNodeId: R_kgDOT698ag
+  subpath: null
+  commit: f6c96745cbc9b8fd1a376b20d090ce27c464806e
+creator:
+  github: yabolee-kkk
+package:
+  ecosystem: npm
+  name: dsh-streaming-mcp-bridge
+  version: 0.1.1
+  integrity: sha512-MJ6uSwgOBIp7bL9mQOXE4TRJ+dlchWiG+j0ChjnDC9aobq9EFRtOWg1Nc2B8kVK7GaiM3RstVz9m/IF7d8jKTg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:40.405Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yabolee-kkk-dsh-streaming-mcp-bridge`
- Submission type: community curation
- Created by `yabolee-kkk` — https://github.com/yabolee-kkk
- Original source repository: https://github.com/yabolee-kkk/dsh-streaming-mcp-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.