### PR TITLE
catalog: add seetraum-dsh-session-recycle-bin (community curation, created by @Seetraum)

### DIFF
--- a/catalog/plugins/seetraum-dsh-session-recycle-bin.yaml
+++ b/catalog/plugins/seetraum-dsh-session-recycle-bin.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: seetraum-dsh-session-recycle-bin
+name: dsh-session-recycle-bin
+description:
+  en: Session recycle bin & permanent delete for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - session
+  - trash
+  - recycle-bin
+  - session-management
+source:
+  repository: https://github.com/Seetraum/harness-session-delete
+  repositoryNodeId: R_kgDOUDOxHA
+  subpath: null
+  commit: 930170eabfbea1217eb5a3c1561db00367c4824c
+creator:
+  github: Seetraum
+package:
+  ecosystem: npm
+  name: dsh-session-recycle-bin
+  version: 0.2.1
+  integrity: sha512-3JbkdPdFrMDFTywvR7d03IJ94aIeTIaE3PQN2vgn/8ILOTKQn3q5AtiQEX49I5JpFge+7fmz782CzcqNolQWvQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:56.214Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `seetraum-dsh-session-recycle-bin`
- Submission type: community curation
- Created by `Seetraum` — https://github.com/Seetraum
- Original source repository: https://github.com/Seetraum/harness-session-delete
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.