### PR TITLE
catalog: add perrylink-dsh-score (community curation, created by @PerryLink)

### DIFF
--- a/catalog/plugins/perrylink-dsh-score.yaml
+++ b/catalog/plugins/perrylink-dsh-score.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: perrylink-dsh-score
+name: dsh-score
+description:
+  en: "Multi-dimensional quality scoring for DeepSeek Harness plugins: scores one repo or npm package across install success (consuming dsh-test-drive results), maintenance activity, documentation completeness, security scan, and protocol compliance — every conclusion backed by real CLI evidence with audit timestamps — and pr"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - plugin-scoring
+  - quality-score
+  - leaderboard
+  - supply-chain
+source:
+  repository: https://github.com/PerryLink/dsh-score
+  repositoryNodeId: R_kgDOT6oNJg
+  subpath: null
+  commit: c2a87601dadc28e07a72170446b0af27f626e388
+creator:
+  github: PerryLink
+package:
+  ecosystem: npm
+  name: dsh-score
+  version: 0.2.1
+  integrity: sha512-FVSmviVC6OYVyZ1Rd1qOMot36szila242PxE5gsZe2dpu3quj44okPVUDeJdn7PoZqsD8MmZR3ab3QxEdeLC8Q==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:53.914Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `perrylink-dsh-score`
- Submission type: community curation
- Created by `PerryLink` — https://github.com/PerryLink
- Original source repository: https://github.com/PerryLink/dsh-score
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.