### PR TITLE
catalog: add zjuhbh-dsh-full-with-approval (community curation, created by @zjuhbh)

### DIFF
--- a/catalog/plugins/zjuhbh-dsh-full-with-approval.yaml
+++ b/catalog/plugins/zjuhbh-dsh-full-with-approval.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: zjuhbh-dsh-full-with-approval
+name: dsh-full-with-approval
+description:
+  en: "DSH profile plugin: unconfined (GPU-capable) session sandbox plus per-operation user approval for writes outside the workspace or to protected files."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - sandbox
+  - approval
+  - permission
+source:
+  repository: https://github.com/zjuhbh/dsh-full-with-approval
+  repositoryNodeId: R_kgDOUA9YtA
+  subpath: null
+  commit: c664cdae654088cbdbb81b5fac67c1b81e4ec84a
+creator:
+  github: zjuhbh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:04.286Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zjuhbh-dsh-full-with-approval`
- Submission type: community curation
- Created by `zjuhbh` — https://github.com/zjuhbh
- Original source repository: https://github.com/zjuhbh/dsh-full-with-approval
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.