### PR TITLE
catalog: add hellosky983-dsh-qrcode (community curation, created by @hellosky983)

### DIFF
--- a/catalog/plugins/hellosky983-dsh-qrcode.yaml
+++ b/catalog/plugins/hellosky983-dsh-qrcode.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: hellosky983-dsh-qrcode
+name: dsh-qrcode
+description:
+  en: "Offline QR code generator for DeepSeek Harness (dsh): pure-JS, no network, no shell, cross-platform. Model tools (qrcode + barcode) with SVG/PNG/ASCII output."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - qrcode
+  - barcode
+  - code128
+  - ean13
+source:
+  repository: https://github.com/hellosky983/dsh-qrcode
+  repositoryNodeId: R_kgDOT3_z8g
+  subpath: null
+  commit: d0fcd706cf2e6f9bdc6b5b873fe374d898840359
+creator:
+  github: hellosky983
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:00.854Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hellosky983-dsh-qrcode`
- Submission type: community curation
- Created by `hellosky983` — https://github.com/hellosky983
- Original source repository: https://github.com/hellosky983/dsh-qrcode
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.