### PR TITLE
catalog: add sryimnoob123-dsh-tool-pwsh-safe (community curation, created by @sryimnoob123)

### DIFF
--- a/catalog/plugins/sryimnoob123-dsh-tool-pwsh-safe.yaml
+++ b/catalog/plugins/sryimnoob123-dsh-tool-pwsh-safe.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: sryimnoob123-dsh-tool-pwsh-safe
+name: dsh-tool-pwsh-safe
+description:
+  en: "Elbow-proof PowerShell for DeepSeek Harness: run multiline pwsh scripts via -EncodedCommand, immune to quoting/escaping pain."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - powershell
+  - pwsh
+  - tool
+source:
+  repository: https://github.com/sryimnoob123/dsh-tool-pwsh-safe
+  repositoryNodeId: R_kgDOT-7ffw
+  subpath: null
+  commit: af74e2c208ab1315b4c8d0e902b31364cc188cc5
+creator:
+  github: sryimnoob123
+package:
+  ecosystem: npm
+  name: dsh-tool-pwsh-safe
+  version: 0.1.1
+  integrity: sha512-9s258slTDE1yIGaPPWv6vc5TTQHU5/jwpvZBoz2RareCXWwrxSDDJMx5QaFVzc7CCjYIlKjcJxtjC6fYkZn/7w==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:04.118Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sryimnoob123-dsh-tool-pwsh-safe`
- Submission type: community curation
- Created by `sryimnoob123` — https://github.com/sryimnoob123
- Original source repository: https://github.com/sryimnoob123/dsh-tool-pwsh-safe
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.