### PR TITLE
catalog: add cuhaitiang0405-collab-dsh-indexbookmark (community curation, created by @cuhaitiang0405-collab)

### DIFF
--- a/catalog/plugins/cuhaitiang0405-collab-dsh-indexbookmark.yaml
+++ b/catalog/plugins/cuhaitiang0405-collab-dsh-indexbookmark.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: cuhaitiang0405-collab-dsh-indexbookmark
+name: dsh-indexbookmark
+description:
+  en: "A DSH (DeepSeek Harness) web client plugin: conversation question index . Adds a ☰ button beside the input box; click it to see every question you asked in the current session, and click any entry to scroll the conversation straight to that message with a highlight."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - conversation
+  - index
+  - question
+  - navigation
+source:
+  repository: https://github.com/cuhaitiang0405-collab/dsh-indexbookmark
+  repositoryNodeId: R_kgDOT8Ktlw
+  subpath: null
+  commit: b526c3905abef12f6476d41b90a80ab62cbc4870
+creator:
+  github: cuhaitiang0405-collab
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:07.463Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cuhaitiang0405-collab-dsh-indexbookmark`
- Submission type: community curation
- Created by `cuhaitiang0405-collab` — https://github.com/cuhaitiang0405-collab
- Original source repository: https://github.com/cuhaitiang0405-collab/dsh-indexbookmark
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.