### PR TITLE
catalog: add blackbearcc-dsh-pet-sprite (community curation, created by @BlackBearCC)

### DIFF
--- a/catalog/plugins/blackbearcc-dsh-pet-sprite.yaml
+++ b/catalog/plugins/blackbearcc-dsh-pet-sprite.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: blackbearcc-dsh-pet-sprite
+name: dsh-pet-sprite
+description:
+  en: "A playable pixel companion for the DeepSeek Harness Web UI: hatch an egg and pick one of three companions (girl / tabby cat / baby whale), left-click to chat with it through your configured DSH models, platform-jump over chat messages, WASD controllable, with a full nurture system fed by your agent's real token usage."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - playable
+  - pixel
+  - companion
+  - hatch
+  - pick
+  - three
+  - companions
+  - girl
+  - tabby
+  - baby
+  - whale
+  - left
+  - click
+  - chat
+  - through
+  - configured
+source:
+  repository: https://github.com/BlackBearCC/dsh-pet-sprite
+  repositoryNodeId: R_kgDOT8PtRw
+  subpath: null
+  commit: 019f19574aded1d721e06e2788c2091f0d7eb95c
+creator:
+  github: BlackBearCC
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:16.670Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `blackbearcc-dsh-pet-sprite`
- Submission type: community curation
- Created by `BlackBearCC` — https://github.com/BlackBearCC
- Original source repository: https://github.com/BlackBearCC/dsh-pet-sprite
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.