### PR TITLE
catalog: add ciceroyang-dsh-report-studio (community curation, created by @ciceroyang)

### DIFF
--- a/catalog/plugins/ciceroyang-dsh-report-studio.yaml
+++ b/catalog/plugins/ciceroyang-dsh-report-studio.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ciceroyang-dsh-report-studio
+name: dsh-report-studio
+description:
+  en: Turn a DeepSeek Harness session into deliverable work reports (daily/weekly/handoff/article) with verifiable receipts
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - report
+  - daily-report
+  - handoff
+  - agent
+  - deliverable
+source:
+  repository: https://github.com/ciceroyang/dsh-report-studio
+  repositoryNodeId: R_kgDOT4CDzw
+  subpath: null
+  commit: 257a5385b307a7bcf6a55452c09f8bf756d3b678
+creator:
+  github: ciceroyang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:02.755Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ciceroyang-dsh-report-studio`
- Submission type: community curation
- Created by `ciceroyang` — https://github.com/ciceroyang
- Original source repository: https://github.com/ciceroyang/dsh-report-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.