### PR TITLE
catalog: add mexiaosqwq-want-a-init (community curation, created by @mexiaosqwq)

### DIFF
--- a/catalog/plugins/mexiaosqwq-want-a-init.yaml
+++ b/catalog/plugins/mexiaosqwq-want-a-init.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: mexiaosqwq-want-a-init
+name: want-a-init
+description:
+  en: "Model-driven /init command for DeepSeek Harness: analyzes the current project and generates/updates a high-signal AGENTS.md."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - init
+  - agents-md
+  - claude-code
+  - dsh
+source:
+  repository: https://github.com/mexiaosqwq/want-a-init
+  repositoryNodeId: R_kgDOT5HPIA
+  subpath: null
+  commit: 601916d73221e44afc81fcdcf6acc4d4e0326a16
+creator:
+  github: mexiaosqwq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:34.334Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mexiaosqwq-want-a-init`
- Submission type: community curation
- Created by `mexiaosqwq` — https://github.com/mexiaosqwq
- Original source repository: https://github.com/mexiaosqwq/want-a-init
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.