### PR TITLE
catalog: add songoao25-dsh-auto-compact (community curation, created by @songoao25)

### DIFF
--- a/catalog/plugins/songoao25-dsh-auto-compact.yaml
+++ b/catalog/plugins/songoao25-dsh-auto-compact.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: songoao25-dsh-auto-compact
+name: dsh-auto-compact
+description:
+  en: Enhanced auto-compaction defaults for DeepSeek Harness agent presets
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - enhanced
+  - auto
+  - compaction
+  - defaults
+  - agent
+  - presets
+  - dsh
+source:
+  repository: https://github.com/songoao25/dsh-auto-compact
+  repositoryNodeId: R_kgDOT5eXTA
+  subpath: null
+  commit: 6ba59f4ccfdbd0be1397712f879fe415af73eefc
+creator:
+  github: songoao25
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:04.331Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `songoao25-dsh-auto-compact`
- Submission type: community curation
- Created by `songoao25` — https://github.com/songoao25
- Original source repository: https://github.com/songoao25/dsh-auto-compact
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.