### PR TITLE
catalog: add kobenfang-dsh-eyes (community curation, created by @kobenfang)

### DIFF
--- a/catalog/plugins/kobenfang-dsh-eyes.yaml
+++ b/catalog/plugins/kobenfang-dsh-eyes.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: kobenfang-dsh-eyes
+name: "@kobenfang/dsh-eyes"
+description:
+  en: "Agent Skill for DeepSeek Harness (dsh): eyes."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - agent
+  - skill
+  - eyes
+  - dsh
+source:
+  repository: https://github.com/kobenfang/Eyes
+  repositoryNodeId: R_kgDOSoaBPQ
+  subpath: null
+  commit: 853957e11e369a65fb1a92cdd177ff8a1de10d75
+creator:
+  github: kobenfang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:42.420Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kobenfang-dsh-eyes`
- Submission type: community curation
- Created by `kobenfang` — https://github.com/kobenfang
- Original source repository: https://github.com/kobenfang/Eyes
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.