### PR TITLE
catalog: add tuogusa-dsh-session-tags (community curation, created by @tuogusa)

### DIFF
--- a/catalog/plugins/tuogusa-dsh-session-tags.yaml
+++ b/catalog/plugins/tuogusa-dsh-session-tags.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tuogusa-dsh-session-tags
+name: dsh-session-tags
+description:
+  en: bash dsh plugin --profile web add github:tuogusa/dsh-session-tags
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - bash
+  - profile
+  - tuogusa
+  - session
+  - tags
+  - dsh
+source:
+  repository: https://github.com/tuogusa/dsh-session-tags
+  repositoryNodeId: R_kgDOT4pjaw
+  subpath: null
+  commit: 4ef4858916ae28fd3caa8c322116bb344396051a
+creator:
+  github: tuogusa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:06.909Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tuogusa-dsh-session-tags`
- Submission type: community curation
- Created by `tuogusa` — https://github.com/tuogusa
- Original source repository: https://github.com/tuogusa/dsh-session-tags
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.