### PR TITLE
catalog: add yu-tao-li-dsh-reference-checker (community curation, created by @Yu-tao-Li)

### DIFF
--- a/catalog/plugins/yu-tao-li-dsh-reference-checker.yaml
+++ b/catalog/plugins/yu-tao-li-dsh-reference-checker.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: yu-tao-li-dsh-reference-checker
+name: dsh-reference-checker
+description:
+  en: "Reference verification for DeepSeek Harness (参考文献真实性检查器): the reference checker model tool checks a paper's bibliography (.pdf/.bib/.tex/.txt/.md or pasted text) against Crossref, OpenAlex and arXiv, reports found/partial/not found/error per entry, and emits corrected citations in the input's style (APA, GB/T 7714, IEE"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - references
+  - refcheck
+  - bibliography
+  - verification
+  - crossref
+  - openalex
+  - arxiv
+source:
+  repository: https://github.com/Yu-tao-Li/dsh-reference-checker
+  repositoryNodeId: R_kgDOT7h79A
+  subpath: null
+  commit: b6c1cf95937e4d19837702d1cd14f7679762a61e
+creator:
+  github: Yu-tao-Li
+package:
+  ecosystem: npm
+  name: dsh-reference-checker
+  version: 1.1.0
+  integrity: sha512-i9iIf3s2uu8bgUlCjFQ+UrZbvoja6Jw1hN4ZzEo62kOAbZnsOdeVm+gUTRrLaqyjIBtMdReYVkYx0KYEavQ8Sw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:07.945Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Yu-tao-Li/dsh-reference-checker/b6c1cf95937e4d19837702d1cd14f7679762a61e/assets/screenshot-1.png
+    alt: dsh-reference-checker 示例报告


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yu-tao-li-dsh-reference-checker`
- Submission type: community curation
- Created by `Yu-tao-Li` — https://github.com/Yu-tao-Li
- Original source repository: https://github.com/Yu-tao-Li/dsh-reference-checker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.