### PR TITLE
catalog: add zyh20041227-dsh-vision-tiler (community curation, created by @zyh20041227)

### DIFF
--- a/catalog/plugins/zyh20041227-dsh-vision-tiler.yaml
+++ b/catalog/plugins/zyh20041227-dsh-vision-tiler.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: zyh20041227-dsh-vision-tiler
+name: dsh-vision-tiler
+description:
+  en: Loss-aware, full-coverage image tiling for DeepSeek Harness vision models
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - vision
+  - ocr
+  - document-ai
+  - image-tiling
+  - dsh
+source:
+  repository: https://github.com/zyh20041227/improved_vision_for_deepseek
+  repositoryNodeId: R_kgDOUA2mUg
+  subpath: null
+  commit: cbcf80280074082e7299daddeeaa1542385e372c
+creator:
+  github: zyh20041227
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:04.619Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zyh20041227/improved_vision_for_deepseek/cbcf80280074082e7299daddeeaa1542385e372c/assets/benchmark-comparison.png
+    alt: Dense-text benchmark comparison
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zyh20041227/improved_vision_for_deepseek/cbcf80280074082e7299daddeeaa1542385e372c/assets/dsh-web-installed-v0.2.3.png
+    alt: DSH Web showing Vision Tiler enabled


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zyh20041227-dsh-vision-tiler`
- Submission type: community curation
- Created by `zyh20041227` — https://github.com/zyh20041227
- Original source repository: https://github.com/zyh20041227/improved_vision_for_deepseek
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.