### PR TITLE
catalog: add laoyuehanni-dsh-token-usage (community curation, created by @LaoYueHanNi)

### DIFF
--- a/catalog/plugins/laoyuehanni-dsh-token-usage.yaml
+++ b/catalog/plugins/laoyuehanni-dsh-token-usage.yaml
@@ -1,0 +1,62 @@
+schemaVersion: 1
+id: laoyuehanni-dsh-token-usage
+name: "@laoyuehanni/dsh-token-usage"
+description:
+  en: "dsh local plugin: persist per-request model token usage (live hook + first-run history backfill + web settings stats page)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - cordis
+  - token-usage
+  - tokens
+  - statistics
+source:
+  repository: https://github.com/LaoYueHanNi/dsh-token-usage
+  repositoryNodeId: R_kgDOT37cwA
+  subpath: null
+  commit: c808f443088bd430d244bdac801d3a80f38a508f
+creator:
+  github: LaoYueHanNi
+package:
+  ecosystem: npm
+  name: "@laoyuehanni/dsh-token-usage"
+  version: 0.3.12
+  integrity: sha512-oBWoGmUK+SVplq1pRk5dXTxNOJv6CEnYnBpYx+/nfuVwqdwKuHgU6wVUJetqR/oRBdhyuFE7HNd8D4mZEAdxtg==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:00.361Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LaoYueHanNi/dsh-token-usage/c808f443088bd430d244bdac801d3a80f38a508f/docs/images/token-usage.png
+    alt: Token Usage stats page
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LaoYueHanNi/dsh-token-usage/c808f443088bd430d244bdac801d3a80f38a508f/docs/images/usage-tab.png
+    alt: Session Usage tab
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LaoYueHanNi/dsh-token-usage/c808f443088bd430d244bdac801d3a80f38a508f/docs/images/model-price.png
+    alt: Model pricing dialog
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LaoYueHanNi/dsh-token-usage/c808f443088bd430d244bdac801d3a80f38a508f/docs/images/zhipu-plan-usage.png
+    alt: Zhipu GLM quota panel
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LaoYueHanNi/dsh-token-usage/c808f443088bd430d244bdac801d3a80f38a508f/docs/images/opencode-go-plan-usage.png
+    alt: OpenCode Go quota panel


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `laoyuehanni-dsh-token-usage`
- Submission type: community curation
- Created by `LaoYueHanNi` — https://github.com/LaoYueHanNi
- Original source repository: https://github.com/LaoYueHanNi/dsh-token-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.