### PR TITLE
catalog: add dsh-admin-dsh-drop-any-file (community curation, created by @DSH-Admin)

### DIFF
--- a/catalog/plugins/dsh-admin-dsh-drop-any-file.yaml
+++ b/catalog/plugins/dsh-admin-dsh-drop-any-file.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: dsh-admin-dsh-drop-any-file
+name: dsh-drop-any-file
+description:
+  en: "Extend the DeepSeek Harness (DSH) web chat drag-and-drop to accept every file type: dropping any file in the composer saves it into the current session's workspace so the agent can read and use it."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - drag-drop
+  - file-upload
+  - workspace
+  - attachment
+source:
+  repository: https://github.com/Zenjibad/dsh-drop-any-file
+  repositoryNodeId: R_kgDOT8aZcQ
+  subpath: null
+  commit: a7bfde698e0d8495616c9f0eed750e3cec601408
+creator:
+  github: DSH-Admin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:07.360Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-admin-dsh-drop-any-file`
- Submission type: community curation
- Created by `DSH-Admin` — https://github.com/DSH-Admin
- Original source repository: https://github.com/Zenjibad/dsh-drop-any-file
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.