### PR TITLE
catalog: add duhu2000-dsh-mcp-connector (community curation, created by @duhu2000)

### DIFF
--- a/catalog/plugins/duhu2000-dsh-mcp-connector.yaml
+++ b/catalog/plugins/duhu2000-dsh-mcp-connector.yaml
@@ -1,0 +1,72 @@
+schemaVersion: 1
+id: duhu2000-dsh-mcp-connector
+name: dsh-mcp-connector
+description:
+  en: Connect and manage MCP servers in DeepSeek Harness — a universal MCP connector and marketplace with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, tools, and prompts. Maintained by Qichacha/QCC.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - mcp
+  - mcp-client
+  - mcp-server
+  - mcp-connector
+  - mcp-marketplace
+  - model-context-protocol
+  - mcp-hub
+  - mcp-manager
+  - mcp-registry
+  - mcp-tools
+  - mcp-store
+  - remote-mcp
+source:
+  repository: https://github.com/duhu2000/dsh-mcp-connector
+  repositoryNodeId: R_kgDOT-uRIg
+  subpath: null
+  commit: 7fca199a2680fb67e11516f14eeb374a1e46938c
+creator:
+  github: duhu2000
+package:
+  ecosystem: npm
+  name: dsh-mcp-connector
+  version: 0.2.30
+  integrity: sha512-uiH+I4FHcIVubkzl8oYRUM4sbM80ibl8UUvkosgBE2D/rhNkFAE/ugizvM9S0pyCAP7M+iLbRHGBssTpjIwXdw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:51.269Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector/7fca199a2680fb67e11516f14eeb374a1e46938c/docs/demo.gif
+    alt: MCP 连接器 16 秒演示
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector/7fca199a2680fb67e11516f14eeb374a1e46938c/docs/screenshots/01-market-overview.jpg
+    alt: 市场总览
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector/7fca199a2680fb67e11516f14eeb374a1e46938c/docs/screenshots/02-connector-detail.jpg
+    alt: 连接器详情
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector/7fca199a2680fb67e11516f14eeb374a1e46938c/docs/screenshots/03-tool-discovery.jpg
+    alt: 工具发现
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector/7fca199a2680fb67e11516f14eeb374a1e46938c/docs/screenshots/04-json-import.jpg
+    alt: JSON 导入


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `duhu2000-dsh-mcp-connector`
- Submission type: community curation
- Created by `duhu2000` — https://github.com/duhu2000
- Original source repository: https://github.com/duhu2000/dsh-mcp-connector
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.