### PR TITLE
catalog: add 1123762794-dsh-web-restart (community curation, created by @1123762794)

### DIFF
--- a/catalog/plugins/1123762794-dsh-web-restart.yaml
+++ b/catalog/plugins/1123762794-dsh-web-restart.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: 1123762794-dsh-web-restart
+name: dsh-web-restart
+description:
+  en: One-click restart button for the DeepSeek Harness Web UI .
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - web
+  - restart
+  - ui
+source:
+  repository: https://github.com/1123762794/dsh-web-restart
+  repositoryNodeId: R_kgDOT5NmJw
+  subpath: null
+  commit: 5de8214051b3245a8cfc825e7e907cf5e57f51d8
+creator:
+  github: "1123762794"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:05.937Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1123762794-dsh-web-restart`
- Submission type: community curation
- Created by `1123762794` — https://github.com/1123762794
- Original source repository: https://github.com/1123762794/dsh-web-restart
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.