### PR TITLE
catalog: add zaiwenj-dsh-cdp-browser (community curation, created by @zaiwenJ)

### DIFF
--- a/catalog/plugins/zaiwenj-dsh-cdp-browser.yaml
+++ b/catalog/plugins/zaiwenj-dsh-cdp-browser.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zaiwenj-dsh-cdp-browser
+name: dsh-cdp-browser
+description:
+  en: "Zero-spawn browser automation + pixel-level visual verification as a DeepSeek Harness plugin. Drives an already-running Chrome/Edge over CDP using Node built-ins only: global fetch + global WebSocket (Node ≥ 22) + zlib PNG decode. No child process , no npm dependencies, no per-use approval."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cdp
+  - browser
+  - screenshot
+  - visual-testing
+  - pixel-assertion
+  - chrome
+  - edge
+source:
+  repository: https://github.com/zaiwenJ/dsh-cdp-browser
+  repositoryNodeId: R_kgDOT5z1wA
+  subpath: null
+  commit: caecd3bded2ea29fd6258ef7e667f14d0c8444eb
+creator:
+  github: zaiwenJ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:01.365Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zaiwenj-dsh-cdp-browser`
- Submission type: community curation
- Created by `zaiwenJ` — https://github.com/zaiwenJ
- Original source repository: https://github.com/zaiwenJ/dsh-cdp-browser
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.