### PR TITLE
catalog: add zihaovistonwang-stata-ai-skill (community curation, created by @ZihaoVistonWang)

### DIFF
--- a/catalog/plugins/zihaovistonwang-stata-ai-skill.yaml
+++ b/catalog/plugins/zihaovistonwang-stata-ai-skill.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zihaovistonwang-stata-ai-skill
+name: "@zihaovistonwang/stata-ai-skill"
+description:
+  en: Start the native Stata AI Skill service together with DeepSeek Harness — platform-aware (macOS arm64 / Windows x64 / Windows arm64), reuses an already-running service, restarts on crash, and shuts down cleanly with DSH.
+  evidencePath: dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - stata
+  - econometrics
+  - skill
+source:
+  repository: https://github.com/ZihaoVistonWang/Stata-AI-Skill
+  repositoryNodeId: R_kgDOS5XL7A
+  subpath: dsh-plugin
+  commit: 8ed19243fbb4864b6177b5a855de14fda55771c7
+creator:
+  github: ZihaoVistonWang
+package:
+  ecosystem: npm
+  name: "@zihaovistonwang/stata-ai-skill"
+  version: 1.3.0
+  integrity: sha512-AAMTfA0jH3cOq6X4gaj+2V7NixzAGUMtsVfVl6aa4dC9dxc/S+XIzccrotjGfoHkgp4FEhUy19CCLlialBC9cQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:09.866Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zihaovistonwang-stata-ai-skill`
- Submission type: community curation
- Created by `ZihaoVistonWang` — https://github.com/ZihaoVistonWang
- Original source repository: https://github.com/ZihaoVistonWang/Stata-AI-Skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.