### PR TITLE
catalog: add liu3734-dsh-jira-tasks (community curation, created by @liu3734)

### DIFF
--- a/catalog/plugins/liu3734-dsh-jira-tasks.yaml
+++ b/catalog/plugins/liu3734-dsh-jira-tasks.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: liu3734-dsh-jira-tasks
+name: dsh-jira-tasks
+description:
+  en: "JIRA open tasks panel for DeepSeek Harness (DSH): shows the current user's open/reopened issues below the composer, per-workspace project key, persistent profile bundle."
+  evidencePath: profile-package/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - deepseek-harness
+  - jira
+  - cordis
+  - tasks
+source:
+  repository: https://github.com/liu3734/jira-tasks-dsh-plugin
+  repositoryNodeId: R_kgDOT7B2Zw
+  subpath: profile-package
+  commit: e99a5778b77c50e4e014c9a9bbb02fd4b98a9763
+creator:
+  github: liu3734
+package:
+  ecosystem: npm
+  name: dsh-jira-tasks
+  version: 1.0.2
+  integrity: sha512-owJUeG1oiW2yS5UsV0E+hXy/YyieOD4ZWC6ywOqRs9GRt7xiTITXwalEIoiyM8+us98RJEbduroeyfIZIuSuMg==
+dsh:
+  profiles:
+    - web
+  evidencePath: profile-package/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:51.200Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liu3734-dsh-jira-tasks`
- Submission type: community curation
- Created by `liu3734` — https://github.com/liu3734
- Original source repository: https://github.com/liu3734/jira-tasks-dsh-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.