### PR TITLE
catalog: add taxueseek-dsh-healthcheck (community curation, created by @taxueseek)

### DIFF
--- a/catalog/plugins/taxueseek-dsh-healthcheck.yaml
+++ b/catalog/plugins/taxueseek-dsh-healthcheck.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: taxueseek-dsh-healthcheck
+name: dsh-healthcheck
+description:
+  en: sh dsh plugin --profile web add "github:taxueseek/dsh-healthcheck main&path:."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - cordis
+  - health
+  - diagnostic
+  - cleanup
+source:
+  repository: https://github.com/taxueseek/dsh-healthcheck
+  repositoryNodeId: R_kgDOT5WeuQ
+  subpath: null
+  commit: 1d85d1dc61e96c12354cf9bf2fbb252bdffb48f6
+creator:
+  github: taxueseek
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:05.980Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taxueseek-dsh-healthcheck`
- Submission type: community curation
- Created by `taxueseek` — https://github.com/taxueseek
- Original source repository: https://github.com/taxueseek/dsh-healthcheck
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.