### PR TITLE
catalog: add zoahdev-dsh-rule-evolve (community curation, created by @zoahdev)

### DIFF
--- a/catalog/plugins/zoahdev-dsh-rule-evolve.yaml
+++ b/catalog/plugins/zoahdev-dsh-rule-evolve.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zoahdev-dsh-rule-evolve
+name: dsh-rule-evolve
+description:
+  en: "In-session self-evolution for DeepSeek Harness: agents extract lessons from failures, verify them, and install auditable rules into the profile's AGENTS.md."
+  evidencePath: plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - self-evolution
+  - agent
+  - memory
+  - rules
+source:
+  repository: https://github.com/zoahdev/dsh-rule-evolve
+  repositoryNodeId: R_kgDOT5LYeg
+  subpath: plugin
+  commit: d95d6705f62857edb68ce4dce364d8d1a77f9f54
+creator:
+  github: zoahdev
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:25:11.563Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zoahdev-dsh-rule-evolve`
- Submission type: community curation
- Created by `zoahdev` — https://github.com/zoahdev
- Original source repository: https://github.com/zoahdev/dsh-rule-evolve
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.