### PR TITLE
catalog: add cavan-ou-dsh-observation-journal (community curation, created by @Cavan-Ou)

### DIFF
--- a/catalog/plugins/cavan-ou-dsh-observation-journal.yaml
+++ b/catalog/plugins/cavan-ou-dsh-observation-journal.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: cavan-ou-dsh-observation-journal
+name: dsh-observation-journal
+description:
+  en: "Zero-touch runtime telemetry for DeepSeek Harness: every session writes its own report card."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - observation
+  - journal
+  - telemetry
+  - session-log
+source:
+  repository: https://github.com/Cavan-Ou/dsh-observation-journal
+  repositoryNodeId: R_kgDOT4rTsA
+  subpath: null
+  commit: 0fbbaf098d3cf462c4e315771b75d9a25b82ff10
+creator:
+  github: Cavan-Ou
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:54.898Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cavan-ou-dsh-observation-journal`
- Submission type: community curation
- Created by `Cavan-Ou` — https://github.com/Cavan-Ou
- Original source repository: https://github.com/Cavan-Ou/dsh-observation-journal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.