### PR TITLE
catalog: add laoyuehanni-dsh-git-worktree (community curation, created by @LaoYueHanNi)

### DIFF
--- a/catalog/plugins/laoyuehanni-dsh-git-worktree.yaml
+++ b/catalog/plugins/laoyuehanni-dsh-git-worktree.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: laoyuehanni-dsh-git-worktree
+name: "@laoyuehanni/dsh-git-worktree"
+description:
+  en: "DSH plugin: branch visibility and git worktree isolation for Web UI sessions"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - cordis
+  - git
+  - worktree
+  - branch
+source:
+  repository: https://github.com/LaoYueHanNi/dsh-git-worktree
+  repositoryNodeId: R_kgDOT5wIpA
+  subpath: null
+  commit: 2c602e091bbf412932e222a8ef28cf34f31e5599
+creator:
+  github: LaoYueHanNi
+package:
+  ecosystem: npm
+  name: "@laoyuehanni/dsh-git-worktree"
+  version: 0.4.0
+  integrity: sha512-qXfGX5s5Fswh7TmszriMEUHHbo47S/1kNG1+CgN64Nez8UIunmbqSPFdEKv2Lc56V/kVcWt6Q3Z3lGV+QBddbA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:02.751Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LaoYueHanNi/dsh-git-worktree/2c602e091bbf412932e222a8ef28cf34f31e5599/gitworktree.png
+    alt: dsh-git-worktree in the Web UI


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `laoyuehanni-dsh-git-worktree`
- Submission type: community curation
- Created by `LaoYueHanNi` — https://github.com/LaoYueHanNi
- Original source repository: https://github.com/LaoYueHanNi/dsh-git-worktree
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.