### PR TITLE
catalog: add zhijun-dai-dsh-fonts (community curation, created by @zhijun-dai)

### DIFF
--- a/catalog/plugins/zhijun-dai-dsh-fonts.yaml
+++ b/catalog/plugins/zhijun-dai-dsh-fonts.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: zhijun-dai-dsh-fonts
+name: dsh-fonts
+description:
+  en: "Font system plugin for DeepSeek Harness: bundled OFL webfonts served offline, user-imported custom fonts, and a ctx.fonts registry other plugins can extend"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - fonts
+  - typography
+  - webfonts
+  - web-ui
+source:
+  repository: https://github.com/zhijun-dai/dsh-Fonts
+  repositoryNodeId: R_kgDOT49bfw
+  subpath: null
+  commit: 46014ec5663435bdd39acee2e77c3979810b1967
+creator:
+  github: zhijun-dai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:03.822Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhijun-dai/dsh-Fonts/46014ec5663435bdd39acee2e77c3979810b1967/assets/fonts-settings.webp
+    alt: 字体设置行
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhijun-dai/dsh-Fonts/46014ec5663435bdd39acee2e77c3979810b1967/assets/fonts-jetbrains-inter.webp
+    alt: JetBrains Mono + Inter


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhijun-dai-dsh-fonts`
- Submission type: community curation
- Created by `zhijun-dai` — https://github.com/zhijun-dai
- Original source repository: https://github.com/zhijun-dai/dsh-Fonts
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.