### PR TITLE
catalog: add amatsumeakira-opencode-usage (community curation, created by @AmaTsumeAkira)

### DIFF
--- a/catalog/plugins/amatsumeakira-opencode-usage.yaml
+++ b/catalog/plugins/amatsumeakira-opencode-usage.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: amatsumeakira-opencode-usage
+name: opencode-usage
+description:
+  en: OpenCode Go quota badge plugin (bundle) — shows rolling / weekly / monthly quota usage and reset times for OpenCode Go right in the dsh Web UI.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - opencode
+  - quota
+  - badge
+  - bundle
+  - shows
+  - rolling
+  - weekly
+  - monthly
+  - usage
+  - reset
+  - times
+  - right
+  - dsh
+source:
+  repository: https://github.com/AmaTsumeAkira/opencode-usage
+  repositoryNodeId: R_kgDOT4CZGA
+  subpath: null
+  commit: d9f87058597f35a9189fa5ca3dafbb7a47ee954e
+creator:
+  github: AmaTsumeAkira
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:22.027Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/AmaTsumeAkira/opencode-usage/d9f87058597f35a9189fa5ca3dafbb7a47ee954e/docs/screenshot.png
+    alt: OpenCode Go quota badge in the composer dock
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/AmaTsumeAkira/opencode-usage/d9f87058597f35a9189fa5ca3dafbb7a47ee954e/docs/screenshot.en.png
+    alt: OpenCode Go quota badge in the composer dock


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `amatsumeakira-opencode-usage`
- Submission type: community curation
- Created by `AmaTsumeAkira` — https://github.com/AmaTsumeAkira
- Original source repository: https://github.com/AmaTsumeAkira/opencode-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.