### PR TITLE
catalog: add songoao25-dsh-contract-drafting-agent (community curation, created by @songoao25)

### DIFF
--- a/catalog/plugins/songoao25-dsh-contract-drafting-agent.yaml
+++ b/catalog/plugins/songoao25-dsh-contract-drafting-agent.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: songoao25-dsh-contract-drafting-agent
+name: dsh-contract-drafting-agent
+description:
+  en: A staged contract-drafting skill pack for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - agent-preset
+  - contract-drafting
+source:
+  repository: https://github.com/songoao25/dsh-contract-drafting-agent
+  repositoryNodeId: R_kgDOT5s8hg
+  subpath: null
+  commit: 25ed02bbb81a57ab3e6f1cb116882bd865151ce9
+creator:
+  github: songoao25
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:08.608Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `songoao25-dsh-contract-drafting-agent`
- Submission type: community curation
- Created by `songoao25` — https://github.com/songoao25
- Original source repository: https://github.com/songoao25/dsh-contract-drafting-agent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.