### PR TITLE
catalog: add yhyfhgs-dsh-model-hub (community curation, created by @yhyfhgs)

### DIFF
--- a/catalog/plugins/yhyfhgs-dsh-model-hub.yaml
+++ b/catalog/plugins/yhyfhgs-dsh-model-hub.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: yhyfhgs-dsh-model-hub
+name: "@fhxgs/dsh-model-hub"
+description:
+  en: "DeepSeek Harness plugin: provider sign-in, model catalog, and selection routing over a loopback-only /model-hub channel"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - model-hub
+  - oauth
+  - llm
+  - dsh
+source:
+  repository: https://github.com/yhyfhgs/dsh-model-hub
+  repositoryNodeId: R_kgDOUDgIJw
+  subpath: null
+  commit: 2bb54c6543c8faac05d2b54162b33f1c80915e1a
+creator:
+  github: yhyfhgs
+package:
+  ecosystem: npm
+  name: "@fhxgs/dsh-model-hub"
+  version: 0.2.4
+  integrity: sha512-3gSZ5DGF8cjeoeHp3gANQGVxEeK3P2vi4LQTY3zF2uwjr3BhIPGi0/efzk90wlsPWIbmi9zVSSBHprh0xUmWeA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:18.341Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yhyfhgs/dsh-model-hub/2bb54c6543c8faac05d2b54162b33f1c80915e1a/docs/screenshots/composer-picker.png
+    alt: Composer picker bubble with the reasoning-effort slider
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yhyfhgs/dsh-model-hub/2bb54c6543c8faac05d2b54162b33f1c80915e1a/docs/screenshots/settings-providers.png
+    alt: Model Hub settings, Providers panel
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yhyfhgs/dsh-model-hub/2bb54c6543c8faac05d2b54162b33f1c80915e1a/docs/screenshots/settings-catalog.png
+    alt: Model Hub settings, Catalog panel


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yhyfhgs-dsh-model-hub`
- Submission type: community curation
- Created by `yhyfhgs` — https://github.com/yhyfhgs
- Original source repository: https://github.com/yhyfhgs/dsh-model-hub
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.