### PR TITLE
catalog: add jerryqx-dsh-ximalaya (community curation, created by @jerryqx)

### DIFF
--- a/catalog/plugins/jerryqx-dsh-ximalaya.yaml
+++ b/catalog/plugins/jerryqx-dsh-ximalaya.yaml
@@ -1,0 +1,60 @@
+schemaVersion: 1
+id: jerryqx-dsh-ximalaya
+name: dsh-ximalaya
+description:
+  en: sh dsh plugin --profile <profile add dsh-ximalaya
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ximalaya
+  - podcast
+  - audio
+  - player
+source:
+  repository: https://github.com/jerryqx/dsh-ximalaya
+  repositoryNodeId: R_kgDOUDz7Nw
+  subpath: null
+  commit: 2fbd8296e3032fe626f41e8ea2f56605ecf48d15
+creator:
+  github: jerryqx
+package:
+  ecosystem: npm
+  name: dsh-ximalaya
+  version: 0.5.2
+  integrity: sha512-TQJPQBi89A4wc+TmEzsl/9SGZ8Uv5/phXOOGzcq2DcAyqffF0ArubR3f3+xRM0wewnTayz6omjRQqCEjCP6Qrg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:46.984Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/2fbd8296e3032fe626f41e8ea2f56605ecf48d15/assets/panel-search.png
+    alt: 搜索
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/2fbd8296e3032fe626f41e8ea2f56605ecf48d15/assets/panel-album.png
+    alt: 专辑
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/2fbd8296e3032fe626f41e8ea2f56605ecf48d15/assets/panel-mine-subs.png
+    alt: 订阅
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/jerryqx/dsh-ximalaya/2fbd8296e3032fe626f41e8ea2f56605ecf48d15/assets/panel-mine-anchors.png
+    alt: 主播


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jerryqx-dsh-ximalaya`
- Submission type: community curation
- Created by `jerryqx` — https://github.com/jerryqx
- Original source repository: https://github.com/jerryqx/dsh-ximalaya
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.