### PR TITLE
catalog: add zoahdev-dsh-discussions-radar (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-discussions-radar.yaml
+++ b/catalog/plugins/zoahdev-dsh-discussions-radar.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zoahdev-dsh-discussions-radar
+name: dsh-discussions-radar
+description:
+  en: "Official GitHub Discussions radar for DeepSeek Harness (dsh): list, filter and search the deepseek-ai/deepseek-harness discussion boards (Ideas / Q&A / Show Your Plugins / General / Announcements) from inside dsh. CLI + agent-callable discussions radar tool, zero runtime dependencies, read-only."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - discussions
+  - radar
+  - community
+  - announcements
+source:
+  repository: https://github.com/zoahdev/dsh-discussions-radar
+  repositoryNodeId: R_kgDOT8eD7w
+  subpath: null
+  commit: d2af74955988b000ed535fe45d22d12a5bf67030
+creator:
+  github: zoahdev
+package:
+  ecosystem: npm
+  name: dsh-discussions-radar
+  version: 0.1.0
+  integrity: sha512-qVKx8fPNESosIMf01aowL2vDuNJQNgNU2vhmv6IqjaiFUS8/LUcScTXFXzd72q+1D9xD4K6muWBtD9mp4UpWhw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:58.465Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-discussions-radar`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-discussions-radar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.