### PR TITLE
catalog: add sanshanya-better-model-provider (community curation, created by @sanshanya)

### DIFF
--- a/catalog/plugins/sanshanya-better-model-provider.yaml
+++ b/catalog/plugins/sanshanya-better-model-provider.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: sanshanya-better-model-provider
+name: better-model-provider
+description:
+  en: "Per-model capability declaration for DeepSeek Harness: reasoning-effort levels (with wire spellings) and request modalities (text/image) for OpenAI-compatible providers — one settings section, no YAML hand-editing."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - model-capabilities
+  - reasoning-effort
+  - multimodal
+  - llm-settings
+  - dsh
+source:
+  repository: https://github.com/sanshanya/better-model-provider
+  repositoryNodeId: R_kgDOT4Jw1g
+  subpath: null
+  commit: 73a647425b1e5dc106ade408e770af9cb50f1bad
+creator:
+  github: sanshanya
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:42.921Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 11
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/sanshanya/better-model-provider/73a647425b1e5dc106ade408e770af9cb50f1bad/docs/screenshot.png
+    alt: Editing one model row


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sanshanya-better-model-provider`
- Submission type: community curation
- Created by `sanshanya` — https://github.com/sanshanya
- Original source repository: https://github.com/sanshanya/better-model-provider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.