### PR TITLE
catalog: add pensivefei-dsh-voice-scribe (community curation, created by @PensiveFei)

### DIFF
--- a/catalog/plugins/pensivefei-dsh-voice-scribe.yaml
+++ b/catalog/plugins/pensivefei-dsh-voice-scribe.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: pensivefei-dsh-voice-scribe
+name: dsh-voice-scribe
+description:
+  en: bash dsh plugin --profile web add dsh-voice-scribe 重启 dsh web 后生效
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - voice
+  - speech-to-text
+  - asr
+  - whisper
+  - voice-input
+source:
+  repository: https://github.com/PensiveFei/dsh-voice-scribe
+  repositoryNodeId: R_kgDOUDeCVQ
+  subpath: null
+  commit: 1edc8b2b8351a46d1fc2e6ed7b33f0c3be8eeb49
+creator:
+  github: PensiveFei
+package:
+  ecosystem: npm
+  name: dsh-voice-scribe
+  version: 0.4.1
+  integrity: sha512-yr74joWDH5E8tjUwLuzys8TlQpeasB8vW+6UJKAlaMqaQ9X5yYkZ35vRraJS5NFrfxxJyt+CIj15i6BKPDvW1g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:00.308Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 24
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pensivefei-dsh-voice-scribe`
- Submission type: community curation
- Created by `PensiveFei` — https://github.com/PensiveFei
- Original source repository: https://github.com/PensiveFei/dsh-voice-scribe
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.