### PR TITLE
catalog: add yukiykchen-dsh-scan-remote (community curation, created by @yukiykchen)

### DIFF
--- a/catalog/plugins/yukiykchen-dsh-scan-remote.yaml
+++ b/catalog/plugins/yukiykchen-dsh-scan-remote.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: yukiykchen-dsh-scan-remote
+name: "@yukiykchen/dsh-scan-remote"
+description:
+  en: Passwordless QR remote access plugin for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - remote-access
+  - dsh
+source:
+  repository: https://github.com/yukiykchen/dsh-scan-remote
+  repositoryNodeId: R_kgDOUCJOyQ
+  subpath: null
+  commit: ba18aaff97c51516497bbc73971ca696fc1ea3bc
+creator:
+  github: yukiykchen
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:33.987Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yukiykchen-dsh-scan-remote`
- Submission type: community curation
- Created by `yukiykchen` — https://github.com/yukiykchen
- Original source repository: https://github.com/yukiykchen/dsh-scan-remote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.