### PR TITLE
catalog: add 452926826-dsh-at-skill (community curation, created by @452926826)

### DIFF
--- a/catalog/plugins/452926826-dsh-at-skill.yaml
+++ b/catalog/plugins/452926826-dsh-at-skill.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: 452926826-dsh-at-skill
+name: dsh-at-skill
+description:
+  en: Invoke DeepSeek Harness skills with @name and show skill suggestions in the composer
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skill
+  - autocomplete
+source:
+  repository: https://github.com/452926826/dsh-at-skill
+  repositoryNodeId: R_kgDOUDqvEg
+  subpath: null
+  commit: 7502c9bce1a65597188c12d4ab1e33e9365e3a22
+creator:
+  github: "452926826"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:21.172Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `452926826-dsh-at-skill`
- Submission type: community curation
- Created by `452926826` — https://github.com/452926826
- Original source repository: https://github.com/452926826/dsh-at-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.