### PR TITLE
catalog: add yangbobo2021-relay-dsh-plugin-claude (community curation, created by @yangbobo2021)

### DIFF
--- a/catalog/plugins/yangbobo2021-relay-dsh-plugin-claude.yaml
+++ b/catalog/plugins/yangbobo2021-relay-dsh-plugin-claude.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: yangbobo2021-relay-dsh-plugin-claude
+name: relay-dsh-plugin-claude
+description:
+  en: Claude Code integration plugin for DeepSeek Harness, providing native Claude conversations powered by the Claude Agent SDK, with model selection, approvals, questions, tools, and session continuation.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+source:
+  repository: https://github.com/yangbobo2021/relay-dsh-plugin-claude
+  repositoryNodeId: R_kgDOUBSjlQ
+  subpath: null
+  commit: dc209eb82966933b0895f37d86e1ab82a3d2f77e
+creator:
+  github: yangbobo2021
+package:
+  ecosystem: npm
+  name: relay-dsh-plugin-claude
+  version: 0.1.5
+  integrity: sha512-U70gcl9+qTe17xvF4zk6RilgOezqyWKWysk+imTB7fjJiws3957w3gDQzuLqXUzuTN+XVcuvUeSMQXVI20jvrg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:23.140Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yangbobo2021/relay-dsh-plugin-claude/dc209eb82966933b0895f37d86e1ab82a3d2f77e/docs/images/dsh-new-session-backends.jpg
+    alt: Codex and Claude Code in the DSH New Session mode menu


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangbobo2021-relay-dsh-plugin-claude`
- Submission type: community curation
- Created by `yangbobo2021` — https://github.com/yangbobo2021
- Original source repository: https://github.com/yangbobo2021/relay-dsh-plugin-claude
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.