### PR TITLE
catalog: add byte-info-dsh-projectmodel (community curation, created by @byte-info)

### DIFF
--- a/catalog/plugins/byte-info-dsh-projectmodel.yaml
+++ b/catalog/plugins/byte-info-dsh-projectmodel.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: byte-info-dsh-projectmodel
+name: dsh-projectmodel
+description:
+  en: bash dsh plugin --profile web add .
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - project-groups
+  - workspace
+source:
+  repository: https://github.com/Youngxj/dsh-ProjectModel
+  repositoryNodeId: R_kgDOT35JAQ
+  subpath: null
+  commit: 68789298dd2a572ac026ecebef106c542995611e
+creator:
+  github: byte-info
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:32.153Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Youngxj/dsh-ProjectModel/68789298dd2a572ac026ecebef106c542995611e/preview.png
+    alt: dsh-ProjectModel 界面预览


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `byte-info-dsh-projectmodel`
- Submission type: community curation
- Created by `byte-info` — https://github.com/byte-info
- Original source repository: https://github.com/Youngxj/dsh-ProjectModel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.