### PR TITLE
catalog: add zicheng-dsh-window-kit (community curation, created by @zicheng)

### DIFF
--- a/catalog/plugins/zicheng-dsh-window-kit.yaml
+++ b/catalog/plugins/zicheng-dsh-window-kit.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zicheng-dsh-window-kit
+name: dsh-window-kit
+description:
+  en: sh dsh plugin --profile web add github:ZichengGurrr/dsh-window path:/kit
+  evidencePath: kit/README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - desktop
+  - windows
+  - vision
+  - glm
+  - voice
+  - speech
+source:
+  repository: https://github.com/ZichengGurrr/dsh-window
+  repositoryNodeId: R_kgDOT4ht9g
+  subpath: kit
+  commit: aad20bef0f6d0475efef102d1b3b5f357f005680
+creator:
+  github: zicheng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: kit/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:08.813Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zicheng-dsh-window-kit`
- Submission type: community curation
- Created by `zicheng` — https://github.com/zicheng
- Original source repository: https://github.com/ZichengGurrr/dsh-window
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.