### PR TITLE
catalog: add zzhzz-dsh-ask-peer (community curation, created by @zzhzz)

### DIFF
--- a/catalog/plugins/zzhzz-dsh-ask-peer.yaml
+++ b/catalog/plugins/zzhzz-dsh-ask-peer.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zzhzz-dsh-ask-peer
+name: dsh-ask-peer
+description:
+  en: Decentralized peer-to-peer 'ask a colleague's agent' plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - p2p
+  - peer-to-peer
+  - decentralized
+  - agent-collaboration
+  - lan
+  - ask-peer
+  - agents
+source:
+  repository: https://github.com/zzhzz/dsh-ask-peer
+  repositoryNodeId: R_kgDOT7RJFQ
+  subpath: null
+  commit: b803fcd94bd231d8f9055a2116beabdd5de25c1c
+creator:
+  github: zzhzz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:00.266Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zzhzz-dsh-ask-peer`
- Submission type: community curation
- Created by `zzhzz` — https://github.com/zzhzz
- Original source repository: https://github.com/zzhzz/dsh-ask-peer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.