### PR TITLE
catalog: add htcqp802-dsh-knowledge-base (community curation, created by @htcqp802)

### DIFF
--- a/catalog/plugins/htcqp802-dsh-knowledge-base.yaml
+++ b/catalog/plugins/htcqp802-dsh-knowledge-base.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: htcqp802-dsh-knowledge-base
+name: dsh-knowledge-base
+description:
+  en: A general-purpose knowledge base plugin for DeepSeek Harness (DSH)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - knowledge-base
+  - kb
+  - rag
+  - retrieval
+  - fts5
+  - bm25
+  - pdf
+  - document-management
+  - file-import
+  - agent
+  - llm
+  - ai
+source:
+  repository: https://github.com/htcqp802/dsh-knowledge-base
+  repositoryNodeId: R_kgDOT5y4ng
+  subpath: null
+  commit: c084a21afe28f96c6b05ec548bd9f6f3e0f47138
+creator:
+  github: htcqp802
+package:
+  ecosystem: npm
+  name: dsh-knowledge-base
+  version: 0.1.5
+  integrity: sha512-krEcGeDYx22xDU27X/Cm410EEk2ZSaNebAgwn2JofFFzUhgk4QKIGNNCBIG58JTknedgV2VSPUt2TKW6XsPZ1g==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:56:52.567Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `htcqp802-dsh-knowledge-base`
- Submission type: community curation
- Created by `htcqp802` — https://github.com/htcqp802
- Original source repository: https://github.com/htcqp802/dsh-knowledge-base
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.