### PR TITLE
catalog: add e2mcc-dsh-popout-sidebar (community curation, created by @e2mcc)

### DIFF
--- a/catalog/plugins/e2mcc-dsh-popout-sidebar.yaml
+++ b/catalog/plugins/e2mcc-dsh-popout-sidebar.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: e2mcc-dsh-popout-sidebar
+name: dsh-popout-sidebar
+description:
+  en: 可弹出侧边栏 · A DeepSeek Harness sidebar that shows artifacts and pops out into a larger web tab.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - sidebar
+  - artifacts
+source:
+  repository: https://github.com/e2mcc/dsh-popout-sidebar
+  repositoryNodeId: R_kgDOT5N4Sg
+  subpath: null
+  commit: e9a8458cb65c0a863ba5c86bf4ad272b1e0e3162
+creator:
+  github: e2mcc
+package:
+  ecosystem: npm
+  name: dsh-popout-sidebar
+  version: 1.0.1
+  integrity: sha512-Yr9L/CZGTFGhjd2utH/xJbw0w7YAe8XHDPkqdkhAOBQrxMrpleoDUtx+LR5VgoP9mZKU4AsLI2rFQR4Le6RHPQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:48.832Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 166
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `e2mcc-dsh-popout-sidebar`
- Submission type: community curation
- Created by `e2mcc` — https://github.com/e2mcc
- Original source repository: https://github.com/e2mcc/dsh-popout-sidebar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.