### PR TITLE
catalog: add skyloveqiu-dsh-finreport (community curation, created by @SkyloveQiu)

### DIFF
--- a/catalog/plugins/skyloveqiu-dsh-finreport.yaml
+++ b/catalog/plugins/skyloveqiu-dsh-finreport.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: skyloveqiu-dsh-finreport
+name: dsh-finreport
+description:
+  en: sh dsh plugin --profile web add file:/path/to/dsh-finreport
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - profile
+  - file
+  - path
+  - finreport
+  - dsh
+source:
+  repository: https://github.com/SkyloveQiu/dsh-finreport
+  repositoryNodeId: R_kgDOT7puEw
+  subpath: null
+  commit: ffc2987a8c6938cb26132dfa6b848274497c2c65
+creator:
+  github: SkyloveQiu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:58.125Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `skyloveqiu-dsh-finreport`
- Submission type: community curation
- Created by `SkyloveQiu` — https://github.com/SkyloveQiu
- Original source repository: https://github.com/SkyloveQiu/dsh-finreport
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.