### PR TITLE
catalog: add isanti2016-dsh-console (community curation, created by @Isanti2016)

### DIFF
--- a/catalog/plugins/isanti2016-dsh-console.yaml
+++ b/catalog/plugins/isanti2016-dsh-console.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: isanti2016-dsh-console
+name: dsh-console
+description:
+  en: "Console commands for DeepSeek Harness: web service / SSH tunnel management, one-shot ask, and the dsh-tui launcher."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - bundle
+  - console
+  - tunnel
+  - web
+source:
+  repository: https://github.com/Isanti2016/dsh-console
+  repositoryNodeId: R_kgDOT5vMuA
+  subpath: null
+  commit: b137d5f67cf70bad2ddab28b3203f46852419e48
+creator:
+  github: Isanti2016
+package:
+  ecosystem: npm
+  name: dsh-console
+  version: 0.1.0
+  integrity: sha512-AVkSa+8FeecFaLn8NgWobtWm9CsbgRrj4vZJlzOBmuLkOpGz/W0tpWqplKV9z9w3MIFzSSBr3hrLiD1w4Dffrg==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:45.848Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `isanti2016-dsh-console`
- Submission type: community curation
- Created by `Isanti2016` — https://github.com/Isanti2016
- Original source repository: https://github.com/Isanti2016/dsh-console
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.