### PR TITLE
catalog: add bing-bryan-dsh-unread-dot (community curation, created by @Bing-Bryan)

### DIFF
--- a/catalog/plugins/bing-bryan-dsh-unread-dot.yaml
+++ b/catalog/plugins/bing-bryan-dsh-unread-dot.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: bing-bryan-dsh-unread-dot
+name: dsh-unread-dot
+description:
+  en: "DSH web plugin: macOS Dock unread red dot (dot = running, number = results) + bubble chime when the app is hidden/minimized — built on the Badging API"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - badging-api
+  - dock-badge
+  - notification
+  - macos
+source:
+  repository: https://github.com/Bing-Bryan/dsh-unread-dot
+  repositoryNodeId: R_kgDOT5IzDQ
+  subpath: null
+  commit: c6dbc1dae83928f10f4f713f5fcfc7423babefd9
+creator:
+  github: Bing-Bryan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:09.809Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bing-bryan-dsh-unread-dot`
- Submission type: community curation
- Created by `Bing-Bryan` — https://github.com/Bing-Bryan
- Original source repository: https://github.com/Bing-Bryan/dsh-unread-dot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.