### PR TITLE
catalog: add delaydai-dsh-jumpbar (community curation, created by @delaydai)

### DIFF
--- a/catalog/plugins/delaydai-dsh-jumpbar.yaml
+++ b/catalog/plugins/delaydai-dsh-jumpbar.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: delaydai-dsh-jumpbar
+name: dsh-jumpbar
+description:
+  en: "User message jump bar for the DSH web GUI: a minimap-style dash strip on the right edge of the conversation, hover for message preview, click to jump. · DSH Web 用户消息跳转条：对话区右缘 minimap 式横杠，悬停预览、点击跳转。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - ui
+  - conversation
+  - jump
+  - minimap
+source:
+  repository: https://github.com/delaydai/dsh-jumpbar
+  repositoryNodeId: R_kgDOT_0wow
+  subpath: null
+  commit: 3f453be4d1c0cce6c8494fd5ddfc661e7e3553b8
+creator:
+  github: delaydai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:08.915Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `delaydai-dsh-jumpbar`
- Submission type: community curation
- Created by `delaydai` — https://github.com/delaydai
- Original source repository: https://github.com/delaydai/dsh-jumpbar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.