### PR TITLE
catalog: add asakumizy-dsh-local-skills (community curation, created by @asakumizy)

### DIFF
--- a/catalog/plugins/asakumizy-dsh-local-skills.yaml
+++ b/catalog/plugins/asakumizy-dsh-local-skills.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: asakumizy-dsh-local-skills
+name: dsh-local-skills
+description:
+  en: "Local SKILL browser plugin for DeepSeek Harness: discovers local skills with live filesystem updates and surfaces them in the web UI with a Use button that explains how to invoke each skill."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - local
+  - skill
+  - browser
+  - discovers
+  - skills
+  - live
+  - filesystem
+  - updates
+  - surfaces
+  - button
+  - explains
+  - invoke
+  - each
+  - dsh
+source:
+  repository: https://github.com/asakumizy/dsh-local-skills
+  repositoryNodeId: R_kgDOT6mg3g
+  subpath: null
+  commit: 038d6059fb36ca5d5e1e8456befb8d928c7b958e
+creator:
+  github: asakumizy
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:22.318Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `asakumizy-dsh-local-skills`
- Submission type: community curation
- Created by `asakumizy` — https://github.com/asakumizy
- Original source repository: https://github.com/asakumizy/dsh-local-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.