### PR TITLE
catalog: add yzz-s-dsh-notifier (community curation, created by @YZz-S)

### DIFF
--- a/catalog/plugins/yzz-s-dsh-notifier.yaml
+++ b/catalog/plugins/yzz-s-dsh-notifier.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: yzz-s-dsh-notifier
+name: dsh-notifier
+description:
+  en: '- Task-finished notification : when a top-level session goes from running back to idle (a turn ends), sends "Task completed" - Confirmation / input notification : when an approval is triggered ( approval/request , e.g. a tool needs your confirmation), sends "Action required" with the tool name and reason - Does not int'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - notification
+  - notifier
+  - toast
+source:
+  repository: https://github.com/YZz-S/dsh-notifier
+  repositoryNodeId: R_kgDOT4-A0w
+  subpath: null
+  commit: 1979ea18ed4ac20591db1852f7c1a6e198f79cf2
+creator:
+  github: YZz-S
+package:
+  ecosystem: npm
+  name: dsh-notifier
+  version: 0.2.0
+  integrity: sha512-b2EF21ve7t4Jp6AD1+0aTsOEkNVBArhqUYeY7cPHEqSlHhCbvPdTt1YXjbq0BM2X8g5KtkGMH+TXKWHkQmU+Zg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:20.731Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yzz-s-dsh-notifier`
- Submission type: community curation
- Created by `YZz-S` — https://github.com/YZz-S
- Original source repository: https://github.com/YZz-S/dsh-notifier
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.