### PR TITLE
catalog: add uckkk-dsh-flour-swap (community curation, created by @uckkk)

### DIFF
--- a/catalog/plugins/uckkk-dsh-flour-swap.yaml
+++ b/catalog/plugins/uckkk-dsh-flour-swap.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: uckkk-dsh-flour-swap
+name: dsh-flour-swap
+description:
+  en: bash dsh plugin add github:uckkk/dsh-flour-swap
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-flour-swap
+source:
+  repository: https://github.com/uckkk/dsh-flour-swap
+  repositoryNodeId: R_kgDOT-tHQA
+  subpath: null
+  commit: 450d3354a02e85d8bbd9839350616015c1e33e79
+creator:
+  github: uckkk
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:27.078Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `uckkk-dsh-flour-swap`
- Submission type: community curation
- Created by `uckkk` — https://github.com/uckkk
- Original source repository: https://github.com/uckkk/dsh-flour-swap
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.