### PR TITLE
catalog: add mozhuanzuojing-dsh-liangwengu (community curation, created by @mozhuanzuojing)

### DIFF
--- a/catalog/plugins/mozhuanzuojing-dsh-liangwengu.yaml
+++ b/catalog/plugins/mozhuanzuojing-dsh-liangwengu.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: mozhuanzuojing-dsh-liangwengu
+name: dsh-liangwengu
+description:
+  en: sh dsh plugin --profile <name add ./dsh-liangwengu
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - liangwengu
+  - deepseek-pricing
+  - reminder
+source:
+  repository: https://github.com/mozhuanzuojing/dsh-liangwengu
+  repositoryNodeId: R_kgDOT89fPw
+  subpath: null
+  commit: 568cb121a966390442819e38d10fa27cbc71a4c2
+creator:
+  github: mozhuanzuojing
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:48.428Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mozhuanzuojing-dsh-liangwengu`
- Submission type: community curation
- Created by `mozhuanzuojing` — https://github.com/mozhuanzuojing
- Original source repository: https://github.com/mozhuanzuojing/dsh-liangwengu
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.