### PR TITLE
catalog: add maoyuching-dsh-voice-chat (community curation, created by @maoyuching)

### DIFF
--- a/catalog/plugins/maoyuching-dsh-voice-chat.yaml
+++ b/catalog/plugins/maoyuching-dsh-voice-chat.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: maoyuching-dsh-voice-chat
+name: dsh-voice-chat
+description:
+  en: "A Doubao-style voice chat plugin for the DeepSeek Harness Web GUI: click 🎤 and talk — the AI's reply is read back to you aloud."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - voice
+  - tts
+  - stt
+  - edge-tts
+  - voice-chat
+source:
+  repository: https://github.com/maoyuching/dsh-voice-chat
+  repositoryNodeId: R_kgDOUBNknA
+  subpath: null
+  commit: 9354d54d95f82c9f20e19bb812a48cce540a6ac1
+creator:
+  github: maoyuching
+package:
+  ecosystem: npm
+  name: dsh-voice-chat
+  version: 0.1.1
+  integrity: sha512-Zaa7bnBBzl00l5dt7INTSNPAqsMAyQOm4BmMzrw6/+rlfdZalpYbkW6gNtJrvKA06++OABL5ZaRb/ZDDwReNGw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:48.503Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `maoyuching-dsh-voice-chat`
- Submission type: community curation
- Created by `maoyuching` — https://github.com/maoyuching
- Original source repository: https://github.com/maoyuching/dsh-voice-chat
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.