### PR TITLE
catalog: add ccch713-ddw-teams-panel (community curation, created by @ccch713)

### DIFF
--- a/catalog/plugins/ccch713-ddw-teams-panel.yaml
+++ b/catalog/plugins/ccch713-ddw-teams-panel.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: ccch713-ddw-teams-panel
+name: "@deepddw/ddw-teams-panel"
+description:
+  en: deepDDW gives DeepSeek Harness (DSH) the three pieces it's missing — memory, a knowledge base, and document search — and makes all of it reachable from any device on your LAN. No app install. No DSH source changes.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepddw
+  - teams
+  - settings
+source:
+  repository: https://github.com/ccch713/deepddw
+  repositoryNodeId: R_kgDOT5l0dA
+  subpath: plugins/ddw-teams-panel
+  commit: 22646509fa21521adcab916405a60f35dee141f9
+creator:
+  github: ccch713
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/ddw-teams-panel/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:12.180Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ccch713-ddw-teams-panel`
- Submission type: community curation
- Created by `ccch713` — https://github.com/ccch713
- Original source repository: https://github.com/ccch713/deepddw
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.