### PR TITLE
catalog: add marvin9551-dynamic-schulte-dsh (community curation, created by @marvin9551)

### DIFF
--- a/catalog/plugins/marvin9551-dynamic-schulte-dsh.yaml
+++ b/catalog/plugins/marvin9551-dynamic-schulte-dsh.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: marvin9551-dynamic-schulte-dsh
+name: dynamic-schulte-dsh
+description:
+  en: Dynamic Schulte Table · a waiting-room mini-game plugin for DeepSeek Harness.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dynamic
+  - schulte
+  - table
+  - waiting
+  - room
+  - mini
+  - game
+  - dsh
+source:
+  repository: https://github.com/marvin9551/dynamic-schulte-dsh
+  repositoryNodeId: R_kgDOT5DttQ
+  subpath: null
+  commit: bba63b7d430c598915c824704238fa21a52f96d2
+creator:
+  github: marvin9551
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:48.552Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/marvin9551/dynamic-schulte-dsh/bba63b7d430c598915c824704238fa21a52f96d2/docs/screenshots/gameplay.png
+    alt: 动态轮盘游戏截图


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `marvin9551-dynamic-schulte-dsh`
- Submission type: community curation
- Created by `marvin9551` — https://github.com/marvin9551
- Original source repository: https://github.com/marvin9551/dynamic-schulte-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.