### PR TITLE
catalog: add 3403473060-dsh-inline-images (community curation, created by @3403473060)

### DIFF
--- a/catalog/plugins/3403473060-dsh-inline-images.yaml
+++ b/catalog/plugins/3403473060-dsh-inline-images.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: 3403473060-dsh-inline-images
+name: dsh-inline-images
+description:
+  en: sh pnpm install pnpm run build dsh plugin --profile web add ./dsh-inline-images
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - pnpm
+  - install
+  - build
+  - profile
+  - inline
+  - images
+  - dsh
+source:
+  repository: https://github.com/3403473060/dsh-inline-images
+  repositoryNodeId: R_kgDOT4VF0g
+  subpath: null
+  commit: 79f8ba778441c86738dedba574f5911fd2b5b2be
+creator:
+  github: "3403473060"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:11.674Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/3403473060/dsh-inline-images/79f8ba778441c86738dedba574f5911fd2b5b2be/assets/screenshots/demo.png
+    alt: 示例


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `3403473060-dsh-inline-images`
- Submission type: community curation
- Created by `3403473060` — https://github.com/3403473060
- Original source repository: https://github.com/3403473060/dsh-inline-images
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.