### PR TITLE
catalog: add lyq3-dsh-skin-nebula (community curation, created by @lyq3)

### DIFF
--- a/catalog/plugins/lyq3-dsh-skin-nebula.yaml
+++ b/catalog/plugins/lyq3-dsh-skin-nebula.yaml
@@ -1,0 +1,60 @@
+schemaVersion: 1
+id: lyq3-dsh-skin-nebula
+name: dsh-skin-nebula
+description:
+  en: Nebula skin for DeepSeek Harness Web UI — deep-space neon theme with HD generated backgrounds. · DSH 深空霓虹皮肤，自带高清星云背景。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+source:
+  repository: https://github.com/lyq3/dsh-skin-nebula
+  repositoryNodeId: R_kgDOT6PeGg
+  subpath: null
+  commit: 57b9f7ff42faf9e71e038fb4f7c1826804eb47c7
+creator:
+  github: lyq3
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:44.637Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/ninja-dark.png
+    alt: Screenshot 1
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/ninja-light.png
+    alt: Screenshot 2
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/sakura-dark.png
+    alt: Screenshot 3
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/sakura-light.png
+    alt: Screenshot 4
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/bamboo-dark.png
+    alt: Screenshot 5
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/bamboo-light.png
+    alt: Screenshot 6


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lyq3-dsh-skin-nebula`
- Submission type: community curation
- Created by `lyq3` — https://github.com/lyq3
- Original source repository: https://github.com/lyq3/dsh-skin-nebula
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.