### PR TITLE
catalog: add lujianjun19-dsh-llm-github-copilot (community curation, created by @lujianjun19)

### DIFF
--- a/catalog/plugins/lujianjun19-dsh-llm-github-copilot.yaml
+++ b/catalog/plugins/lujianjun19-dsh-llm-github-copilot.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: lujianjun19-dsh-llm-github-copilot
+name: "@lujianjun19/dsh-llm-github-copilot"
+description:
+  en: "GitHub Copilot adapter for the DeepSeek Harness LLM seam: OAuth device-flow sign-in, Copilot token exchange, and OpenAI-compatible chat completions against api.githubcopilot.com"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - copilot
+  - adapter
+  - seam
+  - oauth
+  - device
+  - flow
+  - sign
+  - token
+  - exchange
+  - openai
+  - compatible
+  - chat
+  - completions
+  - against
+  - githubcopilot
+  - dsh
+source:
+  repository: https://github.com/lujianjun19/dsh-llm-github-copilot
+  repositoryNodeId: R_kgDOT6451g
+  subpath: null
+  commit: 8133b50931a261af344b33e0f711772d2f1d51a6
+creator:
+  github: lujianjun19
+package:
+  ecosystem: npm
+  name: "@lujianjun19/dsh-llm-github-copilot"
+  version: 0.4.5
+  integrity: sha512-qsomxmkzok1qqe1kcK13DLsOcqeHLcuoYPeAjgR3YQ7a5iaWI8Utfu68AB8hsdxv0T5KldNy2V6sINz6fnp3Ow==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:27.399Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lujianjun19-dsh-llm-github-copilot`
- Submission type: community curation
- Created by `lujianjun19` — https://github.com/lujianjun19
- Original source repository: https://github.com/lujianjun19/dsh-llm-github-copilot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.