### PR TITLE
catalog: add leemancheung-dsh-whale-animation (community curation, created by @LeemanCheung)

### DIFF
--- a/catalog/plugins/leemancheung-dsh-whale-animation.yaml
+++ b/catalog/plugins/leemancheung-dsh-whale-animation.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: leemancheung-dsh-whale-animation
+name: dsh-whale-animation
+description:
+  en: Brand-aligned whale animation director with two preserved legacy loops and five spine-driven states for DeepSeek Harness Web.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - web-ui
+  - animation
+  - whale
+source:
+  repository: https://github.com/LeemanCheung/dsh-whale-animation
+  repositoryNodeId: R_kgDOT4VePQ
+  subpath: null
+  commit: 8cf2d04390d0ccc15a065f622dee90066fba4904
+creator:
+  github: LeemanCheung
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:29.053Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/8cf2d04390d0ccc15a065f622dee90066fba4904/docs/hero.png
+    alt: dsh-whale-animation six-state whale animation system
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/8cf2d04390d0ccc15a065f622dee90066fba4904/docs/preview.webp
+    alt: Deep Dive, Sonar, Tool Run, Stream, and Calm whale animations rotating in sequence
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-whale-animation/8cf2d04390d0ccc15a065f622dee90066fba4904/docs/state-gallery.png
+    alt: Gallery of the six whale animation states


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leemancheung-dsh-whale-animation`
- Submission type: community curation
- Created by `LeemanCheung` — https://github.com/LeemanCheung
- Original source repository: https://github.com/LeemanCheung/dsh-whale-animation
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.