### PR TITLE
catalog: add 0xkcyzz-dsh-plugin-store (community curation, created by @0xKcyzz)

### DIFF
--- a/catalog/plugins/0xkcyzz-dsh-plugin-store.yaml
+++ b/catalog/plugins/0xkcyzz-dsh-plugin-store.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: 0xkcyzz-dsh-plugin-store
+name: dsh-plugin-store
+description:
+  en: bash dsh plugin --profile web add github:0xKcyzz/dsh-plugin-store
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - plugin-store
+  - plugin-marketplace
+source:
+  repository: https://github.com/0xKcyzz/dsh-plugin-store
+  repositoryNodeId: R_kgDOT4M98A
+  subpath: null
+  commit: e3616ab4ede79cdca5af9aaa965fcc88ef115f18
+creator:
+  github: 0xKcyzz
+package:
+  ecosystem: npm
+  name: dsh-plugin-store
+  version: 0.1.0
+  integrity: sha512-0aqBdtGqXX/706SF9+bSp6vpQvdO+fDD7h8iCIutr7ROyVrJbxC/SsJqu20lShmQCwC47EoR5r6lL0Bfw0W6SA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:05.948Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `0xkcyzz-dsh-plugin-store`
- Submission type: community curation
- Created by `0xKcyzz` — https://github.com/0xKcyzz
- Original source repository: https://github.com/0xKcyzz/dsh-plugin-store
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.