### PR TITLE
catalog: add kobenfang-dsh-bigplan (community curation, created by @kobenfang)

### DIFF
--- a/catalog/plugins/kobenfang-dsh-bigplan.yaml
+++ b/catalog/plugins/kobenfang-dsh-bigplan.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: kobenfang-dsh-bigplan
+name: "@kobenfang/dsh-bigplan"
+description:
+  en: "Agent Skill for DeepSeek Harness (dsh): bigplan."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - agent
+  - skill
+  - bigplan
+  - dsh
+source:
+  repository: https://github.com/kobenfang/BigPlan
+  repositoryNodeId: R_kgDOT62abQ
+  subpath: null
+  commit: 52065045c5001e38d9802618a66f9c1afcce587a
+creator:
+  github: kobenfang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:41.077Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kobenfang-dsh-bigplan`
- Submission type: community curation
- Created by `kobenfang` — https://github.com/kobenfang
- Original source repository: https://github.com/kobenfang/BigPlan
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.