### PR TITLE
catalog: add mlittlefriend-dsh-character-profiler (community curation, created by @MlittleFriend)

### DIFF
--- a/catalog/plugins/mlittlefriend-dsh-character-profiler.yaml
+++ b/catalog/plugins/mlittlefriend-dsh-character-profiler.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: mlittlefriend-dsh-character-profiler
+name: dsh-character-profiler
+description:
+  en: "DSH writing plugin: character personality profiling + appearance-weight statistics + behavioral-drift detection . Quantified consistency monitoring for long-form fiction — every character's personality stays grounded, verifiable, and drift-free."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - novel
+  - writing
+  - character
+  - profiling
+  - consistency
+  - dsh
+source:
+  repository: https://github.com/MlittleFriend/dsh-character-profiler
+  repositoryNodeId: R_kgDOT6m1kg
+  subpath: null
+  commit: 9417ad1a6d084a29c7e050c39afb823cbbce3273
+creator:
+  github: MlittleFriend
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:31.005Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mlittlefriend-dsh-character-profiler`
- Submission type: community curation
- Created by `MlittleFriend` — https://github.com/MlittleFriend
- Original source repository: https://github.com/MlittleFriend/dsh-character-profiler
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.