### PR TITLE
catalog: add mjorgin-dsh-media-skills (community curation, created by @MJorgin)

### DIFF
--- a/catalog/plugins/mjorgin-dsh-media-skills.yaml
+++ b/catalog/plugins/mjorgin-dsh-media-skills.yaml
@@ -1,0 +1,69 @@
+schemaVersion: 1
+id: mjorgin-dsh-media-skills
+name: dsh-media-skills
+description:
+  en: Free image reading (vision) and image generation skills for DeepSeek Harness (rc.7/rc.8/v0.1.1-rc.1) — GLM-4V-Flash free reading with DeepSeek-V4-Flash-Vision-Exp / SenseNova / Gemini failover, SiliconFlow Kolors for generation.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - free
+  - image
+  - reading
+  - vision
+  - generation
+  - skills
+  - flash
+  - sensenova
+  - gemini
+  - failover
+  - siliconflow
+  - kolors
+  - dsh
+source:
+  repository: https://github.com/MJorgin/dsh-media-skills
+  repositoryNodeId: R_kgDOT36WVw
+  subpath: null
+  commit: e682e265a5f7c7d46686ba76e27275175c0c0f7e
+creator:
+  github: MJorgin
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:24.913Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 19
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/MJorgin/dsh-media-skills/e682e265a5f7c7d46686ba76e27275175c0c0f7e/docs/social-preview.png
+    alt: dsh-media-skills — free image reading & generation for DeepSeek Harness
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/MJorgin/dsh-media-skills/e682e265a5f7c7d46686ba76e27275175c0c0f7e/docs/screenshots/demo-paste.png
+    alt: "Demo: paste an image into a text-only DeepSeek Harness session, the vision model reads it, and the model answers; the sa"
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/MJorgin/dsh-media-skills/e682e265a5f7c7d46686ba76e27275175c0c0f7e/docs/screenshots/how-it-works.png
+    alt: "How paste-image reading works: paste → vision model describes → text description arrives at the current model"
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/MJorgin/dsh-media-skills/e682e265a5f7c7d46686ba76e27275175c0c0f7e/examples/generated/fox-forest.jpg
+    alt: Screenshot 4
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/MJorgin/dsh-media-skills/e682e265a5f7c7d46686ba76e27275175c0c0f7e/examples/generated/cat-astronaut.jpg
+    alt: Screenshot 5
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/MJorgin/dsh-media-skills/e682e265a5f7c7d46686ba76e27275175c0c0f7e/examples/vision-test-card.png
+    alt: Screenshot 6


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mjorgin-dsh-media-skills`
- Submission type: community curation
- Created by `MJorgin` — https://github.com/MJorgin
- Original source repository: https://github.com/MJorgin/dsh-media-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.