### PR TITLE
catalog: add yzz-s-dsh-token-cost-meter (community curation, created by @YZz-S)

### DIFF
--- a/catalog/plugins/yzz-s-dsh-token-cost-meter.yaml
+++ b/catalog/plugins/yzz-s-dsh-token-cost-meter.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: yzz-s-dsh-token-cost-meter
+name: dsh-token-cost-meter
+description:
+  en: "Supports two forms: an installable dsh.bundle package (recommended, persists across DSH restarts) and the dynamic cordis define usage (temporary run)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - token
+  - pricing
+  - cost
+source:
+  repository: https://github.com/YZz-S/dsh-token-cost-meter
+  repositoryNodeId: R_kgDOT484Lw
+  subpath: null
+  commit: c36087118c8df000ec721ea4f2553aca480b50e2
+creator:
+  github: YZz-S
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:49.984Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yzz-s-dsh-token-cost-meter`
- Submission type: community curation
- Created by `YZz-S` — https://github.com/YZz-S
- Original source repository: https://github.com/YZz-S/dsh-token-cost-meter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.