### PR TITLE
catalog: add leeclouddragon-dsh-all-in (community curation, created by @leeclouddragon)

### DIFF
--- a/catalog/plugins/leeclouddragon-dsh-all-in.yaml
+++ b/catalog/plugins/leeclouddragon-dsh-all-in.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: leeclouddragon-dsh-all-in
+name: dsh-all-in
+description:
+  en: A local-only Texas Hold'em table for DeepSeek Harness — play while your agent thinks.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - texas-holdem
+  - poker
+  - game
+source:
+  repository: https://github.com/leeclouddragon/dsh-all-in
+  repositoryNodeId: R_kgDOT8Jt3A
+  subpath: null
+  commit: 8a442058143f96c4ea4ee5b7f33a73d270d50eef
+creator:
+  github: leeclouddragon
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:27.899Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/leeclouddragon/dsh-all-in/8a442058143f96c4ea4ee5b7f33a73d270d50eef/assets/table-preview.png
+    alt: dsh-all-in running inside DeepSeek Harness


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leeclouddragon-dsh-all-in`
- Submission type: community curation
- Created by `leeclouddragon` — https://github.com/leeclouddragon
- Original source repository: https://github.com/leeclouddragon/dsh-all-in
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.