### PR TITLE
catalog: add fan56-dsh-tui-pi (community curation, created by @fan56)

### DIFF
--- a/catalog/plugins/fan56-dsh-tui-pi.yaml
+++ b/catalog/plugins/fan56-dsh-tui-pi.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: fan56-dsh-tui-pi
+name: "@aiwayds/dsh-tui-pi"
+description:
+  en: pi-style terminal UI for DeepSeek Harness (dsh) — pi-tui look & feel, dsh slash commands, GitHub light/dark themes, powerline footer
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - tui
+  - terminal
+  - pi
+  - powerline
+  - ui
+source:
+  repository: https://github.com/fan56/dsh-tui-pi
+  repositoryNodeId: R_kgDOT4YOMQ
+  subpath: null
+  commit: 014bdca26c655bb897a3dd8df97855a73e27a453
+creator:
+  github: fan56
+package:
+  ecosystem: npm
+  name: "@aiwayds/dsh-tui-pi"
+  version: 1.0.8
+  integrity: sha512-WdMhQy5Rj5hbRVTbh/fGSu52MJ2yig+lvRtXoA+5/1IkFnZCmSBnmZXnFMTkS5r9efUM5TjTARhtKqKPF6dE3A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:06.119Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fan56-dsh-tui-pi`
- Submission type: community curation
- Created by `fan56` — https://github.com/fan56
- Original source repository: https://github.com/fan56/dsh-tui-pi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.