### PR TITLE
catalog: add zhifengjiang-dsh-hover-archive (community curation, created by @zhifengjiang)

### DIFF
--- a/catalog/plugins/zhifengjiang-dsh-hover-archive.yaml
+++ b/catalog/plugins/zhifengjiang-dsh-hover-archive.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: zhifengjiang-dsh-hover-archive
+name: dsh-hover-archive
+description:
+  en: "Codex-style hover archive for DeepSeek Harness web: hovering a sidebar session row reveals an Archive icon at the far right; one click archives the session through the official workspaces.archiveSession API."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - dsh-plugin
+  - session
+  - archive
+  - sidebar
+  - hover
+  - codex
+  - ui
+  - web
+source:
+  repository: https://github.com/zhifengjiang/dsh-hover-archive
+  repositoryNodeId: R_kgDOT8m0BA
+  subpath: null
+  commit: 430491ab1e36db6019a7d6d11b2f7506e5c2915d
+creator:
+  github: zhifengjiang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:02.856Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhifengjiang-dsh-hover-archive`
- Submission type: community curation
- Created by `zhifengjiang` — https://github.com/zhifengjiang
- Original source repository: https://github.com/zhifengjiang/dsh-hover-archive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.