### PR TITLE
catalog: add jingxuanc-causal-memory-dsh-plugin (community curation, created by @JingxuanC)

### DIFF
--- a/catalog/plugins/jingxuanc-causal-memory-dsh-plugin.yaml
+++ b/catalog/plugins/jingxuanc-causal-memory-dsh-plugin.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: jingxuanc-causal-memory-dsh-plugin
+name: causal-memory-dsh-plugin
+description:
+  en: "DeepSeek Harness native plugin bridging the causal-memory MCP server: clean-named causal memory tools + a system-prompt section. Zero runtime dependencies."
+  evidencePath: dsh-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - native
+  - bridging
+  - causal
+  - memory
+  - server
+  - clean
+  - named
+  - tools
+  - system
+  - prompt
+  - section
+  - zero
+  - runtime
+  - dependencies
+  - dsh
+source:
+  repository: https://github.com/JingxuanC/causal-memory
+  repositoryNodeId: R_kgDOTkGjsA
+  subpath: dsh-plugin
+  commit: c162eef51332f37b682541f91220e3f19f7371b3
+creator:
+  github: JingxuanC
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:50.065Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jingxuanc-causal-memory-dsh-plugin`
- Submission type: community curation
- Created by `JingxuanC` — https://github.com/JingxuanC
- Original source repository: https://github.com/JingxuanC/causal-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.