### PR TITLE
catalog: add necromanalbert-dsh-skill-slash-fuzzy (community curation, created by @NecromanAlbert)

### DIFF
--- a/catalog/plugins/necromanalbert-dsh-skill-slash-fuzzy.yaml
+++ b/catalog/plugins/necromanalbert-dsh-skill-slash-fuzzy.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: necromanalbert-dsh-skill-slash-fuzzy
+name: dsh-skill-slash-fuzzy
+description:
+  en: Resolve unique kebab-case skill substrings in DeepSeek Harness slash tokens, so /oneshot can load game-package-oneshot.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - skill
+  - slash
+  - fuzzy
+source:
+  repository: https://github.com/NecromanAlbert/dsh-skill-slash-fuzzy
+  repositoryNodeId: R_kgDOUD77Jg
+  subpath: null
+  commit: 66ddb8867f47598a2a0bb02abca33d142e0e3bfa
+creator:
+  github: NecromanAlbert
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:07.134Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `necromanalbert-dsh-skill-slash-fuzzy`
- Submission type: community curation
- Created by `NecromanAlbert` — https://github.com/NecromanAlbert
- Original source repository: https://github.com/NecromanAlbert/dsh-skill-slash-fuzzy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.