### PR TITLE
catalog: add yangdongzhen590-dsh-knj-menu (community curation, created by @yangdongzhen590)

### DIFF
--- a/catalog/plugins/yangdongzhen590-dsh-knj-menu.yaml
+++ b/catalog/plugins/yangdongzhen590-dsh-knj-menu.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yangdongzhen590-dsh-knj-menu
+name: dsh-knj-menu
+description:
+  en: sh dsh plugin --profile web add dsh-knj-menu
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - profile
+  - menu
+  - dsh
+source:
+  repository: https://github.com/yangdongzhen590/dsh-knj-menu
+  repositoryNodeId: R_kgDOUByW5A
+  subpath: null
+  commit: f7380be2e15bf25f9cdc26fd5b58a4870b28bb7b
+creator:
+  github: yangdongzhen590
+package:
+  ecosystem: npm
+  name: dsh-knj-menu
+  version: 2026.8.251
+  integrity: sha512-4/XsrRYhPZaBVqVDSBs8Piw/8zDYUK8jogKo31PqP/kvdVdkEfOi4uyudgks/kbYeG2jSp7z2TbVXl40GoQvrw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:35.664Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangdongzhen590-dsh-knj-menu`
- Submission type: community curation
- Created by `yangdongzhen590` — https://github.com/yangdongzhen590
- Original source repository: https://github.com/yangdongzhen590/dsh-knj-menu
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.