### PR TITLE
catalog: add nagasakisoyo-ui-dsh-llm-deepseek-vision (community curation, created by @NagasakiSoyo-ui)

### DIFF
--- a/catalog/plugins/nagasakisoyo-ui-dsh-llm-deepseek-vision.yaml
+++ b/catalog/plugins/nagasakisoyo-ui-dsh-llm-deepseek-vision.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: nagasakisoyo-ui-dsh-llm-deepseek-vision
+name: "@deepseek-ai/dsh-llm-deepseek-vision"
+description:
+  en: "Vision-augmented DeepSeek adapter plugin for DeepSeek Harness: a vision-capable model describes image input, then a text-only DeepSeek model reasons over the description"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - vision
+  - multimodal
+  - llm
+  - cordis
+source:
+  repository: https://github.com/NagasakiSoyo-ui/dsh-llm-deepseek-vision
+  repositoryNodeId: R_kgDOT4FeEA
+  subpath: null
+  commit: 4347929795042b665b6ddccd6806f22b92689f32
+creator:
+  github: NagasakiSoyo-ui
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:52.670Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nagasakisoyo-ui-dsh-llm-deepseek-vision`
- Submission type: community curation
- Created by `NagasakiSoyo-ui` — https://github.com/NagasakiSoyo-ui
- Original source repository: https://github.com/NagasakiSoyo-ui/dsh-llm-deepseek-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.