### PR TITLE
catalog: add kentleenot-dsh-trading-toolkit (community curation, created by @kentleenot)

### DIFF
--- a/catalog/plugins/kentleenot-dsh-trading-toolkit.yaml
+++ b/catalog/plugins/kentleenot-dsh-trading-toolkit.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: kentleenot-dsh-trading-toolkit
+name: dsh-trading-toolkit
+description:
+  en: "A-share + US stock trading toolkit for DeepSeek Harness agents: A股/美股行情查询 (EastMoney, no key), ADX regime signals (trend/oscillating/noise), and simple backtest previews. Read-only, no order placement."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - trading
+  - quant
+  - market
+  - signal
+  - adx
+  - a-share
+  - us-stock
+  - china-stock
+  - eastmoney
+source:
+  repository: https://github.com/kentleenot/dsh-trading-toolkit
+  repositoryNodeId: R_kgDOT76ZpQ
+  subpath: null
+  commit: 23924eadacacf4ed866952949a01d2d977f50ed9
+creator:
+  github: kentleenot
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:39.539Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kentleenot-dsh-trading-toolkit`
- Submission type: community curation
- Created by `kentleenot` — https://github.com/kentleenot
- Original source repository: https://github.com/kentleenot/dsh-trading-toolkit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.