### PR TITLE
catalog: add dfycaly98931680-dsh-trajectory-governance (community curation, created by @dfycaly98931680)

### DIFF
--- a/catalog/plugins/dfycaly98931680-dsh-trajectory-governance.yaml
+++ b/catalog/plugins/dfycaly98931680-dsh-trajectory-governance.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: dfycaly98931680-dsh-trajectory-governance
+name: dsh-trajectory-governance
+description:
+  en: "Agent trajectory governance & anomaly diagnosis for DeepSeek Harness: rebuild structured multi-branch trajectory trees from the session/event feed, keep observation-layer snapshots, and run three temporal anomaly strategies (loop deadlock / invalid retry / goal drift)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - trajectory
+  - anomaly-detection
+  - observability
+  - dsh-plugin
+source:
+  repository: https://github.com/dfycaly98931680/dsh-trajectory-governance
+  repositoryNodeId: R_kgDOT4iktg
+  subpath: null
+  commit: 4fa614af844aff601c473ac31d7cb1dd8d786d9d
+creator:
+  github: dfycaly98931680
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:56.386Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dfycaly98931680-dsh-trajectory-governance`
- Submission type: community curation
- Created by `dfycaly98931680` — https://github.com/dfycaly98931680
- Original source repository: https://github.com/dfycaly98931680/dsh-trajectory-governance
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.