### PR TITLE
catalog: add twork097-dsh-llm-governor (community curation, created by @twork097)

### DIFF
--- a/catalog/plugins/twork097-dsh-llm-governor.yaml
+++ b/catalog/plugins/twork097-dsh-llm-governor.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: twork097-dsh-llm-governor
+name: dsh-llm-governor
+description:
+  en: Multi-model governance, routing, fallback, quota, and usage for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - llm-routing
+  - governance
+source:
+  repository: https://github.com/young-tim/dsh-llm-governor
+  repositoryNodeId: R_kgDOT9vSUg
+  subpath: null
+  commit: cb027ceb14492d4cecf04a4e6e879370459f924a
+creator:
+  github: twork097
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:19.759Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `twork097-dsh-llm-governor`
- Submission type: community curation
- Created by `twork097` — https://github.com/twork097
- Original source repository: https://github.com/young-tim/dsh-llm-governor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.