### PR TITLE
catalog: add shrekcg-dsh-lark-bridge-web (community curation, created by @shrekcg)

### DIFF
--- a/catalog/plugins/shrekcg-dsh-lark-bridge-web.yaml
+++ b/catalog/plugins/shrekcg-dsh-lark-bridge-web.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: shrekcg-dsh-lark-bridge-web
+name: dsh-lark-bridge-web
+description:
+  en: "DSH web GUI plugin: IM 机器人 tab in plugin settings — Feishu channel status"
+  evidencePath: web-plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - settings
+  - feishu
+  - channel
+  - status
+  - dsh
+source:
+  repository: https://github.com/shrekcg/dsh-im-channel
+  repositoryNodeId: R_kgDOT5Emvw
+  subpath: web-plugin
+  commit: fb64263341fba403a051b3c3fa9875933c425f8c
+creator:
+  github: shrekcg
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: web-plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:46.927Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shrekcg-dsh-lark-bridge-web`
- Submission type: community curation
- Created by `shrekcg` — https://github.com/shrekcg
- Original source repository: https://github.com/shrekcg/dsh-im-channel
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.