### PR TITLE
catalog: add zuoyunlai-lunheng-article-pipeline (community curation, created by @zuoyunlai)

### DIFF
--- a/catalog/plugins/zuoyunlai-lunheng-article-pipeline.yaml
+++ b/catalog/plugins/zuoyunlai-lunheng-article-pipeline.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zuoyunlai-lunheng-article-pipeline
+name: lunheng-article-pipeline
+description:
+  en: sh dsh plugin --profile web add lunheng-article-pipeline
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - skill
+  - bundle
+  - article-pipeline
+  - agent
+source:
+  repository: https://github.com/zuoyunlai/lunheng-article-pipeline-dsh
+  repositoryNodeId: R_kgDOT62vvg
+  subpath: null
+  commit: 0d3954b070e10f003dfca054b15b5fd3df354a66
+creator:
+  github: zuoyunlai
+package:
+  ecosystem: npm
+  name: lunheng-article-pipeline
+  version: 2.5.2-dsh.4
+  integrity: sha512-DRoAMpITWxgT1HWa/gbMQOCusG4Osl65MRHdjt5pxhXTTi1jLJBAUMZbdhFe0CxJyD/xlGLXEGW5BZ9OG5A0dw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:04.494Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zuoyunlai-lunheng-article-pipeline`
- Submission type: community curation
- Created by `zuoyunlai` — https://github.com/zuoyunlai
- Original source repository: https://github.com/zuoyunlai/lunheng-article-pipeline-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.