### PR TITLE
catalog: add yuanyuanma03-dsh-funnel (community curation, created by @YuanyuanMa03)

### DIFF
--- a/catalog/plugins/yuanyuanma03-dsh-funnel.yaml
+++ b/catalog/plugins/yuanyuanma03-dsh-funnel.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: yuanyuanma03-dsh-funnel
+name: dsh-funnel
+description:
+  en: "Curate tool output before it enters the model's context: keep error/warning lines and head/tail, spill the full text to disk with a pointer. Faster turns, smaller context, sharper attention — for every tool, not just bash."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - context
+  - tokens
+  - performance
+  - tool-output
+source:
+  repository: https://github.com/YuanyuanMa03/dsh-funnel
+  repositoryNodeId: R_kgDOT5HeVQ
+  subpath: null
+  commit: 596361966226a89c2361ac0250b41f6541ce9ea5
+creator:
+  github: YuanyuanMa03
+package:
+  ecosystem: npm
+  name: dsh-funnel
+  version: 0.1.0
+  integrity: sha512-mvg/4scAtyB7l3ILtmkX5uLgYzvIO/uh1QbB5YccyUTTbNi5ZwAM+UAbxjHefXrw8NRZ+NjCJiJsO+KxON3+eQ==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:24.020Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yuanyuanma03-dsh-funnel`
- Submission type: community curation
- Created by `YuanyuanMa03` — https://github.com/YuanyuanMa03
- Original source repository: https://github.com/YuanyuanMa03/dsh-funnel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.