### PR TITLE
catalog: add zzy1601-dsh-zcode-sync (community curation, created by @zzy1601)

### DIFF
--- a/catalog/plugins/zzy1601-dsh-zcode-sync.yaml
+++ b/catalog/plugins/zzy1601-dsh-zcode-sync.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zzy1601-dsh-zcode-sync
+name: dsh-zcode-sync
+description:
+  en: "English : A DeepSeek Harness (DSH) plugin that syncs your ZCode custom model providers into DSH — in-process via the settings & credentials services, with llm-pi-ai 's own validation as the gatekeeper. Idempotent, zero hardcoded paths, works on any machine. See English summary below."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - zcode
+  - model-providers
+  - sync
+  - dsh
+source:
+  repository: https://github.com/zzy1601/dsh-zcode-sync
+  repositoryNodeId: R_kgDOUCMPYw
+  subpath: null
+  commit: c11b0a76d8c20372744f7ede8559da9448943132
+creator:
+  github: zzy1601
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T16:41:39.255Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zzy1601-dsh-zcode-sync`
- Submission type: community curation
- Created by `zzy1601` — https://github.com/zzy1601
- Original source repository: https://github.com/zzy1601/dsh-zcode-sync
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.