### PR TITLE
catalog: add good-boy4069-dsh-vision-guard (community curation, created by @good-boy4069)

### DIFF
--- a/catalog/plugins/good-boy4069-dsh-vision-guard.yaml
+++ b/catalog/plugins/good-boy4069-dsh-vision-guard.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: good-boy4069-dsh-vision-guard
+name: dsh-vision-guard
+description:
+  en: "Transparent image guard + vision analysis for DeepSeek Harness: text-only models read pasted images without the 400 session deadlock."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - vision
+  - image
+  - ocr
+  - guard
+  - multimodal
+source:
+  repository: https://github.com/good-boy4069/dsh-vision-guard
+  repositoryNodeId: R_kgDOT5LUAg
+  subpath: null
+  commit: 54706cde2e2624f270c0beb1f4f339f932d14320
+creator:
+  github: good-boy4069
+package:
+  ecosystem: npm
+  name: dsh-vision-guard
+  version: 0.1.3
+  integrity: sha512-E4hOLiM75l2LRoRqyy2RfpR2PfGBXxTeF3/3cF2QeUI0oXfQj12vx3KXhOCgy3FVDlWU3heJVou1s+B3Z5PYVg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:10.796Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `good-boy4069-dsh-vision-guard`
- Submission type: community curation
- Created by `good-boy4069` — https://github.com/good-boy4069
- Original source repository: https://github.com/good-boy4069/dsh-vision-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.