### PR TITLE
catalog: add jesse-njx-cli (community curation, created by @Jesse-njx)

### DIFF
--- a/catalog/plugins/jesse-njx-cli.yaml
+++ b/catalog/plugins/jesse-njx-cli.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: jesse-njx-cli
+name: "@dsh-pm/cli"
+description:
+  en: "@dsh-pm/cli — the dsh pm command group: search, install, remove, list, update, and doctor for dsh plugins, wiring the registry, installer, and core contract together"
+  evidencePath: packages/cli/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - plugin-manager
+  - cli
+source:
+  repository: https://github.com/Jesse-njx/dsh-plugin-manager
+  repositoryNodeId: R_kgDOT36tPQ
+  subpath: packages/cli
+  commit: d0fbacf017706bc05ec415d07c38bd0a79b05cec
+creator:
+  github: Jesse-njx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/cli/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:49.902Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jesse-njx-cli`
- Submission type: community curation
- Created by `Jesse-njx` — https://github.com/Jesse-njx
- Original source repository: https://github.com/Jesse-njx/dsh-plugin-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.