### PR TITLE
catalog: add 452926826-dsh-feishu-bot (community curation, created by @452926826)

### DIFF
--- a/catalog/plugins/452926826-dsh-feishu-bot.yaml
+++ b/catalog/plugins/452926826-dsh-feishu-bot.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: 452926826-dsh-feishu-bot
+name: dsh-feishu-bot
+description:
+  en: Connect a Feishu bot to DeepSeek Harness projects and conversations
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - feishu
+  - lark
+  - bot
+source:
+  repository: https://github.com/452926826/dsh-feishu-bot
+  repositoryNodeId: R_kgDOUDqvUg
+  subpath: null
+  commit: 130084a2618bebe52a5b226964479c3b2f255b6e
+creator:
+  github: "452926826"
+package:
+  ecosystem: npm
+  name: dsh-feishu-bot
+  version: 0.1.4
+  integrity: sha512-C9I0ISxTgKEX5a1/dLQv1ii6uDFhQNC7JExbVTFMn9WDloiCMHRomtvZb2U61EmIbmqia7pZgoK8HcQf7bL2Yg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:25.887Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `452926826-dsh-feishu-bot`
- Submission type: community curation
- Created by `452926826` — https://github.com/452926826
- Original source repository: https://github.com/452926826/dsh-feishu-bot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.