### PR TITLE
catalog: add yoza10635-dsh-argp (community curation, created by @yoza10635)

### DIFF
--- a/catalog/plugins/yoza10635-dsh-argp.yaml
+++ b/catalog/plugins/yoza10635-dsh-argp.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: yoza10635-dsh-argp
+name: dsh-argp
+description:
+  en: "Guarded context compaction for DeepSeek Harness (dsh): the LLM proposes, deterministic guards dispose — eager per-atom shrink (extract/summary/false under verbatim guards) + lazy reference-graph eviction (0-LLM) + byte-exact recall from an append-only log. 压缩率精确兑现，历史永不销毁。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - guarded
+  - context
+  - compaction
+  - proposes
+  - deterministic
+  - guards
+  - dispose
+  - eager
+  - atom
+  - shrink
+  - extract
+  - summary
+  - "false"
+  - under
+  - verbatim
+  - lazy
+source:
+  repository: https://github.com/yoza10635/dsh-argp
+  repositoryNodeId: R_kgDOT6t8VA
+  subpath: null
+  commit: aa52be542892325302a597284aa5550a62c98fbe
+creator:
+  github: yoza10635
+package:
+  ecosystem: npm
+  name: dsh-argp
+  version: 1.0.0
+  integrity: sha512-k/+fXG5CQql4qMzaJL+f+RUhU+ItQTWszk1A3HmFFP56enwkVhr+dDsAK79ZkV9czOGEc0k1rOXDmFdE2rWdKw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:11.043Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yoza10635-dsh-argp`
- Submission type: community curation
- Created by `yoza10635` — https://github.com/yoza10635
- Original source repository: https://github.com/yoza10635/dsh-argp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.