### PR TITLE
catalog: add feizhuniu-infja-dsh-stock-ticker (community curation, created by @FeiZhuNiU-INFJA)

### DIFF
--- a/catalog/plugins/feizhuniu-infja-dsh-stock-ticker.yaml
+++ b/catalog/plugins/feizhuniu-infja-dsh-stock-ticker.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: feizhuniu-infja-dsh-stock-ticker
+name: dsh-stock-ticker
+description:
+  en: bash dsh plugin --profile web add github:FeiZhuNiU-INFJA/dsh-stock-ticker
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - stock
+  - market
+  - quote
+  - index
+  - shanghai
+  - hangseng
+source:
+  repository: https://github.com/FeiZhuNiU-INFJA/dsh-stock-ticker
+  repositoryNodeId: R_kgDOT-i5OA
+  subpath: null
+  commit: c04e09146a222ece70dcda535294c25a88c49eae
+creator:
+  github: FeiZhuNiU-INFJA
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:54.590Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/FeiZhuNiU-INFJA/dsh-stock-ticker/c04e09146a222ece70dcda535294c25a88c49eae/assets/screenshot.png
+    alt: dsh-stock-ticker 悬浮行情


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `feizhuniu-infja-dsh-stock-ticker`
- Submission type: community curation
- Created by `FeiZhuNiU-INFJA` — https://github.com/FeiZhuNiU-INFJA
- Original source repository: https://github.com/FeiZhuNiU-INFJA/dsh-stock-ticker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.