### PR TITLE
catalog: add zhaoyuntao-wl-dsh-thread (community curation, created by @zhaoyuntao-wl)

### DIFF
--- a/catalog/plugins/zhaoyuntao-wl-dsh-thread.yaml
+++ b/catalog/plugins/zhaoyuntao-wl-dsh-thread.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: zhaoyuntao-wl-dsh-thread
+name: dsh-thread
+description:
+  en: Thread session memory for dsh — lossless event capture + status-card injection (dsh plugin, standalone repo).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - thread
+  - session
+  - memory
+  - lossless
+  - event
+  - capture
+  - status
+  - card
+  - injection
+  - standalone
+  - repo
+  - dsh
+source:
+  repository: https://github.com/zhaoyuntao-wl/dsh-plugin-thread
+  repositoryNodeId: R_kgDOT7bjIA
+  subpath: null
+  commit: 37872789424c4cb81214ac1edf2b10c4e640346f
+creator:
+  github: zhaoyuntao-wl
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:50.265Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhaoyuntao-wl-dsh-thread`
- Submission type: community curation
- Created by `zhaoyuntao-wl` — https://github.com/zhaoyuntao-wl
- Original source repository: https://github.com/zhaoyuntao-wl/dsh-plugin-thread
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.