### PR TITLE
catalog: add litestartup-com-dsh-api-gateway (community curation, created by @litestartup-com)

### DIFF
--- a/catalog/plugins/litestartup-com-dsh-api-gateway.yaml
+++ b/catalog/plugins/litestartup-com-dsh-api-gateway.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: litestartup-com-dsh-api-gateway
+name: dsh-api-gateway
+description:
+  en: "Open-source API Gateway plugin for DeepSeek Harness: give any third-party client a simple REST + SSE interface to chat with your agents."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - api
+  - gateway
+  - sse
+  - rest
+source:
+  repository: https://github.com/litestartup-com/dsh-api-gateway
+  repositoryNodeId: R_kgDOT5XsoQ
+  subpath: null
+  commit: da0291512bffefbe56e91dd1018131cdbf2fb914
+creator:
+  github: litestartup-com
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:28.921Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `litestartup-com-dsh-api-gateway`
- Submission type: community curation
- Created by `litestartup-com` — https://github.com/litestartup-com
- Original source repository: https://github.com/litestartup-com/dsh-api-gateway
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.