### PR TITLE
catalog: add zasenjc-dsh-plugins-store (community curation, created by @ZASENJC)

### DIFF
--- a/catalog/plugins/zasenjc-dsh-plugins-store.yaml
+++ b/catalog/plugins/zasenjc-dsh-plugins-store.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zasenjc-dsh-plugins-store
+name: dsh-plugins-store
+description:
+  en: Native DSH browser integration for the DSH Plugin Store
+  evidencePath: packages/dsh-plugins-store/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - plugin-store
+  - marketplace
+  - web-ui
+source:
+  repository: https://github.com/ZASENJC/dsh-plugins-store
+  repositoryNodeId: R_kgDOT3zODg
+  subpath: packages/dsh-plugins-store
+  commit: d785835a8a622c36abefaae2af122230a8366a3d
+creator:
+  github: ZASENJC
+package:
+  ecosystem: npm
+  name: dsh-plugins-store
+  version: 0.1.3
+  integrity: sha512-hq7wNHv6BaLqPt0EdHriMrDPCAIQuovFcZRG4nyruvQTa3zsn4QLSL3u2s7jZX4dugtz53VtMrWD4BfnABw4jw==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-plugins-store/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:06.866Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zasenjc-dsh-plugins-store`
- Submission type: community curation
- Created by `ZASENJC` — https://github.com/ZASENJC
- Original source repository: https://github.com/ZASENJC/dsh-plugins-store
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.