### PR TITLE
catalog: add it-lu-dsh-imbot (community curation, created by @IT-lu)

### DIFF
--- a/catalog/plugins/it-lu-dsh-imbot.yaml
+++ b/catalog/plugins/it-lu-dsh-imbot.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: it-lu-dsh-imbot
+name: dsh-imbot
+description:
+  en: "DSH plugin: two-way agent bridge over Feishu (Lark) and DingTalk. Chat with a DeepSeek Harness agent from an IM group via Feishu long-connection / DingTalk Stream Mode — no public port needed. Configurable from the DSH settings page."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - feishu
+  - lark
+  - bot
+  - agent-bridge
+  - im
+source:
+  repository: https://github.com/IT-lu/dsh-imbot
+  repositoryNodeId: R_kgDOUBJFIw
+  subpath: null
+  commit: 53594ba50572ea7415c658f9b71f7c16b83ad847
+creator:
+  github: IT-lu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:49.508Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `it-lu-dsh-imbot`
- Submission type: community curation
- Created by `IT-lu` — https://github.com/IT-lu
- Original source repository: https://github.com/IT-lu/dsh-imbot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.