### PR TITLE
catalog: add loguhan-dsh-workshop (community curation, created by @loguhan)

### DIFF
--- a/catalog/plugins/loguhan-dsh-workshop.yaml
+++ b/catalog/plugins/loguhan-dsh-workshop.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: loguhan-dsh-workshop
+name: dsh-workshop
+description:
+  en: "Steam Workshop style plugin store for DSH Web UI: browse, search and one-click install community plugins with mirror acceleration"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - deepseek-harness
+  - workshop
+  - store
+  - marketplace
+  - web-ui
+source:
+  repository: https://github.com/loguhan/dsh-workshop
+  repositoryNodeId: R_kgDOT4L7qA
+  subpath: null
+  commit: cf36f61f708100d9f2c67db3a1722a8b85b53757
+creator:
+  github: loguhan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:33.771Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/loguhan/dsh-workshop/cf36f61f708100d9f2c67db3a1722a8b85b53757/docs/screenshots/workshop.png
+    alt: features


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `loguhan-dsh-workshop`
- Submission type: community curation
- Created by `loguhan` — https://github.com/loguhan
- Original source repository: https://github.com/loguhan/dsh-workshop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.