### PR TITLE
catalog: add sakikotgw-pack-agent-dsh (community curation, created by @sakikoTGW)

### DIFF
--- a/catalog/plugins/sakikotgw-pack-agent-dsh.yaml
+++ b/catalog/plugins/sakikotgw-pack-agent-dsh.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: sakikotgw-pack-agent-dsh
+name: "@sakikotgw/pack-agent-dsh"
+description:
+  en: "DeepSeek Harness plugin: project Agent Modpacks into .agent-pack/modpacks and allow them"
+  evidencePath: agent-pack-dsh/plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-modpack
+  - pack-agent
+  - dsh
+source:
+  repository: https://github.com/sakikoTGW/pack-agent
+  repositoryNodeId: R_kgDOTEJVkg
+  subpath: agent-pack-dsh/plugin
+  commit: 4c929ead1d937661d58e13a553f047678a9534e2
+creator:
+  github: sakikoTGW
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: agent-pack-dsh/plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:13.602Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sakikotgw-pack-agent-dsh`
- Submission type: community curation
- Created by `sakikoTGW` — https://github.com/sakikoTGW
- Original source repository: https://github.com/sakikoTGW/pack-agent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.