### PR TITLE
catalog: add yha9806-dsh-subagent-admission (community curation, created by @yha9806)

### DIFF
--- a/catalog/plugins/yha9806-dsh-subagent-admission.yaml
+++ b/catalog/plugins/yha9806-dsh-subagent-admission.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yha9806-dsh-subagent-admission
+name: dsh-subagent-admission
+description:
+  en: Shared lifecycle admission protocol and reference policy kernel for DSH subagents.
+  evidencePath: packages/dsh-subagent-admission/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - subagent
+  - admission-control
+  - agent-infrastructure
+source:
+  repository: https://github.com/yha9806/dsh-subagent-admission
+  repositoryNodeId: R_kgDOT4QQmg
+  subpath: packages/dsh-subagent-admission
+  commit: 2e2e921e7154d9e11d23f97800723d712bcda2c3
+creator:
+  github: yha9806
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-subagent-admission/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:30.874Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yha9806/dsh-subagent-admission/2e2e921e7154d9e11d23f97800723d712bcda2c3/packages/dsh-subagent-admission/docs/assets/admission-control.png
+    alt: Admission Control view


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yha9806-dsh-subagent-admission`
- Submission type: community curation
- Created by `yha9806` — https://github.com/yha9806
- Original source repository: https://github.com/yha9806/dsh-subagent-admission
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.