### PR TITLE
catalog: add zephyr-vibe-dsh-personalize (community curation, created by @Zephyr-vibe)

### DIFF
--- a/catalog/plugins/zephyr-vibe-dsh-personalize.yaml
+++ b/catalog/plugins/zephyr-vibe-dsh-personalize.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: zephyr-vibe-dsh-personalize
+name: dsh-personalize
+description:
+  en: "DSH web plugin: per-host personalization — global custom instructions, local long-term memory (collect / retain / integrate / manage), and reply tone presets."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - host
+  - personalization
+  - global
+  - custom
+  - instructions
+  - local
+  - long
+  - term
+  - memory
+  - collect
+  - retain
+  - integrate
+  - manage
+  - reply
+  - tone
+  - presets
+source:
+  repository: https://github.com/Zephyr-vibe/dsh-personalize
+  repositoryNodeId: R_kgDOT4MoEg
+  subpath: null
+  commit: 96f5525c0b65819fdb12c88cf1a9309747095c1f
+creator:
+  github: Zephyr-vibe
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:46.922Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zephyr-vibe-dsh-personalize`
- Submission type: community curation
- Created by `Zephyr-vibe` — https://github.com/Zephyr-vibe
- Original source repository: https://github.com/Zephyr-vibe/dsh-personalize
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.