### PR TITLE
catalog: add chuantianml-dsh-open-with (community curation, created by @ChuanTianML)

### DIFF
--- a/catalog/plugins/chuantianml-dsh-open-with.yaml
+++ b/catalog/plugins/chuantianml-dsh-open-with.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: chuantianml-dsh-open-with
+name: dsh-open-with
+description:
+  en: Open registered DeepSeek Harness workspaces in detected or configured local editors from the Web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - editor
+  - workspace
+source:
+  repository: https://github.com/ChuanTianML/dsh-open-with
+  repositoryNodeId: R_kgDOT36p5g
+  subpath: null
+  commit: bfccd740dd86e02c77ee23193b9e8614af59416f
+creator:
+  github: ChuanTianML
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:07.463Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `chuantianml-dsh-open-with`
- Submission type: community curation
- Created by `ChuanTianML` — https://github.com/ChuanTianML
- Original source repository: https://github.com/ChuanTianML/dsh-open-with
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.