### PR TITLE
catalog: add eeyzs1-dsh-chime (community curation, created by @eeyzs1)

### DIFF
--- a/catalog/plugins/eeyzs1-dsh-chime.yaml
+++ b/catalog/plugins/eeyzs1-dsh-chime.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: eeyzs1-dsh-chime
+name: "@eeyzs1/dsh-chime"
+description:
+  en: Play a chime when any conversation finishes a turn or waits for user input.
+  evidencePath: packages/chime/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - play
+  - chime
+  - conversation
+  - finishes
+  - turn
+  - waits
+  - user
+  - input
+  - dsh
+source:
+  repository: https://github.com/eeyzs1/dsh-plugins
+  repositoryNodeId: R_kgDOT5anVw
+  subpath: packages/chime
+  commit: 7b5019388f5c5ff168f67e802e4945db46407d9f
+creator:
+  github: eeyzs1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/chime/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:13.877Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `eeyzs1-dsh-chime`
- Submission type: community curation
- Created by `eeyzs1` — https://github.com/eeyzs1
- Original source repository: https://github.com/eeyzs1/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.