### PR TITLE
catalog: add gusu45-dsh-wechat-persistent (community curation, created by @gusu45)

### DIFF
--- a/catalog/plugins/gusu45-dsh-wechat-persistent.yaml
+++ b/catalog/plugins/gusu45-dsh-wechat-persistent.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: gusu45-dsh-wechat-persistent
+name: dsh-wechat-persistent
+description:
+  en: Persistent WeChat bridge for DeepSeek Harness. One WeChat user = one persistent DSH session.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - wechat
+  - weixin
+  - ilink
+  - persistent-session
+  - dsh
+source:
+  repository: https://github.com/gusu45/dsh-wechat-persistent
+  repositoryNodeId: R_kgDOT-q77g
+  subpath: null
+  commit: 0c1f3b0f11d872ee8b70080db683102ff82c1c8c
+creator:
+  github: gusu45
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:17.045Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `gusu45-dsh-wechat-persistent`
- Submission type: community curation
- Created by `gusu45` — https://github.com/gusu45
- Original source repository: https://github.com/gusu45/dsh-wechat-persistent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.