### PR TITLE
catalog: add listenj-axiom-kb-dsh (community curation, created by @ListenJ)

### DIFF
--- a/catalog/plugins/listenj-axiom-kb-dsh.yaml
+++ b/catalog/plugins/listenj-axiom-kb-dsh.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: listenj-axiom-kb-dsh
+name: axiom-kb-dsh
+description:
+  en: "Axiom Knowledge Base (KB) as a DeepSeek Harness (dsh) plugin: bridges the Vault memory (memory ) and knowledge-graph (kg /kal /dip ) tools into dsh under the kb prefix. Bundles its own memory + KG backend; no web-search tools."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - knowledge-base
+  - memory
+  - knowledge-graph
+  - mcp
+source:
+  repository: https://github.com/ListenJ/axiom-kb-dsh
+  repositoryNodeId: R_kgDOT8_VLw
+  subpath: null
+  commit: 7f9047f4b9c41eeaec67fb68dc53c8c8a9672eea
+creator:
+  github: ListenJ
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:50.989Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `listenj-axiom-kb-dsh`
- Submission type: community curation
- Created by `ListenJ` — https://github.com/ListenJ
- Original source repository: https://github.com/ListenJ/axiom-kb-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.