### PR TITLE
catalog: add zenjibad-dsh-any-attachment (community curation, created by @Zenjibad)

### DIFF
--- a/catalog/plugins/zenjibad-dsh-any-attachment.yaml
+++ b/catalog/plugins/zenjibad-dsh-any-attachment.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: zenjibad-dsh-any-attachment
+name: dsh-any-attachment
+description:
+  en: "dsh bundle: attach any file type in dsh web — text-likes inline, binaries as workspace path references, rasters via the built-in pipeline"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - bundle
+  - attach
+  - file
+  - type
+  - text
+  - likes
+  - inline
+  - binaries
+  - workspace
+  - path
+  - references
+  - rasters
+  - built
+  - pipeline
+  - dsh
+source:
+  repository: https://github.com/Zenjibad/dsh-any-attachment
+  repositoryNodeId: R_kgDOT4gXXg
+  subpath: null
+  commit: 290edabc213eb2802676a7d7bf6b8894492ddbc6
+creator:
+  github: Zenjibad
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:50.166Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zenjibad-dsh-any-attachment`
- Submission type: community curation
- Created by `Zenjibad` — https://github.com/Zenjibad
- Original source repository: https://github.com/Zenjibad/dsh-any-attachment
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.