### PR TITLE
catalog: add zjsthmjialin-dsh-pdf-background-gray (community curation, created by @zjsthmjialin)

### DIFF
--- a/catalog/plugins/zjsthmjialin-dsh-pdf-background-gray.yaml
+++ b/catalog/plugins/zjsthmjialin-dsh-pdf-background-gray.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zjsthmjialin-dsh-pdf-background-gray
+name: dsh-pdf-background-gray
+description:
+  en: sh dsh plugin --profile web add dsh-pdf-background-gray
+  evidencePath: dsh-pdf-background-gray/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - skill
+  - pdf
+  - background-removal
+  - image-processing
+  - dsh
+source:
+  repository: https://github.com/zjsthmjialin/pdf-background-gray-codex-skill
+  repositoryNodeId: R_kgDOS-ESHg
+  subpath: dsh-pdf-background-gray
+  commit: c224d16deba0c48c247403707f14b11f416473f3
+creator:
+  github: zjsthmjialin
+package:
+  ecosystem: npm
+  name: dsh-pdf-background-gray
+  version: 0.1.0
+  integrity: sha512-z9ETUElAJhfIPxbJxuYxyovQBLmNCAIvkLzrVZbrybwfmB/qr+vFTT2Z30PsaiTbcD4eF3Lp3axQSZpTasf4Ww==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-pdf-background-gray/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:10.754Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zjsthmjialin-dsh-pdf-background-gray`
- Submission type: community curation
- Created by `zjsthmjialin` — https://github.com/zjsthmjialin
- Original source repository: https://github.com/zjsthmjialin/pdf-background-gray-codex-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.