### PR TITLE
catalog: add yvesgao-dsh-env-profile (community curation, created by @Yvesgao)

### DIFF
--- a/catalog/plugins/yvesgao-dsh-env-profile.yaml
+++ b/catalog/plugins/yvesgao-dsh-env-profile.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: yvesgao-dsh-env-profile
+name: dsh-env-profile
+description:
+  en: dsh plugin --profile web add "E:\My Documents\DskHarness-PC\dsh-env-profile"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - memory
+  - environment
+  - experience
+  - token-saving
+source:
+  repository: https://github.com/Yvesgao/dsh-env-profile
+  repositoryNodeId: R_kgDOT6Cg7A
+  subpath: null
+  commit: a3b589208906e97701b1fa111d5080bb8e1463d3
+creator:
+  github: Yvesgao
+package:
+  ecosystem: npm
+  name: dsh-env-profile
+  version: 0.1.3
+  integrity: sha512-bGQENc9wYDbKBNPHPIAyjTE6NCcgG3c0QCwLD2RLzsDphAki5IfylYtu/zMN0GjMXRS39M7hA1xNh+PESORFZA==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:01.213Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yvesgao-dsh-env-profile`
- Submission type: community curation
- Created by `Yvesgao` — https://github.com/Yvesgao
- Original source repository: https://github.com/Yvesgao/dsh-env-profile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.