### PR TITLE
catalog: add funcwei-dsh-wechat-mp-studio (community curation, created by @FuncWei)

### DIFF
--- a/catalog/plugins/funcwei-dsh-wechat-mp-studio.yaml
+++ b/catalog/plugins/funcwei-dsh-wechat-mp-studio.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: funcwei-dsh-wechat-mp-studio
+name: dsh-wechat-mp-studio
+description:
+  en: "WeChat Official Account content studio for DeepSeek Harness: anti-homogenization writing methodology, blessing-image visual baseline, gpt-image cover pipeline with OCR acceptance, interaction rules, and the measured xiaolvshu (newspic) draft web API."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - wechat
+  - weixin
+  - xiaolvshu
+  - content
+  - writing
+  - gpt-image
+  - ocr
+source:
+  repository: https://github.com/FuncWei/dsh-wechat-mp-studio
+  repositoryNodeId: R_kgDOT5313A
+  subpath: null
+  commit: d5341aeaaf67830f0193cd004ade402b99de93d9
+creator:
+  github: FuncWei
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:04.672Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `funcwei-dsh-wechat-mp-studio`
- Submission type: community curation
- Created by `FuncWei` — https://github.com/FuncWei
- Original source repository: https://github.com/FuncWei/dsh-wechat-mp-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.