### PR TITLE
catalog: add yeyeyeyeshifu-dsh-result-only-view (community curation, created by @YEYEYEYESHIFU)

### DIFF
--- a/catalog/plugins/yeyeyeyeshifu-dsh-result-only-view.yaml
+++ b/catalog/plugins/yeyeyeyeshifu-dsh-result-only-view.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: yeyeyeyeshifu-dsh-result-only-view
+name: dsh-result-only-view
+description:
+  en: "Results-only toggle for the DeepSeek Harness Web GUI: hides thinking and tool-call process nodes so a conversation shows only final answers, while keeping a single live status line (the latest running step) during agent activity. Whitelisted interactive cards (ask user question, cordis run) stay visible; approval promp"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ui
+  - results-only
+  - productivity
+source:
+  repository: https://github.com/YEYEYEYESHIFU/dsh-result-only-view
+  repositoryNodeId: R_kgDOT5dUnA
+  subpath: null
+  commit: 7fcc3f0979767f89b937758b5b3f566f458f05b1
+creator:
+  github: YEYEYEYESHIFU
+package:
+  ecosystem: npm
+  name: dsh-result-only-view
+  version: 1.6.3
+  integrity: sha512-wjSeCKTVVmhvQHSLVnGD+q88NW4Kwd0LVH4PTRvVxog5u7v4esbpizigOQiQPS4fcOwchUTt7P+5oYD8hpt/nw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:17.987Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yeyeyeyeshifu-dsh-result-only-view`
- Submission type: community curation
- Created by `YEYEYEYESHIFU` — https://github.com/YEYEYEYESHIFU
- Original source repository: https://github.com/YEYEYEYESHIFU/dsh-result-only-view
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.