### PR TITLE
catalog: add yoyudev-dsh-ping (community curation, created by @YoyuDev)

### DIFF
--- a/catalog/plugins/yoyudev-dsh-ping.yaml
+++ b/catalog/plugins/yoyudev-dsh-ping.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: yoyudev-dsh-ping
+name: dsh-ping
+description:
+  en: "DeepSeek Harness plugin: play a sound and show a desktop notification when the agent needs you"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - notification
+  - sound
+source:
+  repository: https://github.com/YoyuDev/dsh-ping
+  repositoryNodeId: R_kgDOT9GM7Q
+  subpath: null
+  commit: 836841548e053b9ccc3649837b692bd266ec6da2
+creator:
+  github: YoyuDev
+package:
+  ecosystem: npm
+  name: dsh-ping
+  version: 1.9.0
+  integrity: sha512-Wrqkrfrz4oMEQ0g7GklgXAKpuKBD7ehTs6xpepxO7oUO1At3J5eYhEHxOcAiI6BADKocM5bpwzw6qDyQ+Y4zVA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:32.387Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/YoyuDev/dsh-ping/836841548e053b9ccc3649837b692bd266ec6da2/docs/settings-page.png
+    alt: dsh-ping 设置页面


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yoyudev-dsh-ping`
- Submission type: community curation
- Created by `YoyuDev` — https://github.com/YoyuDev
- Original source repository: https://github.com/YoyuDev/dsh-ping
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.