### PR TITLE
catalog: add ziduup-dsh-programming-mode (community curation, created by @ziduup)

### DIFF
--- a/catalog/plugins/ziduup-dsh-programming-mode.yaml
+++ b/catalog/plugins/ziduup-dsh-programming-mode.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: ziduup-dsh-programming-mode
+name: dsh-programming-mode
+description:
+  en: "A DeepSeek Harness bundle that ships the 编程模式 agent preset: the full standard coding agent with its persona replaced by a mandatory Superpowers engineering discipline."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - dsh-bundle
+  - agent-preset
+  - superpowers
+  - dsh
+source:
+  repository: https://github.com/ziduup/dsh-programming-mode
+  repositoryNodeId: R_kgDOUCQo5w
+  subpath: null
+  commit: e51b32cc0732be81b1d563bd3a0d4911d4e7deaa
+creator:
+  github: ziduup
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:50.356Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ziduup-dsh-programming-mode`
- Submission type: community curation
- Created by `ziduup` — https://github.com/ziduup
- Original source repository: https://github.com/ziduup/dsh-programming-mode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.