### PR TITLE
catalog: add suntianc-dsh-codex-auth (community curation, created by @suntianc)

### DIFF
--- a/catalog/plugins/suntianc-dsh-codex-auth.yaml
+++ b/catalog/plugins/suntianc-dsh-codex-auth.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: suntianc-dsh-codex-auth
+name: dsh-codex-auth
+description:
+  en: One DeepSeek Harness Codex capability bundle for ChatGPT login, LLM access, Web Search, and durable Image Creation
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - codex
+  - chatgpt
+  - oauth
+  - web-search
+  - image-generation
+  - dsh
+source:
+  repository: https://github.com/suntianc/dsh-codex-auth
+  repositoryNodeId: R_kgDOT36FGw
+  subpath: null
+  commit: c3550ad56f1d40baef1fc64eb40297eb279caa71
+creator:
+  github: suntianc
+package:
+  ecosystem: npm
+  name: dsh-codex-auth
+  version: 0.3.1
+  integrity: sha512-xZrC9eAOrPrjzqyybjWStgFuPNMmT8jQquGwZwkMI5OqvXBgYzMW+k9pRfdVsXpeI0vc39NpuZDUYqE0nkm8JQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:42.895Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 13
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `suntianc-dsh-codex-auth`
- Submission type: community curation
- Created by `suntianc` — https://github.com/suntianc
- Original source repository: https://github.com/suntianc/dsh-codex-auth
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.