### PR TITLE
catalog: add wingsky-1-dsh-codegraph (community curation, created by @wingsky-1)

### DIFF
--- a/catalog/plugins/wingsky-1-dsh-codegraph.yaml
+++ b/catalog/plugins/wingsky-1-dsh-codegraph.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: wingsky-1-dsh-codegraph
+name: "@wingsky-1/dsh-codegraph"
+description:
+  en: "A collection of plugins for the DSH (DeepSeek Harness) web GUI, distributed via npm: install them all at once as a single bundle, or pick individual plugins as needed."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - codegraph
+  - mcp
+  - worktree
+source:
+  repository: https://github.com/wingsky-1/dsh-plugin-hub
+  repositoryNodeId: R_kgDOT6Jr1Q
+  subpath: packages/dsh-codegraph
+  commit: 4fdd64b0af07c9321308667784e9349bdf7c17b1
+creator:
+  github: wingsky-1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh-codegraph/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:27.526Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wingsky-1-dsh-codegraph`
- Submission type: community curation
- Created by `wingsky-1` — https://github.com/wingsky-1
- Original source repository: https://github.com/wingsky-1/dsh-plugin-hub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.