### PR TITLE
catalog: add lcq-1024-dsh-prompt-enhancer (community curation, created by @LCQ-1024)

### DIFF
--- a/catalog/plugins/lcq-1024-dsh-prompt-enhancer.yaml
+++ b/catalog/plugins/lcq-1024-dsh-prompt-enhancer.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: lcq-1024-dsh-prompt-enhancer
+name: dsh-prompt-enhancer
+description:
+  en: text ~/.dsh/profiles/web/node modules/dsh-prompt-enhancer
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - prompt
+  - enhance
+  - deepseek-harness
+source:
+  repository: https://github.com/LCQ-1024/dsh-prompt-enhancer
+  repositoryNodeId: R_kgDOT6td7g
+  subpath: null
+  commit: 8ed8036bf1b60403210228c0e02edba5c959db11
+creator:
+  github: LCQ-1024
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:32.857Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lcq-1024-dsh-prompt-enhancer`
- Submission type: community curation
- Created by `LCQ-1024` — https://github.com/LCQ-1024
- Original source repository: https://github.com/LCQ-1024/dsh-prompt-enhancer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.