### PR TITLE
catalog: add han-yao94-dsh-session-toolkit (community curation, created by @Han-Yao94)

### DIFF
--- a/catalog/plugins/han-yao94-dsh-session-toolkit.yaml
+++ b/catalog/plugins/han-yao94-dsh-session-toolkit.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: han-yao94-dsh-session-toolkit
+name: dsh-session-toolkit
+description:
+  en: "Unified local plugin: session identity, global prompt, auto-resume, web restart, session log reposition, peer message (6 plugins consolidated)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - unified
+  - local
+  - session
+  - identity
+  - global
+  - prompt
+  - auto
+  - resume
+  - restart
+  - reposition
+  - peer
+  - message
+  - consolidated
+  - dsh
+source:
+  repository: https://github.com/Han-Yao94/dsh-session-toolkit
+  repositoryNodeId: R_kgDOT9tQQQ
+  subpath: null
+  commit: 779d67954b59ab7c0869252fc977ff535236f198
+creator:
+  github: Han-Yao94
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:59.610Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `han-yao94-dsh-session-toolkit`
- Submission type: community curation
- Created by `Han-Yao94` — https://github.com/Han-Yao94
- Original source repository: https://github.com/Han-Yao94/dsh-session-toolkit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.