### PR TITLE
catalog: add maple-pwn-dsh-paperlab (community curation, created by @maple-pwn)

### DIFF
--- a/catalog/plugins/maple-pwn-dsh-paperlab.yaml
+++ b/catalog/plugins/maple-pwn-dsh-paperlab.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: maple-pwn-dsh-paperlab
+name: dsh-paperlab
+description:
+  en: "DeepSeek Harness bundle for PaperLab: an Overleaf-style workbench where you annotate a rendered PDF and a dsh agent revises the LaTeX sources."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - latex
+  - paper
+  - revision
+  - annotation
+  - dsh
+source:
+  repository: https://github.com/maple-pwn/paperlab
+  repositoryNodeId: R_kgDOT5bI6A
+  subpath: null
+  commit: 2792dc632634835f81b2d1cac27daa2a28bf4491
+creator:
+  github: maple-pwn
+package:
+  ecosystem: npm
+  name: dsh-paperlab
+  version: 0.1.2
+  integrity: sha512-SFTP73ijZg2biVEd+EXUtC1HrpM1ScKith1PngmI92lZ/LkAR9QScj7cZc4A7Q2HYviLB4yGGyjL1hqE9ZjNTA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:34.246Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/maple-pwn/paperlab/2792dc632634835f81b2d1cac27daa2a28bf4491/docs/assets/screenshot.png
+    alt: PaperLab 界面截图


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `maple-pwn-dsh-paperlab`
- Submission type: community curation
- Created by `maple-pwn` — https://github.com/maple-pwn
- Original source repository: https://github.com/maple-pwn/paperlab
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.