### PR TITLE
catalog: add lxfu1-dsh-plugin-chart (community curation, created by @lxfu1)

### DIFF
--- a/catalog/plugins/lxfu1-dsh-plugin-chart.yaml
+++ b/catalog/plugins/lxfu1-dsh-plugin-chart.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: lxfu1-dsh-plugin-chart
+name: dsh-plugin-chart
+description:
+  en: Community DeepSeek Harness plugin that bundles the AntV chart visualization skill and a native chart-generation tool.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - antv
+  - chart
+  - data-visualization
+  - deepseek-harness
+  - dsh-plugin
+  - skill
+  - dsh
+source:
+  repository: https://github.com/lxfu1/dsh-plugin-chart
+  repositoryNodeId: R_kgDOT_-6ZQ
+  subpath: null
+  commit: 469445d0fc374431aed6ca19107941db2d63f419
+creator:
+  github: lxfu1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:30.736Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lxfu1-dsh-plugin-chart`
- Submission type: community curation
- Created by `lxfu1` — https://github.com/lxfu1
- Original source repository: https://github.com/lxfu1/dsh-plugin-chart
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.