### PR TITLE
catalog: add noirbright-dsh-usage-monitor (community curation, created by @NOirBRight)

### DIFF
--- a/catalog/plugins/noirbright-dsh-usage-monitor.yaml
+++ b/catalog/plugins/noirbright-dsh-usage-monitor.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: noirbright-dsh-usage-monitor
+name: dsh-usage-monitor
+description:
+  en: Session-log usage dashboard for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - session
+  - usage
+  - dashboard
+  - dsh
+source:
+  repository: https://github.com/NOirBRight/dsh-usage-monitor
+  repositoryNodeId: R_kgDOT644qA
+  subpath: null
+  commit: f1b99007d11b10a0fd667befa4b94a90c8ea299a
+creator:
+  github: NOirBRight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:46.878Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/NOirBRight/dsh-usage-monitor/f1b99007d11b10a0fd667befa4b94a90c8ea299a/docs/screenshots/settings-usage.png
+    alt: "Settings → Usage: tiles, stacked chart, and provider table"


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noirbright-dsh-usage-monitor`
- Submission type: community curation
- Created by `NOirBRight` — https://github.com/NOirBRight
- Original source repository: https://github.com/NOirBRight/dsh-usage-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.