### PR TITLE
catalog: add zoahdev-dsh-readme-forge (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-readme-forge.yaml
+++ b/catalog/plugins/zoahdev-dsh-readme-forge.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zoahdev-dsh-readme-forge
+name: dsh-readme-forge
+description:
+  en: Generate a README.md for DeepSeek Harness (dsh) plugin repositories from package.json + cordis.patch.yml + source layout — deterministic, zero runtime dependencies, read-only by default. CLI + agent-callable readme forge tool.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - generator
+  - documentation
+  - scaffold
+source:
+  repository: https://github.com/zoahdev/dsh-readme-forge
+  repositoryNodeId: R_kgDOT8fQfA
+  subpath: null
+  commit: b4ccc786999693eaa93918d990e16b5a93728b46
+creator:
+  github: zoahdev
+package:
+  ecosystem: npm
+  name: dsh-readme-forge
+  version: 0.1.0
+  integrity: sha512-sLR/6dqxP4XaaaTS+hyfZ3ZHHesJ0ssP6uWB24FdwkhmGI/oOqQX4uwPQDhKRd8i01f6M//CU8+gzJ7wIlOcnQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:59.723Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-readme-forge`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-readme-forge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.