### PR TITLE
catalog: add uckkk-dsh-api-contract (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-api-contract.yaml
+++ b/catalog/plugins/uckkk-dsh-api-contract.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: uckkk-dsh-api-contract
+name: dsh-api-contract
+description:
+  en: bash dsh plugin add dsh-api-contract
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - openapi
+  - swagger
+  - client
+source:
+  repository: https://github.com/uckkk/dsh-api-contract
+  repositoryNodeId: R_kgDOT57NbA
+  subpath: null
+  commit: 92930413dc519e0b165b11d19587d0ebad6226de
+creator:
+  github: uckkk
+package:
+  ecosystem: npm
+  name: dsh-api-contract
+  version: 0.1.0
+  integrity: sha512-0xpp84QWUl6HXbNJZc6q4Gnoi94ZwUFuEKjLCv6yb8VHWh0EDKjY0I3EauNbv+e4holrKVMzIiIvOiZh+Yen6g==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:10.130Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-api-contract`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-api-contract
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.