### PR TITLE
catalog: add good-boy4069-dsh-mobile-remote (community curation, created by @good-boy4069)

### DIFF
--- a/catalog/plugins/good-boy4069-dsh-mobile-remote.yaml
+++ b/catalog/plugins/good-boy4069-dsh-mobile-remote.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: good-boy4069-dsh-mobile-remote
+name: dsh-mobile-remote
+description:
+  en: "DeepSeek Harness WeChat remote-control plugin: control your dsh agent from WeChat (iLink long-polling, fully outbound, works over any network)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - wechat
+  - weixin
+  - ilink
+  - remote-control
+  - chat-channel
+source:
+  repository: https://github.com/good-boy4069/dsh-mobile-remote
+  repositoryNodeId: R_kgDOT5z-cQ
+  subpath: null
+  commit: f0ce76aeac09896835f3ca482d78d7854185ad82
+creator:
+  github: good-boy4069
+package:
+  ecosystem: npm
+  name: dsh-mobile-remote
+  version: 0.1.0
+  integrity: sha512-fiYv6KWxlwXtcD+2LJiZrIvY186qNAfdWCzp+LGbfL7I+a1IbQgHBXY7XS7M+n1LxWoiBWU4TGfx3KEJmgIvSQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:05.397Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `good-boy4069-dsh-mobile-remote`
- Submission type: community curation
- Created by `good-boy4069` — https://github.com/good-boy4069
- Original source repository: https://github.com/good-boy4069/dsh-mobile-remote
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.