### PR TITLE
catalog: add yangbobo2021-relay-dsh-plugin-manager (community curation, created by @yangbobo2021)

### DIFF
--- a/catalog/plugins/yangbobo2021-relay-dsh-plugin-manager.yaml
+++ b/catalog/plugins/yangbobo2021-relay-dsh-plugin-manager.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: yangbobo2021-relay-dsh-plugin-manager
+name: relay-dsh-plugin-manager
+description:
+  en: Conversation-first plugin discovery and lifecycle management for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-manager
+  - ai-agent
+source:
+  repository: https://github.com/yangbobo2021/relay-dsh-plugin-manager
+  repositoryNodeId: R_kgDOUEvW2g
+  subpath: null
+  commit: 2115aa26734ec4cf0b6a2fe5c4b65fbff857812e
+creator:
+  github: yangbobo2021
+package:
+  ecosystem: npm
+  name: relay-dsh-plugin-manager
+  version: 0.1.0-rc.4
+  integrity: sha512-3c7puTHvaaWw6NrSq21zZejpBSO5niQvg7Esa/F9+8HnOK40yR4fays6bmLe02NIODqtz+tXBxtKJXZOKE2Lyw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:35.492Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangbobo2021-relay-dsh-plugin-manager`
- Submission type: community curation
- Created by `yangbobo2021` — https://github.com/yangbobo2021
- Original source repository: https://github.com/yangbobo2021/relay-dsh-plugin-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.