### PR TITLE
catalog: add twork097-dsh-profile-lab (community curation, created by @twork097)

### DIFF
--- a/catalog/plugins/twork097-dsh-profile-lab.yaml
+++ b/catalog/plugins/twork097-dsh-profile-lab.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: twork097-dsh-profile-lab
+name: dsh-profile-lab
+description:
+  en: Reproducible local experiment matrices for DSH profiles
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - evaluation
+  - benchmark
+  - profiles
+source:
+  repository: https://github.com/young-tim/dsh-profile-lab
+  repositoryNodeId: R_kgDOT88Tzw
+  subpath: null
+  commit: 2cf8c3b7ae29c9ad67465161ee683615c6884cba
+creator:
+  github: twork097
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:14.709Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `twork097-dsh-profile-lab`
- Submission type: community curation
- Created by `twork097` — https://github.com/twork097
- Original source repository: https://github.com/young-tim/dsh-profile-lab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.