### PR TITLE
catalog: add yu-tao-li-dsh-computer-use-win (community curation, created by @Yu-tao-Li)

### DIFF
--- a/catalog/plugins/yu-tao-li-dsh-computer-use-win.yaml
+++ b/catalog/plugins/yu-tao-li-dsh-computer-use-win.yaml
@@ -1,0 +1,58 @@
+schemaVersion: 1
+id: yu-tao-li-dsh-computer-use-win
+name: dsh-computer-use-win
+description:
+  en: "Windows computer use for DeepSeek Harness: an MCP stdio server + PowerShell UIA backend, bridged into DSH via @deepseek-ai/dsh-mcp-client. Read/act on real Windows desktop apps (UI Automation tree, screenshots, typed input, OCR, window management)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - computer-use
+  - windows
+  - uia
+  - desktop-automation
+source:
+  repository: https://github.com/Yu-tao-Li/dsh-computer-use-win
+  repositoryNodeId: R_kgDOT6YEZw
+  subpath: null
+  commit: 04f4643eba86b28ee26788dbe72e34fa87503852
+creator:
+  github: Yu-tao-Li
+package:
+  ecosystem: npm
+  name: dsh-computer-use-win
+  version: 0.1.2
+  integrity: sha512-byIWWKzJIP7LuCQF5VskK68XjcfQtQuHBGgE3rjqSuXOt6CDRqWqHDwFpY5tSKPNgtgP/+CRluQf97Z5iJ2MJQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:03.223Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/04f4643eba86b28ee26788dbe72e34fa87503852/assets/screenshot-1.png
+    alt: "1"
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/04f4643eba86b28ee26788dbe72e34fa87503852/assets/screenshot-2.png
+    alt: "2"
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Yu-tao-Li/dsh-computer-use-win/04f4643eba86b28ee26788dbe72e34fa87503852/assets/screenshot-3.png
+    alt: "3"


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yu-tao-li-dsh-computer-use-win`
- Submission type: community curation
- Created by `Yu-tao-Li` — https://github.com/Yu-tao-Li
- Original source repository: https://github.com/Yu-tao-Li/dsh-computer-use-win
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.