### PR TITLE
catalog: add normanfxxkingrockwell-dsh-auto-vision (community curation, created by @NormanFxxkingRockwell)

### DIFF
--- a/catalog/plugins/normanfxxkingrockwell-dsh-auto-vision.yaml
+++ b/catalog/plugins/normanfxxkingrockwell-dsh-auto-vision.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: normanfxxkingrockwell-dsh-auto-vision
+name: dsh-auto-vision
+description:
+  en: sh dsh plugin --profile <你的profile名 add dsh-auto-vision
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - vision
+  - image
+  - multimodal
+  - qwen
+source:
+  repository: https://github.com/NormanFxxkingRockwell/dsh-auto-vision
+  repositoryNodeId: R_kgDOT7AQ6g
+  subpath: null
+  commit: 78f7933a7ce9fc2ec8ab777af672e6d324a3481c
+creator:
+  github: NormanFxxkingRockwell
+package:
+  ecosystem: npm
+  name: dsh-auto-vision
+  version: 0.4.0
+  integrity: sha512-WGUJCjJULZDAwtpCdjHWg5u5pkdg/9syZmN0wo+ZBGiZgfm9r6IWCj2Nlb3wz3fM5dYdUrPcpT3zXsAfbGMmYw==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:53.039Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `normanfxxkingrockwell-dsh-auto-vision`
- Submission type: community curation
- Created by `NormanFxxkingRockwell` — https://github.com/NormanFxxkingRockwell
- Original source repository: https://github.com/NormanFxxkingRockwell/dsh-auto-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.