### PR TITLE
catalog: add hyt-ao-dsh-llm-qianfan (community curation, created by @hyt-ao)

### DIFF
--- a/catalog/plugins/hyt-ao-dsh-llm-qianfan.yaml
+++ b/catalog/plugins/hyt-ao-dsh-llm-qianfan.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: hyt-ao-dsh-llm-qianfan
+name: dsh-llm-qianfan
+description:
+  en: Baidu Qianfan chat-completions adapter for the DeepSeek Harness LLM seam
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - baidu
+  - qianfan
+  - chat
+  - completions
+  - adapter
+  - seam
+  - dsh
+source:
+  repository: https://github.com/hyt-ao/dsh-llm-qianfan
+  repositoryNodeId: R_kgDOT9ZzGQ
+  subpath: null
+  commit: bb7ab03dca19330e3a09238e30176fe6848f24b2
+creator:
+  github: hyt-ao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:37.586Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hyt-ao-dsh-llm-qianfan`
- Submission type: community curation
- Created by `hyt-ao` — https://github.com/hyt-ao
- Original source repository: https://github.com/hyt-ao/dsh-llm-qianfan
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.