### PR TITLE
catalog: add classicoke-cleverer-dsh (community curation, created by @Classicoke)

### DIFF
--- a/catalog/plugins/classicoke-cleverer-dsh.yaml
+++ b/catalog/plugins/classicoke-cleverer-dsh.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: classicoke-cleverer-dsh
+name: cleverer-dsh
+description:
+  en: "Execution-discipline plugin suite for DeepSeek Harness: anti-stuck retry interception, forced reflection, todo discipline, memory dedup, and self-evolving skills. Zero dependencies, never touches DSH source."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - cordis
+  - ai-agents
+  - agent-skills
+source:
+  repository: https://github.com/Classicoke/cleverer-dsh
+  repositoryNodeId: R_kgDOT5TgiA
+  subpath: null
+  commit: 40bd216ea9c7a95da887aa97fb661a0e8c7b1dd2
+creator:
+  github: Classicoke
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:50.879Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `classicoke-cleverer-dsh`
- Submission type: community curation
- Created by `Classicoke` — https://github.com/Classicoke
- Original source repository: https://github.com/Classicoke/cleverer-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.