### PR TITLE
catalog: add dabouben-dsh-daily-tasks (community curation, created by @Dabouben)

### DIFF
--- a/catalog/plugins/dabouben-dsh-daily-tasks.yaml
+++ b/catalog/plugins/dabouben-dsh-daily-tasks.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dabouben-dsh-daily-tasks
+name: "@dabouben/dsh-daily-tasks"
+description:
+  en: sh dsh plugin --profile web add @dabouben/dsh-daily-tasks
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - todo
+  - tasks
+  - daily-tasks
+  - token-usage
+  - balance
+source:
+  repository: https://github.com/Dabouben/dsh-daily-tasks
+  repositoryNodeId: R_kgDOT7Tc-Q
+  subpath: null
+  commit: fb5fccbb8d24aa941897f4651e808f24ff78c476
+creator:
+  github: Dabouben
+package:
+  ecosystem: npm
+  name: "@dabouben/dsh-daily-tasks"
+  version: 0.1.0
+  integrity: sha512-ZgmlyVxVkWrA2PwxkoTHIeW+ET6gRNX+EYNLF+KFB7kOi3dRxM+grMc3mBtBekyNzDHgV9I5oqZ4wjeqrLiXvQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:07.720Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dabouben-dsh-daily-tasks`
- Submission type: community curation
- Created by `Dabouben` — https://github.com/Dabouben
- Original source repository: https://github.com/Dabouben/dsh-daily-tasks
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.