### PR TITLE
catalog: add geekricardo-claude-in-dsh (community curation, created by @GeekRicardo)

### DIFF
--- a/catalog/plugins/geekricardo-claude-in-dsh.yaml
+++ b/catalog/plugins/geekricardo-claude-in-dsh.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: geekricardo-claude-in-dsh
+name: claude-in-dsh
+description:
+  en: bash curl -fsSL https://raw.githubusercontent.com/GeekRicardo/claude-in-dsh/main/install.sh bash
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - bash
+  - curl
+  - fssl
+  - githubusercontent
+  - geekricardo
+  - claude
+  - main
+  - install
+  - dsh
+source:
+  repository: https://github.com/GeekRicardo/claude-in-dsh
+  repositoryNodeId: R_kgDOT-JVsg
+  subpath: null
+  commit: 62e3805b3572f3478e5db73968b9c1d29233047e
+creator:
+  github: GeekRicardo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:59.299Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `geekricardo-claude-in-dsh`
- Submission type: community curation
- Created by `GeekRicardo` — https://github.com/GeekRicardo
- Original source repository: https://github.com/GeekRicardo/claude-in-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.