### PR TITLE
catalog: add yihefeikong-rgb-dsh-dream (community curation, created by @yihefeikong-rgb)

### DIFF
--- a/catalog/plugins/yihefeikong-rgb-dsh-dream.yaml
+++ b/catalog/plugins/yihefeikong-rgb-dsh-dream.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yihefeikong-rgb-dsh-dream
+name: dsh-dream
+description:
+  en: powershell dsh plugin --profile web add C:\Users\huangxinyang\.dsh\plugins\dsh-dream dsh plugin --profile web add D:\claude\...\dsh-dream
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - powershell
+  - profile
+  - users
+  - huangxinyang
+  - dream
+  - claude
+  - dsh
+source:
+  repository: https://github.com/yihefeikong-rgb/dsh-cc-haha-dream
+  repositoryNodeId: R_kgDOT-tCUA
+  subpath: null
+  commit: b8b3277e94ea7c57cd8e990010cc9614b0f98abb
+creator:
+  github: yihefeikong-rgb
+package:
+  ecosystem: npm
+  name: dsh-dream
+  version: 0.1.0
+  integrity: sha512-1Da6A0CIhAIuGB7RzaPACr93ba1GORGQqCSEmSxxutorN0o8sWTbMIgnGgKEadQ0j8uECXcV1yuGcUCUP+jEYg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:23.936Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yihefeikong-rgb-dsh-dream`
- Submission type: community curation
- Created by `yihefeikong-rgb` — https://github.com/yihefeikong-rgb
- Original source repository: https://github.com/yihefeikong-rgb/dsh-cc-haha-dream
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.