### PR TITLE
catalog: add leavestring-awesome-dsh-background-plugin (community curation, created by @leavestring)

### DIFF
--- a/catalog/plugins/leavestring-awesome-dsh-background-plugin.yaml
+++ b/catalog/plugins/leavestring-awesome-dsh-background-plugin.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: leavestring-awesome-dsh-background-plugin
+name: awesome-dsh-background-plugin
+description:
+  en: DSH Web background settings plugin with local image upload and live preview.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - background
+  - settings
+  - local
+  - image
+  - upload
+  - live
+  - preview
+  - dsh
+source:
+  repository: https://github.com/leavestring/awesome-dsh-background-plugin
+  repositoryNodeId: R_kgDOT4M6vw
+  subpath: null
+  commit: 2b758a6fed8dfc79644c0cfb755eae11a7778332
+creator:
+  github: leavestring
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:29.732Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/leavestring/awesome-dsh-background-plugin/2b758a6fed8dfc79644c0cfb755eae11a7778332/screenshots/dark-mode-image.png
+    alt: 暗色模式自定义背景
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/leavestring/awesome-dsh-background-plugin/2b758a6fed8dfc79644c0cfb755eae11a7778332/screenshots/light-mode-image.png
+    alt: 浅色模式自定义背景
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/leavestring/awesome-dsh-background-plugin/2b758a6fed8dfc79644c0cfb755eae11a7778332/screenshots/banner.png
+    alt: DSH Background


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leavestring-awesome-dsh-background-plugin`
- Submission type: community curation
- Created by `leavestring` — https://github.com/leavestring
- Original source repository: https://github.com/leavestring/awesome-dsh-background-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.