### PR TITLE
catalog: add mrpulor-gh-dsh-nuphus-mcp (community curation, created by @mrpulor-gh)

### DIFF
--- a/catalog/plugins/mrpulor-gh-dsh-nuphus-mcp.yaml
+++ b/catalog/plugins/mrpulor-gh-dsh-nuphus-mcp.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: mrpulor-gh-dsh-nuphus-mcp
+name: dsh-nuphus-mcp
+description:
+  en: "DeepSeek Harness (DSH) plugin: mount the nuphus-mcp desktop automation MCP server as native tools (mcp nuphus-mcp )."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - mcp
+  - model-context-protocol
+  - stdio
+  - desktop-automation
+  - computer-use
+  - dsh-plugin
+  - cordis
+source:
+  repository: https://github.com/mrpulor-gh/dsh-nuphus-mcp
+  repositoryNodeId: R_kgDOT8MFiw
+  subpath: null
+  commit: 299e6bfc8c4a18920eafd1381704a9645349595f
+creator:
+  github: mrpulor-gh
+package:
+  ecosystem: npm
+  name: dsh-nuphus-mcp
+  version: 0.2.1
+  integrity: sha512-AHozqmarBTL1/ieR2UvnXRYWoO1WxydZqnTrH4RSa+s/bnHdT76VoNICk8EyoNvECHJvgwy5U40XC+xJTz5QBQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:46.740Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mrpulor-gh-dsh-nuphus-mcp`
- Submission type: community curation
- Created by `mrpulor-gh` — https://github.com/mrpulor-gh
- Original source repository: https://github.com/mrpulor-gh/dsh-nuphus-mcp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.