### PR TITLE
catalog: add swaylq-dsh-genie (community curation, created by @swaylq)

### DIFF
--- a/catalog/plugins/swaylq-dsh-genie.yaml
+++ b/catalog/plugins/swaylq-dsh-genie.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: swaylq-dsh-genie
+name: dsh-genie
+description:
+  en: Wishes that outlive the session — turn a DeepSeek Harness agent's runtime plugins into permanently installed ones, with no pnpm, no network, and no build authorization.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - cordis
+  - ai-agents
+source:
+  repository: https://github.com/swaylq/dsh-genie
+  repositoryNodeId: R_kgDOT5AJcg
+  subpath: null
+  commit: d917d28c7d903de8247771cbf6ad09c6b1a0bae7
+creator:
+  github: swaylq
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:00.116Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `swaylq-dsh-genie`
- Submission type: community curation
- Created by `swaylq` — https://github.com/swaylq
- Original source repository: https://github.com/swaylq/dsh-genie
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.