### PR TITLE
catalog: add zrui-c-dsh-minimal-first-turn (community curation, created by @ZRui-C)

### DIFF
--- a/catalog/plugins/zrui-c-dsh-minimal-first-turn.yaml
+++ b/catalog/plugins/zrui-c-dsh-minimal-first-turn.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zrui-c-dsh-minimal-first-turn
+name: dsh-minimal-first-turn
+description:
+  en: Minimal first-turn conditioning for DeepSeek Harness Web sessions, with a persistent UI toggle.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - agent
+  - prompt
+  - tools
+source:
+  repository: https://github.com/ZRui-C/dsh-minimal-first-turn
+  repositoryNodeId: R_kgDOT5ur2A
+  subpath: null
+  commit: 02aaf1f5f0c9a294c877fcc07b3e3abff1e5847f
+creator:
+  github: ZRui-C
+package:
+  ecosystem: npm
+  name: dsh-minimal-first-turn
+  version: 0.1.0
+  integrity: sha512-3KXGzg1FlVIdxEMvL8ItA2kjfhdNnQy9ZbdJaHjzuaIkpvLeIcCOUIWOPSjndtQ9APeGJhHI1+O/ZeS7OWBbmQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T11:24:59.991Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zrui-c-dsh-minimal-first-turn`
- Submission type: community curation
- Created by `ZRui-C` — https://github.com/ZRui-C
- Original source repository: https://github.com/ZRui-C/dsh-minimal-first-turn
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.