### PR TITLE
catalog: add rj-jiangyichen-dsh-rules (community curation, created by @rj-jiangyichen)

### DIFF
--- a/catalog/plugins/rj-jiangyichen-dsh-rules.yaml
+++ b/catalog/plugins/rj-jiangyichen-dsh-rules.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: rj-jiangyichen-dsh-rules
+name: dsh-rules
+description:
+  en: "DSH rules plugin: activate rule prompts / markdown documents by glob-matching the files an agent reads or edits (Claude Code rules.md style)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - rules
+  - claude-code
+  - agents
+  - prompt
+source:
+  repository: https://github.com/rj-jiangyichen/dsh-rules
+  repositoryNodeId: R_kgDOT5r_fQ
+  subpath: null
+  commit: 12dbeb1810403fac936e0aadfa52389d05fad6fe
+creator:
+  github: rj-jiangyichen
+package:
+  ecosystem: npm
+  name: dsh-rules
+  version: 0.1.1
+  integrity: sha512-+RO4mWCKy19F1R9zIYrYOKvzQraDnvqE5Gq5hhcwdjNdvWZ8cDtd5Nr0B3uTNBGMBAJQ70pnnSAAssZ0DTYZOA==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:50.789Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `rj-jiangyichen-dsh-rules`
- Submission type: community curation
- Created by `rj-jiangyichen` — https://github.com/rj-jiangyichen
- Original source repository: https://github.com/rj-jiangyichen/dsh-rules
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.