### PR TITLE
catalog: add antarescorn-dsh-auto-reviewer (community curation, created by @AntaresCorn)

### DIFF
--- a/catalog/plugins/antarescorn-dsh-auto-reviewer.yaml
+++ b/catalog/plugins/antarescorn-dsh-auto-reviewer.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: antarescorn-dsh-auto-reviewer
+name: "@dsh-external/dsh-auto-reviewer"
+description:
+  en: Codex-style auto reviewer (approve for me) permission mode for DSH
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - permission
+  - auto-reviewer
+  - approve-for-me
+  - dsh
+source:
+  repository: https://github.com/AntaresCorn/dsh-auto-reviewer
+  repositoryNodeId: R_kgDOT6SThg
+  subpath: null
+  commit: 4ab578384aea0f7ac374c23591e4609558353533
+creator:
+  github: AntaresCorn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:25.571Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `antarescorn-dsh-auto-reviewer`
- Submission type: community curation
- Created by `AntaresCorn` — https://github.com/AntaresCorn
- Original source repository: https://github.com/AntaresCorn/dsh-auto-reviewer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.