### PR TITLE
catalog: add zhangbo-cn-dsh-client-ui-voice-input (community curation, created by @Zhangbo-cn)

### DIFF
--- a/catalog/plugins/zhangbo-cn-dsh-client-ui-voice-input.yaml
+++ b/catalog/plugins/zhangbo-cn-dsh-client-ui-voice-input.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: zhangbo-cn-dsh-client-ui-voice-input
+name: "@zhangbo-cn/dsh-client-ui-voice-input"
+description:
+  en: "Composer mic for DeepSeek Harness Web: tap-to-monitor live transcription and hold-to-talk, with host Edge TTS reply reading that streams while the model generates, echo-pause during reading, and tap-to-stop."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - composer
+  - monitor
+  - live
+  - transcription
+  - hold
+  - talk
+  - host
+  - edge
+  - reply
+  - reading
+  - streams
+  - while
+  - model
+  - generates
+  - echo
+  - pause
+source:
+  repository: https://github.com/Zhangbo-cn/dsh-voice-input-plugin
+  repositoryNodeId: R_kgDOT5agVA
+  subpath: null
+  commit: bf9ecf74dd84b341b28173802ab76f1e244a0a77
+creator:
+  github: Zhangbo-cn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:45.262Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhangbo-cn-dsh-client-ui-voice-input`
- Submission type: community curation
- Created by `Zhangbo-cn` — https://github.com/Zhangbo-cn
- Original source repository: https://github.com/Zhangbo-cn/dsh-voice-input-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.