### PR TITLE
catalog: add skitse-dsh-dev-actions (community curation, created by @skitse)

### DIFF
--- a/catalog/plugins/skitse-dsh-dev-actions.yaml
+++ b/catalog/plugins/skitse-dsh-dev-actions.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: skitse-dsh-dev-actions
+name: dsh-dev-actions
+description:
+  en: AI turns repeated dev commands, prompts, and instructions into one-click DeepSeek Harness actions.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - ai-agent
+  - developer-tools
+  - human-in-the-loop
+  - workflow-automation
+  - flutter
+  - dev-server
+  - prompt
+  - productivity
+source:
+  repository: https://github.com/skitse/dsh-dev-actions
+  repositoryNodeId: R_kgDOT3qjxA
+  subpath: null
+  commit: ba3428e4101a9451ee87361a49c71787ef6898e7
+creator:
+  github: skitse
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:57.209Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/skitse/dsh-dev-actions/ba3428e4101a9451ee87361a49c71787ef6898e7/docs/assets/dev-actions-panel.png
+    alt: DSH 快捷动作面板，展示命令、Prompt 和 AI 指令三种可复用动作


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `skitse-dsh-dev-actions`
- Submission type: community curation
- Created by `skitse` — https://github.com/skitse
- Original source repository: https://github.com/skitse/dsh-dev-actions
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.