### PR TITLE
catalog: add luxiwusuobuneng-dsh-plugin-context-manager (community curation, created by @luxiwusuobuneng)

### DIFF
--- a/catalog/plugins/luxiwusuobuneng-dsh-plugin-context-manager.yaml
+++ b/catalog/plugins/luxiwusuobuneng-dsh-plugin-context-manager.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: luxiwusuobuneng-dsh-plugin-context-manager
+name: dsh-plugin-context-manager
+description:
+  en: "DeepSeek Harness context manager: auto-records every turn, injects priority-sorted memory and pinned cross-session notes into each model request, and folds real conversation history to save tokens. NOTE: manual multi-step install — copy the three package folders into profiles/node modules and add the provided cordis.pa"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - context-manager
+  - memory
+source:
+  repository: https://github.com/luxiwusuobuneng/dsh-plugin-context-manager
+  repositoryNodeId: R_kgDOT8fgHg
+  subpath: null
+  commit: be110699f9f605566c03151675cd32ab64abbd01
+creator:
+  github: luxiwusuobuneng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:44.484Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `luxiwusuobuneng-dsh-plugin-context-manager`
- Submission type: community curation
- Created by `luxiwusuobuneng` — https://github.com/luxiwusuobuneng
- Original source repository: https://github.com/luxiwusuobuneng/dsh-plugin-context-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.