### PR TITLE
catalog: add lucky8197-dsh-doc-guard (community curation, created by @lucky8197)

### DIFF
--- a/catalog/plugins/lucky8197-dsh-doc-guard.yaml
+++ b/catalog/plugins/lucky8197-dsh-doc-guard.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: lucky8197-dsh-doc-guard
+name: dsh-doc-guard
+description:
+  en: "Document-Code Consistency Guard for DeepSeek Harness. A read-only DSH plugin that audits your versioned Markdown design docs against the actual repository: header version numbers, changelog tables, directory-structure trees, module/test counts, and cross-document references. It detects drift (docs saying one thing, cod"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - document
+  - code
+  - consistency
+  - guard
+  - read
+  - only
+  - audits
+  - versioned
+  - markdown
+  - design
+  - docs
+  - against
+  - actual
+  - repository
+  - header
+  - version
+source:
+  repository: https://github.com/lucky8197/dsh-doc-guard
+  repositoryNodeId: R_kgDOT5ADWg
+  subpath: null
+  commit: 7f232e8c4b1253b47aeb78952195f07fa73af565
+creator:
+  github: lucky8197
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:44.318Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lucky8197-dsh-doc-guard`
- Submission type: community curation
- Created by `lucky8197` — https://github.com/lucky8197
- Original source repository: https://github.com/lucky8197/dsh-doc-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.