### PR TITLE
catalog: add zhao1012-dsh-fix-duplicate-loader-id (community curation, created by @zhao1012)

### DIFF
--- a/catalog/plugins/zhao1012-dsh-fix-duplicate-loader-id.yaml
+++ b/catalog/plugins/zhao1012-dsh-fix-duplicate-loader-id.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zhao1012-dsh-fix-duplicate-loader-id
+name: dsh-fix-duplicate-loader-id
+description:
+  en: "DSH skill: detect & fix duplicate loader entry id boot crashes - converts duplicate - insert: rows into id-targeted patches so dsh web / tui profiles boot reliably."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skill
+  - cordis
+source:
+  repository: https://github.com/zhao1012/dsh-fix-duplicate-loader-id
+  repositoryNodeId: R_kgDOT9rYSQ
+  subpath: null
+  commit: 64f0d6fc80d03cb07b563abcfce66b8c8665aeaa
+creator:
+  github: zhao1012
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:56.713Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhao1012/dsh-fix-duplicate-loader-id/64f0d6fc80d03cb07b563abcfce66b8c8665aeaa/sponsor-qr.jpg
+    alt: 赞助收款码


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhao1012-dsh-fix-duplicate-loader-id`
- Submission type: community curation
- Created by `zhao1012` — https://github.com/zhao1012
- Original source repository: https://github.com/zhao1012/dsh-fix-duplicate-loader-id
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.