### PR TITLE
catalog: add zizhongfeiyang-dsh-settings-drawer (community curation, created by @zizhongfeiyang)

### DIFF
--- a/catalog/plugins/zizhongfeiyang-dsh-settings-drawer.yaml
+++ b/catalog/plugins/zizhongfeiyang-dsh-settings-drawer.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zizhongfeiyang-dsh-settings-drawer
+name: dsh-settings-drawer
+description:
+  en: "Settings drawer for DSH: choose which settings nav items stay visible."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - settings
+  - web-ui
+source:
+  repository: https://github.com/zizhongfeiyang/dsh-settings-drawer
+  repositoryNodeId: R_kgDOT7kSeA
+  subpath: null
+  commit: 9482b9f53679ba50e1f94f07c2380b8345ad739a
+creator:
+  github: zizhongfeiyang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:48.471Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zizhongfeiyang/dsh-settings-drawer/9482b9f53679ba50e1f94f07c2380b8345ad739a/docs/screenshots/settings-drawer.png
+    alt: Settings Drawer


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zizhongfeiyang-dsh-settings-drawer`
- Submission type: community curation
- Created by `zizhongfeiyang` — https://github.com/zizhongfeiyang
- Original source repository: https://github.com/zizhongfeiyang/dsh-settings-drawer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.