### PR TITLE
catalog: add delightor-dsh-depguard (community curation, created by @DeLightor)

### DIFF
--- a/catalog/plugins/delightor-dsh-depguard.yaml
+++ b/catalog/plugins/delightor-dsh-depguard.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: delightor-dsh-depguard
+name: dsh-depguard
+description:
+  en: "DeepSeek Harness plugin: predict (pre-install) and detect (post-install) duplicate @deepseek-ai/dsh- copies, version drift, and vendored core services to prevent Symbol-key crashes like \"Cannot read properties of undefined (reading 'prepare')\"."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - predict
+  - install
+  - detect
+  - post
+  - duplicate
+  - copies
+  - version
+  - drift
+  - vendored
+  - core
+  - services
+  - prevent
+  - symbol
+  - crashes
+  - cannot
+  - read
+source:
+  repository: https://github.com/DeLightor/dsh-depguard
+  repositoryNodeId: R_kgDOT5xpww
+  subpath: null
+  commit: 3f2e9814a5fa510707114086f25c5b0f7e7003df
+creator:
+  github: DeLightor
+package:
+  ecosystem: npm
+  name: dsh-depguard
+  version: 0.1.0
+  integrity: sha512-RRJkRzNzmcOZPfuzQ+UF1GGY51MERt90uF25yLl1V2kRVxPCXznBiLh6qJsS0Ms+wFkN0avK8BLMwvHgifC/nw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:09.008Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `delightor-dsh-depguard`
- Submission type: community curation
- Created by `DeLightor` — https://github.com/DeLightor
- Original source repository: https://github.com/DeLightor/dsh-depguard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.