### PR TITLE
catalog: add little-star888-dsh-pelican (community curation, created by @Little-Star888)

### DIFF
--- a/catalog/plugins/little-star888-dsh-pelican.yaml
+++ b/catalog/plugins/little-star888-dsh-pelican.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: little-star888-dsh-pelican
+name: dsh-pelican
+description:
+  en: bash dsh plugin --profile web add ./dsh-pelican
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - pelican
+  - fun
+  - animation
+source:
+  repository: https://github.com/Little-Star888/dsh-pelican
+  repositoryNodeId: R_kgDOT7XEiw
+  subpath: null
+  commit: 7a67c5e7e80be4ad14602e23666128859c4ef533
+creator:
+  github: Little-Star888
+package:
+  ecosystem: npm
+  name: dsh-pelican
+  version: 0.1.1
+  integrity: sha512-ALOQqXVn5/cmSweAGxGvyGmXkEz8Hv1q80gmNqmCxyIMm/IAqKE+j486T0iCFwVUtIdR9loJfBj21zC8Sanbyg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:47.671Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `little-star888-dsh-pelican`
- Submission type: community curation
- Created by `Little-Star888` — https://github.com/Little-Star888
- Original source repository: https://github.com/Little-Star888/dsh-pelican
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.