### PR TITLE
catalog: add coderdailyone-dsh-plugin-web-search-tavily (community curation, created by @coderdailyone)

### DIFF
--- a/catalog/plugins/coderdailyone-dsh-plugin-web-search-tavily.yaml
+++ b/catalog/plugins/coderdailyone-dsh-plugin-web-search-tavily.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: coderdailyone-dsh-plugin-web-search-tavily
+name: dsh-plugin-web-search-tavily
+description:
+  en: "Tavily search provider bundle for DeepSeek Harness (dsh): registers a WebSearchProvider into ctx.web"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - tavily
+  - web-search
+  - agent
+source:
+  repository: https://github.com/coderdailyone/dsh-plugin-web-search-tavily
+  repositoryNodeId: R_kgDOT4m41Q
+  subpath: null
+  commit: e307834e4f59c61f5019e28403f4d01115b06b90
+creator:
+  github: coderdailyone
+package:
+  ecosystem: npm
+  name: dsh-plugin-web-search-tavily
+  version: 0.1.2
+  integrity: sha512-nCWXb/q5neG46YM5IqemdwGgXvgnRQDc7FL57bYaj62BHrhoy8RBXAf+Nb88oa6+Sw675jr7eCDBhLonjtksMA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:02.836Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `coderdailyone-dsh-plugin-web-search-tavily`
- Submission type: community curation
- Created by `coderdailyone` — https://github.com/coderdailyone
- Original source repository: https://github.com/coderdailyone/dsh-plugin-web-search-tavily
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.