### PR TITLE
catalog: add zoahdev-dsh-cn-boot (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-cn-boot.yaml
+++ b/catalog/plugins/zoahdev-dsh-cn-boot.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: zoahdev-dsh-cn-boot
+name: dsh-cn-boot
+description:
+  en: "China-network bootstrap for DeepSeek Harness (dsh): connectivity probes to npm/GitHub/HuggingFace/mirrors, local proxy detection, mirror recommendations, and a generated PowerShell/bash bootstrap script. Read-only by default; apply is explicit. CLI + agent-callable cn boot tool."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - china
+  - mirror
+  - proxy
+  - network
+  - bootstrap
+  - npmmirror
+source:
+  repository: https://github.com/zoahdev/dsh-cn-boot
+  repositoryNodeId: R_kgDOT8SzgA
+  subpath: null
+  commit: 86b9f804ef4763e60d665b1a422a216a653170f3
+creator:
+  github: zoahdev
+package:
+  ecosystem: npm
+  name: dsh-cn-boot
+  version: 0.1.0
+  integrity: sha512-T0GUhVcG9ivxU7Ow1slsvDZIdySJu25V15cdwQmoH3GAt5Z7YZ45J1HEaIiwuDq93/AeHdq3uzuiYTmZoApLAg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:58.230Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-cn-boot`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-cn-boot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.