### PR TITLE
catalog: add kuaiyukuaikuai-dsh-agent-sync (community curation, created by @kuaiyukuaikuai)

### DIFF
--- a/catalog/plugins/kuaiyukuaikuai-dsh-agent-sync.yaml
+++ b/catalog/plugins/kuaiyukuaikuai-dsh-agent-sync.yaml
@@ -1,0 +1,64 @@
+schemaVersion: 1
+id: kuaiyukuaikuai-dsh-agent-sync
+name: dsh-agent-sync
+description:
+  en: DSH plugin that scans other AI agents on this machine (Codex, Claude Code, cc-switch, custom sources) and one-click syncs their MCP servers and skills into DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - mcp
+  - skills
+  - codex
+  - claude-code
+  - cc-switch
+  - hermes
+  - opencode
+  - gemini
+  - grok
+  - kimi
+  - codebuddy
+  - trae
+  - openclaw
+source:
+  repository: https://github.com/kuaiyukuaikuai/dsh-agent-sync
+  repositoryNodeId: R_kgDOT8fazw
+  subpath: null
+  commit: d0dde63bdda9e50408a23b15fc79494f54b5fcb8
+creator:
+  github: kuaiyukuaikuai
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:32.773Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/kuaiyukuaikuai/dsh-agent-sync/d0dde63bdda9e50408a23b15fc79494f54b5fcb8/assets/screenshot-main.png
+    alt: main
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/kuaiyukuaikuai/dsh-agent-sync/d0dde63bdda9e50408a23b15fc79494f54b5fcb8/assets/screenshot-sync.png
+    alt: sync
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/kuaiyukuaikuai/dsh-agent-sync/d0dde63bdda9e50408a23b15fc79494f54b5fcb8/assets/screenshot-add.png
+    alt: add


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kuaiyukuaikuai-dsh-agent-sync`
- Submission type: community curation
- Created by `kuaiyukuaikuai` — https://github.com/kuaiyukuaikuai
- Original source repository: https://github.com/kuaiyukuaikuai/dsh-agent-sync
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.