### PR TITLE
catalog: add gastronomicluna-dsh-plugin-matrix (community curation, created by @Gastronomicluna)

### DIFF
--- a/catalog/plugins/gastronomicluna-dsh-plugin-matrix.yaml
+++ b/catalog/plugins/gastronomicluna-dsh-plugin-matrix.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: gastronomicluna-dsh-plugin-matrix
+name: dsh-plugin-matrix
+description:
+  en: bash dsh plugin --profile web add "."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - matrix
+  - code-rain
+  - cli
+  - terminal
+source:
+  repository: https://github.com/Gastronomicluna/Matrix-code
+  repositoryNodeId: R_kgDOT_YJnQ
+  subpath: null
+  commit: 990576ab3116f6bb85534f28fc0d815a75055850
+creator:
+  github: Gastronomicluna
+package:
+  ecosystem: npm
+  name: dsh-plugin-matrix
+  version: 1.0.0
+  integrity: sha512-ocSvm6/m1A/DdLR/+Z2Q2R50stdQtl/TEMcTTxZaqEOOgFbJ++3BlVuOnQqVoYocYgSpsOKphUBmfT7mDCwY9Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:09.358Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Gastronomicluna/Matrix-code/990576ab3116f6bb85534f28fc0d815a75055850/assets/demo.png
+    alt: 矩阵思维 CLI 演示


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gastronomicluna-dsh-plugin-matrix`
- Submission type: community curation
- Created by `Gastronomicluna` — https://github.com/Gastronomicluna
- Original source repository: https://github.com/Gastronomicluna/Matrix-code
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.