### PR TITLE
catalog: add zhengqingjing-dsh-session-tree (community curation, created by @ZhengQingJing)

### DIFF
--- a/catalog/plugins/zhengqingjing-dsh-session-tree.yaml
+++ b/catalog/plugins/zhengqingjing-dsh-session-tree.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zhengqingjing-dsh-session-tree
+name: dsh-session-tree
+description:
+  en: Lightweight read-only session lineage navigation for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - session-lineage
+  - conversation
+  - typescript
+source:
+  repository: https://github.com/ZhengQingJing/dsh-session-tree
+  repositoryNodeId: R_kgDOT4NIjg
+  subpath: null
+  commit: 28e7887a888adf1747e9a35b38b96f1dac233a23
+creator:
+  github: ZhengQingJing
+package:
+  ecosystem: npm
+  name: dsh-session-tree
+  version: 0.2.0-beta.1
+  integrity: sha512-Yl8Su/cmHMYAn8kZjvMdLW1EG30S9Ds9n2tmYWGqgBxN3368zc01zxszVTLeTUHLeMQ6+yqh9kkgryhbLFtaKw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:50.290Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhengqingjing-dsh-session-tree`
- Submission type: community curation
- Created by `ZhengQingJing` — https://github.com/ZhengQingJing
- Original source repository: https://github.com/ZhengQingJing/dsh-session-tree
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.