### PR TITLE
catalog: add sddft97-dsh-client-ui-skin-verdandi (community curation, created by @Sddft97)

### DIFF
--- a/catalog/plugins/sddft97-dsh-client-ui-skin-verdandi.yaml
+++ b/catalog/plugins/sddft97-dsh-client-ui-skin-verdandi.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: sddft97-dsh-client-ui-skin-verdandi
+name: "@hjbztlbr/dsh-client-ui-skin-verdandi"
+description:
+  en: "Verdandi White Vow skin for the DSH Web GUI: deep crimson navigation, bridal-white workspace, soft-gold knight details, and scoped plugin-safe surfaces."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - dsh-skin
+  - theme
+  - aether-gazer
+  - verdandi
+source:
+  repository: https://github.com/Sddft97/dsh-client-ui-skin-verdandi
+  repositoryNodeId: R_kgDOUAoZvA
+  subpath: null
+  commit: bbfbdb8e8b12bf0f791cb5c335ce776da6b46ef8
+creator:
+  github: Sddft97
+package:
+  ecosystem: npm
+  name: "@hjbztlbr/dsh-client-ui-skin-verdandi"
+  version: 0.1.0
+  integrity: sha512-mAvsLEMZiMZqRVvD0GKfNHxOLOd03/NyqRBH/uk/ZL5O2X5vsVTzy3DrnKjInTvxxyG5MkJ3V/Aj4nLYjGb9rA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:55.430Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Sddft97/dsh-client-ui-skin-verdandi/bbfbdb8e8b12bf0f791cb5c335ce776da6b46ef8/preview/light.png
+    alt: 亮色模式预览
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Sddft97/dsh-client-ui-skin-verdandi/bbfbdb8e8b12bf0f791cb5c335ce776da6b46ef8/preview/dark.png
+    alt: 暗色模式预览
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Sddft97/dsh-client-ui-skin-verdandi/bbfbdb8e8b12bf0f791cb5c335ce776da6b46ef8/preview/settings.png
+    alt: 设置界面兼容性预览


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sddft97-dsh-client-ui-skin-verdandi`
- Submission type: community curation
- Created by `Sddft97` — https://github.com/Sddft97
- Original source repository: https://github.com/Sddft97/dsh-client-ui-skin-verdandi
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.