### PR TITLE
catalog: add cavan-ou-hermes-dsh-collab (community curation, created by @Cavan-Ou)

### DIFF
--- a/catalog/plugins/cavan-ou-hermes-dsh-collab.yaml
+++ b/catalog/plugins/cavan-ou-hermes-dsh-collab.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: cavan-ou-hermes-dsh-collab
+name: hermes-dsh-collab
+description:
+  en: "Hook DeepSeek Harness into your Hermes pipeline: dispatch-spec template, model-tier routing, quality gates, git single-writer rule — as an installable skill pack."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - cordis
+  - skill
+  - hermes
+  - multi-agent
+  - dsh-plugin
+source:
+  repository: https://github.com/Cavan-Ou/hermes-dsh-collab
+  repositoryNodeId: R_kgDOT4jS-A
+  subpath: null
+  commit: 3a70cb3f5590ef03bc3772ca37c991273c593914
+creator:
+  github: Cavan-Ou
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:52.567Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cavan-ou-hermes-dsh-collab`
- Submission type: community curation
- Created by `Cavan-Ou` — https://github.com/Cavan-Ou
- Original source repository: https://github.com/Cavan-Ou/hermes-dsh-collab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.