### PR TITLE
catalog: add noirbright-dsh-llm-ollama (community curation, created by @NOirBRight)

### DIFF
--- a/catalog/plugins/noirbright-dsh-llm-ollama.yaml
+++ b/catalog/plugins/noirbright-dsh-llm-ollama.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: noirbright-dsh-llm-ollama
+name: dsh-llm-ollama
+description:
+  en: Ollama Cloud models, OpenAI-compatible chat, and Web Search/Fetch for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - ollama
+  - cloud
+  - models
+  - openai
+  - compatible
+  - chat
+  - search
+  - fetch
+  - dsh
+source:
+  repository: https://github.com/NOirBRight/dsh-llm-ollama
+  repositoryNodeId: R_kgDOT449zA
+  subpath: null
+  commit: 6f59423885ff2f082c91c3746eac2b51d1b41c89
+creator:
+  github: NOirBRight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:48.807Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/NOirBRight/dsh-llm-ollama/6f59423885ff2f082c91c3746eac2b51d1b41c89/docs/images/ollama-cloud-usage.png
+    alt: Ollama Cloud connection and usage
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/NOirBRight/dsh-llm-ollama/6f59423885ff2f082c91c3746eac2b51d1b41c89/docs/images/ollama-model-catalog.png
+    alt: Ollama Cloud sortable model catalog


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noirbright-dsh-llm-ollama`
- Submission type: community curation
- Created by `NOirBRight` — https://github.com/NOirBRight
- Original source repository: https://github.com/NOirBRight/dsh-llm-ollama
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.