### PR TITLE
catalog: add sakuraqqq-dsh-auto-paste (community curation, created by @sakuraqqq)

### DIFF
--- a/catalog/plugins/sakuraqqq-dsh-auto-paste.yaml
+++ b/catalog/plugins/sakuraqqq-dsh-auto-paste.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sakuraqqq-dsh-auto-paste
+name: dsh-auto-paste
+description:
+  en: "sh npm i dsh-auto-paste 最新版（dist-tag: latest）；--save-exact 可锁版 npm i dsh-auto-paste@0.1.2 或指定版本 dsh plugin --profile web add dsh-auto-paste dsh --profile web 重启 web profile，观察: [dsh-auto-paste] host ready ..."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - paste
+  - attachment
+source:
+  repository: https://github.com/sakuraqqq/dsh-auto-paste
+  repositoryNodeId: R_kgDOT5zTiw
+  subpath: null
+  commit: 4240952e0ece7a6415380e9ed4c10ee0b5f4e131
+creator:
+  github: sakuraqqq
+package:
+  ecosystem: npm
+  name: dsh-auto-paste
+  version: 0.1.2
+  integrity: sha512-tY7mczjqlIChQQOhc1jEm6KtHgXW5zyWFptFfVYEW6Js6cXb+CFDtiHjL5xJs9bN793/VPPxr+Q7Y+tLdhgiqQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:55.235Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sakuraqqq-dsh-auto-paste`
- Submission type: community curation
- Created by `sakuraqqq` — https://github.com/sakuraqqq
- Original source repository: https://github.com/sakuraqqq/dsh-auto-paste
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.