### PR TITLE
catalog: add yzz-s-dsh-plugin-bili-summary (community curation, created by @YZz-S)

### DIFF
--- a/catalog/plugins/yzz-s-dsh-plugin-bili-summary.yaml
+++ b/catalog/plugins/yzz-s-dsh-plugin-bili-summary.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yzz-s-dsh-plugin-bili-summary
+name: dsh-plugin-bili-summary
+description:
+  en: "DeepSeek Harness Host plugin: bili summary tool — Bilibili video metadata, subtitle timeline and sharp-based frame cutting"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - bilibili
+  - video-summary
+  - subtitle
+  - tool
+  - sharp
+source:
+  repository: https://github.com/YZz-S/dsh-bili-summary
+  repositoryNodeId: R_kgDOT4-OIw
+  subpath: null
+  commit: 81b7a0e2991e311b74de22b5414dcdbdac5648aa
+creator:
+  github: YZz-S
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:53.554Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yzz-s-dsh-plugin-bili-summary`
- Submission type: community curation
- Created by `YZz-S` — https://github.com/YZz-S
- Original source repository: https://github.com/YZz-S/dsh-bili-summary
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.