### PR TITLE
catalog: add zhousun55-byte-dsh-postman (community curation, created by @zhousun55-byte)

### DIFF
--- a/catalog/plugins/zhousun55-byte-dsh-postman.yaml
+++ b/catalog/plugins/zhousun55-byte-dsh-postman.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zhousun55-byte-dsh-postman
+name: dsh-postman
+description:
+  en: "DeepSeek Harness web plugin — upload files and folders straight into the conversation (no workspace copy needed): images attach as real image blocks, text content is written into the composer, folders land under ~/.dsh/uploads by directory structure"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - upload
+  - attachment
+  - file-drop
+  - chat
+source:
+  repository: https://github.com/zhousun55-byte/dsh-postman
+  repositoryNodeId: R_kgDOT6NSQA
+  subpath: null
+  commit: 11a2cc95925b85e4e30594f6d71a525bf445bdc3
+creator:
+  github: zhousun55-byte
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:04.141Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhousun55-byte-dsh-postman`
- Submission type: community curation
- Created by `zhousun55-byte` — https://github.com/zhousun55-byte
- Original source repository: https://github.com/zhousun55-byte/dsh-postman
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.