### PR TITLE
catalog: add yangyunsong023-dsh-sxs-anti-bot-http (community curation, created by @yangyunsong023)

### DIFF
--- a/catalog/plugins/yangyunsong023-dsh-sxs-anti-bot-http.yaml
+++ b/catalog/plugins/yangyunsong023-dsh-sxs-anti-bot-http.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yangyunsong023-dsh-sxs-anti-bot-http
+name: dsh-sxs-anti-bot-http
+description:
+  en: "Anti-bot HTTP fetch tools for DeepSeek Harness: UA pool rotation, retry with exponential backoff, anti-bot wall detection, and adaptive rate limiting."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - anti-bot
+  - crawler
+  - rate-limit
+source:
+  repository: https://github.com/yangyunsong023/dsh-sxs-anti-bot-http
+  repositoryNodeId: R_kgDOT51xBA
+  subpath: null
+  commit: 5a956bf01da88fef35ae689d21feeded60c75261
+creator:
+  github: yangyunsong023
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:18.135Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangyunsong023-dsh-sxs-anti-bot-http`
- Submission type: community curation
- Created by `yangyunsong023` — https://github.com/yangyunsong023
- Original source repository: https://github.com/yangyunsong023/dsh-sxs-anti-bot-http
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.