### PR TITLE
catalog: add 1514100951-dsh-usage-footer (community curation, created by @1514100951)

### DIFF
--- a/catalog/plugins/1514100951-dsh-usage-footer.yaml
+++ b/catalog/plugins/1514100951-dsh-usage-footer.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: 1514100951-dsh-usage-footer
+name: dsh-usage-footer
+description:
+  en: "DSH web plugin: a floating usage/cost button with a hover panel (account balance, peak/off-peak bracket, cost estimate, session tokens, today's spend) and a General-settings on/off toggle, backed by the loopback-only GET /usage-status host route"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - bundle
+  - usage
+  - cost
+  - balance
+source:
+  repository: https://github.com/1514100951/dsh-usage-footer
+  repositoryNodeId: R_kgDOT4FnJQ
+  subpath: null
+  commit: 04fcd235d8fadd289b1d8355f58f493ef40440ac
+creator:
+  github: "1514100951"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:09.351Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `1514100951-dsh-usage-footer`
- Submission type: community curation
- Created by `1514100951` — https://github.com/1514100951
- Original source repository: https://github.com/1514100951/dsh-usage-footer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.