### PR TITLE
catalog: add yueeeey-dsh-desktop-tools (community curation, created by @YUEEEEY)

### DIFF
--- a/catalog/plugins/yueeeey-dsh-desktop-tools.yaml
+++ b/catalog/plugins/yueeeey-dsh-desktop-tools.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: yueeeey-dsh-desktop-tools
+name: dsh-desktop-tools
+description:
+  en: "dsh environment management plugin (TypeScript): desktop window, runtime management, platform compatibility, billing panel, code editor."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - environment
+  - management
+  - typescript
+  - desktop
+  - window
+  - runtime
+  - platform
+  - compatibility
+  - billing
+  - panel
+  - code
+  - editor
+  - dsh
+source:
+  repository: https://github.com/YUEEEEY/dsh-desktop-tools
+  repositoryNodeId: R_kgDOT8KT_A
+  subpath: null
+  commit: 910e6bb167fe42121f10088ae48062b24627a287
+creator:
+  github: YUEEEEY
+package:
+  ecosystem: npm
+  name: dsh-desktop-tools
+  version: 0.5.3
+  integrity: sha512-rbtFEFE+VKCjjKv+M1ciBANBWc6Msy2Dwn3ULrxPKIUuOPBxFuN5Ur9862oOgVd4pFXEtE26ua2Em9K7wSnYLg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:20.312Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yueeeey-dsh-desktop-tools`
- Submission type: community curation
- Created by `YUEEEEY` — https://github.com/YUEEEEY
- Original source repository: https://github.com/YUEEEEY/dsh-desktop-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.