### PR TITLE
catalog: add zfu691531-hash-dsh-codex-collab (community curation, created by @zfu691531-hash)

### DIFF
--- a/catalog/plugins/zfu691531-hash-dsh-codex-collab.yaml
+++ b/catalog/plugins/zfu691531-hash-dsh-codex-collab.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: zfu691531-hash-dsh-codex-collab
+name: dsh-codex-collab
+description:
+  en: Visible, bidirectional local collaboration between DeepSeek Harness and Codex Desktop.
+  evidencePath: plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - codex
+  - codex-desktop
+  - mcp
+source:
+  repository: https://github.com/zfu691531-hash/dsh-codex-collab
+  repositoryNodeId: R_kgDOT5P-Qg
+  subpath: plugin
+  commit: 1fc8b34f942ba7aad1616a137a1f7f7659884dc4
+creator:
+  github: zfu691531-hash
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:08.051Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zfu691531-hash-dsh-codex-collab`
- Submission type: community curation
- Created by `zfu691531-hash` — https://github.com/zfu691531-hash
- Original source repository: https://github.com/zfu691531-hash/dsh-codex-collab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.