### PR TITLE
catalog: add cosmic-snail-dsh-travel-plan (community curation, created by @cosmic-snail)

### DIFF
--- a/catalog/plugins/cosmic-snail-dsh-travel-plan.yaml
+++ b/catalog/plugins/cosmic-snail-dsh-travel-plan.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: cosmic-snail-dsh-travel-plan
+name: dsh-travel-plan
+description:
+  en: "DeepSeek Harness bundle: plan-travel-guide skill with map/OTA/ticketing catalog sweep, Xiaohongshu/Douyin/Weibo/Bilibili discovery, POI verification, and day-by-day route clustering."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - travel
+  - skill
+  - xiaohongshu
+  - dsh
+source:
+  repository: https://github.com/cosmic-snail/dsh-travel-plan
+  repositoryNodeId: R_kgDOT8MYZA
+  subpath: null
+  commit: 285466a0cfdb9996524c14f20e760e14f74f2f3c
+creator:
+  github: cosmic-snail
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:03.049Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cosmic-snail-dsh-travel-plan`
- Submission type: community curation
- Created by `cosmic-snail` — https://github.com/cosmic-snail
- Original source repository: https://github.com/cosmic-snail/dsh-travel-plan
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.