### PR TITLE
catalog: add small-miao-dsh-statusbar (community curation, created by @Small-Miao)

### DIFF
--- a/catalog/plugins/small-miao-dsh-statusbar.yaml
+++ b/catalog/plugins/small-miao-dsh-statusbar.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: small-miao-dsh-statusbar
+name: dsh-statusbar
+description:
+  en: "VSCode-like bottom status bar for DSH Web: conversation token usage, host CPU/memory with Linux-style colored char bars, clock, and a public API for other plugins."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - vscode
+  - bottom
+  - status
+  - conversation
+  - token
+  - usage
+  - host
+  - memory
+  - linux
+  - style
+  - colored
+  - char
+  - bars
+  - clock
+  - public
+  - other
+source:
+  repository: https://github.com/Small-Miao/dsh-statusbar
+  repositoryNodeId: R_kgDOT419XQ
+  subpath: null
+  commit: a5a9cd026533dfd57f3b88a6fea11f591a5a1d22
+creator:
+  github: Small-Miao
+package:
+  ecosystem: npm
+  name: dsh-statusbar
+  version: 0.1.0
+  integrity: sha512-/7yACbJE6Ui2R9BbCdjA5khhzDuzO/ND+rz56Rhom2GGc1y7jN/k80mR4so3IAARyJpGSmFAuTTx0TzD7fpI4A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:58.729Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `small-miao-dsh-statusbar`
- Submission type: community curation
- Created by `Small-Miao` — https://github.com/Small-Miao
- Original source repository: https://github.com/Small-Miao/dsh-statusbar
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.