### PR TITLE
catalog: add alaxrpg-dsh-adaptive-model-router (community curation, created by @alaxrpg)

### DIFF
--- a/catalog/plugins/alaxrpg-dsh-adaptive-model-router.yaml
+++ b/catalog/plugins/alaxrpg-dsh-adaptive-model-router.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: alaxrpg-dsh-adaptive-model-router
+name: dsh-adaptive-model-router
+description:
+  en: Adaptive model discovery, evaluation, tiering, and subagent routing for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - adaptive
+  - model
+  - discovery
+  - evaluation
+  - tiering
+  - subagent
+  - routing
+  - dsh
+source:
+  repository: https://github.com/alaxrpg/dsh-adaptive-model-router
+  repositoryNodeId: R_kgDOT4BHbQ
+  subpath: null
+  commit: f095794278246e345b48bcffde470e1ceb7c99b5
+creator:
+  github: alaxrpg
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:21.984Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alaxrpg-dsh-adaptive-model-router`
- Submission type: community curation
- Created by `alaxrpg` — https://github.com/alaxrpg
- Original source repository: https://github.com/alaxrpg/dsh-adaptive-model-router
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.