### PR TITLE
catalog: add lucky8197-dsh-git-hygiene (community curation, created by @lucky8197)

### DIFF
--- a/catalog/plugins/lucky8197-dsh-git-hygiene.yaml
+++ b/catalog/plugins/lucky8197-dsh-git-hygiene.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: lucky8197-dsh-git-hygiene
+name: dsh-git-hygiene
+description:
+  en: "Git Hygiene Checker for DeepSeek Harness. A read-only DSH plugin that inspects a repository's hygiene: merged-but-not-deleted branches, stale branches with no commits for months, oversized tracked files, untracked files, and uncommitted work — then outputs a health report with cleanup suggestions. It never deletes or m"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - hygiene
+  - checker
+  - read
+  - only
+  - inspects
+  - repository
+  - merged
+  - deleted
+  - branches
+  - stale
+  - commits
+  - months
+  - oversized
+  - tracked
+  - files
+  - untracked
+source:
+  repository: https://github.com/lucky8197/dsh-git-hygiene
+  repositoryNodeId: R_kgDOT5CaMw
+  subpath: null
+  commit: 05a56bace438ba7630b7a1797190694b143770b6
+creator:
+  github: lucky8197
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: BSD-3-Clause
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:36.076Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lucky8197-dsh-git-hygiene`
- Submission type: community curation
- Created by `lucky8197` — https://github.com/lucky8197
- Original source repository: https://github.com/lucky8197/dsh-git-hygiene
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.