### PR TITLE
catalog: add dsh-admin-dsh-mcp-toggle (community curation, created by @DSH-Admin)

### DIFF
--- a/catalog/plugins/dsh-admin-dsh-mcp-toggle.yaml
+++ b/catalog/plugins/dsh-admin-dsh-mcp-toggle.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dsh-admin-dsh-mcp-toggle
+name: dsh-mcp-toggle
+description:
+  en: "Enable/disable MCP servers directly from DSH Settings: a 'MCP Servers' page that stops/starts @deepseek-ai/dsh-mcp-client connections live and persists the change across restarts."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - mcp
+  - mcp-client
+  - settings
+  - enable
+  - disable
+  - toggle
+source:
+  repository: https://github.com/Zenjibad/dsh-mcp-toggle
+  repositoryNodeId: R_kgDOT8x2xA
+  subpath: null
+  commit: e9a7ed6a0adceb039f6ea0540af117130c9fa6c4
+creator:
+  github: DSH-Admin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:01.382Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-admin-dsh-mcp-toggle`
- Submission type: community curation
- Created by `DSH-Admin` — https://github.com/DSH-Admin
- Original source repository: https://github.com/Zenjibad/dsh-mcp-toggle
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.