### PR TITLE
catalog: add yxy050208-multisim-mcp-dsh-plugin (community curation, created by @yxy050208)

### DIFF
--- a/catalog/plugins/yxy050208-multisim-mcp-dsh-plugin.yaml
+++ b/catalog/plugins/yxy050208-multisim-mcp-dsh-plugin.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: yxy050208-multisim-mcp-dsh-plugin
+name: multisim-mcp-dsh-plugin
+description:
+  en: DeepSeek Harness plugin for NI Multisim circuit generation, simulation, optimization, and lab reports via MCP
+  evidencePath: integrations/deepseek-harness/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - mcp
+  - multisim
+  - ni-multisim
+  - circuit-simulation
+  - electronics
+  - eda
+  - dsh
+source:
+  repository: https://github.com/yxy050208/multisim-mcp
+  repositoryNodeId: R_kgDOTyZ-dQ
+  subpath: integrations/deepseek-harness
+  commit: dc037c853f5e9dae416d39967c26e57f3ddb9ae8
+creator:
+  github: yxy050208
+package:
+  ecosystem: npm
+  name: multisim-mcp-dsh-plugin
+  version: 1.1.0
+  integrity: sha512-tdZ2d3tw5lxe7Dg5aCTEZekw8tIb0jqk3d8j8o39BylKrEs+aPOiuXka1mNT4pYVLLdkzAZ6gEiRUHzf0pMEqQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: integrations/deepseek-harness/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:06.747Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yxy050208-multisim-mcp-dsh-plugin`
- Submission type: community curation
- Created by `yxy050208` — https://github.com/yxy050208
- Original source repository: https://github.com/yxy050208/multisim-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.