### PR TITLE
catalog: add jofe2-kaleidosphere-dsh-plugin (community curation, created by @JoFe2)

### DIFF
--- a/catalog/plugins/jofe2-kaleidosphere-dsh-plugin.yaml
+++ b/catalog/plugins/jofe2-kaleidosphere-dsh-plugin.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: jofe2-kaleidosphere-dsh-plugin
+name: kaleidosphere-dsh-plugin
+description:
+  en: Native KaleidoSphere database-analysis tools for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh-plugin
+  - kaleidosphere
+  - database-analysis
+  - ai-agents
+  - dsh
+source:
+  repository: https://github.com/JoFe2/kaleidosphere-dsh-plugin
+  repositoryNodeId: R_kgDOT-L6oQ
+  subpath: null
+  commit: f2d94d7a87236adf99409b4b4018cc29696a7ba5
+creator:
+  github: JoFe2
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:39.035Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jofe2-kaleidosphere-dsh-plugin`
- Submission type: community curation
- Created by `JoFe2` — https://github.com/JoFe2
- Original source repository: https://github.com/JoFe2/kaleidosphere-dsh-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.