### PR TITLE
catalog: add lamost423-dsh-todo-freshness-guard (community curation, created by @lamost423)

### DIFF
--- a/catalog/plugins/lamost423-dsh-todo-freshness-guard.yaml
+++ b/catalog/plugins/lamost423-dsh-todo-freshness-guard.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: lamost423-dsh-todo-freshness-guard
+name: dsh-todo-freshness-guard
+description:
+  en: Remind and block stale tool work until todo write is reconciled in DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - todo
+  - guard
+  - agent
+source:
+  repository: https://github.com/lamost423/dsh-todo-freshness-guard
+  repositoryNodeId: R_kgDOT4T8dg
+  subpath: null
+  commit: ea0866eaddf33973ff756d7ab1dcb90d3fe2f4bf
+creator:
+  github: lamost423
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:47.323Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/lamost423/dsh-todo-freshness-guard/ea0866eaddf33973ff756d7ab1dcb90d3fe2f4bf/assets/progress-stays-visible.png
+    alt: DSH Todo Freshness Guard keeps long-running task progress visible


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lamost423-dsh-todo-freshness-guard`
- Submission type: community curation
- Created by `lamost423` — https://github.com/lamost423
- Original source repository: https://github.com/lamost423/dsh-todo-freshness-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.