### PR TITLE
catalog: add yan-zero-dsh-remote-ssh (community curation, created by @Yan-Zero)

### DIFF
--- a/catalog/plugins/yan-zero-dsh-remote-ssh.yaml
+++ b/catalog/plugins/yan-zero-dsh-remote-ssh.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: yan-zero-dsh-remote-ssh
+name: dsh-remote-ssh
+description:
+  en: Transparent local and Remote SSH workspaces for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - transparent
+  - local
+  - remote
+  - workspaces
+  - dsh
+source:
+  repository: https://github.com/Yan-Zero/dsh-remote-ssh
+  repositoryNodeId: R_kgDOT4SNLA
+  subpath: null
+  commit: 21d727cbe24fbae283196e5101adb3de2bdd9157
+creator:
+  github: Yan-Zero
+package:
+  ecosystem: npm
+  name: dsh-remote-ssh
+  version: 0.2.4
+  integrity: sha512-CkvAhbaZNpE8Pp6FYGWuw3QQrivBz92VkuijDTsOb2h8as+OlJ+ABYP8paq1hufuX/KfHMmhF6mRfyhJclqINQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:16.950Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yan-zero-dsh-remote-ssh`
- Submission type: community curation
- Created by `Yan-Zero` — https://github.com/Yan-Zero
- Original source repository: https://github.com/Yan-Zero/dsh-remote-ssh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.