### PR TITLE
catalog: add zenjibad-deepseek-cost-usage-status-plugin (community curation, created by @Zenjibad)

### DIFF
--- a/catalog/plugins/zenjibad-deepseek-cost-usage-status-plugin.yaml
+++ b/catalog/plugins/zenjibad-deepseek-cost-usage-status-plugin.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: zenjibad-deepseek-cost-usage-status-plugin
+name: deepseek-cost-usage-status-plugin
+description:
+  en: A packaged Cordis plugin for DeepSeek Harness (DSH) that adds a second, colored status line under the shipped conversation stats line, showing live DeepSeek API cost, usage, and account balance .
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - deepseek-api
+  - cost
+  - usage
+  - tokens
+  - balance
+  - stats
+  - pricing
+  - ai-agent
+source:
+  repository: https://github.com/Zenjibad/deepseek-cost-usage-status-plugin
+  repositoryNodeId: R_kgDOT5qjYQ
+  subpath: null
+  commit: 4d3de23b82a4412a32d933fec06ffc570e50b77f
+creator:
+  github: Zenjibad
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:55.152Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zenjibad-deepseek-cost-usage-status-plugin`
- Submission type: community curation
- Created by `Zenjibad` — https://github.com/Zenjibad
- Original source repository: https://github.com/Zenjibad/deepseek-cost-usage-status-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.