### PR TITLE
catalog: add perrylink-dsh-auto-review (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/perrylink-dsh-auto-review.yaml
+++ b/catalog/plugins/perrylink-dsh-auto-review.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: perrylink-dsh-auto-review
+name: dsh-auto-review
+description:
+  en: "Second-model AI auto-review for DeepSeek Harness approval requests: a read-only reviewer subagent decides allow/deny on the approval answerer chain, with fail-closed fallback and full session-log audit."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - approval
+  - auto-review
+  - second-model
+  - ai-safety
+  - sandbox
+  - subagent
+source:
+  repository: https://github.com/PerryLink/dsh-auto-review
+  repositoryNodeId: R_kgDOT3tUeg
+  subpath: null
+  commit: 850639dc362ffeec57ac06cfd4dddba922f96e9a
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-auto-review
+  version: 0.8.0
+  integrity: sha512-l05weldha5J4QUDzaI5Up8PuqzvsEgRay6QdppIUCxu39kjEx49lmXEXYiPvxrX+wyhkHIP07R65245ofaGTkA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:40.261Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 120
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `perrylink-dsh-auto-review`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-auto-review
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.