### PR TITLE
catalog: add jame100101-dsh-tui-app (community curation, created by @jame100101)

### DIFF
--- a/catalog/plugins/jame100101-dsh-tui-app.yaml
+++ b/catalog/plugins/jame100101-dsh-tui-app.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: jame100101-dsh-tui-app
+name: "@deepseek-ai/dsh-tui-app"
+description:
+  en: "The dsh terminal-surface bundle: a thin patch layer over dsh-base mounting the in-process TUI"
+  evidencePath: packages/bundle/tui-app/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - terminal
+  - surface
+  - bundle
+  - thin
+  - patch
+  - layer
+  - over
+  - base
+  - mounting
+  - process
+  - dsh
+source:
+  repository: https://github.com/jame100101/dsh-terminal-ui
+  repositoryNodeId: R_kgDOT5NAhQ
+  subpath: packages/bundle/tui-app
+  commit: a1d8ee0a1e949d5b9bcd6da946f7d89786808c44
+creator:
+  github: jame100101
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: packages/bundle/tui-app/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:28.846Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jame100101-dsh-tui-app`
- Submission type: community curation
- Created by `jame100101` — https://github.com/jame100101
- Original source repository: https://github.com/jame100101/dsh-terminal-ui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.