### PR TITLE
catalog: add particlelight-dsh-browser-plus (community curation, created by @ParticleLight)

### DIFF
--- a/catalog/plugins/particlelight-dsh-browser-plus.yaml
+++ b/catalog/plugins/particlelight-dsh-browser-plus.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: particlelight-dsh-browser-plus
+name: dsh-browser-plus
+description:
+  en: "Enhanced shared browser for DeepSeek Harness: one visible window with isolated task views, a page task manager, non-stealing background tasks, built-in toolbar and operation trail, and pinned Electron 42.9.3 compositing."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - browser
+  - cdp
+  - dsh
+source:
+  repository: https://github.com/ParticleLight/dsh-browser-plus
+  repositoryNodeId: R_kgDOT__S3w
+  subpath: null
+  commit: 61da65472a04b14a2fdf2ebaf2f116bd80047288
+creator:
+  github: ParticleLight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:44.847Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/ParticleLight/dsh-browser-plus/61da65472a04b14a2fdf2ebaf2f116bd80047288/assets/readme-glass-workspace.png
+    alt: dsh-browser-plus 任务工作区


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `particlelight-dsh-browser-plus`
- Submission type: community curation
- Created by `ParticleLight` — https://github.com/ParticleLight
- Original source repository: https://github.com/ParticleLight/dsh-browser-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.