### PR TITLE
catalog: add zzx-dear-dsh-capybara-notify (community curation, created by @zzx-dear)

### DIFF
--- a/catalog/plugins/zzx-dear-dsh-capybara-notify.yaml
+++ b/catalog/plugins/zzx-dear-dsh-capybara-notify.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: zzx-dear-dsh-capybara-notify
+name: dsh-capybara-notify
+description:
+  en: English quickstart at the bottom.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - pet
+  - notification
+  - secretary
+  - capybara
+source:
+  repository: https://github.com/zzx-dear/dsh-capybara-notify
+  repositoryNodeId: R_kgDOT8CI_Q
+  subpath: null
+  commit: 2341191c21555eb71d744b4dc8723c64e7ece330
+creator:
+  github: zzx-dear
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:13.274Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zzx-dear-dsh-capybara-notify`
- Submission type: community curation
- Created by `zzx-dear` — https://github.com/zzx-dear
- Original source repository: https://github.com/zzx-dear/dsh-capybara-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.