### PR TITLE
catalog: add jhuanxx44-dsh-paste-path (community curation, created by @jhuanxx44)

### DIFF
--- a/catalog/plugins/jhuanxx44-dsh-paste-path.yaml
+++ b/catalog/plugins/jhuanxx44-dsh-paste-path.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: jhuanxx44-dsh-paste-path
+name: dsh-paste-path
+description:
+  en: "DeepSeek Harness plugin: paste Finder file paths into the composer with Ctrl+V"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - finder
+  - clipboard
+  - absolute-path
+source:
+  repository: https://github.com/jhuanxx44/dsh-paste-path
+  repositoryNodeId: R_kgDOT8etMg
+  subpath: null
+  commit: 000cfbe9cb5fb0b6f337d120bce65f0933e4bfa0
+creator:
+  github: jhuanxx44
+package:
+  ecosystem: npm
+  name: dsh-paste-path
+  version: 0.1.2
+  integrity: sha512-fNW0f0RUMk5/Vhw3C1l9FI+zIzb8eo3o8rCsMZ2X+EgZuVHDBCxsQe3YJW0KH17W41NuYH7E1x0g/wzPDy1CTA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:37.591Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jhuanxx44-dsh-paste-path`
- Submission type: community curation
- Created by `jhuanxx44` — https://github.com/jhuanxx44
- Original source repository: https://github.com/jhuanxx44/dsh-paste-path
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.