### PR TITLE
catalog: add yoiizesdev-crypto-dsh-quota-badge (community curation, created by @yoiizesdev-crypto)

### DIFF
--- a/catalog/plugins/yoiizesdev-crypto-dsh-quota-badge.yaml
+++ b/catalog/plugins/yoiizesdev-crypto-dsh-quota-badge.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: yoiizesdev-crypto-dsh-quota-badge
+name: dsh-quota-badge
+description:
+  en: bash cd ~/.dsh/profiles/desktop npm install <git仓库地址
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - quota
+  - balance
+source:
+  repository: https://github.com/yoiizesdev-crypto/DSH-Balance-display
+  repositoryNodeId: R_kgDOT6AY2g
+  subpath: null
+  commit: dcfde8263e25d2471901c69754081f6559577d02
+creator:
+  github: yoiizesdev-crypto
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:06.087Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yoiizesdev-crypto-dsh-quota-badge`
- Submission type: community curation
- Created by `yoiizesdev-crypto` — https://github.com/yoiizesdev-crypto
- Original source repository: https://github.com/yoiizesdev-crypto/DSH-Balance-display
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.