### PR TITLE
catalog: add huasecc-dsh-usage (community curation, created by @Huasecc)

### DIFF
--- a/catalog/plugins/huasecc-dsh-usage.yaml
+++ b/catalog/plugins/huasecc-dsh-usage.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: huasecc-dsh-usage
+name: "@dsh-external/dsh-usage"
+description:
+  en: sh dsh plugin --profile web add "github:Huasecc/dsh-usage main"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - profile
+  - huasecc
+  - usage
+  - main
+  - dsh
+source:
+  repository: https://github.com/Huasecc/dsh-usage
+  repositoryNodeId: R_kgDOT5HnXQ
+  subpath: null
+  commit: 62a8bb5df65516a74f51713780706670bc3cbac5
+creator:
+  github: Huasecc
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T17:57:11.978Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huasecc-dsh-usage`
- Submission type: community curation
- Created by `Huasecc` — https://github.com/Huasecc
- Original source repository: https://github.com/Huasecc/dsh-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.