### PR TITLE
catalog: add yokesky-dsh-usage-lens (community curation, created by @yokesky)

### DIFF
--- a/catalog/plugins/yokesky-dsh-usage-lens.yaml
+++ b/catalog/plugins/yokesky-dsh-usage-lens.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: yokesky-dsh-usage-lens
+name: "@yokesky/dsh-usage-lens"
+description:
+  en: "DSH web plugin: a usage statistics dashboard (basic info, activity heatmap, daily token trend, model usage donut) with provider/model drill-down, following the DSH theme system."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - usage-statistics
+  - token-usage
+  - dashboard
+  - analytics
+  - heatmap
+  - cordis
+  - usage-dashboard
+  - token-analytics
+  - statistics
+  - stats
+source:
+  repository: https://github.com/yokesky/dsh-usage-lens
+  repositoryNodeId: R_kgDOT49gCw
+  subpath: null
+  commit: 8111fcc1c205c0a9155723bc03bf1a9a2b0fac1a
+creator:
+  github: yokesky
+package:
+  ecosystem: npm
+  name: "@yokesky/dsh-usage-lens"
+  version: 0.1.3
+  integrity: sha512-p0XF+Iqo/SpUF87JRx8pyMVTWXvAUkMgN+Q7QnxpwR66EOt7Yx2yrjN4jWBXi6uCP8ro9lVuqQ7ChzP3Wq6YMw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:14.514Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yokesky/dsh-usage-lens/8111fcc1c205c0a9155723bc03bf1a9a2b0fac1a/assets/demo.gif
+    alt: dsh-usage-lens demo


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yokesky-dsh-usage-lens`
- Submission type: community curation
- Created by `yokesky` — https://github.com/yokesky
- Original source repository: https://github.com/yokesky/dsh-usage-lens
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.