### PR TITLE
catalog: add scwlkq-dsh-task-board (community curation, created by @scwlkq)

### DIFF
--- a/catalog/plugins/scwlkq-dsh-task-board.yaml
+++ b/catalog/plugins/scwlkq-dsh-task-board.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: scwlkq-dsh-task-board
+name: dsh-task-board
+description:
+  en: Durable reviewed task cards for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - task-board
+  - kanban
+  - dsh
+source:
+  repository: https://github.com/scwlkq/dsh-task-board
+  repositoryNodeId: R_kgDOT5gQYA
+  subpath: null
+  commit: 7fe31114b7dfe959ede4d4993c98f6b6e3b3c0e4
+creator:
+  github: scwlkq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:02.982Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `scwlkq-dsh-task-board`
- Submission type: community curation
- Created by `scwlkq` — https://github.com/scwlkq
- Original source repository: https://github.com/scwlkq/dsh-task-board
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.