### PR TITLE
catalog: add mdr-ex1000-dsh-rw (community curation, created by @MDR-EX1000)

### DIFF
--- a/catalog/plugins/mdr-ex1000-dsh-rw.yaml
+++ b/catalog/plugins/mdr-ex1000-dsh-rw.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: mdr-ex1000-dsh-rw
+name: dsh-rw
+description:
+  en: "Remote-SSH-style workspace for DeepSeek Harness (DSH): pick an SSH host and a remote directory as a native DSH workspace; the agent operates the remote filesystem directly via rw tools (SFTP/exec). No mirror, no sync — the remote is the source of truth."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - remote
+  - remote-ssh
+  - ssh
+  - sftp
+  - workspace
+source:
+  repository: https://github.com/MDR-EX1000/dsh-rw
+  repositoryNodeId: R_kgDOT9EQ9g
+  subpath: null
+  commit: 87dc8e8c825562b43cb03ed03121ce204cb266fc
+creator:
+  github: MDR-EX1000
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:48.890Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mdr-ex1000-dsh-rw`
- Submission type: community curation
- Created by `MDR-EX1000` — https://github.com/MDR-EX1000
- Original source repository: https://github.com/MDR-EX1000/dsh-rw
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.