### PR TITLE
catalog: add alexyin-tongji-dsh-ui-enhancer (community curation, created by @AlexYin-Tongji)

### DIFF
--- a/catalog/plugins/alexyin-tongji-dsh-ui-enhancer.yaml
+++ b/catalog/plugins/alexyin-tongji-dsh-ui-enhancer.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: alexyin-tongji-dsh-ui-enhancer
+name: dsh-ui-enhancer
+description:
+  en: A desktop-style workspace, wallpaper, pet, and file-reference UI for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - desktop-ui
+  - wallpaper
+  - file-preview
+source:
+  repository: https://github.com/AlexYin-Tongji/dsh-ui-enhancer
+  repositoryNodeId: R_kgDOT9ALbg
+  subpath: null
+  commit: 87f17fe74076570023e01e5d0fc55c21affd2c23
+creator:
+  github: AlexYin-Tongji
+package:
+  ecosystem: npm
+  name: dsh-ui-enhancer
+  version: 0.2.0
+  integrity: sha512-fKABrDkQtWXYSEyhb2EWNshf8z8BBRVZlS4x2KAaFVoph9M0NRo3u45fvtHtXPy/PZEGKi3nvnAWNEYI1Zfltg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:16.121Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alexyin-tongji-dsh-ui-enhancer`
- Submission type: community curation
- Created by `AlexYin-Tongji` — https://github.com/AlexYin-Tongji
- Original source repository: https://github.com/AlexYin-Tongji/dsh-ui-enhancer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.