### PR TITLE
catalog: add leemancheung-dsh-agent-preset-recommender (community curation, created by @LeemanCheung)

### DIFF
--- a/catalog/plugins/leemancheung-dsh-agent-preset-recommender.yaml
+++ b/catalog/plugins/leemancheung-dsh-agent-preset-recommender.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: leemancheung-dsh-agent-preset-recommender
+name: dsh-agent-preset-recommender
+description:
+  en: Privacy-safe local activity scanner and agent preset recommender for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - agent-preset
+  - codex
+  - claude-code
+  - workbuddy
+  - workflow
+  - privacy
+source:
+  repository: https://github.com/LeemanCheung/dsh-agent-preset-recommender
+  repositoryNodeId: R_kgDOT4iMmg
+  subpath: null
+  commit: 409a3218cf139838a5c4189a5e3c9c048cb0b68e
+creator:
+  github: LeemanCheung
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:35.925Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/409a3218cf139838a5c4189a5e3c9c048cb0b68e/docs/screenshot.png
+    alt: Synthetic aggregate recommendation overview in DeepSeek Harness
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-agent-preset-recommender/409a3218cf139838a5c4189a5e3c9c048cb0b68e/docs/project-detail.png
+    alt: Synthetic aggregate project detail in DeepSeek Harness


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leemancheung-dsh-agent-preset-recommender`
- Submission type: community curation
- Created by `LeemanCheung` — https://github.com/LeemanCheung
- Original source repository: https://github.com/LeemanCheung/dsh-agent-preset-recommender
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.