### PR TITLE
catalog: add zjuzhiyucai-dsh-ivory (community curation, created by @ZJUZhiyuCai)

### DIFF
--- a/catalog/plugins/zjuzhiyucai-dsh-ivory.yaml
+++ b/catalog/plugins/zjuzhiyucai-dsh-ivory.yaml
@@ -1,0 +1,59 @@
+schemaVersion: 1
+id: zjuzhiyucai-dsh-ivory
+name: dsh-ivory
+description:
+  en: An unofficial Claude-inspired light/dark theme for DeepSeek Harness with responsive layout, safe Markdown preview, and zero telemetry.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - theme
+  - skin
+  - claude-inspired
+  - dark-mode
+  - accessibility
+  - responsive
+source:
+  repository: https://github.com/ZJUZhiyuCai/dsh-ivory
+  repositoryNodeId: R_kgDOT57HmA
+  subpath: null
+  commit: 6da0020d145213ce10433f28983e69cc598508c7
+creator:
+  github: ZJUZhiyuCai
+package:
+  ecosystem: npm
+  name: dsh-ivory
+  version: 0.2.7
+  integrity: sha512-k5yEwkFKHNceqtOJhWIk2MTD4+v5Mw5tSyQFrZSkXPZsWQF4Z0ovL4H8lrPhw9IlDL6nA+BUVBtMS8UGOF4W3w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:58.081Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/6da0020d145213ce10433f28983e69cc598508c7/assets/hero-light.png
+    alt: Ivory for DSH home screen
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/6da0020d145213ce10433f28983e69cc598508c7/assets/conversation-light.png
+    alt: Ivory conversation view on desktop
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/6da0020d145213ce10433f28983e69cc598508c7/assets/mobile-light.png
+    alt: Ivory conversation view on mobile


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zjuzhiyucai-dsh-ivory`
- Submission type: community curation
- Created by `ZJUZhiyuCai` — https://github.com/ZJUZhiyuCai
- Original source repository: https://github.com/ZJUZhiyuCai/dsh-ivory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.