### PR TITLE
catalog: add suntianc-dsh-antigravity-auth (community curation, created by @suntianc)

### DIFF
--- a/catalog/plugins/suntianc-dsh-antigravity-auth.yaml
+++ b/catalog/plugins/suntianc-dsh-antigravity-auth.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: suntianc-dsh-antigravity-auth
+name: dsh-antigravity-auth
+description:
+  en: Private, single-account, unofficial Antigravity OAuth capability bundle for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - private
+  - single
+  - account
+  - unofficial
+  - antigravity
+  - oauth
+  - capability
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/suntianc/dsh-antigravity-auth
+  repositoryNodeId: R_kgDOT_NeeQ
+  subpath: null
+  commit: 315df057ecd0e19c47833588b3b43c2e7e671524
+creator:
+  github: suntianc
+package:
+  ecosystem: npm
+  name: dsh-antigravity-auth
+  version: 0.1.2
+  integrity: sha512-+36EchyevZ61BgSfjv1J/8q6pnyY40qSq2vBnH+wMWyhkIOCwJTbClBBluWSCnRxpBZtsm3dPPYgOeoGERHJdw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:46.431Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `suntianc-dsh-antigravity-auth`
- Submission type: community curation
- Created by `suntianc` — https://github.com/suntianc
- Original source repository: https://github.com/suntianc/dsh-antigravity-auth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.