### PR TITLE
catalog: add zdx8637-dshmobile-bridge (community curation, created by @zdx8637)

### DIFF
--- a/catalog/plugins/zdx8637-dshmobile-bridge.yaml
+++ b/catalog/plugins/zdx8637-dshmobile-bridge.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: zdx8637-dshmobile-bridge
+name: "@zdx8637/dshmobile-bridge"
+description:
+  en: sh npx -y @deepseek-ai/dsh plugin --profile web add @zdx8637/dshmobile-bridge@latest
+  evidencePath: plugins/README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - profile
+  - zdx8637
+  - dshmobile
+  - bridge
+  - latest
+  - dsh
+source:
+  repository: https://github.com/zdx8637-gitdog/dshmobile
+  repositoryNodeId: R_kgDOT56l4w
+  subpath: plugins
+  commit: 4ef818b539d628a997f4f6a8b4c07f4d2f4779fa
+creator:
+  github: zdx8637
+package:
+  ecosystem: npm
+  name: "@zdx8637/dshmobile-bridge"
+  version: 0.1.0-beta.11
+  integrity: sha512-UjeG7GoDFZQxRFzsV33xgMsS2lOAAT3JDsprEAq+xaybcTdJPW/feDR2LzpQcB3UXQ93EkLOdvdeMZYeD6ZEzQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:18:34.143Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zdx8637-gitdog/dshmobile/4ef818b539d628a997f4f6a8b4c07f4d2f4779fa/docs/images/plugin-panel.jpg
+    alt: DSH 插件面板（左侧栏常驻二维码）


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zdx8637-dshmobile-bridge`
- Submission type: community curation
- Created by `zdx8637` — https://github.com/zdx8637
- Original source repository: https://github.com/zdx8637-gitdog/dshmobile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.