### PR TITLE
catalog: add luxueliu-luxueliu-agent-discipline-skills (community curation, created by @luxueliu)

### DIFF
--- a/catalog/plugins/luxueliu-luxueliu-agent-discipline-skills.yaml
+++ b/catalog/plugins/luxueliu-luxueliu-agent-discipline-skills.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: luxueliu-luxueliu-agent-discipline-skills
+name: luxueliu-agent-discipline-skills
+description:
+  en: powershell dsh plugin --profile web add luxueliu/luxueliu-agent-discipline-skills
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-skills
+  - claude-code
+  - codex-cli
+source:
+  repository: https://github.com/luxueliu/luxueliu-agent-discipline-skills
+  repositoryNodeId: R_kgDOUDmsdQ
+  subpath: null
+  commit: df50bb2fc6d838a63433d4666027675fa2e829d4
+creator:
+  github: luxueliu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:28.442Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luxueliu-luxueliu-agent-discipline-skills`
- Submission type: community curation
- Created by `luxueliu` — https://github.com/luxueliu
- Original source repository: https://github.com/luxueliu/luxueliu-agent-discipline-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.