### PR TITLE
catalog: add yzke-dsh-icon-theme (community curation, created by @yzke)

### DIFF
--- a/catalog/plugins/yzke-dsh-icon-theme.yaml
+++ b/catalog/plugins/yzke-dsh-icon-theme.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: yzke-dsh-icon-theme
+name: dsh-icon-theme
+description:
+  en: Auto-detected, user-customizable icons for DeepSeek Harness settings and sidebar surfaces.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - icons
+  - theme
+source:
+  repository: https://github.com/yzke/dsh-icon-theme
+  repositoryNodeId: R_kgDOT6bAww
+  subpath: null
+  commit: cf5d18f738900467c72b0247df18aa5cb76c3d69
+creator:
+  github: yzke
+package:
+  ecosystem: npm
+  name: dsh-icon-theme
+  version: 0.2.2
+  integrity: sha512-LwFCOWKPY/Wx9q3pF57822pSVjaQvTpLJgwnOy7kyofuaN0HWSD/t6Hq1yMd7mo5tbyx/ktUUEmYhY33JgQryg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:48.564Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yzke/dsh-icon-theme/cf5d18f738900467c72b0247df18aa5cb76c3d69/docs/images/settings-overview.png
+    alt: Settings overview
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yzke/dsh-icon-theme/cf5d18f738900467c72b0247df18aa5cb76c3d69/docs/images/icon-picker.png
+    alt: Icon picker


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yzke-dsh-icon-theme`
- Submission type: community curation
- Created by `yzke` — https://github.com/yzke
- Original source repository: https://github.com/yzke/dsh-icon-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.