### PR TITLE
catalog: add yongshuai0314-dsh-readcache (community curation, created by @yongshuai0314)

### DIFF
--- a/catalog/plugins/yongshuai0314-dsh-readcache.yaml
+++ b/catalog/plugins/yongshuai0314-dsh-readcache.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: yongshuai0314-dsh-readcache
+name: dsh-readcache
+description:
+  en: 'json { "hits": 2, "misses": 4, "hitRatio": 33.3, "stale": 1, "stores": 4, "evictions": 0, "savedChars": 1210, "clearedEntries": 0, "entries": 3, "cachedChars": 1662, "maxEntries": 300 }'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - cache
+  - read
+  - performance
+source:
+  repository: https://github.com/yongshuai0314/dsh-readcache
+  repositoryNodeId: R_kgDOUBqtFg
+  subpath: null
+  commit: f4657b76bb786059426ba275a7619804c30841c8
+creator:
+  github: yongshuai0314
+package:
+  ecosystem: npm
+  name: dsh-readcache
+  version: 1.0.1
+  integrity: sha512-wDP1Z5h5Z5MYxXNIjGS7XKd+TuOU5FYn52UEeOC/F68S7WEOeOrhF6mNE0FqzJYeO8UcoPVsOyNRkJHsZpg8Kw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:19.735Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yongshuai0314-dsh-readcache`
- Submission type: community curation
- Created by `yongshuai0314` — https://github.com/yongshuai0314
- Original source repository: https://github.com/yongshuai0314/dsh-readcache
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.