### PR TITLE
catalog: add owlcodetech-dsh-market-plus (community curation, created by @OwlCodeTech)

### DIFF
--- a/catalog/plugins/owlcodetech-dsh-market-plus.yaml
+++ b/catalog/plugins/owlcodetech-dsh-market-plus.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: owlcodetech-dsh-market-plus
+name: dsh-market-plus
+description:
+  en: 安装： dsh plugin --profile web add dsh-market-plus （或本地 npm install file:<路径 + profile bundles 注册）。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - marketplace
+  - market
+  - plugin-manager
+source:
+  repository: https://github.com/OwlCodeTech/dsh-market-plus
+  repositoryNodeId: R_kgDOT564Xg
+  subpath: null
+  commit: 5c859af5431be0a03b20166f3273cb3b1ca7e2e2
+creator:
+  github: OwlCodeTech
+package:
+  ecosystem: npm
+  name: dsh-market-plus
+  version: 0.1.1
+  integrity: sha512-CTvie/nNdcgPr0/vsd+XaRkY9IcvKOFzVsZVc+45o82po4WqwKPmkQc05JdTYceHxfsH4XbzFM481oZ5jWZsKg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:11.260Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/OwlCodeTech/dsh-market-plus/5c859af5431be0a03b20166f3273cb3b1ca7e2e2/assets/demo-en.png
+    alt: dsh-market
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/OwlCodeTech/dsh-market-plus/5c859af5431be0a03b20166f3273cb3b1ca7e2e2/assets/themes-en.png
+    alt: Themes tab


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `owlcodetech-dsh-market-plus`
- Submission type: community curation
- Created by `OwlCodeTech` — https://github.com/OwlCodeTech
- Original source repository: https://github.com/OwlCodeTech/dsh-market-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.