### PR TITLE
catalog: add ye-yi7-dsh-search-fast (community curation, created by @YE-YI7)

### DIFF
--- a/catalog/plugins/ye-yi7-dsh-search-fast.yaml
+++ b/catalog/plugins/ye-yi7-dsh-search-fast.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: ye-yi7-dsh-search-fast
+name: "@fixture/dsh-search-fast"
+description:
+  en: The agent economy has discovery and it's getting payment rails. The layer in between — deciding which tool an agent uses and who gets paid — is missing. ASM is our bid to build it.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - agent
+  - economy
+  - discovery
+  - getting
+  - payment
+  - rails
+  - layer
+  - between
+  - deciding
+  - tool
+  - uses
+  - gets
+  - paid
+  - missing
+  - build
+  - dsh
+source:
+  repository: https://github.com/YE-YI7/asm-spec
+  repositoryNodeId: R_kgDOR5s7rA
+  subpath: examples/interop/deepseek-harness-selection-boundary/bundles/search-fast
+  commit: cf2276c425a72d84390ffccb208f6e570093fb12
+creator:
+  github: YE-YI7
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: examples/interop/deepseek-harness-selection-boundary/bundles/search-fast/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:28.745Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/YE-YI7/asm-spec/cf2276c425a72d84390ffccb208f6e570093fb12/docs/assets/asm-openrouter-demo.gif
+    alt: ASM OpenRouter CLI demo


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ye-yi7-dsh-search-fast`
- Submission type: community curation
- Created by `YE-YI7` — https://github.com/YE-YI7
- Original source repository: https://github.com/YE-YI7/asm-spec
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.