### PR TITLE
catalog: add dsh-admin-llmtrim-stats-plugin (community curation, created by @DSH-Admin)

### DIFF
--- a/catalog/plugins/dsh-admin-llmtrim-stats-plugin.yaml
+++ b/catalog/plugins/dsh-admin-llmtrim-stats-plugin.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dsh-admin-llmtrim-stats-plugin
+name: llmtrim-stats-plugin
+description:
+  en: "Live llmtrim savings dashboard inside the DeepSeek Harness (DSH) Web UI: a settings dashboard plus a rotating carousel stats strip under the composer."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - llmtrim
+  - compression
+  - tokens
+  - savings
+  - stats
+  - dashboard
+source:
+  repository: https://github.com/Zenjibad/llmtrim-stats-plugin
+  repositoryNodeId: R_kgDOT9YWoA
+  subpath: null
+  commit: f9aa5e69f26d4c675d0dda8ae051faba67bd0cfa
+creator:
+  github: DSH-Admin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:55.501Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dsh-admin-llmtrim-stats-plugin`
- Submission type: community curation
- Created by `DSH-Admin` — https://github.com/DSH-Admin
- Original source repository: https://github.com/Zenjibad/llmtrim-stats-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.