### PR TITLE
catalog: add jinsiyu-dsh-auto-open-web (community curation, created by @jinsiyu)

### DIFF
--- a/catalog/plugins/jinsiyu-dsh-auto-open-web.yaml
+++ b/catalog/plugins/jinsiyu-dsh-auto-open-web.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: jinsiyu-dsh-auto-open-web
+name: dsh-auto-open-web
+description:
+  en: Open the DSH Web GUI in an app-style WebView2 window on profile start, with a settings card for browser paths
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - open
+  - style
+  - webview2
+  - window
+  - profile
+  - start
+  - settings
+  - card
+  - browser
+  - paths
+  - dsh
+source:
+  repository: https://github.com/jinsiyu/dsh-auto-open-web
+  repositoryNodeId: R_kgDOT54IRQ
+  subpath: null
+  commit: 6c6d06976c5b2a14ccd921b5e81470fdccf461be
+creator:
+  github: jinsiyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:37.885Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jinsiyu-dsh-auto-open-web`
- Submission type: community curation
- Created by `jinsiyu` — https://github.com/jinsiyu
- Original source repository: https://github.com/jinsiyu/dsh-auto-open-web
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.