### PR TITLE
catalog: add yeqingtang-dsh-task-watcher-plugin (community curation, created by @YeqingTang)

### DIFF
--- a/catalog/plugins/yeqingtang-dsh-task-watcher-plugin.yaml
+++ b/catalog/plugins/yeqingtang-dsh-task-watcher-plugin.yaml
@@ -1,0 +1,60 @@
+schemaVersion: 1
+id: yeqingtang-dsh-task-watcher-plugin
+name: "@yeqingtang/dsh-task-watcher-plugin"
+description:
+  en: "Windows tray monitor for DeepSeek Harness tasks: deploys and launches DshTaskWatcher (standalone PowerShell tray app) from the plugin bundle. Status/start/stop via loopback API. The watcher runs detached from the host process."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - windows
+  - tray
+  - monitor
+  - tasks
+  - deploys
+  - launches
+  - dshtaskwatcher
+  - standalone
+  - powershell
+  - bundle
+  - status
+  - start
+  - stop
+  - loopback
+  - watcher
+  - runs
+source:
+  repository: https://github.com/YeqingTang/dsh-task-watcher-plugin
+  repositoryNodeId: R_kgDOT-tYAw
+  subpath: null
+  commit: ba4210feb6de4f9b9c4ea2d66dec0caee80dc350
+creator:
+  github: YeqingTang
+package:
+  ecosystem: npm
+  name: "@yeqingtang/dsh-task-watcher-plugin"
+  version: 0.5.4
+  integrity: sha512-UfZDLV5K2+p9+/65vr/bl6OvePQJLAdpvFtG2EOW1Zsq49OQWJWeGeFpiwhBhevnPOHOodzdMDM/hUiMAqhFWQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:30.802Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/YeqingTang/dsh-task-watcher-plugin/ba4210feb6de4f9b9c4ea2d66dec0caee80dc350/assets/screenshots/preview.png
+    alt: preview


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yeqingtang-dsh-task-watcher-plugin`
- Submission type: community curation
- Created by `YeqingTang` — https://github.com/YeqingTang
- Original source repository: https://github.com/YeqingTang/dsh-task-watcher-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.