### PR TITLE
catalog: add yzz-s-workspace-files-explorer (community curation, created by @YZz-S)

### DIFF
--- a/catalog/plugins/yzz-s-workspace-files-explorer.yaml
+++ b/catalog/plugins/yzz-s-workspace-files-explorer.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: yzz-s-workspace-files-explorer
+name: workspace-files-explorer
+description:
+  en: "- Floating file panel : registered on shell.overlay , additive registration — replaces no built-in UI; docks at the top right by default - File tree : lazy-loaded expansion, directories first, hidden files (dot-prefixed) dimmed, file sizes shown, truncation notice at 500 items per directory, one-click refresh - Code pr"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - file-explorer
+  - markdown-preview
+  - code-preview
+  - syntax-highlighting
+source:
+  repository: https://github.com/YZz-S/dsh-workspace-files-explorer
+  repositoryNodeId: R_kgDOT49Odw
+  subpath: null
+  commit: 5e2fb92f3226fab47f7cb87d66ddb440ae215706
+creator:
+  github: YZz-S
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:53.658Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yzz-s-workspace-files-explorer`
- Submission type: community curation
- Created by `YZz-S` — https://github.com/YZz-S
- Original source repository: https://github.com/YZz-S/dsh-workspace-files-explorer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.