### PR TITLE
catalog: add singleone-dsh-notify-center (community curation, created by @SingleOne)

### DIFF
--- a/catalog/plugins/singleone-dsh-notify-center.yaml
+++ b/catalog/plugins/singleone-dsh-notify-center.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: singleone-dsh-notify-center
+name: dsh-notify-center
+description:
+  en: Unified native desktop and webhook notifications for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - notification
+  - webhook
+  - toast
+source:
+  repository: https://github.com/SingleOne/dsh-notify-center
+  repositoryNodeId: R_kgDOT5pWpQ
+  subpath: null
+  commit: c8a38ab945bfdaa8cd240fbe1ebfd4a55183cc5b
+creator:
+  github: SingleOne
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:44.547Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `singleone-dsh-notify-center`
- Submission type: community curation
- Created by `SingleOne` — https://github.com/SingleOne
- Original source repository: https://github.com/SingleOne/dsh-notify-center
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.