### PR TITLE
catalog: add andrew111888-dsh-plugin-balance (community curation, created by @Andrew111888)

### DIFF
--- a/catalog/plugins/andrew111888-dsh-plugin-balance.yaml
+++ b/catalog/plugins/andrew111888-dsh-plugin-balance.yaml
@@ -1,0 +1,62 @@
+schemaVersion: 1
+id: andrew111888-dsh-plugin-balance
+name: dsh-plugin-balance
+description:
+  en: A floating credit / quota widget for the DeepSeek Harness Web — plus DSH session token usage & cost stats.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - balance
+  - opencode
+  - usage
+  - tokens
+source:
+  repository: https://github.com/Andrew111888/dsh-plugin-balance
+  repositoryNodeId: R_kgDOT-MNFw
+  subpath: null
+  commit: 96bb1592c949456aa37ccc3a296085f59df2ee9c
+creator:
+  github: Andrew111888
+package:
+  ecosystem: npm
+  name: dsh-plugin-balance
+  version: 1.4.4
+  integrity: sha512-Lrp7+1rEhbInQfnuk4epIwnI0WGKZIiNWU0bT5SJhs5jLHvAb13FZz5EPBLubvjXUK6xTfHFqvilB2EpsIAwsw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:07.844Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Andrew111888/dsh-plugin-balance/96bb1592c949456aa37ccc3a296085f59df2ee9c/docs/preview-anim.gif
+    alt: 动画演示
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Andrew111888/dsh-plugin-balance/96bb1592c949456aa37ccc3a296085f59df2ee9c/docs/preview-usage.png
+    alt: 用量明细
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Andrew111888/dsh-plugin-balance/96bb1592c949456aa37ccc3a296085f59df2ee9c/docs/preview-tokens.png
+    alt: Token 统计
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Andrew111888/dsh-plugin-balance/96bb1592c949456aa37ccc3a296085f59df2ee9c/docs/preview-context.png
+    alt: 实际效果
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Andrew111888/dsh-plugin-balance/96bb1592c949456aa37ccc3a296085f59df2ee9c/docs/preview-balance-type.png
+    alt: 余额类型


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `andrew111888-dsh-plugin-balance`
- Submission type: community curation
- Created by `Andrew111888` — https://github.com/Andrew111888
- Original source repository: https://github.com/Andrew111888/dsh-plugin-balance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.