### PR TITLE
catalog: add zoahdev-dsh-github-release-radar (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-github-release-radar.yaml
+++ b/catalog/plugins/zoahdev-dsh-github-release-radar.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zoahdev-dsh-github-release-radar
+name: dsh-github-release-radar
+description:
+  en: "GitHub Release Radar for DeepSeek Harness: query releases, repo stats, repository search, and Git tags without an API key."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh
+  - releases
+  - cordis
+  - agent
+source:
+  repository: https://github.com/zoahdev/dsh-github-release-radar
+  repositoryNodeId: R_kgDOT43Wng
+  subpath: null
+  commit: ea998b22171b697185853e3ce04dbbe772527aed
+creator:
+  github: zoahdev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:51.711Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-github-release-radar`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-github-release-radar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.