### PR TITLE
catalog: add necromanalbert-dsh-show-media (community curation, created by @NecromanAlbert)

### DIFF
--- a/catalog/plugins/necromanalbert-dsh-show-media.yaml
+++ b/catalog/plugins/necromanalbert-dsh-show-media.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: necromanalbert-dsh-show-media
+name: dsh-show-media
+description:
+  en: Show a local image or short video inside the current DeepSeek Harness conversation card, with click-to-preview. Does not replace the official read image model path.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - conversation
+  - image
+  - video
+  - preview
+source:
+  repository: https://github.com/NecromanAlbert/dsh-show-media
+  repositoryNodeId: R_kgDOUDyaLA
+  subpath: null
+  commit: cc3e0df1b4dc89e937834b11cb13752818b7bbc4
+creator:
+  github: NecromanAlbert
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:00.883Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `necromanalbert-dsh-show-media`
- Submission type: community curation
- Created by `NecromanAlbert` — https://github.com/NecromanAlbert
- Original source repository: https://github.com/NecromanAlbert/dsh-show-media
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.