### PR TITLE
catalog: add zjl1989-li-dsh-harness-zh-cn (community curation, created by @zjl1989-li)

### DIFF
--- a/catalog/plugins/zjl1989-li-dsh-harness-zh-cn.yaml
+++ b/catalog/plugins/zjl1989-li-dsh-harness-zh-cn.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zjl1989-li-dsh-harness-zh-cn
+name: dsh-harness-zh-cn
+description:
+  en: bash npm install dsh-harness-zh-cn pnpm add dsh-harness-zh-cn
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - chinese
+  - zh-cn
+  - localization
+  - i18n
+  - l10n
+source:
+  repository: https://github.com/zjl1989-li/dsh-harness-zh-cn
+  repositoryNodeId: R_kgDOT50HEw
+  subpath: null
+  commit: 7b282c4d6665d149f81a37059921a9108251167f
+creator:
+  github: zjl1989-li
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:45.116Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zjl1989-li-dsh-harness-zh-cn`
- Submission type: community curation
- Created by `zjl1989-li` — https://github.com/zjl1989-li
- Original source repository: https://github.com/zjl1989-li/dsh-harness-zh-cn
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.