### PR TITLE
catalog: add fengb3-dsh-session-icons (community curation, created by @fengb3)

### DIFF
--- a/catalog/plugins/fengb3-dsh-session-icons.yaml
+++ b/catalog/plugins/fengb3-dsh-session-icons.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: fengb3-dsh-session-icons
+name: dsh-session-icons
+description:
+  en: powershell dsh plugin --profile web add dsh-session-icons
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - session
+  - icon
+  - svg
+  - sidebar
+source:
+  repository: https://github.com/fengb3/dsh-session-icons
+  repositoryNodeId: R_kgDOUAqtxA
+  subpath: null
+  commit: 56c3d950de96ceb2777e3c99cf48e2b7feae29d4
+creator:
+  github: fengb3
+package:
+  ecosystem: npm
+  name: dsh-session-icons
+  version: 0.1.0
+  integrity: sha512-RqiiXTLLbfy9H8l5bGgguyFfGpSNkrW2Mr0msYfwbq+Yu1rB8aSljcadKdTxXUS4LEi3y8AIknc0UKxRVJvr9A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:58.030Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/fengb3/dsh-session-icons/56c3d950de96ceb2777e3c99cf48e2b7feae29d4/docs/screenshot.png
+    alt: 侧边栏会话标题图标效果


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `fengb3-dsh-session-icons`
- Submission type: community curation
- Created by `fengb3` — https://github.com/fengb3
- Original source repository: https://github.com/fengb3/dsh-session-icons
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.