### PR TITLE
catalog: add alloevil-dsh-xray (community curation, created by @alloevil)

### DIFF
--- a/catalog/plugins/alloevil-dsh-xray.yaml
+++ b/catalog/plugins/alloevil-dsh-xray.yaml
@@ -1,0 +1,66 @@
+schemaVersion: 1
+id: alloevil-dsh-xray
+name: dsh-xray
+description:
+  en: "X-ray for your DeepSeek Harness — diagnostics for what's actually loaded, why, and what it costs: per-plugin context-tax attribution, per-request token ledger, skill catalog pricing, dependency cascades."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - cordis
+  - diagnostics
+  - introspection
+  - plugin-tree
+  - dependency-graph
+  - observability
+  - audit
+  - security-scan
+  - token-cost
+  - lockfile
+  - troubleshooting
+  - context-cost
+  - token-attribution
+source:
+  repository: https://github.com/alloevil/dsh-xray
+  repositoryNodeId: R_kgDOT-YrRQ
+  subpath: null
+  commit: 6d86469f04e29ea61e21cd8c230e119d1c5a97c9
+creator:
+  github: alloevil
+package:
+  ecosystem: npm
+  name: dsh-xray
+  version: 0.10.2
+  integrity: sha512-JNqwOeNWtSfMiHUxicu1DTr3qRpDrPIP9L2l5xM77paGluXfpWOEIOG3ioAg8Pb+edWw/eijH7czPf0VVigPXg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:16.206Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/alloevil/dsh-xray/6d86469f04e29ea61e21cd8c230e119d1c5a97c9/assets/tab-cost.webp
+    alt: "The X-Ray tab: every plugin's per-request context tax, attributed and ranked"
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/alloevil/dsh-xray/6d86469f04e29ea61e21cd8c230e119d1c5a97c9/assets/tab-expand.webp
+    alt: A plugin unfolds into its registered entries
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/alloevil/dsh-xray/6d86469f04e29ea61e21cd8c230e119d1c5a97c9/assets/tab-entry.webp
+    alt: The raw text behind ~184 tokens, with a chars/tokens ruler


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `alloevil-dsh-xray`
- Submission type: community curation
- Created by `alloevil` — https://github.com/alloevil
- Original source repository: https://github.com/alloevil/dsh-xray
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.