### PR TITLE
catalog: add yzz-s-dsh-billing-balance (community curation, created by @YZz-S)

### DIFF
--- a/catalog/plugins/yzz-s-dsh-billing-balance.yaml
+++ b/catalog/plugins/yzz-s-dsh-billing-balance.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: yzz-s-dsh-billing-balance
+name: dsh-billing-balance
+description:
+  en: "- DeepSeek balance : total / top-up / gift balance and account availability ( GET https://api.deepseek.com/user/balance ). - Volcengine Ark Coding Plan : used percentage, progress bar and countdown to reset (ticking every second) for the session (5-hour) / weekly / monthly windows; if you also subscribe to Agent Plan ("
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - balance
+  - billing
+  - volcengine
+  - coding-plan
+source:
+  repository: https://github.com/YZz-S/dsh-billing-balance
+  repositoryNodeId: R_kgDOT49DNQ
+  subpath: null
+  commit: 0550c7c76924c56c89f4a8e1756ee680bd4140e0
+creator:
+  github: YZz-S
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:48.155Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yzz-s-dsh-billing-balance`
- Submission type: community curation
- Created by `YZz-S` — https://github.com/YZz-S
- Original source repository: https://github.com/YZz-S/dsh-billing-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.