### PR TITLE
catalog: add ddsg-x-dsh-workspace-dir (community curation, created by @DDSG-X)

### DIFF
--- a/catalog/plugins/ddsg-x-dsh-workspace-dir.yaml
+++ b/catalog/plugins/ddsg-x-dsh-workspace-dir.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: ddsg-x-dsh-workspace-dir
+name: dsh-workspace-dir
+description:
+  en: "DeepSeek Harness plugin: show the current conversation's working directory in a draggable directory panel with adjustable opacity."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - workspace
+  - file-explorer
+  - dsh
+source:
+  repository: https://github.com/DDSG-X/dsh-workspace-dir
+  repositoryNodeId: R_kgDOT46pSQ
+  subpath: null
+  commit: 0a05dbb6562677eeb7b478883abe04631e970b6e
+creator:
+  github: DDSG-X
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:09.215Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ddsg-x-dsh-workspace-dir`
- Submission type: community curation
- Created by `DDSG-X` — https://github.com/DDSG-X
- Original source repository: https://github.com/DDSG-X/dsh-workspace-dir
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.