### PR TITLE
catalog: add my-dsh-dsh-token-usage-dashboard (community curation, created by @my-dsh)

### DIFF
--- a/catalog/plugins/my-dsh-dsh-token-usage-dashboard.yaml
+++ b/catalog/plugins/my-dsh-dsh-token-usage-dashboard.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: my-dsh-dsh-token-usage-dashboard
+name: "@deepseek-ai/dsh-token-usage-dashboard"
+description:
+  en: "The Token consumption dashboard as a profile bundle: a patch layer inserting the host-side token-usage listener and its SQLite provider plus the browser dashboard panel over any web-surface profile"
+  evidencePath: packages/bundle/token-usage-dashboard/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - token
+  - consumption
+  - dashboard
+  - profile
+  - bundle
+  - patch
+  - layer
+  - inserting
+  - host
+  - side
+  - usage
+  - listener
+  - sqlite
+  - provider
+  - plus
+  - browser
+source:
+  repository: https://github.com/my-dsh/oh-my-dsh
+  repositoryNodeId: R_kgDOT6HYEg
+  subpath: packages/bundle/token-usage-dashboard
+  commit: a2ed77218b391f514d7550cf30e4dc5c24cac31a
+creator:
+  github: my-dsh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: packages/bundle/token-usage-dashboard/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:07.070Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `my-dsh-dsh-token-usage-dashboard`
- Submission type: community curation
- Created by `my-dsh` — https://github.com/my-dsh
- Original source repository: https://github.com/my-dsh/oh-my-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.