### PR TITLE
catalog: add yangbobo2021-relay-dsh-plugin-codex (community curation, created by @yangbobo2021)

### DIFF
--- a/catalog/plugins/yangbobo2021-relay-dsh-plugin-codex.yaml
+++ b/catalog/plugins/yangbobo2021-relay-dsh-plugin-codex.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yangbobo2021-relay-dsh-plugin-codex
+name: relay-dsh-plugin-codex
+description:
+  en: Codex conversation backend for DeepSeek Harness, powered by the Codex App Server with approvals and DSH tool support.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+source:
+  repository: https://github.com/yangbobo2021/relay-dsh-plugin-codex
+  repositoryNodeId: R_kgDOUBSg_w
+  subpath: null
+  commit: cac79ddc271264e83604f2d3828b8d2f5c55261d
+creator:
+  github: yangbobo2021
+package:
+  ecosystem: npm
+  name: relay-dsh-plugin-codex
+  version: 0.1.4
+  integrity: sha512-F7Hklrx/plGy9rI/9lc2DAfylTDASeDdYjLjhlWgNruSxHkfCDQSI7QN+bZegUwPnlFVdquaXyObP9J2iZ8Odw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:23.240Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yangbobo2021/relay-dsh-plugin-codex/cac79ddc271264e83604f2d3828b8d2f5c55261d/docs/images/dsh-new-session-backends.jpg
+    alt: Codex and Claude Code in the DSH New Session mode menu


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangbobo2021-relay-dsh-plugin-codex`
- Submission type: community curation
- Created by `yangbobo2021` — https://github.com/yangbobo2021
- Original source repository: https://github.com/yangbobo2021/relay-dsh-plugin-codex
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.