### PR TITLE
catalog: add zizaiwo-dsh-session-categories (community curation, created by @zizaiwo)

### DIFF
--- a/catalog/plugins/zizaiwo-dsh-session-categories.yaml
+++ b/catalog/plugins/zizaiwo-dsh-session-categories.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zizaiwo-dsh-session-categories
+name: "@zizaiwo/dsh-session-categories"
+description:
+  en: Organize DeepSeek Harness (dsh) sidebar sessions into custom category folders. dsh 侧边栏会话分类插件。
+  evidencePath: dsh-session-categories/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session
+  - categories
+  - workspace
+  - sidebar
+  - dsh-plugin
+source:
+  repository: https://github.com/zizaiwo/dsh_plugins
+  repositoryNodeId: R_kgDOUAd86A
+  subpath: dsh-session-categories
+  commit: 2b4be364f874b954ad00e6549c7ad6a1aa0c5771
+creator:
+  github: zizaiwo
+package:
+  ecosystem: npm
+  name: "@zizaiwo/dsh-session-categories"
+  version: 0.1.3
+  integrity: sha512-9MUYb4edOS8lbMKItUarVAMb7THL3G20Yg5LeFNyniTlTLZU4kzIJKlZdp5EwBTbgFKIgxLrHRjbKPFUfWo4Kg==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-session-categories/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:09.839Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zizaiwo-dsh-session-categories`
- Submission type: community curation
- Created by `zizaiwo` — https://github.com/zizaiwo
- Original source repository: https://github.com/zizaiwo/dsh_plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.