### PR TITLE
catalog: add crtnt-dsh-plugin-center (community curation, created by @crTnT)

### DIFF
--- a/catalog/plugins/crtnt-dsh-plugin-center.yaml
+++ b/catalog/plugins/crtnt-dsh-plugin-center.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: crtnt-dsh-plugin-center
+name: dsh-plugin-center
+description:
+  en: powershell & .\scripts\install.ps1
+  evidencePath: dsh-plugin-center/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - marketplace
+source:
+  repository: https://github.com/crTnT/dsh-plugin-suite
+  repositoryNodeId: R_kgDOT4P-Og
+  subpath: dsh-plugin-center
+  commit: 5582b6035563bf6146a35746b9259a0dbbca5e23
+creator:
+  github: crTnT
+package:
+  ecosystem: npm
+  name: dsh-plugin-center
+  version: 0.1.0
+  integrity: sha512-Kz7JP7ighGLq0J9M3RB5SArasjIASDSC/85N43EK/Ye8hPU7TpTZGoAYofXitfAKPKTKQDnkSp9g1iM4OUQKWg==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugin-center/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:12.436Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `crtnt-dsh-plugin-center`
- Submission type: community curation
- Created by `crTnT` — https://github.com/crTnT
- Original source repository: https://github.com/crTnT/dsh-plugin-suite
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.