### PR TITLE
catalog: add zn-dk-dsh-session-explorer (community curation, created by @Zn-Dk)

### DIFF
--- a/catalog/plugins/zn-dk-dsh-session-explorer.yaml
+++ b/catalog/plugins/zn-dk-dsh-session-explorer.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: zn-dk-dsh-session-explorer
+name: dsh-session-explorer
+description:
+  en: "DSH Web plugin: message-level full-text search across sessions. Search a specific message (user / assistant / tool / system-injected), preview context read-only, and jump to the real session with one click."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - message
+  - level
+  - full
+  - text
+  - search
+  - across
+  - sessions
+  - specific
+  - user
+  - assistant
+  - tool
+  - system
+  - injected
+  - preview
+  - context
+  - read
+source:
+  repository: https://github.com/Zn-Dk/dsh-session-explorer
+  repositoryNodeId: R_kgDOUCRUpg
+  subpath: null
+  commit: 73ab99e399550d3daf65730b3a012ab2b2c5c5ec
+creator:
+  github: Zn-Dk
+package:
+  ecosystem: npm
+  name: dsh-session-explorer
+  version: 0.4.2
+  integrity: sha512-vgVqR5pHf9cdk4WmkkICKv9XU32yTpSW7KTJeX1AJrCf3bUpQlhqxAe2m0G5ljN5gVXiXfr4fkkJLqqwyxl7tA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:04.361Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zn-dk-dsh-session-explorer`
- Submission type: community curation
- Created by `Zn-Dk` — https://github.com/Zn-Dk
- Original source repository: https://github.com/Zn-Dk/dsh-session-explorer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.