### PR TITLE
catalog: add ricketts-guo-dsh-shortcuts (community curation, created by @Ricketts-Guo)

### DIFF
--- a/catalog/plugins/ricketts-guo-dsh-shortcuts.yaml
+++ b/catalog/plugins/ricketts-guo-dsh-shortcuts.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: ricketts-guo-dsh-shortcuts
+name: dsh-shortcuts
+description:
+  en: Fully customizable keyboard shortcuts for the DeepSeek Harness WebUI — macOS-first defaults, 34 pre-registered features across session/view/clipboard/model/permission/system groups, one-click recording to add your own bindings, silent permission cycling with color feedback.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - keyboard-shortcuts
+  - hotkeys
+  - web-ui
+  - productivity
+source:
+  repository: https://github.com/Ricketts-Guo/dsh-shortcuts
+  repositoryNodeId: R_kgDOT5CxbQ
+  subpath: null
+  commit: bf392410868c9686ed3292d2c2272469da3a3293
+creator:
+  github: Ricketts-Guo
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:50.370Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ricketts-guo-dsh-shortcuts`
- Submission type: community curation
- Created by `Ricketts-Guo` — https://github.com/Ricketts-Guo
- Original source repository: https://github.com/Ricketts-Guo/dsh-shortcuts
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.