### PR TITLE
catalog: add tobysunsun-dsh-code-reading-coach (community curation, created by @tobysunsun)

### DIFF
--- a/catalog/plugins/tobysunsun-dsh-code-reading-coach.yaml
+++ b/catalog/plugins/tobysunsun-dsh-code-reading-coach.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: tobysunsun-dsh-code-reading-coach
+name: dsh-code-reading-coach
+description:
+  en: bash dsh plugin --profile web add github:tobysunsun/dsh-code-reading-coach
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - agent-preset
+  - code-reading
+  - paper
+source:
+  repository: https://github.com/tobysunsun/dsh-code-reading-coach
+  repositoryNodeId: R_kgDOUAbCTw
+  subpath: null
+  commit: f48388d4a79e13c43b7168a06a8838b14d933fe6
+creator:
+  github: tobysunsun
+package:
+  ecosystem: npm
+  name: dsh-code-reading-coach
+  version: 0.1.0
+  integrity: sha512-YmSCw3axli8i4eIELiZ25SBngrO4Lp6DcboAssXT6ilEoec/L5/cJZnfIIDNiN1HtHOTL9wYyoD2lt48iDkM9w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:04.174Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tobysunsun-dsh-code-reading-coach`
- Submission type: community curation
- Created by `tobysunsun` — https://github.com/tobysunsun
- Original source repository: https://github.com/tobysunsun/dsh-code-reading-coach
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.