### PR TITLE
catalog: add medisean-dsh-tarot-arcana (community curation, created by @medisean)

### DIFF
--- a/catalog/plugins/medisean-dsh-tarot-arcana.yaml
+++ b/catalog/plugins/medisean-dsh-tarot-arcana.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: medisean-dsh-tarot-arcana
+name: dsh-tarot-arcana
+description:
+  en: A deterministic three-card tarot reflection tool for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - tarot
+  - reflection
+  - dsh
+source:
+  repository: https://github.com/medisean/dsh-tarot-arcana
+  repositoryNodeId: R_kgDOT9YOLA
+  subpath: null
+  commit: 80f5488aa9c547e79c750fa7e7d3c8a548040c02
+creator:
+  github: medisean
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:51.894Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `medisean-dsh-tarot-arcana`
- Submission type: community curation
- Created by `medisean` — https://github.com/medisean
- Original source repository: https://github.com/medisean/dsh-tarot-arcana
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.