### PR TITLE
catalog: add zutomayoo-toto-the-cat (community curation, created by @ZutoMayoo)

### DIFF
--- a/catalog/plugins/zutomayoo-toto-the-cat.yaml
+++ b/catalog/plugins/zutomayoo-toto-the-cat.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: zutomayoo-toto-the-cat
+name: toto-the-cat
+description:
+  en: A desktop pet named Toto living inside the DeepSeek Harness web UI. Its look is entirely defined by custom images in assets/ (transparent PNGs — a still idle.png or a frame sequence idle-0.png , idle-1.png , ...). With no images, Toto is not displayed. Zero dependencies, zero build step — installs like a skin.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - desktop-pet
+  - pet
+  - toto
+  - cat
+  - pomodoro
+  - web-ui
+source:
+  repository: https://github.com/ZutoMayoo/totoTheCat
+  repositoryNodeId: R_kgDOT-Th_Q
+  subpath: null
+  commit: dec5e6b5da34dde07fa62d4dff9bac7169c8adf8
+creator:
+  github: ZutoMayoo
+package:
+  ecosystem: npm
+  name: toto-the-cat
+  version: 1.0.1
+  integrity: sha512-bTO/vsxBbnM9zTowTFjLmvZnJyCHmLHFXKoXf7JktWB8+ng6oKYdK43L6PBrFtl6HE5sZeJ/vwhP84EZfAC/Uw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:13.272Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ZutoMayoo/totoTheCat/dec5e6b5da34dde07fa62d4dff9bac7169c8adf8/assets/screenshot.png
+    alt: Screenshot 1


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zutomayoo-toto-the-cat`
- Submission type: community curation
- Created by `ZutoMayoo` — https://github.com/ZutoMayoo
- Original source repository: https://github.com/ZutoMayoo/totoTheCat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.