### PR TITLE
catalog: add simon-world-dsh-eco-indicator (community curation, created by @SIMON-WORLD)

### DIFF
--- a/catalog/plugins/simon-world-dsh-eco-indicator.yaml
+++ b/catalog/plugins/simon-world-dsh-eco-indicator.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: simon-world-dsh-eco-indicator
+name: dsh-eco-indicator
+description:
+  en: Query World Bank open economic indicators — GDP, inflation, trade, population, GDP per capita — by country and year range. No API key required.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - economics
+  - world-bank
+  - indicators
+  - data
+  - econ
+source:
+  repository: https://github.com/SIMON-WORLD/dsh-eco-indicator
+  repositoryNodeId: R_kgDOT7RLEg
+  subpath: null
+  commit: c0b99dcf204640c95165d9044534dc4db532e886
+creator:
+  github: SIMON-WORLD
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:30.097Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `simon-world-dsh-eco-indicator`
- Submission type: community curation
- Created by `SIMON-WORLD` — https://github.com/SIMON-WORLD
- Original source repository: https://github.com/SIMON-WORLD/dsh-eco-indicator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.