### PR TITLE
catalog: add zc277584121-dsh-milvus (community curation, created by @zc277584121)

### DIFF
--- a/catalog/plugins/zc277584121-dsh-milvus.yaml
+++ b/catalog/plugins/zc277584121-dsh-milvus.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zc277584121-dsh-milvus
+name: "@zilliz/dsh-milvus"
+description:
+  en: Milvus for DSH — a read-only dsh Web plugin for Agent and RAG developers
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - milvus
+  - read
+  - only
+  - agent
+  - developers
+  - dsh
+source:
+  repository: https://github.com/zilliztech/dsh-milvus
+  repositoryNodeId: R_kgDOT8PVhA
+  subpath: null
+  commit: 604b041bab952a57c713974f85c97bf4dc1c9386
+creator:
+  github: zc277584121
+package:
+  ecosystem: npm
+  name: "@zilliz/dsh-milvus"
+  version: 0.1.3
+  integrity: sha512-n7yDL0kNqhQ0CgFocSFFGxoXH3BgtXQx52I+rW0A8E/Cq+MuQO8lnP+xALb90ADfv+/02VjmcRZ/Z0DKssMOog==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:48.467Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zc277584121-dsh-milvus`
- Submission type: community curation
- Created by `zc277584121` — https://github.com/zc277584121
- Original source repository: https://github.com/zilliztech/dsh-milvus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.