### PR TITLE
catalog: add tingfeng347-dsh-vscode-workbench (community curation, created by @tingfeng347)

### DIFF
--- a/catalog/plugins/tingfeng347-dsh-vscode-workbench.yaml
+++ b/catalog/plugins/tingfeng347-dsh-vscode-workbench.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: tingfeng347-dsh-vscode-workbench
+name: dsh-vscode-workbench
+description:
+  en: Explorer, Monaco editor, search and local Git overlay for DSH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - explorer
+  - monaco
+  - editor
+  - search
+  - local
+  - overlay
+  - dsh
+source:
+  repository: https://github.com/tingfeng347/dsh-vscode-workbench
+  repositoryNodeId: R_kgDOUBqyyw
+  subpath: null
+  commit: 44401a86fced3166c192309da795f58654ad6bab
+creator:
+  github: tingfeng347
+package:
+  ecosystem: npm
+  name: dsh-vscode-workbench
+  version: 0.1.6
+  integrity: sha512-vTjA39dGB4gqce5a2Wrozf+A4EkTPOAJrUXJ21TsaCCntacZA6C9FqWyHi4J9mX89ytiMGv/u5PpAZi55xsoZg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:03.079Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/tingfeng347/dsh-vscode-workbench/44401a86fced3166c192309da795f58654ad6bab/assets/screenshots/explorer.png
+    alt: 资源管理器与 Monaco 编辑器
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/tingfeng347/dsh-vscode-workbench/44401a86fced3166c192309da795f58654ad6bab/assets/screenshots/source-control.png
+    alt: 源代码管理与提交图表


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tingfeng347-dsh-vscode-workbench`
- Submission type: community curation
- Created by `tingfeng347` — https://github.com/tingfeng347
- Original source repository: https://github.com/tingfeng347/dsh-vscode-workbench
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.