### PR TITLE
catalog: add liujia-io-dsh-image-picker (community curation, created by @liujia-io)

### DIFF
--- a/catalog/plugins/liujia-io-dsh-image-picker.yaml
+++ b/catalog/plugins/liujia-io-dsh-image-picker.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: liujia-io-dsh-image-picker
+name: dsh-image-picker
+description:
+  en: bash dsh plugin --profile web add github:liujia-io/dsh-image-picker
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - client-plugin
+  - image
+  - attachment
+  - dsh
+source:
+  repository: https://github.com/liujia-io/dsh-image-picker
+  repositoryNodeId: R_kgDOUEYw5w
+  subpath: null
+  commit: 6818924614150385b38ca30d87262c024030ac12
+creator:
+  github: liujia-io
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:51.332Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liujia-io-dsh-image-picker`
- Submission type: community curation
- Created by `liujia-io` — https://github.com/liujia-io
- Original source repository: https://github.com/liujia-io/dsh-image-picker
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.