### PR TITLE
catalog: add zhengjunyao000-dsh-skill-studio (community curation, created by @zhengjunyao000)

### DIFF
--- a/catalog/plugins/zhengjunyao000-dsh-skill-studio.yaml
+++ b/catalog/plugins/zhengjunyao000-dsh-skill-studio.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: zhengjunyao000-dsh-skill-studio
+name: dsh-skill-studio
+description:
+  en: "Skill studio for DeepSeek Harness: visualize all agent skills, view/edit their SKILL.md bodies, toggle model/user invocation, and mine session logs to extract reusable personal skills (auto-loadable by the agent) — from the web settings panel (Skill 工作台) and via skillmgr / skillmgr extract tools"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - skill
+  - skills
+  - manager
+  - editor
+  - studio
+  - extract
+  - extractor
+  - session
+source:
+  repository: https://github.com/zhengjy01/dsh-skill-studio
+  repositoryNodeId: R_kgDOUBIwSQ
+  subpath: null
+  commit: 3297482f5c365bcb2949eb52dcce1ec21e5a9d1f
+creator:
+  github: zhengjunyao000
+package:
+  ecosystem: npm
+  name: dsh-skill-studio
+  version: 0.2.0
+  integrity: sha512-gY+p+PEUlOrUIvbYQHbMVMCe4rZZonsBBsquHK2+TAC4vcNbk/8bddNsKqF51UuIX2vqQcVZYwdPSTcJKi+WRg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:50.143Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhengjunyao000-dsh-skill-studio`
- Submission type: community curation
- Created by `zhengjunyao000` — https://github.com/zhengjunyao000
- Original source repository: https://github.com/zhengjy01/dsh-skill-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.