### PR TITLE
catalog: add zeshuochen-dsh-watch-video (community curation, created by @zeshuochen)

### DIFF
--- a/catalog/plugins/zeshuochen-dsh-watch-video.yaml
+++ b/catalog/plugins/zeshuochen-dsh-watch-video.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: zeshuochen-dsh-watch-video
+name: dsh-watch-video
+description:
+  en: Subtitle-first cross-platform video transcription for DeepSeek Harness using yt-dlp and faster-whisper large-v3.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - video
+  - transcription
+  - yt-dlp
+  - whisper
+  - dsh
+source:
+  repository: https://github.com/zeshuochen/dsh-watch-video
+  repositoryNodeId: R_kgDOUAC7iQ
+  subpath: null
+  commit: 30d2f17982256a063f4576c699808e0d0435d61f
+creator:
+  github: zeshuochen
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:02.284Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zeshuochen-dsh-watch-video`
- Submission type: community curation
- Created by `zeshuochen` — https://github.com/zeshuochen
- Original source repository: https://github.com/zeshuochen/dsh-watch-video
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.