### PR TITLE
catalog: add modellix-dsh-modellix (community curation, created by @Modellix)

### DIFF
--- a/catalog/plugins/modellix-dsh-modellix.yaml
+++ b/catalog/plugins/modellix-dsh-modellix.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: modellix-dsh-modellix
+name: dsh-modellix
+description:
+  en: Modellix Design, LLM, and Web providers for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - modellix
+  - llm
+  - image-generation
+  - video-generation
+  - dsh
+source:
+  repository: https://github.com/Modellix/dsh-modellix
+  repositoryNodeId: R_kgDOUCga7A
+  subpath: null
+  commit: 8b273446588ac77641e1f5c1d12a666385d72f53
+creator:
+  github: Modellix
+package:
+  ecosystem: npm
+  name: dsh-modellix
+  version: 0.1.1
+  integrity: sha512-ypbMhTam+qOxryEmNEv3ICDvSe6yGAjV93TAYfA0P3R04x2PKuQJWOdGSMSR4wsrkdGkF0aEPzgK3lCOODimLQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T18:35:49.411Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Modellix/dsh-modellix/8b273446588ac77641e1f5c1d12a666385d72f53/docs/assets/design-desktop-en.webp
+    alt: English Modellix Design desktop layout in a real Harness session, with model and parameters on the left and results on t


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `modellix-dsh-modellix`
- Submission type: community curation
- Created by `Modellix` — https://github.com/Modellix
- Original source repository: https://github.com/Modellix/dsh-modellix
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.