### PR TITLE
catalog: add ygcdsj-dsh-migrate (community curation, created by @ygcdsj)

### DIFF
--- a/catalog/plugins/ygcdsj-dsh-migrate.yaml
+++ b/catalog/plugins/ygcdsj-dsh-migrate.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ygcdsj-dsh-migrate
+name: dsh-migrate
+description:
+  en: bash dsh plugin --profile web add dsh-migrate
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - migration
+  - backup
+  - restore
+  - profile
+source:
+  repository: https://github.com/ygcdsj/dsh-home-migrate
+  repositoryNodeId: R_kgDOT9Krgw
+  subpath: null
+  commit: 4529c2a0d2f13d948ebe3db9f5b462c7d6407860
+creator:
+  github: ygcdsj
+package:
+  ecosystem: npm
+  name: dsh-migrate
+  version: 0.0.11
+  integrity: sha512-ZEh69Oz4Ncxyr73HLZk4vXIi7CGXxNrlAfOz+2DgoiZFWVRNQWe7+yLxE8IJlw3wUH8IDncTlmsqqO/KyaUVaQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:10.144Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ygcdsj-dsh-migrate`
- Submission type: community curation
- Created by `ygcdsj` — https://github.com/ygcdsj
- Original source repository: https://github.com/ygcdsj/dsh-home-migrate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.