### PR TITLE
catalog: add opaimon-dsh-model-gate (community curation, created by @OPaimon)

### DIFF
--- a/catalog/plugins/opaimon-dsh-model-gate.yaml
+++ b/catalog/plugins/opaimon-dsh-model-gate.yaml
@@ -1,0 +1,58 @@
+schemaVersion: 1
+id: opaimon-dsh-model-gate
+name: dsh-model-gate
+description:
+  en: "Single-model disable gate: hides denied models from every discovery path, blocks dispatch with an in-protocol error chunk, and exposes a settings-section UI for the denylist"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - model-gate
+  - denylist
+source:
+  repository: https://github.com/OPaimon/dsh-model-gate
+  repositoryNodeId: R_kgDOUBhU7Q
+  subpath: null
+  commit: 99ff88fc9fe432faf8ba3dfc0b3f3d2e13809896
+creator:
+  github: OPaimon
+package:
+  ecosystem: npm
+  name: dsh-model-gate
+  version: 0.1.2
+  integrity: sha512-wUUHI620JCFNCZM8qvSUMtcnTHpM5pswaWEBh9cwKU4JisVDCrgz0OicTCXiRW0WCgFo41kEDOcmIRpF6vizPg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:02.291Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/OPaimon/dsh-model-gate/99ff88fc9fe432faf8ba3dfc0b3f3d2e13809896/assets/settings-panel.png
+    alt: Model gate settings panel
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/OPaimon/dsh-model-gate/99ff88fc9fe432faf8ba3dfc0b3f3d2e13809896/assets/picker-model-enabled.png
+    alt: Picker with the model enabled
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/OPaimon/dsh-model-gate/99ff88fc9fe432faf8ba3dfc0b3f3d2e13809896/assets/picker-model-denied.png
+    alt: Picker with the model denied
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/OPaimon/dsh-model-gate/99ff88fc9fe432faf8ba3dfc0b3f3d2e13809896/assets/dispatch-blocked.png
+    alt: Dispatch blocked with MODEL_DISABLED


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `opaimon-dsh-model-gate`
- Submission type: community curation
- Created by `OPaimon` — https://github.com/OPaimon
- Original source repository: https://github.com/OPaimon/dsh-model-gate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.