### PR TITLE
catalog: add yantingmo-dsh-lang-zh (community curation, created by @Yantingmo)

### DIFF
--- a/catalog/plugins/yantingmo-dsh-lang-zh.yaml
+++ b/catalog/plugins/yantingmo-dsh-lang-zh.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yantingmo-dsh-lang-zh
+name: dsh-lang-zh
+description:
+  en: sh dsh plugin --profile web add dsh-lang-zh
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - language
+  - chinese
+  - zh-cn
+  - simplified-chinese
+source:
+  repository: https://github.com/Yantingmo/dsh-lang-zh
+  repositoryNodeId: R_kgDOUARJ9w
+  subpath: null
+  commit: bb2990dfbdec46281ac762c70049a5a76fe857e8
+creator:
+  github: Yantingmo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:28.606Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yantingmo-dsh-lang-zh`
- Submission type: community curation
- Created by `Yantingmo` — https://github.com/Yantingmo
- Original source repository: https://github.com/Yantingmo/dsh-lang-zh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.