### PR TITLE
catalog: add raphaelutumn-dsh-change-budget (community curation, created by @Raphaelutumn)

### DIFF
--- a/catalog/plugins/raphaelutumn-dsh-change-budget.yaml
+++ b/catalog/plugins/raphaelutumn-dsh-change-budget.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: raphaelutumn-dsh-change-budget
+name: "@raphelutumn/dsh-change-budget"
+description:
+  en: DeepSeek Harness guardrail that limits how many files an AI coding agent can edit per turn
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - ai-agent
+  - coding-agent
+  - file-safety
+  - file-editing
+  - edit-limit
+  - guardrail
+  - circuit-breaker
+  - tool-budget
+  - dsh
+source:
+  repository: https://github.com/Raphaelutumn/dsh-change-budget
+  repositoryNodeId: R_kgDOT65UTg
+  subpath: null
+  commit: e38a859ca811a49da2ec212002715241b82bd485
+creator:
+  github: Raphaelutumn
+package:
+  ecosystem: npm
+  name: "@raphelutumn/dsh-change-budget"
+  version: 0.1.0
+  integrity: sha512-bEHPK3Z6Uzw5KnbQXQ5FuhiRw7RtjHCoPMxlezcLA+eYMGC0Hy5DxBye50j8ChXVEDrw6dVZPatC4/jD5xUC9Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:54.917Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Raphaelutumn/dsh-change-budget/e38a859ca811a49da2ec212002715241b82bd485/assets/dsh-change-budget-hero.png
+    alt: A bounded change budget protecting structured file mutations


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `raphaelutumn-dsh-change-budget`
- Submission type: community curation
- Created by `Raphaelutumn` — https://github.com/Raphaelutumn
- Original source repository: https://github.com/Raphaelutumn/dsh-change-budget
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.