### PR TITLE
catalog: add eomis-runtime (community curation, created by @eomis)

### DIFF
--- a/catalog/plugins/eomis-runtime.yaml
+++ b/catalog/plugins/eomis-runtime.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: eomis-runtime
+name: "@packhub/runtime"
+description:
+  en: "- DSH Desktop：2.0.2 - DeepSeek Harness：0.1.1-rc.2"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - template
+source:
+  repository: https://github.com/eomis/packhub-workbench-assistant
+  repositoryNodeId: R_kgDOUBjbMg
+  subpath: null
+  commit: 3aaf326df60ae733a23578d6edd5d490eca1a9ee
+creator:
+  github: eomis
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:04.336Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `eomis-runtime`
- Submission type: community curation
- Created by `eomis` — https://github.com/eomis
- Original source repository: https://github.com/eomis/packhub-workbench-assistant
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.