### PR TITLE
catalog: add baosfeng-dsh-my-context (community curation, created by @baosfeng)

### DIFF
--- a/catalog/plugins/baosfeng-dsh-my-context.yaml
+++ b/catalog/plugins/baosfeng-dsh-my-context.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: baosfeng-dsh-my-context
+name: dsh-my-context
+description:
+  en: bash git clone https://github.com/baosfeng/my-dsh-plugins.git
+  evidencePath: plugins/dsh-my-context/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - bash
+  - clone
+  - baosfeng
+  - dsh
+source:
+  repository: https://github.com/baosfeng/my-dsh-plugins
+  repositoryNodeId: R_kgDOUAMi7w
+  subpath: plugins/dsh-my-context
+  commit: 1b8db2b39e88bd6da13b645c9354df8c2af1d3c7
+creator:
+  github: baosfeng
+package:
+  ecosystem: npm
+  name: dsh-my-context
+  version: 0.1.0
+  integrity: sha512-IVgFIoejEbmjx09blTFY26eVMSSmxS+4mkWyAg7qvTfFjAFhMJzJKU1DtRkCSQlfchHIcqe71xTJVhToxBLM9g==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-my-context/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:14.279Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baosfeng-dsh-my-context`
- Submission type: community curation
- Created by `baosfeng` — https://github.com/baosfeng
- Original source repository: https://github.com/baosfeng/my-dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.