### PR TITLE
catalog: add chenbin-dev-dsh-scan-mcp (community curation, created by @chenbin-dev)

### DIFF
--- a/catalog/plugins/chenbin-dev-dsh-scan-mcp.yaml
+++ b/catalog/plugins/chenbin-dev-dsh-scan-mcp.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: chenbin-dev-dsh-scan-mcp
+name: dsh-scan-mcp
+description:
+  en: "Windows MCP Hub for DeepSeek Harness: scan MCP servers configured in Claude Code / Codex / CodeBuddy, probe real connectivity via stdio & streamable-http initialize handshakes, enable/disable from a /mcp popup panel or the settings page."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - mcp
+  - model-context-protocol
+  - windows
+  - claude-code
+  - codex
+  - codebuddy
+  - dsh
+source:
+  repository: https://github.com/chenbin-dev/dsh-scan-mcp
+  repositoryNodeId: R_kgDOUBSNlg
+  subpath: null
+  commit: 5010ce4df9e96841dfb61701e4683e09a35e536a
+creator:
+  github: chenbin-dev
+package:
+  ecosystem: npm
+  name: dsh-scan-mcp
+  version: 0.1.1
+  integrity: sha512-uSv/OTMBClslhfjSEQR7yBZsQPqGYr/odTOiYEW9CCgtML4z+TMZz26VMcnZ1V16dok0IZJb48+ne2ZuY9L2WA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:01.926Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chenbin-dev-dsh-scan-mcp`
- Submission type: community curation
- Created by `chenbin-dev` — https://github.com/chenbin-dev
- Original source repository: https://github.com/chenbin-dev/dsh-scan-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.