### PR TITLE
catalog: add zmh2000829-dsh-grok-acp (community curation, created by @zmh2000829)

### DIFF
--- a/catalog/plugins/zmh2000829-dsh-grok-acp.yaml
+++ b/catalog/plugins/zmh2000829-dsh-grok-acp.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: zmh2000829-dsh-grok-acp
+name: dsh-grok-acp
+description:
+  en: Use Grok Build as an ACP-powered root agent inside DeepSeek Harness Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - grok-build
+  - agent-client-protocol
+  - acp
+  - coding-agent
+source:
+  repository: https://github.com/zmh2000829/DSH-agent-bridge
+  repositoryNodeId: R_kgDOUBJiPg
+  subpath: null
+  commit: e7111741a67269503d1f71c379902354687da7f8
+creator:
+  github: zmh2000829
+package:
+  ecosystem: npm
+  name: dsh-grok-acp
+  version: 0.3.3
+  integrity: sha512-3tXZGBtdaJBWINCm4YMBM70szxHcXaMzRg89IJ30Zhz86eCSBbchavF9214V8G9gI0LrOqmt8qNPOhkcPAy3jw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:46.995Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zmh2000829/DSH-agent-bridge/e7111741a67269503d1f71c379902354687da7f8/docs/assets/dsh-home.png
+    alt: DSH 首页
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zmh2000829/DSH-agent-bridge/e7111741a67269503d1f71c379902354687da7f8/docs/assets/grok-home.png
+    alt: Grok Build 首页
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zmh2000829/DSH-agent-bridge/e7111741a67269503d1f71c379902354687da7f8/docs/assets/harness.gif
+    alt: 在 DSH 首页切换 DSH 与 Grok Build


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zmh2000829-dsh-grok-acp`
- Submission type: community curation
- Created by `zmh2000829` — https://github.com/zmh2000829
- Original source repository: https://github.com/zmh2000829/DSH-agent-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.