### PR TITLE
catalog: add godchen520-dsh-web-remote (community curation, created by @godchen520)

### DIFF
--- a/catalog/plugins/godchen520-dsh-web-remote.yaml
+++ b/catalog/plugins/godchen520-dsh-web-remote.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: godchen520-dsh-web-remote
+name: dsh-web-remote
+description:
+  en: bash dsh plugin --profile web add github:godchen520/dsh-web-remote && dsh web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - remote
+  - cloudflare
+  - tunnel
+  - monitor
+  - weixin
+  - feishu
+  - lark
+source:
+  repository: https://github.com/godchen520/dsh-web-remote
+  repositoryNodeId: R_kgDOT5T6Gg
+  subpath: null
+  commit: 154e360b52f87d848e55b7d6c5042866949e4748
+creator:
+  github: godchen520
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:52.418Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/godchen520/dsh-web-remote/154e360b52f87d848e55b7d6c5042866949e4748/docs/quick-button.png
+    alt: 快捷按钮
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/godchen520/dsh-web-remote/154e360b52f87d848e55b7d6c5042866949e4748/docs/remote-screenshot.png
+    alt: 远程面板


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `godchen520-dsh-web-remote`
- Submission type: community curation
- Created by `godchen520` — https://github.com/godchen520
- Original source repository: https://github.com/godchen520/dsh-web-remote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.