### PR TITLE
catalog: add tancheng33-dsh-egress-guard (community curation, created by @tancheng33)

### DIFF
--- a/catalog/plugins/tancheng33-dsh-egress-guard.yaml
+++ b/catalog/plugins/tancheng33-dsh-egress-guard.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: tancheng33-dsh-egress-guard
+name: dsh-egress-guard
+description:
+  en: "Runtime security gate for DeepSeek Harness: egress host allowlist, secret redaction in tool results, and an append-only audit log"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - security
+  - egress
+  - allowlist
+  - dlp
+  - redaction
+  - audit
+source:
+  repository: https://github.com/tancheng33/dsh-egress-guard
+  repositoryNodeId: R_kgDOT5HADg
+  subpath: null
+  commit: c34b9ca4b874b61c881d7e8172fffb9d294d2abe
+creator:
+  github: tancheng33
+package:
+  ecosystem: npm
+  name: dsh-egress-guard
+  version: 0.1.0
+  integrity: sha512-+uwe09wODJws3hda4e4KepPbyjN0CJYnfBObBhZeKz5naAtSBYAb0v59C98Wy5v/+hKK0faFgYXtbXIGu4Ge4g==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:08.784Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tancheng33-dsh-egress-guard`
- Submission type: community curation
- Created by `tancheng33` — https://github.com/tancheng33
- Original source repository: https://github.com/tancheng33/dsh-egress-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.