### PR TITLE
catalog: add frost-reed-dsh-blocker-notify (community curation, created by @Frost-Reed)

### DIFF
--- a/catalog/plugins/frost-reed-dsh-blocker-notify.yaml
+++ b/catalog/plugins/frost-reed-dsh-blocker-notify.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: frost-reed-dsh-blocker-notify
+name: dsh-blocker-notify
+description:
+  en: "Real-time attention alerts for DeepSeek Harness: a global banner plus flashing workspace entries when the agent is blocked (approval request / sandbox denial), with an audible chime and OS-level notifications for new blockers."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - bundle
+  - notification
+  - approval
+  - sandbox
+source:
+  repository: https://github.com/Frost-Reed/blocker-notify
+  repositoryNodeId: R_kgDOT4ESMQ
+  subpath: null
+  commit: 0a0f396240d955e787b9ad8d64c91fd0151bfb3f
+creator:
+  github: Frost-Reed
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:04.656Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Frost-Reed/blocker-notify/0a0f396240d955e787b9ad8d64c91fd0151bfb3f/assets/show_fullscreen.png
+    alt: 示例


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `frost-reed-dsh-blocker-notify`
- Submission type: community curation
- Created by `Frost-Reed` — https://github.com/Frost-Reed
- Original source repository: https://github.com/Frost-Reed/blocker-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.