### PR TITLE
catalog: add 398894496-arch-dsh-krouter (community curation, created by @398894496-arch)

### DIFF
--- a/catalog/plugins/398894496-arch-dsh-krouter.yaml
+++ b/catalog/plugins/398894496-arch-dsh-krouter.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: 398894496-arch-dsh-krouter
+name: dsh-krouter
+description:
+  en: "DSH-KRouter DSH socket (same product as the repo root: router + writer). Not a second project."
+  evidencePath: extras/dsh/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - obsidian
+  - krouter
+  - knowledge-base
+  - memory-system
+  - second-brain
+  - self-evolution
+  - agent-memory
+source:
+  repository: https://github.com/398894496-arch/runtime36
+  repositoryNodeId: R_kgDOT_ftdA
+  subpath: extras/dsh
+  commit: 904ed76fd8422b0d4ae72f745551c50a2cd65015
+creator:
+  github: 398894496-arch
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: extras/dsh/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:25.392Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `398894496-arch-dsh-krouter`
- Submission type: community curation
- Created by `398894496-arch` — https://github.com/398894496-arch
- Original source repository: https://github.com/398894496-arch/runtime36
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.