### PR TITLE
catalog: add chuantianml-dsh-chat-tidy (community curation, created by @ChuanTianML)

### DIFF
--- a/catalog/plugins/chuantianml-dsh-chat-tidy.yaml
+++ b/catalog/plugins/chuantianml-dsh-chat-tidy.yaml
@@ -1,0 +1,67 @@
+schemaVersion: 1
+id: chuantianml-dsh-chat-tidy
+name: dsh-chat-tidy
+description:
+  en: Codex-aligned chat typography, layout, and polished Markdown tables for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - chat
+  - markdown
+  - tables
+  - typography
+  - web-ui
+source:
+  repository: https://github.com/ChuanTianML/dsh-chat-tidy
+  repositoryNodeId: R_kgDOT5Pc2Q
+  subpath: null
+  commit: 42d40b45e786eb69ce802b3e9a6b8c45ff18ed35
+creator:
+  github: ChuanTianML
+package:
+  ecosystem: npm
+  name: dsh-chat-tidy
+  version: 0.3.0
+  integrity: sha512-0x1pbaTgG2gFF4C/ZN+BtroKBQ6pYop9W3J2o4P0agE2j2FwBuNmeF3SKCt9d9RNFdWe4fqlE6hgdIsSGO0f3g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:52.881Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ChuanTianML/dsh-chat-tidy/42d40b45e786eb69ce802b3e9a6b8c45ff18ed35/docs/images/hero.png
+    alt: The DSH Web conversation page with Tidy Chat applied
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ChuanTianML/dsh-chat-tidy/42d40b45e786eb69ce802b3e9a6b8c45ff18ed35/docs/images/typography.png
+    alt: The heading ladder and body text before and after Tidy Chat
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ChuanTianML/dsh-chat-tidy/42d40b45e786eb69ce802b3e9a6b8c45ff18ed35/docs/images/tidy-tables.png
+    alt: The same Markdown table before and after Tidy Tables
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ChuanTianML/dsh-chat-tidy/42d40b45e786eb69ce802b3e9a6b8c45ff18ed35/docs/images/comparison.png
+    alt: The same viewport before and after Tidy Chat
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ChuanTianML/dsh-chat-tidy/42d40b45e786eb69ce802b3e9a6b8c45ff18ed35/docs/images/density.png
+    alt: Full-height reply flow before and after Tidy Chat
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ChuanTianML/dsh-chat-tidy/42d40b45e786eb69ce802b3e9a6b8c45ff18ed35/docs/images/themes.png
+    alt: The same stylesheet under the built-in dark theme


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chuantianml-dsh-chat-tidy`
- Submission type: community curation
- Created by `ChuanTianML` — https://github.com/ChuanTianML
- Original source repository: https://github.com/ChuanTianML/dsh-chat-tidy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.