### PR TITLE
catalog: add flymysql-dsh-memory-vault (community curation, created by @flymysql)

### DIFF
--- a/catalog/plugins/flymysql-dsh-memory-vault.yaml
+++ b/catalog/plugins/flymysql-dsh-memory-vault.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: flymysql-dsh-memory-vault
+name: dsh-memory-vault
+description:
+  en: "Cross-session memory vault for DeepSeek Harness: remember / recall / forget tools, per-turn prompt injection, and a browser management page."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - memory
+source:
+  repository: https://github.com/flymysql/dsh-memory
+  repositoryNodeId: R_kgDOT386Xw
+  subpath: null
+  commit: d6afee4bb594164193b7e262d6539d0c55b54a8b
+creator:
+  github: flymysql
+package:
+  ecosystem: npm
+  name: dsh-memory-vault
+  version: 0.1.5
+  integrity: sha512-EXk51g7F3DXtVXeaqxaMke9V6Du1xWU5qoIAG61KveJQNHyY98eNGH8UVZmmg++y1HkKn8iCCHqvYLSXAWW8FQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:56.300Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `flymysql-dsh-memory-vault`
- Submission type: community curation
- Created by `flymysql` — https://github.com/flymysql
- Original source repository: https://github.com/flymysql/dsh-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.