### PR TITLE
catalog: add sim-xia-dsh-vscode-theme (community curation, created by @Sim-xia)

### DIFF
--- a/catalog/plugins/sim-xia-dsh-vscode-theme.yaml
+++ b/catalog/plugins/sim-xia-dsh-vscode-theme.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: sim-xia-dsh-vscode-theme
+name: dsh-vscode-theme
+description:
+  en: Import VS Code .vsix themes into DeepSeek Harness Web
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - vscode
+  - theme
+  - vsix
+  - theme-importer
+  - dsh
+source:
+  repository: https://github.com/Sim-xia/dsh-vscode-theme
+  repositoryNodeId: R_kgDOT5EDpQ
+  subpath: null
+  commit: 1e22fa74783f5f84e7ecb8d7b96fb2997dc9d4f8
+creator:
+  github: Sim-xia
+package:
+  ecosystem: npm
+  name: dsh-vscode-theme
+  version: 0.1.0
+  integrity: sha512-ycsUCMhB58J/eIX4gEXZQIfhX6/K/r52KipHYOMfhBOEItLdHvErUBSeoLKWsAwPCZqSqzg7+rIcyEUoyxbIwA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:57.201Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sim-xia-dsh-vscode-theme`
- Submission type: community curation
- Created by `Sim-xia` — https://github.com/Sim-xia
- Original source repository: https://github.com/Sim-xia/dsh-vscode-theme
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.