### PR TITLE
catalog: add ljr282341583-dsh-convo-cost (community curation, created by @ljr282341583)

### DIFF
--- a/catalog/plugins/ljr282341583-dsh-convo-cost.yaml
+++ b/catalog/plugins/ljr282341583-dsh-convo-cost.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ljr282341583-dsh-convo-cost
+name: dsh-convo-cost
+description:
+  en: "Real-time cost tracking for the current DSH conversation: a composer-dock line showing the running token usage and DeepSeek official price estimate (base and peak/valley pricing)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - cost
+  - usage
+  - tokens
+  - billing
+source:
+  repository: https://github.com/ljr282341583/dsh-convo-cost
+  repositoryNodeId: R_kgDOT6YIXA
+  subpath: null
+  commit: e50308bfc9ad3c93dc670cea2c0f7500a5785b41
+creator:
+  github: ljr282341583
+package:
+  ecosystem: npm
+  name: dsh-convo-cost
+  version: 1.0.1
+  integrity: sha512-DaIy3r8Kyj5tnewWlfxyDJuRph4w347VW7oZN1C/jZumzpMqH+oLsPUKGf+nhGrrPdiI4SBN9Y0krPB9w654Fg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:47.988Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ljr282341583-dsh-convo-cost`
- Submission type: community curation
- Created by `ljr282341583` — https://github.com/ljr282341583
- Original source repository: https://github.com/ljr282341583/dsh-convo-cost
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.