### PR TITLE
catalog: add yiran0-dsh-mobile-glass (community curation, created by @YiRan0)

### DIFF
--- a/catalog/plugins/yiran0-dsh-mobile-glass.yaml
+++ b/catalog/plugins/yiran0-dsh-mobile-glass.yaml
@@ -1,0 +1,58 @@
+schemaVersion: 1
+id: yiran0-dsh-mobile-glass
+name: dsh-mobile-glass
+description:
+  en: sh dsh plugin --profile web add github:YiRan0/dsh-mobile-glass
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - web
+  - mobile
+  - ui
+source:
+  repository: https://github.com/YiRan0/dsh-mobile-glass
+  repositoryNodeId: R_kgDOT5C1Ww
+  subpath: null
+  commit: b0cc59979876ff089df2f948eb14b2754f15d480
+creator:
+  github: YiRan0
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:23.910Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/YiRan0/dsh-mobile-glass/b0cc59979876ff089df2f948eb14b2754f15d480/assets/mobile-main.png
+    alt: 移动端主界面
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/YiRan0/dsh-mobile-glass/b0cc59979876ff089df2f948eb14b2754f15d480/assets/mobile-drawer.png
+    alt: 侧栏抽屉
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/YiRan0/dsh-mobile-glass/b0cc59979876ff089df2f948eb14b2754f15d480/assets/mobile-composer.png
+    alt: 悬浮输入框
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/YiRan0/dsh-mobile-glass/b0cc59979876ff089df2f948eb14b2754f15d480/assets/mobile-settings.png
+    alt: 设置底部卡片
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/YiRan0/dsh-mobile-glass/b0cc59979876ff089df2f948eb14b2754f15d480/assets/desktop-unchanged.png
+    alt: 桌面端


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yiran0-dsh-mobile-glass`
- Submission type: community curation
- Created by `YiRan0` — https://github.com/YiRan0
- Original source repository: https://github.com/YiRan0/dsh-mobile-glass
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.