### PR TITLE
catalog: add heyflyingpig-long-draft-input (community curation, created by @Heyflyingpig)

### DIFF
--- a/catalog/plugins/heyflyingpig-long-draft-input.yaml
+++ b/catalog/plugins/heyflyingpig-long-draft-input.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: heyflyingpig-long-draft-input
+name: long-draft-input
+description:
+  en: Collapse very long composer drafts into a summary card without changing DSH message submission.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - collapse
+  - very
+  - long
+  - composer
+  - drafts
+  - summary
+  - card
+  - without
+  - changing
+  - message
+  - submission
+  - dsh
+source:
+  repository: https://github.com/Heyflyingpig/long-draft-input
+  repositoryNodeId: R_kgDOT3_0Dw
+  subpath: null
+  commit: 3c69b87dcef07dc86ac075f078d6aa45e4a44c9d
+creator:
+  github: Heyflyingpig
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:01.103Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Heyflyingpig/long-draft-input/3c69b87dcef07dc86ac075f078d6aa45e4a44c9d/readme_img/image.png
+    alt: alt text


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `heyflyingpig-long-draft-input`
- Submission type: community curation
- Created by `Heyflyingpig` — https://github.com/Heyflyingpig
- Original source repository: https://github.com/Heyflyingpig/long-draft-input
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.