### PR TITLE
catalog: add d-dev0101-open-sea-skin (community curation, created by @d-dev0101)

### DIFF
--- a/catalog/plugins/d-dev0101-open-sea-skin.yaml
+++ b/catalog/plugins/d-dev0101-open-sea-skin.yaml
@@ -1,0 +1,60 @@
+schemaVersion: 1
+id: d-dev0101-open-sea-skin
+name: open-sea-skin
+description:
+  en: Realtime WebGPU ocean skin for DeepSeek Harness on Chrome and Edge
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - theme
+  - skin
+  - webgpu
+  - ocean
+  - dsh
+source:
+  repository: https://github.com/d-dev0101/open-sea-skin
+  repositoryNodeId: R_kgDOT4yoDA
+  subpath: null
+  commit: 2437d80a96de4124c54fbe89872fa7090103f025
+creator:
+  github: d-dev0101
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:48.834Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 194
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/marketplace/open-sea-harness-cover.png
+    alt: Open Sea for DeepSeek Harness
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-dark-overview-40.gif
+    alt: Open Sea inside DeepSeek Harness in dark mode
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-light-overview-40.gif
+    alt: Open Sea inside DeepSeek Harness in light mode
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-wave-control-40.gif
+    alt: Adjusting wave size in DeepSeek Harness
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-daylight-sunset-40.gif
+    alt: Adjusting daylight from midday to sunset


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `d-dev0101-open-sea-skin`
- Submission type: community curation
- Created by `d-dev0101` — https://github.com/d-dev0101
- Original source repository: https://github.com/d-dev0101/open-sea-skin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.