### PR TITLE
catalog: add yytbit-dsh-plugin-cost-tracker (community curation, created by @YYTbit)

### DIFF
--- a/catalog/plugins/yytbit-dsh-plugin-cost-tracker.yaml
+++ b/catalog/plugins/yytbit-dsh-plugin-cost-tracker.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yytbit-dsh-plugin-cost-tracker
+name: dsh-plugin-cost-tracker
+description:
+  en: Token cost tracker for DeepSeek Harness -- track usage, calculate costs, budget warnings
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cost
+  - tokens
+  - pricing
+  - budget
+  - dsh
+source:
+  repository: https://github.com/YYTbit/dsh-plugin-cost-tracker
+  repositoryNodeId: R_kgDOT3g4PA
+  subpath: null
+  commit: 4e861a1ac0304ab027f903e195bff7107e3022a7
+creator:
+  github: YYTbit
+package:
+  ecosystem: npm
+  name: dsh-plugin-cost-tracker
+  version: 0.1.0
+  integrity: sha512-Kc6UiDM7tNUtRCcBRweMscOvFM/gBG0cGP5OheS2p0AfvD13UyopR8t42N/MgH5GMFafKRhqE4dpcMyPaCRJsg==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:48.466Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yytbit-dsh-plugin-cost-tracker`
- Submission type: community curation
- Created by `YYTbit` — https://github.com/YYTbit
- Original source repository: https://github.com/YYTbit/dsh-plugin-cost-tracker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.