### PR TITLE
catalog: add noirbright-dsh-llm-codex (community curation, created by @NOirBRight)

### DIFF
--- a/catalog/plugins/noirbright-dsh-llm-codex.yaml
+++ b/catalog/plugins/noirbright-dsh-llm-codex.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: noirbright-dsh-llm-codex
+name: dsh-llm-codex
+description:
+  en: ChatGPT Codex login, sortable catalog, and Fast models for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - chatgpt
+  - codex
+  - login
+  - sortable
+  - catalog
+  - fast
+  - models
+  - dsh
+source:
+  repository: https://github.com/NOirBRight/dsh-llm-codex
+  repositoryNodeId: R_kgDOT66fxA
+  subpath: null
+  commit: 61f5e99c1176a4bacdd35011b1883a73d6a2b8d9
+creator:
+  github: NOirBRight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:44.823Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/NOirBRight/dsh-llm-codex/61f5e99c1176a4bacdd35011b1883a73d6a2b8d9/docs/images/plugin-card-catalog.png
+    alt: "Codex plugin card: ChatGPT login, usage, and Fast catalog rows"
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/NOirBRight/dsh-llm-codex/61f5e99c1176a4bacdd35011b1883a73d6a2b8d9/docs/images/plugin-card-capabilities.png
+    alt: Optional Codex search and view_image capabilities


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noirbright-dsh-llm-codex`
- Submission type: community curation
- Created by `NOirBRight` — https://github.com/NOirBRight
- Original source repository: https://github.com/NOirBRight/dsh-llm-codex
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.