### PR TITLE
catalog: add zouyuanqing-dsh-vision-primitives (community curation, created by @zouyuanqing)

### DIFF
--- a/catalog/plugins/zouyuanqing-dsh-vision-primitives.yaml
+++ b/catalog/plugins/zouyuanqing-dsh-vision-primitives.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: zouyuanqing-dsh-vision-primitives
+name: dsh-vision-primitives
+description:
+  en: "Native interactive visual-reasoning plugin for DeepSeek Harness: precise pixel grounding (SOM grid, zoom, annotate, measure, diff, color, OCR) + MiMo V2.5 multimodal backend, with zero external MCP servers."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - vision
+  - computer-vision
+  - ocr
+  - multimodal
+source:
+  repository: https://github.com/zouyuanqing/dsh-vision-primitives
+  repositoryNodeId: R_kgDOT4VLtg
+  subpath: null
+  commit: dfcfbc2b2d22ac34ea723dc9b34aae57d7e6a663
+creator:
+  github: zouyuanqing
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:59.963Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zouyuanqing-dsh-vision-primitives`
- Submission type: community curation
- Created by `zouyuanqing` — https://github.com/zouyuanqing
- Original source repository: https://github.com/zouyuanqing/dsh-vision-primitives
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.