### PR TITLE
catalog: add 1070296335-create-taskboard (community curation, created by @1070296335-create)

### DIFF
--- a/catalog/plugins/1070296335-create-taskboard.yaml
+++ b/catalog/plugins/1070296335-create-taskboard.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: 1070296335-create-taskboard
+name: "@dph/taskboard"
+description:
+  en: bash git clone <你的仓库地址 dph-taskboard cd dph-taskboard
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - taskboard
+  - kanban
+source:
+  repository: https://github.com/1070296335-create/dph-taskboard
+  repositoryNodeId: R_kgDOT7Drag
+  subpath: null
+  commit: ceda7a378b713afdfcae4d94b670b026f2e24100
+creator:
+  github: 1070296335-create
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:09.193Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/1070296335-create/dph-taskboard/ceda7a378b713afdfcae4d94b670b026f2e24100/docs/screenshot.png
+    alt: 任务看板截图（占位，发布前请替换为真实界面截图）


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1070296335-create-taskboard`
- Submission type: community curation
- Created by `1070296335-create` — https://github.com/1070296335-create
- Original source repository: https://github.com/1070296335-create/dph-taskboard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.