### PR TITLE
catalog: add zhuifengqug-dsh-adaptive-reasoning (community curation, created by @zhuifengqug)

### DIFF
--- a/catalog/plugins/zhuifengqug-dsh-adaptive-reasoning.yaml
+++ b/catalog/plugins/zhuifengqug-dsh-adaptive-reasoning.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zhuifengqug-dsh-adaptive-reasoning
+name: dsh-adaptive-reasoning
+description:
+  en: Capability-aware reasoning effort slider for the DeepSeek Harness web model selector.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - reasoning
+  - reasoning-effort
+  - models-dev
+source:
+  repository: https://github.com/zhuifengqug/dsh-adaptive-reasoning
+  repositoryNodeId: R_kgDOT-nb3g
+  subpath: null
+  commit: 3d87a31a0162bf06a4ba05058432708bba116809
+creator:
+  github: zhuifengqug
+package:
+  ecosystem: npm
+  name: dsh-adaptive-reasoning
+  version: 2.0.0
+  integrity: sha512-r/fxDrYhRDMsrlBG4B0HHElys77v7yGu+23SRT9BqsbNhfxLI9vJIlAXSzwuThv1R0pQbIELP7KH0y9ecxgE3w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:58.003Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhuifengqug-dsh-adaptive-reasoning`
- Submission type: community curation
- Created by `zhuifengqug` — https://github.com/zhuifengqug
- Original source repository: https://github.com/zhuifengqug/dsh-adaptive-reasoning
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.