### PR TITLE
catalog: add cnyac-dsh-polling (community curation, created by @cnyac)

### DIFF
--- a/catalog/plugins/cnyac-dsh-polling.yaml
+++ b/catalog/plugins/cnyac-dsh-polling.yaml
@@ -1,0 +1,58 @@
+schemaVersion: 1
+id: cnyac-dsh-polling
+name: dsh-polling
+description:
+  en: "Recurring/scheduled tasks (轮询任务/定时任务) plugin for DeepSeek Harness: cron-driven polling jobs as real sessions, natural-language creation, model tools (polling create/list/edit/delete/trigger) and a web UI. Install-and-go via dsh plugin add ."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - cron
+  - cron-scheduler
+  - scheduler
+  - scheduled-tasks
+  - recurring-tasks
+  - automation
+  - polling
+  - agent
+  - dsh
+source:
+  repository: https://github.com/cnyac/dsh-polling
+  repositoryNodeId: R_kgDOT4EscQ
+  subpath: null
+  commit: e14b9dde0c0899e028452c082a20c601210b6e3a
+creator:
+  github: cnyac
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:05.563Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/cnyac/dsh-polling/e14b9dde0c0899e028452c082a20c601210b6e3a/docs/images/task-list.png
+    alt: 轮询任务列表
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/cnyac/dsh-polling/e14b9dde0c0899e028452c082a20c601210b6e3a/docs/images/task-editor.png
+    alt: 轮询任务编辑页
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/cnyac/dsh-polling/e14b9dde0c0899e028452c082a20c601210b6e3a/docs/images/session-controls.png
+    alt: 会话顶部的轮询任务快捷面板


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cnyac-dsh-polling`
- Submission type: community curation
- Created by `cnyac` — https://github.com/cnyac
- Original source repository: https://github.com/cnyac/dsh-polling
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.