### PR TITLE
catalog: add zoahdev-dsh-pet-evolve (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-pet-evolve.yaml
+++ b/catalog/plugins/zoahdev-dsh-pet-evolve.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zoahdev-dsh-pet-evolve
+name: dsh-pet-evolve
+description:
+  en: "The pet that grows with your DeepSeek Harness agent: stage evolution from real signals (verified rules, sessions, tool calls), agent-state mirroring, and one-click growth share cards."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - pet
+  - agent
+  - evolution
+  - gamification
+  - dsh
+source:
+  repository: https://github.com/zoahdev/dsh-pet-evolve
+  repositoryNodeId: R_kgDOT5S-CQ
+  subpath: null
+  commit: ca52329bbf09ab817a4b016f0fec772bd2aef37c
+creator:
+  github: zoahdev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:05.270Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-pet-evolve`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-pet-evolve
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.