### PR TITLE
catalog: add dhb861832993-star-pbr-render (community curation, created by @dhb861832993-star)

### DIFF
--- a/catalog/plugins/dhb861832993-star-pbr-render.yaml
+++ b/catalog/plugins/dhb861832993-star-pbr-render.yaml
@@ -1,0 +1,67 @@
+schemaVersion: 1
+id: dhb861832993-star-pbr-render
+name: pbr-render
+description:
+  en: "PBR model preview for DeepSeek Harness: render GLB/GLTF game art with physically-based materials, textures, environment lighting, and orbit controls — fence language pbr3d + pbr render tool."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - pbr
+  - 3d
+  - gltf
+  - glb
+  - game-art
+  - preview
+  - texture
+  - material
+source:
+  repository: https://github.com/dhb861832993-star/pbr-render
+  repositoryNodeId: R_kgDOT52g8Q
+  subpath: null
+  commit: 5bda86a8f102aae5c061b9ab45c0fe3385ac5484
+creator:
+  github: dhb861832993-star
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:54.688Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/dhb861832993-star/pbr-render/5bda86a8f102aae5c061b9ab45c0fe3385ac5484/assets/mode-pbr.png
+    alt: pbr
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/dhb861832993-star/pbr-render/5bda86a8f102aae5c061b9ab45c0fe3385ac5484/assets/mode-basecolor.png
+    alt: basecolor
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/dhb861832993-star/pbr-render/5bda86a8f102aae5c061b9ab45c0fe3385ac5484/assets/mode-normal.png
+    alt: normal
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/dhb861832993-star/pbr-render/5bda86a8f102aae5c061b9ab45c0fe3385ac5484/assets/mode-roughness.png
+    alt: roughness
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/dhb861832993-star/pbr-render/5bda86a8f102aae5c061b9ab45c0fe3385ac5484/assets/mode-metallic.png
+    alt: metallic
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/dhb861832993-star/pbr-render/5bda86a8f102aae5c061b9ab45c0fe3385ac5484/assets/mode-ao.png
+    alt: ao


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dhb861832993-star-pbr-render`
- Submission type: community curation
- Created by `dhb861832993-star` — https://github.com/dhb861832993-star
- Original source repository: https://github.com/dhb861832993-star/pbr-render
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.