### PR TITLE
catalog: add johnxu22786-dsh-audit-trail (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-audit-trail.yaml
+++ b/catalog/plugins/johnxu22786-dsh-audit-trail.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: johnxu22786-dsh-audit-trail
+name: dsh-audit-trail
+description:
+  en: "Security auditing and session forensics for DeepSeek Harness (dsh): full tool-invocation-chain recording (who/what/files/status/duration) from the session/event stream and tool-dispatch hook, high-risk pattern flagging, SQLite (WAL) persistence with privacy masking, filter/query with JSON/Markdown/JSONL exports, plain-"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - deepseek-harness
+  - cordis
+  - audit
+  - forensics
+  - security
+  - tool-call
+  - sqlite
+  - compliance
+  - replay
+source:
+  repository: https://github.com/JohnXu22786/auditrail
+  repositoryNodeId: R_kgDOUBJz1g
+  subpath: null
+  commit: bf9634db3038a7486abfa2abb96d81e5050fa555
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: npm
+  name: dsh-audit-trail
+  version: 0.1.0
+  integrity: sha512-rRfGHwehkSYrrVGoHF7ciae4jIZHq6bE6UPatxjzhUr7M8/9OKpxocIuMZLG+nIViNbNe2Qv45lBGaIOgwilJQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:39.143Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-audit-trail`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/auditrail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.