### PR TITLE
catalog: add ricketts-guo-dsh-offpeak-send (community curation, created by @Ricketts-Guo)

### DIFF
--- a/catalog/plugins/ricketts-guo-dsh-offpeak-send.yaml
+++ b/catalog/plugins/ricketts-guo-dsh-offpeak-send.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: ricketts-guo-dsh-offpeak-send
+name: dsh-offpeak-send
+description:
+  en: bash pnpm --dir ~/.dsh/profiles/web add --save-prod dsh-offpeak-send
+  evidencePath: dsh-offpeak-send/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - off-peak
+  - scheduler
+  - cordis
+source:
+  repository: https://github.com/Ricketts-Guo/dsh-off-peak-message
+  repositoryNodeId: R_kgDOT9BR5w
+  subpath: dsh-offpeak-send
+  commit: 5332a169f24ec7949cb40bcf13bc2e809e7f18db
+creator:
+  github: Ricketts-Guo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-offpeak-send/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:11.626Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ricketts-guo-dsh-offpeak-send`
- Submission type: community curation
- Created by `Ricketts-Guo` — https://github.com/Ricketts-Guo
- Original source repository: https://github.com/Ricketts-Guo/dsh-off-peak-message
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.