### PR TITLE
catalog: add baosfeng-dsh-task-reliability (community curation, created by @baosfeng)

### DIFF
--- a/catalog/plugins/baosfeng-dsh-task-reliability.yaml
+++ b/catalog/plugins/baosfeng-dsh-task-reliability.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: baosfeng-dsh-task-reliability
+name: dsh-task-reliability
+description:
+  en: bash dsh plugin --profile web add link:<本目录绝对路径
+  evidencePath: plugins/dsh-task-reliability/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - bash
+  - profile
+  - link
+  - dsh
+source:
+  repository: https://github.com/baosfeng/my-dsh-plugins
+  repositoryNodeId: R_kgDOUAMi7w
+  subpath: plugins/dsh-task-reliability
+  commit: 1b8db2b39e88bd6da13b645c9354df8c2af1d3c7
+creator:
+  github: baosfeng
+package:
+  ecosystem: npm
+  name: dsh-task-reliability
+  version: 0.4.0
+  integrity: sha512-REPSVDIGWlQAsGj+Nyq4qVxz8ZnMR8ihAeWQ+PyLUDzg4YFnKzwG+erN99H17mXx2SG7gzY53M2jia1Oju49qw==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-task-reliability/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:14.279Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `baosfeng-dsh-task-reliability`
- Submission type: community curation
- Created by `baosfeng` — https://github.com/baosfeng
- Original source repository: https://github.com/baosfeng/my-dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.