### PR TITLE
catalog: add perrylink-dsh-memento (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/perrylink-dsh-memento.yaml
+++ b/catalog/plugins/perrylink-dsh-memento.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: perrylink-dsh-memento
+name: dsh-memento
+description:
+  en: Bounded, layered, approval-gated, auditable cross-session memory for DeepSeek Harness — a capability seam (ctx.memory service + local SQLite provider + memory tool + frozen snapshot injection), not another memory warehouse
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - memory
+  - agent-memory
+  - approval
+  - audit
+  - sqlite
+  - cordis
+  - llm
+source:
+  repository: https://github.com/PerryLink/dsh-memento
+  repositoryNodeId: R_kgDOT3soog
+  subpath: null
+  commit: 09d0e05132034dd38041a4dea8a3609eea7ad136
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-memento
+  version: 0.5.0
+  integrity: sha512-L34OEFfD8fOCjPFYUt2bYbAS1z44HeC25m3tZN0ePyAvXbNc6Kx/hbm7bDvnCoqwGZoWJt+Erp2zTeHFRh/VlA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:40.264Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 75
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `perrylink-dsh-memento`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-memento
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.