### PR TITLE
catalog: add sujiu222-dsh-one-click-archive (community curation, created by @sujiu222)

### DIFF
--- a/catalog/plugins/sujiu222-dsh-one-click-archive.yaml
+++ b/catalog/plugins/sujiu222-dsh-one-click-archive.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sujiu222-dsh-one-click-archive
+name: dsh-one-click-archive
+description:
+  en: One-click time-based conversation archiving for the DeepSeek Harness Web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - archive
+  - conversation
+  - cleanup
+source:
+  repository: https://github.com/sujiu222/dsh-one-click-archive
+  repositoryNodeId: R_kgDOUAr1Yw
+  subpath: null
+  commit: 80554098d7b940fda37f910de47a5e7a24e2dc6e
+creator:
+  github: sujiu222
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:15.743Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/sujiu222/dsh-one-click-archive/80554098d7b940fda37f910de47a5e7a24e2dc6e/assets/settings-one-click-archive.png
+    alt: One-click archive settings


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sujiu222-dsh-one-click-archive`
- Submission type: community curation
- Created by `sujiu222` — https://github.com/sujiu222
- Original source repository: https://github.com/sujiu222/dsh-one-click-archive
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.