### PR TITLE
catalog: add zsxh1990-pr-genius (community curation, created by @zsxh1990)

### DIFF
--- a/catalog/plugins/zsxh1990-pr-genius.yaml
+++ b/catalog/plugins/zsxh1990-pr-genius.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: zsxh1990-pr-genius
+name: pr-genius
+description:
+  en: "--- type: Knowledge Bundle title: PR Genius — Pre-submission PR Advisor description: Evidence-backed PR contribution advisor for large open-source projects version: 1.4.0 created: 2026-07-01 updated: 2026-07-22 author: zsxh1990 conforms to: OKF v0.1 (Sudhakaran88/okf-conformance) + agent guidelines extension --- mcp-na"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - pr
+  - code-review
+  - dsh
+source:
+  repository: https://github.com/zsxh1990/pr-genius
+  repositoryNodeId: R_kgDOTLoLYg
+  subpath: null
+  commit: ae3bdad1f86a7003f9f51b54a7ea1db55a000b66
+creator:
+  github: zsxh1990
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:04.424Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zsxh1990-pr-genius`
- Submission type: community curation
- Created by `zsxh1990` — https://github.com/zsxh1990
- Original source repository: https://github.com/zsxh1990/pr-genius
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.