### PR TITLE
catalog: add noirbright-dsh-llm-grok (community curation, created by @NOirBRight)

### DIFF
--- a/catalog/plugins/noirbright-dsh-llm-grok.yaml
+++ b/catalog/plugins/noirbright-dsh-llm-grok.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: noirbright-dsh-llm-grok
+name: dsh-llm-grok
+description:
+  en: xAI Grok subscription login and chat for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - grok
+  - subscription
+  - login
+  - chat
+  - dsh
+source:
+  repository: https://github.com/NOirBRight/dsh-llm-grok
+  repositoryNodeId: R_kgDOT6SmZQ
+  subpath: null
+  commit: 45102ca50fddef3294d76f66ac8c87c7f5ab54ee
+creator:
+  github: NOirBRight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:02.030Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/NOirBRight/dsh-llm-grok/45102ca50fddef3294d76f66ac8c87c7f5ab54ee/docs/images/plugin-card.png
+    alt: "Grok Plugin card: subscription login, usage, and model catalog"


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noirbright-dsh-llm-grok`
- Submission type: community curation
- Created by `NOirBRight` — https://github.com/NOirBRight
- Original source repository: https://github.com/NOirBRight/dsh-llm-grok
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.