### PR TITLE
catalog: add baosfeng-dsh-my-plugin-manager (community curation, created by @baosfeng)

### DIFF
--- a/catalog/plugins/baosfeng-dsh-my-plugin-manager.yaml
+++ b/catalog/plugins/baosfeng-dsh-my-plugin-manager.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: baosfeng-dsh-my-plugin-manager
+name: dsh-my-plugin-manager
+description:
+  en: bash dsh plugin --profile web add dsh-my-plugin-manager
+  evidencePath: plugins/dsh-my-plugin-manager/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - bash
+  - profile
+  - manager
+  - dsh
+source:
+  repository: https://github.com/baosfeng/my-dsh-plugins
+  repositoryNodeId: R_kgDOUAMi7w
+  subpath: plugins/dsh-my-plugin-manager
+  commit: 1b8db2b39e88bd6da13b645c9354df8c2af1d3c7
+creator:
+  github: baosfeng
+package:
+  ecosystem: npm
+  name: dsh-my-plugin-manager
+  version: 0.1.1
+  integrity: sha512-znWI/TiGBKRgvtr07ZL641ik2KMntQgZNHViMbse0z2iFDVzbwgz2xaPdNwTmUmZ/wU9gO3maPyeUaGS9iftEA==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-my-plugin-manager/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:14.279Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/baosfeng/my-dsh-plugins/1b8db2b39e88bd6da13b645c9354df8c2af1d3c7/plugins/dsh-my-plugin-manager/assets/screenshot.png
+    alt: 插件管理面板：已安装列表 + 卸载/更新检查
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/baosfeng/my-dsh-plugins/1b8db2b39e88bd6da13b645c9354df8c2af1d3c7/plugins/dsh-my-plugin-manager/assets/market.png
+    alt: 插件管理面板：市场搜索区块


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baosfeng-dsh-my-plugin-manager`
- Submission type: community curation
- Created by `baosfeng` — https://github.com/baosfeng
- Original source repository: https://github.com/baosfeng/my-dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.