### PR TITLE
catalog: add spoon-man569-dsh-token-price (community curation, created by @spoon-man569)

### DIFF
--- a/catalog/plugins/spoon-man569-dsh-token-price.yaml
+++ b/catalog/plugins/spoon-man569-dsh-token-price.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: spoon-man569-dsh-token-price
+name: dsh-token-price
+description:
+  en: Live token cost + account balance readouts for the DeepSeek Harness Web UI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - token
+  - cost
+  - price
+  - balance
+source:
+  repository: https://github.com/spoon-man569/dsh-token-price
+  repositoryNodeId: R_kgDOT5AAPQ
+  subpath: null
+  commit: c39f26f0589e1e618eea59711c0e993bdfabe8b7
+creator:
+  github: spoon-man569
+package:
+  ecosystem: npm
+  name: dsh-token-price
+  version: 0.2.0
+  integrity: sha512-0caABTg8xv1GT+QGPk+Q7W65TgubProE7S/nLM9yGSYhp/H0r2Jy3nWeU3c+2+JA7jgOHTvhDA1NWr35dXq5Xg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:59.067Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `spoon-man569-dsh-token-price`
- Submission type: community curation
- Created by `spoon-man569` — https://github.com/spoon-man569
- Original source repository: https://github.com/spoon-man569/dsh-token-price
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.