### PR TITLE
catalog: add lsz-asd-dsh-plugin-device-info (community curation, created by @lsz-asd)

### DIFF
--- a/catalog/plugins/lsz-asd-dsh-plugin-device-info.yaml
+++ b/catalog/plugins/lsz-asd-dsh-plugin-device-info.yaml
@@ -1,0 +1,39 @@
+schemaVersion: 1
+id: lsz-asd-dsh-plugin-device-info
+name: "@huanlin/dsh-plugin-device-info"
+description:
+  en: DSH plugin exposing Windows device information tools — one tool per Win32 device category (time, system, cpu, memory, disk, gpu, network, battery, processes, usb, audio, printers). Read-only WMI/CIM + Node os collectors.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - dsh
+source:
+  repository: https://github.com/lsz-asd/dsh-plugin-device-info
+  repositoryNodeId: R_kgDOT4Ooog
+  subpath: null
+  commit: cca8aec573c99f1ff78df6d0214bd22232fb958c
+creator:
+  github: lsz-asd
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: AGPL-3.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:44.180Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lsz-asd-dsh-plugin-device-info`
- Submission type: community curation
- Created by `lsz-asd` — https://github.com/lsz-asd
- Original source repository: https://github.com/lsz-asd/dsh-plugin-device-info
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.