### PR TITLE
catalog: add yangyunsong023-dsh-sxs-news-collector (community curation, created by @yangyunsong023)

### DIFF
--- a/catalog/plugins/yangyunsong023-dsh-sxs-news-collector.yaml
+++ b/catalog/plugins/yangyunsong023-dsh-sxs-news-collector.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: yangyunsong023-dsh-sxs-news-collector
+name: dsh-sxs-news-collector
+description:
+  en: sh dsh plugin --profile web add git+https://github.com/yangyunsong023/dsh-sxs-news-collector.git dsh plugin --profile web add link:/path/to/dsh-sxs-news-collector
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - news
+  - hot-search
+  - trending
+  - content
+source:
+  repository: https://github.com/yangyunsong023/dsh-sxs-news-collector
+  repositoryNodeId: R_kgDOT51xWA
+  subpath: null
+  commit: 0c72c77579bd18e0f95dec1f3da73ac5fe3d6ae9
+creator:
+  github: yangyunsong023
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:17.855Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangyunsong023-dsh-sxs-news-collector`
- Submission type: community curation
- Created by `yangyunsong023` — https://github.com/yangyunsong023
- Original source repository: https://github.com/yangyunsong023/dsh-sxs-news-collector
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.