### PR TITLE
catalog: add lihang-lh-dsh-task-panel (community curation, created by @lihang-lh)

### DIFF
--- a/catalog/plugins/lihang-lh-dsh-task-panel.yaml
+++ b/catalog/plugins/lihang-lh-dsh-task-panel.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: lihang-lh-dsh-task-panel
+name: dsh-task-panel
+description:
+  en: "yaml - id: session-query-sqlite config: path: ~/.dsh/session-query/index.sqlite openAt: first-search"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - yaml
+  - session
+  - query
+  - sqlite
+  - config
+  - path
+  - index
+  - openat
+  - first
+  - search
+  - dsh
+source:
+  repository: https://github.com/lihang-lh/dsh-task-panel
+  repositoryNodeId: R_kgDOT-RDRA
+  subpath: null
+  commit: 63cc116952b54cf4e1943429f99e96fedc768a2f
+creator:
+  github: lihang-lh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:00.596Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lihang-lh-dsh-task-panel`
- Submission type: community curation
- Created by `lihang-lh` — https://github.com/lihang-lh
- Original source repository: https://github.com/lihang-lh/dsh-task-panel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.