### PR TITLE
catalog: add kayshen-x-dsh-android (community curation, created by @Kayshen-X)

### DIFF
--- a/catalog/plugins/kayshen-x-dsh-android.yaml
+++ b/catalog/plugins/kayshen-x-dsh-android.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: kayshen-x-dsh-android
+name: "@zseven-w/dsh-android"
+description:
+  en: DeepSeek Harness plugin for Android — build, run, and interact with a live emulator or USB device stream inside a conversation, driven entirely through adb. Tested with DSH 0.1.1-rc.1.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - android
+  - adb
+  - emulator
+source:
+  repository: https://github.com/ZSeven-W/dsh-android
+  repositoryNodeId: R_kgDOT_pUeQ
+  subpath: null
+  commit: 8c1d19a0019f2fbf65265ac8a09225d0b2fdf8c4
+creator:
+  github: Kayshen-X
+package:
+  ecosystem: npm
+  name: "@zseven-w/dsh-android"
+  version: 0.1.0-rc.4
+  integrity: sha512-qPXnh22oTRgSkEsx5OuDG5yHATDnAXuka5djY9254ST6jF2VymL4lHEAmHtJv6XbderOSI0J0UrI9q38mGvIiw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:45.273Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 126
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ZSeven-W/dsh-android/8c1d19a0019f2fbf65265ac8a09225d0b2fdf8c4/docs/images/dsh-android-logo.png
+    alt: DSH Android
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ZSeven-W/dsh-android/8c1d19a0019f2fbf65265ac8a09225d0b2fdf8c4/docs/images/dsh-android-overview.png
+    alt: DSH Android — a live Android device inside the conversation


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kayshen-x-dsh-android`
- Submission type: community curation
- Created by `Kayshen-X` — https://github.com/Kayshen-X
- Original source repository: https://github.com/ZSeven-W/dsh-android
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.