### PR TITLE
catalog: add starfie1d1272-dsh-github-skills (community curation, created by @Starfie1d1272)

### DIFF
--- a/catalog/plugins/starfie1d1272-dsh-github-skills.yaml
+++ b/catalog/plugins/starfie1d1272-dsh-github-skills.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: starfie1d1272-dsh-github-skills
+name: dsh-github-skills
+description:
+  en: GitHub workflow skills for DeepSeek Harness, adapted from OpenAI Codex GitHub workflow semantics.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - dsh-skill
+  - deepseek-harness
+  - github-actions
+  - code-review
+  - agent-skills
+  - developer-tools
+  - git
+  - codex
+  - github-workflows
+  - workflow-orchestration
+  - dsh
+source:
+  repository: https://github.com/Starfie1d1272/dsh-github-skills
+  repositoryNodeId: R_kgDOT5TF8A
+  subpath: null
+  commit: 101d90ff3fb6e1185c1972859c50fc1e95c9e469
+creator:
+  github: Starfie1d1272
+package:
+  ecosystem: npm
+  name: dsh-github-skills
+  version: 0.2.1
+  integrity: sha512-RrR+p1q1+3CPtVwvbYPQpD5O7V2+AdM7nhr9xDNk1Fy9YpS43zgccwXNDq2aEppzaNimiuPWlkOXYBC01dPoAQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:45.094Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Starfie1d1272/dsh-github-skills/101d90ff3fb6e1185c1972859c50fc1e95c9e469/docs/assets/dsh-github-skills-architecture.png
+    alt: dsh-github-skills 架构概览：从 Codex 工作流语义基线到 DSH 多 provider 生态


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `starfie1d1272-dsh-github-skills`
- Submission type: community curation
- Created by `Starfie1d1272` — https://github.com/Starfie1d1272
- Original source repository: https://github.com/Starfie1d1272/dsh-github-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.