### PR TITLE
catalog: add aryswisnu-dsh-eval-regression (community curation, created by @aryswisnu)

### DIFF
--- a/catalog/plugins/aryswisnu-dsh-eval-regression.yaml
+++ b/catalog/plugins/aryswisnu-dsh-eval-regression.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: aryswisnu-dsh-eval-regression
+name: dsh-eval-regression
+description:
+  en: Deterministic, CI-safe golden-output evaluation for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - evaluation
+  - regression-testing
+  - ci
+  - dsh
+source:
+  repository: https://github.com/aryswisnu/dsh-eval-regression
+  repositoryNodeId: R_kgDOT3d-5w
+  subpath: null
+  commit: 39382eb9d97ce19cff848e4f81e6cf6cf5948cb5
+creator:
+  github: aryswisnu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:16.254Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `aryswisnu-dsh-eval-regression`
- Submission type: community curation
- Created by `aryswisnu` — https://github.com/aryswisnu
- Original source repository: https://github.com/aryswisnu/dsh-eval-regression
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.