### PR TITLE
catalog: add sailingloong-loongport (community curation, created by @SailingLoong)

### DIFF
--- a/catalog/plugins/sailingloong-loongport.yaml
+++ b/catalog/plugins/sailingloong-loongport.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: sailingloong-loongport
+name: loongport
+description:
+  en: LoongPort DeepSeek Harness (dsh) Cordis bundle and setup CLI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - loongport
+  - openai-compatible
+  - cordis
+  - cli
+source:
+  repository: https://github.com/SailingLoong/loongport-dsh
+  repositoryNodeId: R_kgDOT3-CyQ
+  subpath: null
+  commit: a5c1c2e8a4f08c72c304078b5cbc5636a641bee9
+creator:
+  github: SailingLoong
+package:
+  ecosystem: npm
+  name: loongport
+  version: 0.2.0
+  integrity: sha512-L/szWvVbDp8oIlTpNoAOZRF15JUh1o2d1wPnJiE7IGuC7SCBDoMRgZ3PWdA7XrPCdvYYAiISvQ48KtHRXNF/qw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:54.834Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sailingloong-loongport`
- Submission type: community curation
- Created by `SailingLoong` — https://github.com/SailingLoong
- Original source repository: https://github.com/SailingLoong/loongport-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.