### PR TITLE
catalog: add botonj-dsh-plugin-sentinel (community curation, created by @BotonJ)

### DIFF
--- a/catalog/plugins/botonj-dsh-plugin-sentinel.yaml
+++ b/catalog/plugins/botonj-dsh-plugin-sentinel.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: botonj-dsh-plugin-sentinel
+name: dsh-plugin-sentinel
+description:
+  en: DSH 插件安检机 — install-time static security auditor for DeepSeek Harness plugin bundles. Zero dependencies, zero install scripts, zero build step.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - security
+  - audit
+  - static-analysis
+source:
+  repository: https://github.com/BotonJ/dsh-plugin-sentinel
+  repositoryNodeId: R_kgDOT5EoTw
+  subpath: null
+  commit: 3dcff7a125d7151f2b75a8962c65425d0d9aa0b8
+creator:
+  github: BotonJ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:06.889Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `botonj-dsh-plugin-sentinel`
- Submission type: community curation
- Created by `BotonJ` — https://github.com/BotonJ
- Original source repository: https://github.com/BotonJ/dsh-plugin-sentinel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.