### PR TITLE
catalog: add chenkai2-dsh-daemon (community curation, created by @chenkai2)

### DIFF
--- a/catalog/plugins/chenkai2-dsh-daemon.yaml
+++ b/catalog/plugins/chenkai2-dsh-daemon.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: chenkai2-dsh-daemon
+name: "@chenkai114/dsh-daemon"
+description:
+  en: "dsh daemon: register the DeepSeek Harness web server (dsh web) as an auto-start, self-healing background service (LaunchAgent / systemd / cron + watchdog)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - daemon
+  - watchdog
+  - launchagent
+  - launchd
+  - systemd
+  - self-healing
+source:
+  repository: https://github.com/chenkai2/dsh-daemon
+  repositoryNodeId: R_kgDOT657cw
+  subpath: null
+  commit: a0f13bc896394a7280d07b3157b0c1f772da7f08
+creator:
+  github: chenkai2
+package:
+  ecosystem: npm
+  name: "@chenkai114/dsh-daemon"
+  version: 0.1.20
+  integrity: sha512-/Mghn1GMtwTYVp/VkVbxo7mfKVrDy9BjDQUShDPS1y7CE2GMJTvvVFlEkgZxjTFM18hiaAENMbXMcNcTyQYLQw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:02.711Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chenkai2-dsh-daemon`
- Submission type: community curation
- Created by `chenkai2` — https://github.com/chenkai2
- Original source repository: https://github.com/chenkai2/dsh-daemon
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.