### PR TITLE
catalog: add shangjian2023-dsh-rss-daily (community curation, created by @shangjian2023)

### DIFF
--- a/catalog/plugins/shangjian2023-dsh-rss-daily.yaml
+++ b/catalog/plugins/shangjian2023-dsh-rss-daily.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: shangjian2023-dsh-rss-daily
+name: dsh-rss-daily
+description:
+  en: "dsh plugin: daily RSS news digest from 46 curated sources, LLM-edited via the model already configured in dsh, delivered to your IM via webhook (ServerChan / PushDeer / WeCom / Telegram / Bark / gotify / custom)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh-plugin
+  - dsh
+  - deepseek-harness
+  - rss
+  - news
+  - digest
+  - daily-briefing
+source:
+  repository: https://github.com/shangjian2023/dsh-rss-daily
+  repositoryNodeId: R_kgDOUAevug
+  subpath: null
+  commit: c3843f13a2a60faecdc8c1399d08de26cf680dfd
+creator:
+  github: shangjian2023
+package:
+  ecosystem: npm
+  name: dsh-rss-daily
+  version: 0.5.0
+  integrity: sha512-TNNFQxTZfccQ+4inqBYbwNLYD6a/rUhL/OFA+ziuBiMuq4dubpNFfuDBR+UUcqTWgocQ2XIYe5wpJT9vZLtwkg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:50.967Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/shangjian2023/dsh-rss-daily/c3843f13a2a60faecdc8c1399d08de26cf680dfd/docs/in-chat.png
+    alt: 对话内日报


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shangjian2023-dsh-rss-daily`
- Submission type: community curation
- Created by `shangjian2023` — https://github.com/shangjian2023
- Original source repository: https://github.com/shangjian2023/dsh-rss-daily
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.