### PR TITLE
catalog: add sryimnoob123-dsh-global-prompt (community curation, created by @sryimnoob123)

### DIFF
--- a/catalog/plugins/sryimnoob123-dsh-global-prompt.yaml
+++ b/catalog/plugins/sryimnoob123-dsh-global-prompt.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: sryimnoob123-dsh-global-prompt
+name: dsh-global-prompt
+description:
+  en: bash dsh plugin --profile <你的profile add dsh-global-prompt
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - bash
+  - profile
+  - global
+  - prompt
+  - dsh
+source:
+  repository: https://github.com/sryimnoob123/dsh-global-prompt
+  repositoryNodeId: R_kgDOUDowcA
+  subpath: null
+  commit: de3c329a28e8e611dcdbfc477a3599f258cea77a
+creator:
+  github: sryimnoob123
+package:
+  ecosystem: npm
+  name: dsh-global-prompt
+  version: 0.1.2
+  integrity: sha512-7N8NGHbMZmt0uP9UfU5+Mc++jlCyEAXpxuv9ewcP7qzz573jNquaoe3jGL4zB+3lKXHDyM90ryJKdztALGVq5w==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:02.991Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sryimnoob123-dsh-global-prompt`
- Submission type: community curation
- Created by `sryimnoob123` — https://github.com/sryimnoob123
- Original source repository: https://github.com/sryimnoob123/dsh-global-prompt
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.