### PR TITLE
catalog: add johnxu22786-dsh-web-submit (community curation, created by @JohnXu22786)

### DIFF
--- a/catalog/plugins/johnxu22786-dsh-web-submit.yaml
+++ b/catalog/plugins/johnxu22786-dsh-web-submit.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: johnxu22786-dsh-web-submit
+name: dsh-web-submit
+description:
+  en: "DeepSeek Harness plugin: run headless-style tasks through the running dsh web process via one HTTP endpoint (POST /x/headless) with status and SSE live-event endpoints — CLI-invoked runs are visible in the Web UI in real time."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - headless
+  - web
+  - bridge
+  - cordis
+  - dsh
+source:
+  repository: https://github.com/JohnXu22786/dsh-web-submit
+  repositoryNodeId: R_kgDOUBISuA
+  subpath: null
+  commit: 98a6f77a1353bdfd13fed26fc5c4eb95187111d2
+creator:
+  github: JohnXu22786
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:39.220Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `johnxu22786-dsh-web-submit`
- Submission type: community curation
- Created by `JohnXu22786` — https://github.com/JohnXu22786
- Original source repository: https://github.com/JohnXu22786/dsh-web-submit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.