### PR TITLE
catalog: add mrliu7219-cell-dsh-memory-kit (community curation, created by @mrliu7219-cell)

### DIFF
--- a/catalog/plugins/mrliu7219-cell-dsh-memory-kit.yaml
+++ b/catalog/plugins/mrliu7219-cell-dsh-memory-kit.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: mrliu7219-cell-dsh-memory-kit
+name: dsh-memory-kit
+description:
+  en: "Persistent memory + learning loop for DeepSeek Harness: MEMORY.md index + notes/ library auto-injected at session start, keyword search (rg), optional semantic search (local embedding), trap library with 3-tier rule escalation. Zero heavy deps; LM Studio optional for semantic/vision."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - memory
+  - memdir
+  - trap-library
+  - learning
+source:
+  repository: https://github.com/mrliu7219-cell/dsh-memory-kit
+  repositoryNodeId: R_kgDOT5nWeQ
+  subpath: null
+  commit: 28f0fee74ef24836222250cf21ca364596f5f18a
+creator:
+  github: mrliu7219-cell
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:07.044Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mrliu7219-cell-dsh-memory-kit`
- Submission type: community curation
- Created by `mrliu7219-cell` — https://github.com/mrliu7219-cell
- Original source repository: https://github.com/mrliu7219-cell/dsh-memory-kit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.