### PR TITLE
catalog: add yiipu-dsh-agentmemory (community curation, created by @Yiipu)

### DIFF
--- a/catalog/plugins/yiipu-dsh-agentmemory.yaml
+++ b/catalog/plugins/yiipu-dsh-agentmemory.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: yiipu-dsh-agentmemory
+name: dsh-agentmemory
+description:
+  en: DSH ↔ agentmemory session-memory bridge (backend-only). Mirrors session lifecycle into agentmemory with standard hookTypes (compression-friendly, dedup-safe), exposes memory recall / memory remember tools, and injects memory context via agent/pre-step. Configuration comes from the cordis.yml row.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - agentmemory
+  - memory
+source:
+  repository: https://github.com/Yiipu/dsh-agentmemory
+  repositoryNodeId: R_kgDOT5H2aA
+  subpath: null
+  commit: 43b06b1a680ee358c5dabc362bbcbebf6918cb27
+creator:
+  github: Yiipu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:13.701Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yiipu-dsh-agentmemory`
- Submission type: community curation
- Created by `Yiipu` — https://github.com/Yiipu
- Original source repository: https://github.com/Yiipu/dsh-agentmemory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.