### PR TITLE
catalog: add shiye-10pages-dsh-whale-meter (community curation, created by @Shiye-10Pages)

### DIFF
--- a/catalog/plugins/shiye-10pages-dsh-whale-meter.yaml
+++ b/catalog/plugins/shiye-10pages-dsh-whale-meter.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: shiye-10pages-dsh-whale-meter
+name: dsh-whale-meter
+description:
+  en: An electricity meter for your whale — usage & cost dashboard for DeepSeek Harness
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - usage
+  - cost
+  - token
+  - billing
+  - dashboard
+source:
+  repository: https://github.com/Shiye-10Pages/dsh-whale-meter
+  repositoryNodeId: R_kgDOT5pk_g
+  subpath: null
+  commit: c484500e6a00d26317dc71ee854ced26df6f2aaa
+creator:
+  github: Shiye-10Pages
+package:
+  ecosystem: npm
+  name: dsh-whale-meter
+  version: 0.1.0
+  integrity: sha512-Ha++mbQNhtsvh+SYsci0vkim4iREYOf3KO66MkTLAOElyPLXp92ldxOFFNhCGKNogx2KUMvyyED/Oy8OsgTPUA==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:43.016Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Shiye-10Pages/dsh-whale-meter/c484500e6a00d26317dc71ee854ced26df6f2aaa/assets/social-preview.png
+    alt: 鲸鱼电表 whale-meter
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Shiye-10Pages/dsh-whale-meter/c484500e6a00d26317dc71ee854ced26df6f2aaa/assets/demo.gif
+    alt: 鲸鱼电表演示


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shiye-10pages-dsh-whale-meter`
- Submission type: community curation
- Created by `Shiye-10Pages` — https://github.com/Shiye-10Pages
- Original source repository: https://github.com/Shiye-10Pages/dsh-whale-meter
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.