### PR TITLE
catalog: add youjiaqi421-dsh-plugin-workspace-rules (community curation, created by @youjiaqi421)

### DIFF
--- a/catalog/plugins/youjiaqi421-dsh-plugin-workspace-rules.yaml
+++ b/catalog/plugins/youjiaqi421-dsh-plugin-workspace-rules.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: youjiaqi421-dsh-plugin-workspace-rules
+name: dsh-plugin-workspace-rules
+description:
+  en: Load Cursor, Gemini CLI, and GitHub Copilot workspace instructions into DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+source:
+  repository: https://github.com/youjiaqi421/dsh-plugin-workspace-rules
+  repositoryNodeId: R_kgDOT37Q4g
+  subpath: null
+  commit: 1f70fd9ba6096753f39f2a2c8f4b51b8dcce71c7
+creator:
+  github: youjiaqi421
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:31.859Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `youjiaqi421-dsh-plugin-workspace-rules`
- Submission type: community curation
- Created by `youjiaqi421` — https://github.com/youjiaqi421
- Original source repository: https://github.com/youjiaqi421/dsh-plugin-workspace-rules
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.