### PR TITLE
catalog: add zmh2000829-dsh-web-search-multi (community curation, created by @zmh2000829)

### DIFF
--- a/catalog/plugins/zmh2000829-dsh-web-search-multi.yaml
+++ b/catalog/plugins/zmh2000829-dsh-web-search-multi.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: zmh2000829-dsh-web-search-multi
+name: dsh-web-search-multi
+description:
+  en: Configurable SearXNG, Brave, Tavily, Gemini, and Wikipedia search provider for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - web-search
+  - searxng
+  - brave-search
+  - tavily
+  - gemini
+  - google-search-grounding
+  - wikipedia
+source:
+  repository: https://github.com/zmh2000829/dsh-web-search-multi
+  repositoryNodeId: R_kgDOT8hI5w
+  subpath: null
+  commit: c4dce6e14283be7b5c10c5f4b8ab353f307f649d
+creator:
+  github: zmh2000829
+package:
+  ecosystem: npm
+  name: dsh-web-search-multi
+  version: 0.2.0
+  integrity: sha512-XgDIYR6uaOaZGQMvkDpv5Zz4GzaveskYCHAp4+xKgxkGpA43iFBSOJ3dW8kFol1TrBAjr5petpD3a97COaHeZQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:45.139Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zmh2000829-dsh-web-search-multi`
- Submission type: community curation
- Created by `zmh2000829` — https://github.com/zmh2000829
- Original source repository: https://github.com/zmh2000829/dsh-web-search-multi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.