### PR TITLE
catalog: add noirbright-ui-layout-mobile (community curation, created by @NOirBRight)

### DIFF
--- a/catalog/plugins/noirbright-ui-layout-mobile.yaml
+++ b/catalog/plugins/noirbright-ui-layout-mobile.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: noirbright-ui-layout-mobile
+name: "@dsh-mobile/ui-layout-mobile"
+description:
+  en: Your own DeepSeek Harness, on your phone. Scan a QR, keep an encrypted tunnel, keep the official UI — composed for a hand.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - phone
+  - scan
+  - keep
+  - encrypted
+  - tunnel
+  - official
+  - composed
+  - hand
+  - dsh
+source:
+  repository: https://github.com/NOirBRight/dsh-mobile
+  repositoryNodeId: R_kgDOT5V62Q
+  subpath: packages/ui-layout-mobile
+  commit: c60dc39a75c4c6785d628048d78206877c7f6fca
+creator:
+  github: NOirBRight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/ui-layout-mobile/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:07.453Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noirbright-ui-layout-mobile`
- Submission type: community curation
- Created by `NOirBRight` — https://github.com/NOirBRight
- Original source repository: https://github.com/NOirBRight/dsh-mobile
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.