### PR TITLE
catalog: add yukari316-dsh-toolcall-compat (community curation, created by @Yukari316)

### DIFF
--- a/catalog/plugins/yukari316-dsh-toolcall-compat.yaml
+++ b/catalog/plugins/yukari316-dsh-toolcall-compat.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yukari316-dsh-toolcall-compat
+name: "@yukari316/dsh-toolcall-compat"
+description:
+  en: "DSH tool-call compatibility: strips sandbox permissions/justification from tool-call arguments for third-party models (GPT etc.), and lets the user skip possibly-stuck tool calls with an LLM-facing notice."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - toolcall
+  - sandbox
+  - gpt
+  - compatibility
+  - stuck
+  - skip
+source:
+  repository: https://github.com/Yukari316/dsh-toolcall-compat
+  repositoryNodeId: R_kgDOT_SM5Q
+  subpath: null
+  commit: 59048ed0879831bd5ef7ca5d6f839c1d4196185e
+creator:
+  github: Yukari316
+package:
+  ecosystem: npm
+  name: "@yukari316/dsh-toolcall-compat"
+  version: 0.1.4
+  integrity: sha512-J1fCZOAtWnULzAgcAHUkbktLVmJQXL5KzfiUqlrvk1UFgSCNUbdf2SKbyqRYDjHYrvPy9qOXyjjGGZ18Rzh7tQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:24.285Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yukari316-dsh-toolcall-compat`
- Submission type: community curation
- Created by `Yukari316` — https://github.com/Yukari316
- Original source repository: https://github.com/Yukari316/dsh-toolcall-compat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.