### PR TITLE
catalog: add ciky20171114-dsh-plugin-midscene (community curation, created by @ciky20171114)

### DIFF
--- a/catalog/plugins/ciky20171114-dsh-plugin-midscene.yaml
+++ b/catalog/plugins/ciky20171114-dsh-plugin-midscene.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ciky20171114-dsh-plugin-midscene
+name: dsh-plugin-midscene
+description:
+  en: "Midscene-based AI UI automation for DeepSeek Harness: one ctx.midscene seam, Android and Web (Puppeteer) providers, and the android ui / web ui model tools"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - midscene
+  - android
+  - puppeteer
+  - ui-automation
+  - dsh
+source:
+  repository: https://github.com/ciky20171114/dsh-plugin-midscene
+  repositoryNodeId: R_kgDOT-YuIw
+  subpath: null
+  commit: 158f751a9cd64ba7ac0204c914474abccedf8649
+creator:
+  github: ciky20171114
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:57.519Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ciky20171114-dsh-plugin-midscene`
- Submission type: community curation
- Created by `ciky20171114` — https://github.com/ciky20171114
- Original source repository: https://github.com/ciky20171114/dsh-plugin-midscene
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.