### PR TITLE
catalog: add suntianc-dsh-ui-settings-icons (community curation, created by @suntianc)

### DIFF
--- a/catalog/plugins/suntianc-dsh-ui-settings-icons.yaml
+++ b/catalog/plugins/suntianc-dsh-ui-settings-icons.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: suntianc-dsh-ui-settings-icons
+name: dsh-ui-settings-icons
+description:
+  en: DeepSeek Harness UI extension plugin providing customizable icons and keyed icon slot for settings sections
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - settings
+  - icons
+  - ui
+  - dsh
+source:
+  repository: https://github.com/suntianc/dsh-ui-settings-icons
+  repositoryNodeId: R_kgDOT_XlUw
+  subpath: null
+  commit: 432c227365764ab99e58a11fabb030c69198394b
+creator:
+  github: suntianc
+package:
+  ecosystem: npm
+  name: dsh-ui-settings-icons
+  version: 0.1.2
+  integrity: sha512-cE9FTMwMCEQ0Zx+E4KuvNEh5X9l9IzE3ru6EHyE4X0NqvoYlNBkxo4IHKJk2tk2hOkCOPg7CWRs79frRq7+mIw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:04.582Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `suntianc-dsh-ui-settings-icons`
- Submission type: community curation
- Created by `suntianc` — https://github.com/suntianc
- Original source repository: https://github.com/suntianc/dsh-ui-settings-icons
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.