### PR TITLE
catalog: add kobenfang-dsh-fruitpi (community curation, created by @kobenfang)

### DIFF
--- a/catalog/plugins/kobenfang-dsh-fruitpi.yaml
+++ b/catalog/plugins/kobenfang-dsh-fruitpi.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: kobenfang-dsh-fruitpi
+name: "@kobenfang/dsh-fruitpi"
+description:
+  en: "Agent Skill for DeepSeek Harness (dsh): fruit-pi."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - agent
+  - skill
+  - fruit
+  - dsh
+source:
+  repository: https://github.com/kobenfang/FruitPi
+  repositoryNodeId: R_kgDOSoaQIA
+  subpath: null
+  commit: 631f06e0ff9dadfb8baf7b1b05eef8b6a88ff079
+creator:
+  github: kobenfang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:42.482Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kobenfang-dsh-fruitpi`
- Submission type: community curation
- Created by `kobenfang` — https://github.com/kobenfang
- Original source repository: https://github.com/kobenfang/FruitPi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.