### PR TITLE
catalog: add 3361805598-gif-dsh-md-annotator (community curation, created by @3361805598-gif)

### DIFF
--- a/catalog/plugins/3361805598-gif-dsh-md-annotator.yaml
+++ b/catalog/plugins/3361805598-gif-dsh-md-annotator.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 3361805598-gif-dsh-md-annotator
+name: dsh-md-annotator
+description:
+  en: sh curl -L -o dsh-md-annotator-0.6.0.tgz \ https://github.com/3361805598-gif/dsh-md-annotator/releases/download/v0.6.0/dsh-md-annotator-0.6.0.tgz shasum -a 256 dsh-md-annotator-0.6.0.tgz
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - dsh-better-sidebar
+  - markdown
+  - annotation
+  - deepseek-harness
+source:
+  repository: https://github.com/3361805598-gif/dsh-md-annotator
+  repositoryNodeId: R_kgDOT5bZ9Q
+  subpath: null
+  commit: 1b7bbf96b7d2df262ad8159b94dc5669baffa73b
+creator:
+  github: 3361805598-gif
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:09.808Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `3361805598-gif-dsh-md-annotator`
- Submission type: community curation
- Created by `3361805598-gif` — https://github.com/3361805598-gif
- Original source repository: https://github.com/3361805598-gif/dsh-md-annotator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.