### PR TITLE
catalog: add jesse-njx-dsh-polyglot-bundle (community curation, created by @Jesse-njx)

### DIFF
--- a/catalog/plugins/jesse-njx-dsh-polyglot-bundle.yaml
+++ b/catalog/plugins/jesse-njx-dsh-polyglot-bundle.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: jesse-njx-dsh-polyglot-bundle
+name: "@dsh-polyglot/bundle"
+description:
+  en: "dsh-polyglot — the model switch for DSH: one generic OpenAI-compatible ctx.llm adapter, curated free/cheap DeepSeek provider presets, and automatic provider fallback when a free tier rate-limits you"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - llm
+  - openai-compatible
+  - adapter
+  - router
+  - fallback
+  - openrouter
+source:
+  repository: https://github.com/Jesse-njx/dsh-polyglot
+  repositoryNodeId: R_kgDOT3jlpQ
+  subpath: null
+  commit: 4c939d75be7c24dcd74de219eb24f4a2355faad9
+creator:
+  github: Jesse-njx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:31.214Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jesse-njx-dsh-polyglot-bundle`
- Submission type: community curation
- Created by `Jesse-njx` — https://github.com/Jesse-njx
- Original source repository: https://github.com/Jesse-njx/dsh-polyglot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.