### PR TITLE
catalog: add alex04130-dsh-forge-bundle (community curation, created by @alex04130)

### DIFF
--- a/catalog/plugins/alex04130-dsh-forge-bundle.yaml
+++ b/catalog/plugins/alex04130-dsh-forge-bundle.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: alex04130-dsh-forge-bundle
+name: "@dsh-forge/bundle"
+description:
+  en: "DSH extension suite host bundle: cross-session mailbox, agent teams, model delegation & routing policy, runtime injector, skill manager, dynamic-plugin boot, and the plugin/skill manager client packages."
+  evidencePath: bundle/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - extension
+  - suite
+  - host
+  - bundle
+  - cross
+  - session
+  - mailbox
+  - agent
+  - teams
+  - model
+  - delegation
+  - routing
+  - policy
+  - runtime
+  - injector
+  - skill
+source:
+  repository: https://github.com/alex04130/dsh-forge
+  repositoryNodeId: R_kgDOT5ExAA
+  subpath: bundle
+  commit: 481725b4086aeb5d7b2bf56d3184d944311a380f
+creator:
+  github: alex04130
+package:
+  ecosystem: npm
+  name: "@dsh-forge/bundle"
+  version: 0.1.4
+  integrity: sha512-8d0WobrXtl11H2/RVEiumJfeOTNHZDXx+U1gJvldgFkwiebVzJ/CODmbeb81CNTQ/bil3kOd7gq7aypLbKdjuA==
+dsh:
+  profiles:
+    - web
+  evidencePath: bundle/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:25.575Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alex04130-dsh-forge-bundle`
- Submission type: community curation
- Created by `alex04130` — https://github.com/alex04130
- Original source repository: https://github.com/alex04130/dsh-forge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.