### PR TITLE
catalog: add taxueseek-dsh-lexicon (community curation, created by @taxueseek)

### DIFF
--- a/catalog/plugins/taxueseek-dsh-lexicon.yaml
+++ b/catalog/plugins/taxueseek-dsh-lexicon.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: taxueseek-dsh-lexicon
+name: dsh-lexicon
+description:
+  en: "IME lexicon manager for DeepSeek Harness: bridge the ime lexicon.py CLI (Doubao / WeType word libraries) into model tools — detect, export, backup, industry-term search, build, optimize, and staging import. Never applies to a live IME without explicit user confirmation."
+  evidencePath: plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - cordis
+  - ime
+  - lexicon
+  - doubao
+  - wetype
+  - input-method
+source:
+  repository: https://github.com/taxueseek/ime-lexicon
+  repositoryNodeId: R_kgDOUAk4WQ
+  subpath: plugin
+  commit: e960d94706009fc3937a3e0e4acc16afe644876e
+creator:
+  github: taxueseek
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:31.970Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `taxueseek-dsh-lexicon`
- Submission type: community curation
- Created by `taxueseek` — https://github.com/taxueseek
- Original source repository: https://github.com/taxueseek/ime-lexicon
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.