### PR TITLE
catalog: add uckkk-dsh-design-tokens (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-design-tokens.yaml
+++ b/catalog/plugins/uckkk-dsh-design-tokens.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: uckkk-dsh-design-tokens
+name: dsh-design-tokens
+description:
+  en: bash dsh plugin add dsh-design-tokens 安装后在 profile 的 package.json 的 dsh.profile.bundles 中加入 "dsh-design-tokens" 。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - design-tokens
+  - design-system
+  - naming
+source:
+  repository: https://github.com/uckkk/dsh-design-tokens
+  repositoryNodeId: R_kgDOT6jA6w
+  subpath: null
+  commit: e5c0fc4a657d17578b2d7fe4bd9410597826d52b
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:07.269Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-design-tokens`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-design-tokens
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.