### PR TITLE
catalog: add nyantused-cpun-folio-dsh-tools (community curation, created by @nyantused-cpun)

### DIFF
--- a/catalog/plugins/nyantused-cpun-folio-dsh-tools.yaml
+++ b/catalog/plugins/nyantused-cpun-folio-dsh-tools.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: nyantused-cpun-folio-dsh-tools
+name: "@nyantused/folio-dsh-tools"
+description:
+  en: "- 记忆面 9 ：folio status / folio pending / folio recall / folio read / folio chunk read / folio graph query / folio session start / folio save / folio load - 质量面 6 ：folio verify / folio review / folio cite audit / folio audit / folio theme verify / folio spec diff"
+  evidencePath: plugins/folio-tools/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - folio
+  - consulting
+  - document-generation
+  - guard
+source:
+  repository: https://github.com/nyantused-cpun/folio
+  repositoryNodeId: R_kgDOT47yoQ
+  subpath: plugins/folio-tools
+  commit: 6ce1ec882cda61dbca5ad56bbce874d1dc127605
+creator:
+  github: nyantused-cpun
+package:
+  ecosystem: npm
+  name: "@nyantused/folio-dsh-tools"
+  version: 1.1.0
+  integrity: sha512-4/sn1RTLnsVdlMyN8wuobUwUMb3pymCbmIAttt73kjXZ0LLHGHWVryvDnyFtpEmJkPcRZmIuWMKNlxmoIPJ6EA==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/folio-tools/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:08.901Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nyantused-cpun-folio-dsh-tools`
- Submission type: community curation
- Created by `nyantused-cpun` — https://github.com/nyantused-cpun
- Original source repository: https://github.com/nyantused-cpun/folio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.