### PR TITLE
catalog: add yujiaoliang-dsh-plugin-amdgpu-inspect (community curation, created by @yujiaoliang)

### DIFF
--- a/catalog/plugins/yujiaoliang-dsh-plugin-amdgpu-inspect.yaml
+++ b/catalog/plugins/yujiaoliang-dsh-plugin-amdgpu-inspect.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: yujiaoliang-dsh-plugin-amdgpu-inspect
+name: dsh-plugin-amdgpu-inspect
+description:
+  en: Structured AMDGPU code-object and ISA inspection for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - rocm
+  - hip
+  - amdgpu
+  - gpu
+  - isa
+  - dsh
+source:
+  repository: https://github.com/yujiaoliang/dsh-plugin-amdgpu-inspect
+  repositoryNodeId: R_kgDOT5W0Mg
+  subpath: null
+  commit: f0b504171367883a0338788e8e4937384d0913a5
+creator:
+  github: yujiaoliang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:33.624Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yujiaoliang-dsh-plugin-amdgpu-inspect`
- Submission type: community curation
- Created by `yujiaoliang` — https://github.com/yujiaoliang
- Original source repository: https://github.com/yujiaoliang/dsh-plugin-amdgpu-inspect
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.