### PR TITLE
catalog: add areium-dsh-fail-logger (community curation, created by @Areium)

### DIFF
--- a/catalog/plugins/areium-dsh-fail-logger.yaml
+++ b/catalog/plugins/areium-dsh-fail-logger.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: areium-dsh-fail-logger
+name: dsh-fail-logger
+description:
+  en: "An all-mode tool failure recorder for DeepSeek Harness: whether the agent runs in native mode or PTC (Code Mode) , any tool failure is automatically written into the machine-maintained section of a skill — normalized-dedup, counted, deterministically ranked, TTL-pruned, and redacted — so the next session's model sees t"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - code-mode
+  - ptc
+  - fail-logger
+  - tool-error
+  - skill
+source:
+  repository: https://github.com/Areium/dsh-fail-logger
+  repositoryNodeId: R_kgDOT3sJVQ
+  subpath: null
+  commit: ab09e90f35d74cabf5af510e4c8bcf4bd6f2ddc5
+creator:
+  github: Areium
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:03.520Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Areium/dsh-fail-logger/ab09e90f35d74cabf5af510e4c8bcf4bd6f2ddc5/assets/demo-session.png
+    alt: Session failure example
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Areium/dsh-fail-logger/ab09e90f35d74cabf5af510e4c8bcf4bd6f2ddc5/assets/demo-skill.png
+    alt: Skill auto-log section


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `areium-dsh-fail-logger`
- Submission type: community curation
- Created by `Areium` — https://github.com/Areium
- Original source repository: https://github.com/Areium/dsh-fail-logger
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.