### PR TITLE
catalog: add nyantused-cpun-folio-dsh-events (community curation, created by @nyantused-cpun)

### DIFF
--- a/catalog/plugins/nyantused-cpun-folio-dsh-events.yaml
+++ b/catalog/plugins/nyantused-cpun-folio-dsh-events.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: nyantused-cpun-folio-dsh-events
+name: "@nyantused/folio-dsh-events"
+description:
+  en: '- agent/session-start / agent/disposed ：dsh-agent 官方 live 词汇（non-vetoing）； - tool/call 会话事件形状 {turn, step, callId, name, arguments} ：dsh-agent-loop appendToolCall （ session.append("tool/call", ...) ）； - agent.followup(message) ：dsh-agent 入队原语（next-turn FIFO 唤醒）； - createUserMessage ：dsh-llm/message 依赖最小入口（mint MessageI'
+  evidencePath: plugins/folio-events/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - folio
+  - consulting
+  - document-generation
+  - session-protocol
+source:
+  repository: https://github.com/nyantused-cpun/folio
+  repositoryNodeId: R_kgDOT47yoQ
+  subpath: plugins/folio-events
+  commit: 6ce1ec882cda61dbca5ad56bbce874d1dc127605
+creator:
+  github: nyantused-cpun
+package:
+  ecosystem: npm
+  name: "@nyantused/folio-dsh-events"
+  version: 1.0.1
+  integrity: sha512-EMOi2D99LMvropgScya7NmFvifs9iijQHT4+igGXEcHuyME1K0t0yADIyCK/zH9+a9+TBPcGzinT40zaYnVn8g==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/folio-events/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:08.901Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nyantused-cpun-folio-dsh-events`
- Submission type: community curation
- Created by `nyantused-cpun` — https://github.com/nyantused-cpun
- Original source repository: https://github.com/nyantused-cpun/folio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.