### PR TITLE
catalog: add clausyang-dsh-bang-shell (community curation, created by @ClausYang)

### DIFF
--- a/catalog/plugins/clausyang-dsh-bang-shell.yaml
+++ b/catalog/plugins/clausyang-dsh-bang-shell.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: clausyang-dsh-bang-shell
+name: "@omdsh-dev/dsh-bang-shell"
+description:
+  en: Run !-prefixed commands directly from the DeepSeek Harness Web composer without sending them to the model.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - shell
+  - bash
+  - command
+  - bang
+  - dsh
+source:
+  repository: https://github.com/ClausYang/dsh-bang-shell
+  repositoryNodeId: R_kgDOT4QiNw
+  subpath: null
+  commit: 96f46e20f3a280f20de73cb8cae6968384c1334e
+creator:
+  github: ClausYang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:12.542Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `clausyang-dsh-bang-shell`
- Submission type: community curation
- Created by `ClausYang` — https://github.com/ClausYang
- Original source repository: https://github.com/ClausYang/dsh-bang-shell
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.