### PR TITLE
catalog: add leemancheung-dsh-token-usage (community curation, created by @LeemanCheung)

### DIFF
--- a/catalog/plugins/leemancheung-dsh-token-usage.yaml
+++ b/catalog/plugins/leemancheung-dsh-token-usage.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: leemancheung-dsh-token-usage
+name: dsh-token-usage
+description:
+  en: Persistent token usage records and dashboard for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - token-usage
+source:
+  repository: https://github.com/LeemanCheung/dsh-token-usage
+  repositoryNodeId: R_kgDOT4WpiQ
+  subpath: null
+  commit: 28f5ffce13cea0a8d6e471a87186b908fa161dbb
+creator:
+  github: LeemanCheung
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:25.182Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 13
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/28f5ffce13cea0a8d6e471a87186b908fa161dbb/assets/token-usage-overview.png
+    alt: DSH Token 用量概览：八项指标、聚合导出、30 周热力图与周期趋势
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/28f5ffce13cea0a8d6e471a87186b908fa161dbb/assets/token-usage-insights.png
+    alt: Agent 效率与归因：尝试次数、压缩率、缓存占比、路由集中度与运行率
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/28f5ffce13cea0a8d6e471a87186b908fa161dbb/assets/token-usage-budget.png
+    alt: 30 日 Token 预算、公开费率说明和 AI 用量分析入口
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/28f5ffce13cea0a8d6e471a87186b908fa161dbb/assets/token-usage-ai-analysis.png
+    alt: AI Token 用量分析：模型选择、隐私说明、模型目录刷新和模型用量热点
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-token-usage/28f5ffce13cea0a8d6e471a87186b908fa161dbb/assets/token-usage-trajectory-analysis.png
+    alt: 会话轨迹分析：视口内滚动预览、四组确定性摘要、安全 Markdown 与导出


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leemancheung-dsh-token-usage`
- Submission type: community curation
- Created by `LeemanCheung` — https://github.com/LeemanCheung
- Original source repository: https://github.com/LeemanCheung/dsh-token-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.