### PR TITLE
catalog: add yxqfg-phone-lens (community curation, created by @yxqfg)

### DIFF
--- a/catalog/plugins/yxqfg-phone-lens.yaml
+++ b/catalog/plugins/yxqfg-phone-lens.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: yxqfg-phone-lens
+name: phone-lens
+description:
+  en: "Phone camera → dsh session: pairing, MJPEG viewfinder, upload-to-attachment pipeline"
+  evidencePath: packages/phone-lens/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - phone
+  - camera
+  - session
+  - pairing
+  - mjpeg
+  - viewfinder
+  - upload
+  - attachment
+  - pipeline
+  - dsh
+source:
+  repository: https://github.com/yxqfg/phone-lens
+  repositoryNodeId: R_kgDOUA0Kvg
+  subpath: packages/phone-lens
+  commit: 1bc5f5f7fad29ac3c2351188b085b4b82aee81f5
+creator:
+  github: yxqfg
+package:
+  ecosystem: npm
+  name: phone-lens
+  version: 0.3.1
+  integrity: sha512-kotyhpAKM4zfHMSv4sqsvmf7SVPYxy46lKMs7JhCr+rmh5KIyUQB09vOP3snTr3R2qDsi5UH1yFtYtXLcwCoLg==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/phone-lens/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:06.077Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yxqfg-phone-lens`
- Submission type: community curation
- Created by `yxqfg` — https://github.com/yxqfg
- Original source repository: https://github.com/yxqfg/phone-lens
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.