### PR TITLE
catalog: add abnerai-dsh-monitor (community curation, created by @AbnerAI)

### DIFF
--- a/catalog/plugins/abnerai-dsh-monitor.yaml
+++ b/catalog/plugins/abnerai-dsh-monitor.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: abnerai-dsh-monitor
+name: dsh-monitor
+description:
+  en: Persistent watchers that wake the DeepSeek Harness agent when new messages arrive — the harness analog of Claude Code's Monitor tool.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - monitor
+  - notification
+  - claude-code
+source:
+  repository: https://github.com/AbnerAI/dsh-monitor
+  repositoryNodeId: R_kgDOT3qxqQ
+  subpath: null
+  commit: 4ef3cc6f3e4332a85d913a13ae929f5eb587818a
+creator:
+  github: AbnerAI
+package:
+  ecosystem: npm
+  name: dsh-monitor
+  version: 0.1.1
+  integrity: sha512-Y9sHB6dQglobdpGgypOwHQ3uRkGNpAGaF7Nf4qFmz8URyuvpIVC+Z/8f2uy0x8n4idAC5b6YA5dSUcw7uBvHMg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:12.637Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `abnerai-dsh-monitor`
- Submission type: community curation
- Created by `AbnerAI` — https://github.com/AbnerAI
- Original source repository: https://github.com/AbnerAI/dsh-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.