### PR TITLE
catalog: add yangdongzhen590-dsh-scheduler (community curation, created by @yangdongzhen590)

### DIFF
--- a/catalog/plugins/yangdongzhen590-dsh-scheduler.yaml
+++ b/catalog/plugins/yangdongzhen590-dsh-scheduler.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: yangdongzhen590-dsh-scheduler
+name: dsh-scheduler
+description:
+  en: sh dsh plugin --profile web add dsh-scheduler
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - scheduler
+  - cron
+  - scheduled-tasks
+source:
+  repository: https://github.com/yangdongzhen590/dsh-knj-scheduler
+  repositoryNodeId: R_kgDOUByXNA
+  subpath: null
+  commit: b31519900290fa5cd74b1ed6a671df82f9add5d7
+creator:
+  github: yangdongzhen590
+package:
+  ecosystem: npm
+  name: dsh-scheduler
+  version: 2026.8.251
+  integrity: sha512-asSCTK8YjQaC+hVoW+QO1QDza6eQCjWGVF8Qdbw1/Rlp0IWO70DjviggkQWBpCbPjAE4ceNhbrmj95rGd1TFBA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:23.281Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangdongzhen590-dsh-scheduler`
- Submission type: community curation
- Created by `yangdongzhen590` — https://github.com/yangdongzhen590
- Original source repository: https://github.com/yangdongzhen590/dsh-knj-scheduler
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.