### PR TITLE
catalog: add zhangzhenwen1-qmd-autosearch (community curation, created by @zhangzhenwen1)

### DIFF
--- a/catalog/plugins/zhangzhenwen1-qmd-autosearch.yaml
+++ b/catalog/plugins/zhangzhenwen1-qmd-autosearch.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zhangzhenwen1-qmd-autosearch
+name: qmd-autosearch
+description:
+  en: "DSH plugin: auto-supplement QMD semantic search when the model greps/globs a knowledge-base directory"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - qmd
+  - semantic-search
+  - mcp
+  - knowledge-base
+source:
+  repository: https://github.com/zhangzhenwen1/qmd-autosearch
+  repositoryNodeId: R_kgDOT5IUwg
+  subpath: null
+  commit: c3eebe32e9e7d8fe1a50ffc3190dffbcaa608c81
+creator:
+  github: zhangzhenwen1
+package:
+  ecosystem: npm
+  name: qmd-autosearch
+  version: 0.1.1
+  integrity: sha512-Cc57f7rBcRMqj3gc9yX/TiFQ8dqS3BrKSbLVVt3MujL8W5i2us2tNEjYerQKEdIRxfU9U/HDExbLbP1RjiCcgw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:02.232Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhangzhenwen1-qmd-autosearch`
- Submission type: community curation
- Created by `zhangzhenwen1` — https://github.com/zhangzhenwen1
- Original source repository: https://github.com/zhangzhenwen1/qmd-autosearch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.