### PR TITLE
catalog: add jinsiyu-dsh-safemode-profile (community curation, created by @jinsiyu)

### DIFF
--- a/catalog/plugins/jinsiyu-dsh-safemode-profile.yaml
+++ b/catalog/plugins/jinsiyu-dsh-safemode-profile.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: jinsiyu-dsh-safemode-profile
+name: dsh-safemode-profile
+description:
+  en: "Safemode profile enforcer: force-restores ~/.dsh/profiles/safemode to a clean whitelist (dsh-base + dsh-web-app) on start and continuously guards it against modification, so dsh --profile safemode always boots with zero third-party plugins. No build scripts: the bundle row does all work."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - safemode
+  - profile
+  - enforcer
+  - force
+  - restores
+  - profiles
+  - clean
+  - whitelist
+  - base
+  - start
+  - continuously
+  - guards
+  - against
+  - modification
+  - always
+  - boots
+source:
+  repository: https://github.com/jinsiyu/dsh-safemode-profile
+  repositoryNodeId: R_kgDOT9d7FA
+  subpath: null
+  commit: f9aab39ca9c4da42f8fc4bebcda14951261889e5
+creator:
+  github: jinsiyu
+package:
+  ecosystem: npm
+  name: dsh-safemode-profile
+  version: 0.3.9
+  integrity: sha512-rnSVniky2GbZEQABPq/SCR4X+BSTQMlEQIbILnLb6uiUErWV5Pr7RO5TgBVUDDy74/zMUXyNA6OFct9x+/HQiA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:34.470Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jinsiyu-dsh-safemode-profile`
- Submission type: community curation
- Created by `jinsiyu` — https://github.com/jinsiyu
- Original source repository: https://github.com/jinsiyu/dsh-safemode-profile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.