### PR TITLE
catalog: add liqiming-whu-dsh-status-card (community curation, created by @liqiming-whu)

### DIFF
--- a/catalog/plugins/liqiming-whu-dsh-status-card.yaml
+++ b/catalog/plugins/liqiming-whu-dsh-status-card.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: liqiming-whu-dsh-status-card
+name: dsh-status-card
+description:
+  en: Inject a configurable dsh-ui status card instruction before every DSH agent reply
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - genui
+  - status-card
+source:
+  repository: https://github.com/liqiming-whu/dsh-status-card
+  repositoryNodeId: R_kgDOT9T9Ug
+  subpath: null
+  commit: 30f11393750647286b4f8f1bb646e8f0b80d040f
+creator:
+  github: liqiming-whu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:42.760Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liqiming-whu-dsh-status-card`
- Submission type: community curation
- Created by `liqiming-whu` — https://github.com/liqiming-whu
- Original source repository: https://github.com/liqiming-whu/dsh-status-card
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.