### PR TITLE
catalog: add yaindrop-dsh-session-favorites (community curation, created by @yaindrop)

### DIFF
--- a/catalog/plugins/yaindrop-dsh-session-favorites.yaml
+++ b/catalog/plugins/yaindrop-dsh-session-favorites.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: yaindrop-dsh-session-favorites
+name: "@dsh-external/dsh-session-favorites"
+description:
+  en: "Persistent favorites section for DeepSeek Harness: a sidebar.favorites list above Workspaces plus a per-session-row star toggle."
+  evidencePath: packages/dsh-session-favorites/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - persistent
+  - favorites
+  - section
+  - sidebar
+  - list
+  - above
+  - workspaces
+  - plus
+  - session
+  - star
+  - toggle
+  - dsh
+source:
+  repository: https://github.com/yaindrop/dsh-session-favorites
+  repositoryNodeId: R_kgDOT4F6aA
+  subpath: packages/dsh-session-favorites
+  commit: 7b125b2c45cc5c992c8558eea85ee3f2adcf827a
+creator:
+  github: yaindrop
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-session-favorites/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:40.895Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yaindrop-dsh-session-favorites`
- Submission type: community curation
- Created by `yaindrop` — https://github.com/yaindrop
- Original source repository: https://github.com/yaindrop/dsh-session-favorites
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.