### PR TITLE
catalog: add shrekcg-dsh-im-channel (community curation, created by @shrekcg)

### DIFF
--- a/catalog/plugins/shrekcg-dsh-im-channel.yaml
+++ b/catalog/plugins/shrekcg-dsh-im-channel.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: shrekcg-dsh-im-channel
+name: dsh-im-channel
+description:
+  en: "Multi-channel IM bridge for DeepSeek Harness: Feishu, Telegram, DingTalk, Slack, Discord — persistent sessions, true streaming, slash commands"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - feishu
+  - lark
+  - dsh
+  - bridge
+  - chatbot
+  - openclaw
+  - dsh-plugin
+source:
+  repository: https://github.com/shrekcg/dsh-im-channel
+  repositoryNodeId: R_kgDOT5Emvw
+  subpath: null
+  commit: fb64263341fba403a051b3c3fa9875933c425f8c
+creator:
+  github: shrekcg
+package:
+  ecosystem: npm
+  name: dsh-im-channel
+  version: 0.2.1
+  integrity: sha512-nKJvw2Qz3P1ZuXE1KCzHi1SPZ37aj6NefBVnWeUy/iDf/7SEvRBibGS4iVy/SujhTMMCO3DeugkHMf+hfjBElw==
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:46.927Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shrekcg-dsh-im-channel`
- Submission type: community curation
- Created by `shrekcg` — https://github.com/shrekcg
- Original source repository: https://github.com/shrekcg/dsh-im-channel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.