### PR TITLE
catalog: add yanglingrise-dsh-erii-boot-splash (community curation, created by @yanglingrise)

### DIFF
--- a/catalog/plugins/yanglingrise-dsh-erii-boot-splash.yaml
+++ b/catalog/plugins/yanglingrise-dsh-erii-boot-splash.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yanglingrise-dsh-erii-boot-splash
+name: dsh-erii-boot-splash
+description:
+  en: 'Erii (Sakura) themed boot splash animation for the DeepSeek Harness Web UI: falling sakura petals, a mint monster mascot with a cherry blossom on its head, a soft pink progress bar, and the line "Sakura, walk slower." Auto fades out after ~3 seconds; pure client-side, zero dependencies.'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - splash
+  - loading-screen
+  - animation
+  - sakura
+  - erii
+  - web-ui
+  - cordis
+source:
+  repository: https://github.com/yanglingrise/dsh-erii-boot-splash
+  repositoryNodeId: R_kgDOUAOujQ
+  subpath: null
+  commit: 406f106b8294e80ddde95e24561f088fbfe843c0
+creator:
+  github: yanglingrise
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:35.762Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yanglingrise-dsh-erii-boot-splash`
- Submission type: community curation
- Created by `yanglingrise` — https://github.com/yanglingrise
- Original source repository: https://github.com/yanglingrise/dsh-erii-boot-splash
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.