### PR TITLE
catalog: add sunnystarye-ui-dsh-plugin-text-quote (community curation, created by @sunnystarye-ui)

### DIFF
--- a/catalog/plugins/sunnystarye-ui-dsh-plugin-text-quote.yaml
+++ b/catalog/plugins/sunnystarye-ui-dsh-plugin-text-quote.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: sunnystarye-ui-dsh-plugin-text-quote
+name: dsh-plugin-text-quote
+description:
+  en: Codex-style text annotation for DeepSeek Harness conversations. Select any text in the chat, add a quote with your comment, and it becomes an annotation card in the composer. On send, the annotation is injected into the message and rendered back as an expandable "N 条注释" pill.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - annotation
+  - quote
+  - notes
+  - composer
+source:
+  repository: https://github.com/sunnystarye-ui/dsh-plugin-text-quote
+  repositoryNodeId: R_kgDOUCrakg
+  subpath: null
+  commit: 24845ffa371e32df7591ca08e98ed940856f3488
+creator:
+  github: sunnystarye-ui
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:31.802Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sunnystarye-ui-dsh-plugin-text-quote`
- Submission type: community curation
- Created by `sunnystarye-ui` — https://github.com/sunnystarye-ui
- Original source repository: https://github.com/sunnystarye-ui/dsh-plugin-text-quote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.