### PR TITLE
catalog: add botonj-dsh-remote-link (community curation, created by @BotonJ)

### DIFF
--- a/catalog/plugins/botonj-dsh-remote-link.yaml
+++ b/catalog/plugins/botonj-dsh-remote-link.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: botonj-dsh-remote-link
+name: dsh-remote-link
+description:
+  en: "Authenticated LAN gateway for DeepSeek Harness: reverse-proxies the official web UI with Basic Auth, advertises via mDNS, and adds a fork session tool."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - remote
+  - gateway
+  - mdns
+source:
+  repository: https://github.com/BotonJ/dsh-remote-link
+  repositoryNodeId: R_kgDOT47aVg
+  subpath: null
+  commit: f7a444eb6e0254c1c2f79a54d8389c01886dfc7f
+creator:
+  github: BotonJ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:52.482Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `botonj-dsh-remote-link`
- Submission type: community curation
- Created by `BotonJ` — https://github.com/BotonJ
- Original source repository: https://github.com/BotonJ/dsh-remote-link
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.