### PR TITLE
catalog: add sleepeggtart-dsh-dev-wrapped (community curation, created by @SleepEggTart)

### DIFF
--- a/catalog/plugins/sleepeggtart-dsh-dev-wrapped.yaml
+++ b/catalog/plugins/sleepeggtart-dsh-dev-wrapped.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sleepeggtart-dsh-dev-wrapped
+name: dsh-dev-wrapped
+description:
+  en: Developer Wrapped for DeepSeek Harness — your coding journey with AI, visualized.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - wrapped
+  - cli
+  - statistics
+  - report
+source:
+  repository: https://github.com/SleepEggTart/dsh-dev-wrapped
+  repositoryNodeId: R_kgDOUFIkpA
+  subpath: null
+  commit: cf4f5a416afd45b7da77b6a4107db7ff187ba7c6
+creator:
+  github: SleepEggTart
+package:
+  ecosystem: npm
+  name: dsh-dev-wrapped
+  version: 1.3.5
+  integrity: sha512-N5JpBdK+VTbGVVsZCbUx9H20ZdImX3RFobhfzg5DCuafY6XB/JI5W3elbtX1UKfaymawIIvzEA2VOpkPla7v+A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:08.708Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sleepeggtart-dsh-dev-wrapped`
- Submission type: community curation
- Created by `SleepEggTart` — https://github.com/SleepEggTart
- Original source repository: https://github.com/SleepEggTart/dsh-dev-wrapped
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.