### PR TITLE
catalog: add zhoufangerqiangu-plugin-esi (community curation, created by @ZhoufangErqiangu)

### DIFF
--- a/catalog/plugins/zhoufangerqiangu-plugin-esi.yaml
+++ b/catalog/plugins/zhoufangerqiangu-plugin-esi.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: zhoufangerqiangu-plugin-esi
+name: "@dsh-esi/plugin-esi"
+description:
+  en: DSH plugin bridging EVE Online ESI API and SDE static data with a small always-visible tool surface plus on-demand endpoint materialization.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - bridging
+  - online
+  - static
+  - data
+  - small
+  - always
+  - visible
+  - tool
+  - surface
+  - plus
+  - demand
+  - endpoint
+  - materialization
+  - dsh
+source:
+  repository: https://github.com/ZhoufangErqiangu/dsh-esi
+  repositoryNodeId: R_kgDOT7W9kw
+  subpath: null
+  commit: 6a0285733bc1d10cd0e2b7bc6581f1721668f9b0
+creator:
+  github: ZhoufangErqiangu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:08.394Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhoufangerqiangu-plugin-esi`
- Submission type: community curation
- Created by `ZhoufangErqiangu` — https://github.com/ZhoufangErqiangu
- Original source repository: https://github.com/ZhoufangErqiangu/dsh-esi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.