### PR TITLE
catalog: add yuunnn-dsh-on-imessage (community curation, created by @yuunnn)

### DIFF
--- a/catalog/plugins/yuunnn-dsh-on-imessage.yaml
+++ b/catalog/plugins/yuunnn-dsh-on-imessage.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yuunnn-dsh-on-imessage
+name: dsh-on-imessage
+description:
+  en: Chat with local DeepSeek Harness (dsh) agents from iPhone iMessage — no extra apps, no servers, no cloud.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - imessage
+  - bridge
+  - macos
+source:
+  repository: https://github.com/yuunnn/dsh-on-imessage
+  repositoryNodeId: R_kgDOT9Zfyw
+  subpath: null
+  commit: 81b99763bf17f6b88a827e173353c487247cb6d9
+creator:
+  github: yuunnn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T10:47:18.613Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yuunnn-dsh-on-imessage`
- Submission type: community curation
- Created by `yuunnn` — https://github.com/yuunnn
- Original source repository: https://github.com/yuunnn/dsh-on-imessage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.