### PR TITLE
catalog: add lucky8197-dsh-code-smell (community curation, created by @lucky8197)

### DIFF
--- a/catalog/plugins/lucky8197-dsh-code-smell.yaml
+++ b/catalog/plugins/lucky8197-dsh-code-smell.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: lucky8197-dsh-code-smell
+name: dsh-code-smell
+description:
+  en: "Code Smell Radar for DeepSeek Harness. A read-only DSH plugin that statically scans a repository for common code smells: TODO/FIXME/HACK debt, stub implementations ( NotImplemented / 未实现 ), over-long lines, oversized files, and duplicated code blocks — then outputs severity-sorted, actionable fix suggestions. Install w"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - code
+  - smell
+  - radar
+  - read
+  - only
+  - statically
+  - scans
+  - repository
+  - common
+  - smells
+  - todo
+  - fixme
+  - hack
+  - debt
+  - stub
+  - implementations
+source:
+  repository: https://github.com/lucky8197/dsh-code-smell
+  repositoryNodeId: R_kgDOT5Bucw
+  subpath: null
+  commit: 44cc94fcf40bdcdcd4cbff0a78806faa68355352
+creator:
+  github: lucky8197
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:44.597Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lucky8197-dsh-code-smell`
- Submission type: community curation
- Created by `lucky8197` — https://github.com/lucky8197
- Original source repository: https://github.com/lucky8197/dsh-code-smell
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.