### PR TITLE
catalog: add henrytang2011win-coder-dsh-task-sounds (community curation, created by @henrytang2011win-coder)

### DIFF
--- a/catalog/plugins/henrytang2011win-coder-dsh-task-sounds.yaml
+++ b/catalog/plugins/henrytang2011win-coder-dsh-task-sounds.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: henrytang2011win-coder-dsh-task-sounds
+name: dsh-task-sounds
+description:
+  en: Task-complete & question notification sounds for the DeepSeek Harness Web UI. A small chime plays when the agent finishes a turn , and a different "ding-dong" plays when the agent asks you a question mid-task (questions, plan reviews, and approval prompts all pause the agent waiting for your input).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - notification
+  - sound
+  - chime
+  - alert
+  - task-complete
+source:
+  repository: https://github.com/henrytang2011win-coder/dsh-task-sounds
+  repositoryNodeId: R_kgDOUDeCbg
+  subpath: null
+  commit: 4e7990b0e561f052c3bcee00a322baecd8fa71c0
+creator:
+  github: henrytang2011win-coder
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:17.655Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `henrytang2011win-coder-dsh-task-sounds`
- Submission type: community curation
- Created by `henrytang2011win-coder` — https://github.com/henrytang2011win-coder
- Original source repository: https://github.com/henrytang2011win-coder/dsh-task-sounds
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.