### PR TITLE
catalog: add liyu34-dsh-wsl-tray (community curation, created by @liyu34)

### DIFF
--- a/catalog/plugins/liyu34-dsh-wsl-tray.yaml
+++ b/catalog/plugins/liyu34-dsh-wsl-tray.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: liyu34-dsh-wsl-tray
+name: dsh-wsl-tray
+description:
+  en: "DSH plugin: Windows desktop shortcut and system-tray launcher for DSH running in WSL"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - wsl
+  - windows
+  - tray
+  - shortcut
+  - launcher
+source:
+  repository: https://github.com/liyu34/dsh-wsl-tray
+  repositoryNodeId: R_kgDOUALiEw
+  subpath: null
+  commit: 90e7cfbb6f2ece2ff1cdbe7cdd12ef21df14c428
+creator:
+  github: liyu34
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:43.443Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `liyu34-dsh-wsl-tray`
- Submission type: community curation
- Created by `liyu34` — https://github.com/liyu34
- Original source repository: https://github.com/liyu34/dsh-wsl-tray
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.