### PR TITLE
catalog: add dingyi580-dsh-conversation-rail (community curation, created by @dingyi580)

### DIFF
--- a/catalog/plugins/dingyi580-dsh-conversation-rail.yaml
+++ b/catalog/plugins/dingyi580-dsh-conversation-rail.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: dingyi580-dsh-conversation-rail
+name: dsh-conversation-rail
+description:
+  en: A locator for long conversations in DSH Web. A vertical rail sits along the left edge of the conversation, one bar per turn ; hover a bar for a preview card, click it to jump to that turn.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - client-plugin
+  - conversation
+  - minimap
+  - navigation
+  - outline
+  - session
+source:
+  repository: https://github.com/dingyi580/dsh-conversation-rail
+  repositoryNodeId: R_kgDOT7c2oQ
+  subpath: null
+  commit: bf198d53833deea611ab86509120ce5bf6a0a35e
+creator:
+  github: dingyi580
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:09.260Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dingyi580-dsh-conversation-rail`
- Submission type: community curation
- Created by `dingyi580` — https://github.com/dingyi580
- Original source repository: https://github.com/dingyi580/dsh-conversation-rail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.