### PR TITLE
catalog: add adonissheldon-dsh-openai-oauth (community curation, created by @AdonisSheldon)

### DIFF
--- a/catalog/plugins/adonissheldon-dsh-openai-oauth.yaml
+++ b/catalog/plugins/adonissheldon-dsh-openai-oauth.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: adonissheldon-dsh-openai-oauth
+name: dsh-openai-oauth
+description:
+  en: Self-contained OpenAI Codex OAuth provider for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - openai
+  - codex
+  - oauth
+  - dsh
+source:
+  repository: https://github.com/AdonisSheldon/dsh-openai-oauth
+  repositoryNodeId: R_kgDOT6GfWg
+  subpath: null
+  commit: ba29660530fe05779b06f129a0c0ed5c2237b73f
+creator:
+  github: AdonisSheldon
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:03.301Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `adonissheldon-dsh-openai-oauth`
- Submission type: community curation
- Created by `AdonisSheldon` — https://github.com/AdonisSheldon
- Original source repository: https://github.com/AdonisSheldon/dsh-openai-oauth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.