### PR TITLE
catalog: add ywleeo-dsh-browser-mcp (community curation, created by @ywleeo)

### DIFF
--- a/catalog/plugins/ywleeo-dsh-browser-mcp.yaml
+++ b/catalog/plugins/ywleeo-dsh-browser-mcp.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: ywleeo-dsh-browser-mcp
+name: "@ywleeo/dsh-browser-mcp"
+description:
+  en: "dsh bundle: register ywleeo/browser-mcp (a local MCP server driving a real Chrome to search, capture, and automate any logged-in site) as native dsh MCP tools (mcp browser )."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - bundle
+  - register
+  - ywleeo
+  - browser
+  - local
+  - server
+  - driving
+  - real
+  - chrome
+  - search
+  - capture
+  - automate
+  - logged
+  - site
+  - native
+  - tools
+source:
+  repository: https://github.com/ywleeo/browser-mcp
+  repositoryNodeId: R_kgDOT2P_NQ
+  subpath: null
+  commit: 9ff03f9aa889bf0f11fb275bd45a1c6b975ef987
+creator:
+  github: ywleeo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:46.823Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ywleeo-dsh-browser-mcp`
- Submission type: community curation
- Created by `ywleeo` — https://github.com/ywleeo
- Original source repository: https://github.com/ywleeo/browser-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.