### PR TITLE
catalog: add yv3507-dsh-webui-launcher (community curation, created by @YV3507)

### DIFF
--- a/catalog/plugins/yv3507-dsh-webui-launcher.yaml
+++ b/catalog/plugins/yv3507-dsh-webui-launcher.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yv3507-dsh-webui-launcher
+name: dsh-webui-launcher
+description:
+  en: "Cross-platform Web UI launcher plugin for DeepSeek Harness: webui start/stop/status/open model tools, a /webui slash command and a Settings-page launch card."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - launcher
+  - web-ui
+source:
+  repository: https://github.com/YV3507/dsh-webui-launcher
+  repositoryNodeId: R_kgDOT5CKUw
+  subpath: null
+  commit: 6af762132027ce94c84d0c052ba3eeee4a27a1ac
+creator:
+  github: YV3507
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:52.211Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yv3507-dsh-webui-launcher`
- Submission type: community curation
- Created by `YV3507` — https://github.com/YV3507
- Original source repository: https://github.com/YV3507/dsh-webui-launcher
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.