### PR TITLE
catalog: add dylanzhangzx-dknowc-dsh (community curation, created by @dylanzhangzx)

### DIFF
--- a/catalog/plugins/dylanzhangzx-dknowc-dsh.yaml
+++ b/catalog/plugins/dylanzhangzx-dknowc-dsh.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: dylanzhangzx-dknowc-dsh
+name: dknowc-dsh
+description:
+  en: sh dsh plugin --profile web add dknowc-dsh
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - dknowc
+  - trusted-consulting
+  - trusted-search
+  - official-doc-writing
+source:
+  repository: https://github.com/dylanzhangzx/dknowc-dsh
+  repositoryNodeId: R_kgDOT7Db_Q
+  subpath: null
+  commit: 8f15792b24634c6e0eb586cdef7533b76e9e96b2
+creator:
+  github: dylanzhangzx
+package:
+  ecosystem: npm
+  name: dknowc-dsh
+  version: 1.1.1
+  integrity: sha512-+QtrvEtuzJtM4XoaEzY3cTE7h2PEpFUR8BRSZSRaAZjGiFB9oHywFYKTf59SrSIPaIzz5k7aH/hXnPrvAFrJow==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:03.702Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `dylanzhangzx-dknowc-dsh`
- Submission type: community curation
- Created by `dylanzhangzx` — https://github.com/dylanzhangzx
- Original source repository: https://github.com/dylanzhangzx/dknowc-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.