### PR TITLE
catalog: add buzzso-dsh-sev (community curation, created by @Buzzso)

### DIFF
--- a/catalog/plugins/buzzso-dsh-sev.yaml
+++ b/catalog/plugins/buzzso-dsh-sev.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: buzzso-dsh-sev
+name: dsh-sev
+description:
+  en: "Remote DSH host management for DeepSeek Harness: manage a headless dsh instance on your own server from the local GUI — SSH tunnels, live remote session list, one-click remote GUI. 远程 DSH 分身管理：本地 GUI 控制服务器上的 dsh 实例。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - remote
+  - ssh
+  - tunnel
+  - server
+  - agent
+source:
+  repository: https://github.com/Buzzso/dsh-sev
+  repositoryNodeId: R_kgDOUEeliA
+  subpath: null
+  commit: 4b0188ab2a1e2871c69d19b52bddb1dfc22ab49c
+creator:
+  github: Buzzso
+package:
+  ecosystem: npm
+  name: dsh-sev
+  version: 0.3.4
+  integrity: sha512-K6ehQLPJ57o01yR9IRyIcyfui0n7mYsUX3+J2kHyCVWhruO2VGzZCD+0c0UkiOcDWLLHMseWfCSJ01EHqdxolw==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:48.889Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 86
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `buzzso-dsh-sev`
- Submission type: community curation
- Created by `Buzzso` — https://github.com/Buzzso
- Original source repository: https://github.com/Buzzso/dsh-sev
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.