### PR TITLE
catalog: add sqfcyily-dsh-workspace-files (community curation, created by @sqfcyily)

### DIFF
--- a/catalog/plugins/sqfcyily-dsh-workspace-files.yaml
+++ b/catalog/plugins/sqfcyily-dsh-workspace-files.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: sqfcyily-dsh-workspace-files
+name: dsh-workspace-files
+description:
+  en: Browse the directories/files of the workspace in DeepSeek Harness Web GUI and display file changes in conjunction with Git.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - workspace
+  - file-browser
+  - git-diff
+source:
+  repository: https://github.com/sqfcyily/dsh-workspace-files
+  repositoryNodeId: R_kgDOUDeCJw
+  subpath: null
+  commit: 68a322f9884cfa4ec5552e3116ab769c97ec9c47
+creator:
+  github: sqfcyily
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:45.136Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/sqfcyily/dsh-workspace-files/68a322f9884cfa4ec5552e3116ab769c97ec9c47/docs/155158.png
+    alt: workspace-files 截图


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sqfcyily-dsh-workspace-files`
- Submission type: community curation
- Created by `sqfcyily` — https://github.com/sqfcyily
- Original source repository: https://github.com/sqfcyily/dsh-workspace-files
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.