### PR TITLE
catalog: add stakeswky-awesome-dsh (community curation, created by @stakeswky)

### DIFF
--- a/catalog/plugins/stakeswky-awesome-dsh.yaml
+++ b/catalog/plugins/stakeswky-awesome-dsh.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: stakeswky-awesome-dsh
+name: awesome-dsh
+description:
+  en: Auto-updating catalog of the dsh-plugin topic, plus an on-demand agent skill that finds and installs DeepSeek Harness plugins for a stated need.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - agent-skill
+  - plugin-discovery
+source:
+  repository: https://github.com/stakeswky/awesome-dsh
+  repositoryNodeId: R_kgDOT5VyoA
+  subpath: null
+  commit: eba902820d847b68b3ae674ed1bcd8d927710e6e
+creator:
+  github: stakeswky
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:59.106Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `stakeswky-awesome-dsh`
- Submission type: community curation
- Created by `stakeswky` — https://github.com/stakeswky
- Original source repository: https://github.com/stakeswky/awesome-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.