### PR TITLE
catalog: add uckkk-dsh-data-visualization (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-data-visualization.yaml
+++ b/catalog/plugins/uckkk-dsh-data-visualization.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: uckkk-dsh-data-visualization
+name: dsh-data-visualization
+description:
+  en: bash dsh plugin add dsh-data-visualization 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-data-visualization" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - chart
+  - dataviz
+  - visualization
+source:
+  repository: https://github.com/uckkk/dsh-data-visualization
+  repositoryNodeId: R_kgDOT6jKlg
+  subpath: null
+  commit: 21ca4b6fc82887c2271100f0c8e8b7bba504d76b
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:11.980Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-data-visualization`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-data-visualization
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.