### PR TITLE
catalog: add changlianxiya-139-dsh-ambiguity-handling (community curation, created by @changlianxiya-139)

### DIFF
--- a/catalog/plugins/changlianxiya-139-dsh-ambiguity-handling.yaml
+++ b/catalog/plugins/changlianxiya-139-dsh-ambiguity-handling.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 1
+id: changlianxiya-139-dsh-ambiguity-handling
+name: dsh-ambiguity-handling
+description:
+  en: Append ambiguity-handling rules to dsh system prompt
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+source:
+  repository: https://github.com/changlianxiya-139/dsh-ambiguity-handling
+  repositoryNodeId: R_kgDOT675gg
+  subpath: null
+  commit: a47dfc9fb3c23aebbb4fb612a833b48bb5f7950c
+creator:
+  github: changlianxiya-139
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:01.414Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `changlianxiya-139-dsh-ambiguity-handling`
- Submission type: community curation
- Created by `changlianxiya-139` — https://github.com/changlianxiya-139
- Original source repository: https://github.com/changlianxiya-139/dsh-ambiguity-handling
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.