### PR TITLE
catalog: add jesse-njx-dsh-crosstalk-bundle (community curation, created by @Jesse-njx)

### DIFF
--- a/catalog/plugins/jesse-njx-dsh-crosstalk-bundle.yaml
+++ b/catalog/plugins/jesse-njx-dsh-crosstalk-bundle.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jesse-njx-dsh-crosstalk-bundle
+name: "@dsh-crosstalk/bundle"
+description:
+  en: "dsh-crosstalk — cross-session messaging for DSH: any session on the machine can list and message any other, Claude Code-style"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - crosstalk
+  - messaging
+  - multi-session
+source:
+  repository: https://github.com/Jesse-njx/dsh-crosstalk
+  repositoryNodeId: R_kgDOT3lFTQ
+  subpath: null
+  commit: 24410fdda54b7e8230648e4394169156da85f564
+creator:
+  github: Jesse-njx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:31.006Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jesse-njx-dsh-crosstalk-bundle`
- Submission type: community curation
- Created by `Jesse-njx` — https://github.com/Jesse-njx
- Original source repository: https://github.com/Jesse-njx/dsh-crosstalk
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.