### PR TITLE
catalog: add yeruizhi-dsh-lark-meeting-notifier (community curation, created by @yeruizhi)

### DIFF
--- a/catalog/plugins/yeruizhi-dsh-lark-meeting-notifier.yaml
+++ b/catalog/plugins/yeruizhi-dsh-lark-meeting-notifier.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: yeruizhi-dsh-lark-meeting-notifier
+name: dsh-lark-meeting-notifier
+description:
+  en: bash dsh plugin --profile web add github:yeruizhi/dsh-lark-meeting-notifier
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - feishu
+  - lark
+  - calendar
+  - meeting
+  - reminder
+source:
+  repository: https://github.com/yeruizhi/dsh-lark-meeting-notifier
+  repositoryNodeId: R_kgDOT4Xp6g
+  subpath: null
+  commit: 65782f8d13f79143af86fec1628dfa0918af335f
+creator:
+  github: yeruizhi
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:06.014Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yeruizhi/dsh-lark-meeting-notifier/65782f8d13f79143af86fec1628dfa0918af335f/docs/screenshot.jpg
+    alt: dsh-lark-meeting-notifier 效果图


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yeruizhi-dsh-lark-meeting-notifier`
- Submission type: community curation
- Created by `yeruizhi` — https://github.com/yeruizhi
- Original source repository: https://github.com/yeruizhi/dsh-lark-meeting-notifier
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.