### PR TITLE
catalog: add ray062-dsh-obvious-grid (community curation, created by @ray062)

### DIFF
--- a/catalog/plugins/ray062-dsh-obvious-grid.yaml
+++ b/catalog/plugins/ray062-dsh-obvious-grid.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: ray062-dsh-obvious-grid
+name: dsh-obvious-grid
+description:
+  en: 'Host plugin for DeepSeek Harness: ambient status grid page + AFK notifications (ntfy push / alarm) on turn-end, error, and approval-wait. The "obvious" idea from opencode-obvious-grid, on DSH seams.'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - status
+  - dashboard
+  - notify
+  - ntfy
+source:
+  repository: https://github.com/ray062/dsh-obvious-grid
+  repositoryNodeId: R_kgDOT6Sdzw
+  subpath: null
+  commit: c09aead64987bf2ed73dea44e7581028196b5dea
+creator:
+  github: ray062
+package:
+  ecosystem: npm
+  name: dsh-obvious-grid
+  version: 0.2.2
+  integrity: sha512-OUQhpMSXMLPPrfHPZuaJZU9C7KObhqoYx0hwGTM8J1Irm40wlMMDbyCz50f0+DsEpQRTJFXDjuT+/EwxPal2Bg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:02.377Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ray062-dsh-obvious-grid`
- Submission type: community curation
- Created by `ray062` — https://github.com/ray062
- Original source repository: https://github.com/ray062/dsh-obvious-grid
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.