### PR TITLE
catalog: add zoahdev-dsh-disk-audit (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-disk-audit.yaml
+++ b/catalog/plugins/zoahdev-dsh-disk-audit.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zoahdev-dsh-disk-audit
+name: dsh-disk-audit
+description:
+  en: "Disk-usage audit for DeepSeek Harness (dsh) data directories: total size, per-directory breakdown, largest files, and oversized-file warnings (session logs can hit hundreds of MB). Zero runtime dependencies, read-only. CLI + agent-callable disk audit tool."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - disk-usage
+  - storage
+  - session-logs
+  - cleanup
+source:
+  repository: https://github.com/zoahdev/dsh-disk-audit
+  repositoryNodeId: R_kgDOT8htAA
+  subpath: null
+  commit: 2299a17c03196ca627adf783f3f759f330c195a8
+creator:
+  github: zoahdev
+package:
+  ecosystem: npm
+  name: dsh-disk-audit
+  version: 0.1.0
+  integrity: sha512-mlP9Db/A+SrIlVvtTzSdgcjRtqEEFQ3+Rfpvib3hiHKXFD1ukCQXVdBluPY+jZcjDvRX9u3iep6C5F2Fb4r75Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:58.439Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-disk-audit`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-disk-audit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.