### PR TITLE
catalog: add zhangjiazhi-dsh-stats-panel (community curation, created by @zhangjiazhi)

### DIFF
--- a/catalog/plugins/zhangjiazhi-dsh-stats-panel.yaml
+++ b/catalog/plugins/zhangjiazhi-dsh-stats-panel.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zhangjiazhi-dsh-stats-panel
+name: "@linxin666/dsh-stats-panel"
+description:
+  en: "Token usage statistics for DeepSeek Harness: per-channel usage, balances and plan quotas for mainstream providers, cost estimates in CNY — a settings-sidebar section."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - token
+  - usage
+  - statistics
+  - balance
+source:
+  repository: https://github.com/zhang-jiazhi/dsh-stats-panel
+  repositoryNodeId: R_kgDOT573nA
+  subpath: null
+  commit: bd28621129036f88ab4ba122829aa4c2ae1fb772
+creator:
+  github: zhangjiazhi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:55.621Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhangjiazhi-dsh-stats-panel`
- Submission type: community curation
- Created by `zhangjiazhi` — https://github.com/zhangjiazhi
- Original source repository: https://github.com/zhang-jiazhi/dsh-stats-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.