### PR TITLE
catalog: add gugu123a-dsh-tool-see-image (community curation, created by @gugu123a)

### DIFF
--- a/catalog/plugins/gugu123a-dsh-tool-see-image.yaml
+++ b/catalog/plugins/gugu123a-dsh-tool-see-image.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: gugu123a-dsh-tool-see-image
+name: dsh-tool-see-image
+description:
+  en: "see image tool for DSH: route image files to a configurable vision model (OpenAI-compatible API) and relay its description back to a text-only model"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - vision
+  - image
+  - image-recognition
+  - see-image
+  - glm-4v
+  - glm
+  - zhipu
+  - llm
+source:
+  repository: https://github.com/gugu123a/dsh-tool-see-image
+  repositoryNodeId: R_kgDOT3h-jw
+  subpath: null
+  commit: 45b9421be610c9a31a1e3f084e047579cf536c18
+creator:
+  github: gugu123a
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:02.713Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gugu123a-dsh-tool-see-image`
- Submission type: community curation
- Created by `gugu123a` — https://github.com/gugu123a
- Original source repository: https://github.com/gugu123a/dsh-tool-see-image
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.