### PR TITLE
catalog: add zchenw-dsh-codex-switch (community curation, created by @ZChenW)

### DIFF
--- a/catalog/plugins/zchenw-dsh-codex-switch.yaml
+++ b/catalog/plugins/zchenw-dsh-codex-switch.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zchenw-dsh-codex-switch
+name: dsh-codex-switch
+description:
+  en: ChatGPT OAuth and Codex models for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - openai-codex
+  - chatgpt-oauth
+  - oauth
+  - codex
+  - dsh
+source:
+  repository: https://github.com/ZChenW/dsh-codex-switch
+  repositoryNodeId: R_kgDOT9NlXQ
+  subpath: null
+  commit: 7cde17417e3b2a194eb033b3e419d50ddff17190
+creator:
+  github: ZChenW
+package:
+  ecosystem: npm
+  name: dsh-codex-switch
+  version: 0.1.0-alpha.8
+  integrity: sha512-2Ygufo77hdDVeN6+xFke2ds6PfLRCxm0+floq3jjXG/UegoSkPVjShRf5BiCYKYzPhrjav/c0jvS8+SrNVKE9g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:54.133Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zchenw-dsh-codex-switch`
- Submission type: community curation
- Created by `ZChenW` — https://github.com/ZChenW
- Original source repository: https://github.com/ZChenW/dsh-codex-switch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.