### PR TITLE
catalog: add txy-ucas-dsh-workspace-snapshot (community curation, created by @txy-ucas)

### DIFF
--- a/catalog/plugins/txy-ucas-dsh-workspace-snapshot.yaml
+++ b/catalog/plugins/txy-ucas-dsh-workspace-snapshot.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: txy-ucas-dsh-workspace-snapshot
+name: dsh-workspace-snapshot
+description:
+  en: A bounded read-only Git workspace status tool for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - bounded
+  - read
+  - only
+  - workspace
+  - status
+  - tool
+  - dsh
+source:
+  repository: https://github.com/txy-ucas/dsh-workspace-snapshot
+  repositoryNodeId: R_kgDOT5P5PQ
+  subpath: null
+  commit: 99bc94a9cf5293f90dc8f043746a7a6ce7fe86a0
+creator:
+  github: txy-ucas
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:06.991Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `txy-ucas-dsh-workspace-snapshot`
- Submission type: community curation
- Created by `txy-ucas` — https://github.com/txy-ucas
- Original source repository: https://github.com/txy-ucas/dsh-workspace-snapshot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.