### PR TITLE
catalog: add yingjunnan-dsh-deepseek-quota (community curation, created by @yingjunnan)

### DIFF
--- a/catalog/plugins/yingjunnan-dsh-deepseek-quota.yaml
+++ b/catalog/plugins/yingjunnan-dsh-deepseek-quota.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: yingjunnan-dsh-deepseek-quota
+name: dsh-deepseek-quota
+description:
+  en: "DeepSeek API quota widget for the dsh web GUI: shows remaining DeepSeek API balance in a floating card pinned to the bottom-right corner (shell.overlay slot)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - quota
+  - balance
+  - web
+source:
+  repository: https://github.com/yingjunnan/dsh-deepseek-quota
+  repositoryNodeId: R_kgDOT4BJHA
+  subpath: null
+  commit: 88bfbd8253b2749f2bba418c90925841c51b5e1c
+creator:
+  github: yingjunnan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:10.759Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yingjunnan/dsh-deepseek-quota/88bfbd8253b2749f2bba418c90925841c51b5e1c/docs/screenshot.png
+    alt: dsh-deepseek-quota 截图


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yingjunnan-dsh-deepseek-quota`
- Submission type: community curation
- Created by `yingjunnan` — https://github.com/yingjunnan
- Original source repository: https://github.com/yingjunnan/dsh-deepseek-quota
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.