### PR TITLE
catalog: add 452926826-dsh-ssh-logs (community curation, created by @452926826)

### DIFF
--- a/catalog/plugins/452926826-dsh-ssh-logs.yaml
+++ b/catalog/plugins/452926826-dsh-ssh-logs.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: 452926826-dsh-ssh-logs
+name: dsh-ssh-logs
+description:
+  en: Read allowlisted remote logs over SSH from DeepSeek Harness conversations
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - ssh
+  - logs
+source:
+  repository: https://github.com/452926826/dsh-ssh-logs
+  repositoryNodeId: R_kgDOUDqYUA
+  subpath: null
+  commit: 4dbc65c4bb250f72388edfd42b3d3e4d0103699c
+creator:
+  github: "452926826"
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:21.482Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `452926826-dsh-ssh-logs`
- Submission type: community curation
- Created by `452926826` — https://github.com/452926826
- Original source repository: https://github.com/452926826/dsh-ssh-logs
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.