### PR TITLE
catalog: add goodandready-dsh-image-gen (community curation, created by @GooDAnDReaDY)

### DIFF
--- a/catalog/plugins/goodandready-dsh-image-gen.yaml
+++ b/catalog/plugins/goodandready-dsh-image-gen.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: goodandready-dsh-image-gen
+name: "@goodandready/dsh-image-gen"
+description:
+  en: "Image generation for DeepSeek Harness: a generate image tool with pluggable providers — the FAL queue, any OpenAI-compatible images API, or a ChatGPT/Grok subscription with no API key at all. The picture is shown inline in the conversation; the model receives either a link (works with any chat model) or the image itsel"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - image-generation
+  - text-to-image
+  - fal
+  - fal-ai
+  - flux
+  - openai
+  - gpt-image
+  - grok
+  - aigc
+source:
+  repository: https://github.com/GooDAnDReaDY/dsh-image-gen
+  repositoryNodeId: R_kgDOT8LK1A
+  subpath: null
+  commit: b7a304c51a63e3b003d4dc9ca8e148463e532871
+creator:
+  github: GooDAnDReaDY
+package:
+  ecosystem: npm
+  name: "@goodandready/dsh-image-gen"
+  version: 0.8.0
+  integrity: sha512-QovJ0JHFA00KStTDTr3Iq4V/Qfm9aFKZtZb0v69bVL95QUBjCQ4AWOwVrtVtFbElu7eNw7yPWTsDCMBv6sCWBw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:05.891Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `goodandready-dsh-image-gen`
- Submission type: community curation
- Created by `GooDAnDReaDY` — https://github.com/GooDAnDReaDY
- Original source repository: https://github.com/GooDAnDReaDY/dsh-image-gen
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.