### PR TITLE
catalog: add guchang-dsh-draw2code (community curation, created by @guchang)

### DIFF
--- a/catalog/plugins/guchang-dsh-draw2code.yaml
+++ b/catalog/plugins/guchang-dsh-draw2code.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: guchang-dsh-draw2code
+name: dsh-draw2code
+description:
+  en: Human-AI collaborative prototyping for DSH, Codex and MCP agents, from product clarification to editable Excalidraw wireframes and verified frontend generation.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - excalidraw
+  - prototype
+  - wireframe
+  - vibe-coding
+source:
+  repository: https://github.com/guchang/draw2code
+  repositoryNodeId: R_kgDOT8iMtw
+  subpath: null
+  commit: 0d7e33e2f3dd5aa38bb1a405f75452b5f054d8ae
+creator:
+  github: guchang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:00.336Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `guchang-dsh-draw2code`
- Submission type: community curation
- Created by `guchang` — https://github.com/guchang
- Original source repository: https://github.com/guchang/draw2code
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.