### PR TITLE
catalog: add luxueliu-luxueliu-intel-scout (community curation, created by @luxueliu)

### DIFF
--- a/catalog/plugins/luxueliu-luxueliu-intel-scout.yaml
+++ b/catalog/plugins/luxueliu-luxueliu-intel-scout.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: luxueliu-luxueliu-intel-scout
+name: luxueliu-intel-scout
+description:
+  en: powershell dsh plugin --profile web add luxueliu/luxueliu-intel-scout
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - automation
+  - intel-scout
+  - rss
+  - daily-brief
+source:
+  repository: https://github.com/luxueliu/luxueliu-intel-scout
+  repositoryNodeId: R_kgDOUDmtpQ
+  subpath: null
+  commit: 44b606c1a091b8d9977212ac1dfb0aaf778ec2fc
+creator:
+  github: luxueliu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:28.676Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luxueliu-luxueliu-intel-scout`
- Submission type: community curation
- Created by `luxueliu` — https://github.com/luxueliu
- Original source repository: https://github.com/luxueliu/luxueliu-intel-scout
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.