### PR TITLE
catalog: add yyyq0325-ai-dsh-webgate (community curation, created by @yyyq0325-ai)

### DIFF
--- a/catalog/plugins/yyyq0325-ai-dsh-webgate.yaml
+++ b/catalog/plugins/yyyq0325-ai-dsh-webgate.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: yyyq0325-ai-dsh-webgate
+name: "@yyyq0325/dsh-webgate"
+description:
+  en: "Login gate for the DeepSeek Harness web GUI: username/password entry page (DeepSeek style), 12-hour session tokens, slash commands for user management. Background tasks keep running while logged out."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - auth
+  - login
+  - webgate
+source:
+  repository: https://github.com/yyyq0325-ai/dsh-webgate
+  repositoryNodeId: R_kgDOUBAj3Q
+  subpath: null
+  commit: 402a10a33e96793bdddb66e00987731f674c93e9
+creator:
+  github: yyyq0325-ai
+package:
+  ecosystem: npm
+  name: "@yyyq0325/dsh-webgate"
+  version: 0.2.2
+  integrity: sha512-F63nPPQpdow3mWAYZjqOWnblS4BQjLV+teipI4ndTB3F71RhvamqCeMoHdt5tw47OfJdL7p/zZkJfM190yaCMQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:01.327Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yyyq0325-ai/dsh-webgate/402a10a33e96793bdddb66e00987731f674c93e9/docs/login-preview.png
+    alt: login


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yyyq0325-ai-dsh-webgate`
- Submission type: community curation
- Created by `yyyq0325-ai` — https://github.com/yyyq0325-ai
- Original source repository: https://github.com/yyyq0325-ai/dsh-webgate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.