### PR TITLE
catalog: add qiushi-dev-dsh-session-nexus (community curation, created by @qiushi-dev)

### DIFF
--- a/catalog/plugins/qiushi-dev-dsh-session-nexus.yaml
+++ b/catalog/plugins/qiushi-dev-dsh-session-nexus.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: qiushi-dev-dsh-session-nexus
+name: dsh-session-nexus
+description:
+  en: "Unofficial DeepSeek Harness plugin — sessions as addressable, first-class citizens: lifecycle controls (/resume, /unarchive, opt-in /rm-session) plus session-addressed messaging (/send-to, /notify, /address, session send message tool). Working companion to the session RFCs (deepseek-harness discussion 3640)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - session
+  - resume
+  - unarchive
+  - mailbox
+  - cross-session
+  - messaging
+  - dsh
+source:
+  repository: https://github.com/qiushi-dev/dsh-session-nexus
+  repositoryNodeId: R_kgDOT-xxxg
+  subpath: null
+  commit: 2a8d733d81b9e63804a9af3f6d36b6c65d231f5f
+creator:
+  github: qiushi-dev
+package:
+  ecosystem: npm
+  name: dsh-session-nexus
+  version: 0.3.0
+  integrity: sha512-YjbV83FnuFqOt3vE48Kq6aF3Pd/XFG6fFSvkOdMo4DqNFbvsuFjRnE943gauSEqtCLxyCmiBErlXFG1ub5IGVQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:50.412Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qiushi-dev-dsh-session-nexus`
- Submission type: community curation
- Created by `qiushi-dev` — https://github.com/qiushi-dev
- Original source repository: https://github.com/qiushi-dev/dsh-session-nexus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.