### PR TITLE
catalog: add mombrane-dsh-ui-subagent-monitor (community curation, created by @Mombrane)

### DIFF
--- a/catalog/plugins/mombrane-dsh-ui-subagent-monitor.yaml
+++ b/catalog/plugins/mombrane-dsh-ui-subagent-monitor.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: mombrane-dsh-ui-subagent-monitor
+name: "@leetoners/dsh-ui-subagent-monitor"
+description:
+  en: "DSH web extension: a live subagent run monitor with a sidebar trigger and a floating card panel"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - extension
+  - live
+  - subagent
+  - monitor
+  - sidebar
+  - trigger
+  - floating
+  - card
+  - panel
+  - dsh
+source:
+  repository: https://github.com/Mombrane/dsh-subagent-monitor
+  repositoryNodeId: R_kgDOT4QT4g
+  subpath: null
+  commit: 3fa30438d5e976b9c0796d15c3d41b211f52904d
+creator:
+  github: Mombrane
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:40.132Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 24
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Mombrane/dsh-subagent-monitor/3fa30438d5e976b9c0796d15c3d41b211f52904d/docs/screenshot.png
+    alt: 运行中的子代理面板（运行中 / 已完成多状态同屏）


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mombrane-dsh-ui-subagent-monitor`
- Submission type: community curation
- Created by `Mombrane` — https://github.com/Mombrane
- Original source repository: https://github.com/Mombrane/dsh-subagent-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.