### PR TITLE
catalog: add chenjie1129-dsh-os-agent-plugin (community curation, created by @chenjie1129)

### DIFF
--- a/catalog/plugins/chenjie1129-dsh-os-agent-plugin.yaml
+++ b/catalog/plugins/chenjie1129-dsh-os-agent-plugin.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: chenjie1129-dsh-os-agent-plugin
+name: dsh-os-agent-plugin
+description:
+  en: Self-contained Volcengine Mobile Use Agent runtime and configuration UI for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - self
+  - contained
+  - volcengine
+  - mobile
+  - agent
+  - runtime
+  - configuration
+  - dsh
+source:
+  repository: https://github.com/chenjie1129/deepseek-harness-os-agent-plugin
+  repositoryNodeId: R_kgDOT_vNKA
+  subpath: null
+  commit: 90416ff7a9faf45d581f9e33d7c22e331e7ea9cf
+creator:
+  github: chenjie1129
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:55.775Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chenjie1129-dsh-os-agent-plugin`
- Submission type: community curation
- Created by `chenjie1129` — https://github.com/chenjie1129
- Original source repository: https://github.com/chenjie1129/deepseek-harness-os-agent-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.