### PR TITLE
catalog: add yuyolin-dsh-decision-log (community curation, created by @yuyolin)

### DIFF
--- a/catalog/plugins/yuyolin-dsh-decision-log.yaml
+++ b/catalog/plugins/yuyolin-dsh-decision-log.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: yuyolin-dsh-decision-log
+name: dsh-decision-log
+description:
+  en: Auto-capture key decisions from dsh sessions into a versionable DECISIONS.md and inject them into future sessions
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - decision
+  - decision-log
+  - adr
+  - documentation
+source:
+  repository: https://github.com/yuyolin/dsh-decision-log
+  repositoryNodeId: R_kgDOUCcYjw
+  subpath: null
+  commit: cb81668adfe1065c9f3a43160e8b9c0708757665
+creator:
+  github: yuyolin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:53.233Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yuyolin-dsh-decision-log`
- Submission type: community curation
- Created by `yuyolin` — https://github.com/yuyolin
- Original source repository: https://github.com/yuyolin/dsh-decision-log
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.