### PR TITLE
catalog: add zhangbo1201-dsh-local-file-upload (community curation, created by @zhangbo1201)

### DIFF
--- a/catalog/plugins/zhangbo1201-dsh-local-file-upload.yaml
+++ b/catalog/plugins/zhangbo1201-dsh-local-file-upload.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: zhangbo1201-dsh-local-file-upload
+name: dsh-local-file-upload
+description:
+  en: Upload local files into the current DeepSeek Harness workspace from the Web composer
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - file-upload
+  - cordis
+source:
+  repository: https://github.com/zhangbo1201/dsh-file-upload
+  repositoryNodeId: R_kgDOT8LyFw
+  subpath: null
+  commit: 94118e7cfb0fc96ce7c9854aad0859e8e468e8d9
+creator:
+  github: zhangbo1201
+package:
+  ecosystem: npm
+  name: dsh-local-file-upload
+  version: 0.1.4
+  integrity: sha512-9l7kWzgiDgYAp48oGITxCHUVogKuU/NJXxyS/C0Qx+ZxEmscct/MPg9TC8McAwO/dKreJRaPGiTqqoNP2ViLyw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:07.587Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhangbo1201-dsh-local-file-upload`
- Submission type: community curation
- Created by `zhangbo1201` — https://github.com/zhangbo1201
- Original source repository: https://github.com/zhangbo1201/dsh-file-upload
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.