### PR TITLE
catalog: add caisiyang123-dsh-tick-rail (community curation, created by @caisiyang123)

### DIFF
--- a/catalog/plugins/caisiyang123-dsh-tick-rail.yaml
+++ b/catalog/plugins/caisiyang123-dsh-tick-rail.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: caisiyang123-dsh-tick-rail
+name: dsh-tick-rail
+description:
+  en: Tick-rail conversation navigator for the DeepSeek Harness web UI — a slim rail with one tick per message you sent, a peak-falloff hover effect, message previews, and click-to-jump.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - navigation
+  - minimap
+  - web-ui
+source:
+  repository: https://github.com/caisiyang123/dsh-tick-rail
+  repositoryNodeId: R_kgDOT69M9g
+  subpath: null
+  commit: 2d103df93a7c4c11e43807cee525321b39730033
+creator:
+  github: caisiyang123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:01.183Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `caisiyang123-dsh-tick-rail`
- Submission type: community curation
- Created by `caisiyang123` — https://github.com/caisiyang123
- Original source repository: https://github.com/caisiyang123/dsh-tick-rail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.