### PR TITLE
catalog: add hazhuchenglong-gmail-dsh-side-chat (community curation, created by @hazhuchenglong-gmail)

### DIFF
--- a/catalog/plugins/hazhuchenglong-gmail-dsh-side-chat.yaml
+++ b/catalog/plugins/hazhuchenglong-gmail-dsh-side-chat.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: hazhuchenglong-gmail-dsh-side-chat
+name: "@zhuchenglong/dsh-side-chat"
+description:
+  en: "DSH web plugin: Codex-style /side side conversations. Open a temporary fork of the current chat in a floating panel — ask side questions without interrupting the main task or polluting its context."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - side-chat
+  - codex
+source:
+  repository: https://github.com/zclDragon/dsh-side-chat
+  repositoryNodeId: R_kgDOUAxkug
+  subpath: null
+  commit: dc52bb74a7682a0921ad3c944e09f06107401847
+creator:
+  github: hazhuchenglong-gmail
+package:
+  ecosystem: npm
+  name: "@zhuchenglong/dsh-side-chat"
+  version: 0.0.9
+  integrity: sha512-2G3ydcNX8cWxiNRDf+TtktKDWH9oL+T9PfXJyT2MHnNNMW74AoEYn3eb9wJ0Lka0cNG15wpJ7d3pHuOJWvEwMw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:53.835Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hazhuchenglong-gmail-dsh-side-chat`
- Submission type: community curation
- Created by `hazhuchenglong-gmail` — https://github.com/hazhuchenglong-gmail
- Original source repository: https://github.com/zclDragon/dsh-side-chat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.