### PR TITLE
catalog: add goodandready-dsh-model-sync (community curation, created by @GooDAnDReaDY)

### DIFF
--- a/catalog/plugins/goodandready-dsh-model-sync.yaml
+++ b/catalog/plugins/goodandready-dsh-model-sync.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: goodandready-dsh-model-sync
+name: "@goodandready/dsh-model-sync"
+description:
+  en: Automatic model catalog synchronization for API-key DeepSeek Harness providers.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - models
+  - api-key
+  - catalog
+source:
+  repository: https://github.com/GooDAnDReaDY/dsh-model-sync
+  repositoryNodeId: R_kgDOUByJtA
+  subpath: null
+  commit: 76906b93743b572fb4ab2a40196a57a8dd2d93e9
+creator:
+  github: GooDAnDReaDY
+package:
+  ecosystem: npm
+  name: "@goodandready/dsh-model-sync"
+  version: 0.3.4
+  integrity: sha512-YbkvQv3JRax2vdAcIp00ug9QCLQ2WnrnWM+PJ542zRy4NoHzKONwubIlGjqx41D+tqmmiM32KejEJKIwGDEPZQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:15.578Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `goodandready-dsh-model-sync`
- Submission type: community curation
- Created by `GooDAnDReaDY` — https://github.com/GooDAnDReaDY
- Original source repository: https://github.com/GooDAnDReaDY/dsh-model-sync
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.