### PR TITLE
catalog: add yaopushen-dsh-plugin-background-tasks (community curation, created by @yaopushen)

### DIFF
--- a/catalog/plugins/yaopushen-dsh-plugin-background-tasks.yaml
+++ b/catalog/plugins/yaopushen-dsh-plugin-background-tasks.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: yaopushen-dsh-plugin-background-tasks
+name: dsh-plugin-background-tasks
+description:
+  en: Seam-aligned background command execution for DeepSeek Harness — run command via ctx.shell under the session sandbox policy, auto-promotion into ctx.jobs
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - cordis
+  - deepseek-harness
+  - dsh-plugin
+  - background-tasks
+  - dsh
+source:
+  repository: https://github.com/yaopushen/dsh-plugin-background-tasks
+  repositoryNodeId: R_kgDOUBy3wA
+  subpath: null
+  commit: f17ee3369bc7beada9071026248e00c20f8db197
+creator:
+  github: yaopushen
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:23.784Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yaopushen-dsh-plugin-background-tasks`
- Submission type: community curation
- Created by `yaopushen` — https://github.com/yaopushen
- Original source repository: https://github.com/yaopushen/dsh-plugin-background-tasks
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.