### PR TITLE
catalog: add favio8-dsh-plugin-deepeye (community curation, created by @Favio8)

### DIFF
--- a/catalog/plugins/favio8-dsh-plugin-deepeye.yaml
+++ b/catalog/plugins/favio8-dsh-plugin-deepeye.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: favio8-dsh-plugin-deepeye
+name: dsh-plugin-deepeye
+description:
+  en: "DeepSeek Harness native plugin: vision capabilities for text-only LLMs (describe, OCR, VQA, layout analysis, clipboard)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - vision
+  - ocr
+  - image-analysis
+source:
+  repository: https://github.com/Favio8/dsh-plugin-deepeye
+  repositoryNodeId: R_kgDOT3jk0A
+  subpath: null
+  commit: 81c172c66e9cd4d9a8e62cc5d699372962169277
+creator:
+  github: Favio8
+package:
+  ecosystem: npm
+  name: dsh-plugin-deepeye
+  version: 0.2.0
+  integrity: sha512-bZbCc5JaxN0zWMgdSuvH1kOw75M7QmLK2jgm/u5auym8mkHvBCuteVEkZ68uT8qAjV684XIkPvpyn+L3gn707w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:56.071Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `favio8-dsh-plugin-deepeye`
- Submission type: community curation
- Created by `Favio8` — https://github.com/Favio8
- Original source repository: https://github.com/Favio8/dsh-plugin-deepeye
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.