### PR TITLE
catalog: add ch1bug-dsh-mimo-agent-tools (community curation, created by @ch1bug)

### DIFF
--- a/catalog/plugins/ch1bug-dsh-mimo-agent-tools.yaml
+++ b/catalog/plugins/ch1bug-dsh-mimo-agent-tools.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: ch1bug-dsh-mimo-agent-tools
+name: dsh-mimo-agent-tools
+description:
+  en: "Xiaomi MiMo search + multimodal tools for DSH agents: mimo search/vision/audio/video/asr/tts."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - xiaomi
+  - mimo
+  - search
+  - multimodal
+  - tools
+  - agents
+  - vision
+  - audio
+  - video
+  - dsh
+source:
+  repository: https://github.com/ch1bug/dsh-mimo-agent-tools
+  repositoryNodeId: R_kgDOT4AjGw
+  subpath: null
+  commit: 38d860417dbad9ade4d88c959ac79e069085ca82
+creator:
+  github: ch1bug
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:52.567Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ch1bug-dsh-mimo-agent-tools`
- Submission type: community curation
- Created by `ch1bug` — https://github.com/ch1bug
- Original source repository: https://github.com/ch1bug/dsh-mimo-agent-tools
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.