### PR TITLE
catalog: add swd146296-dsh-memos-bridge (community curation, created by @Swd146296)

### DIFF
--- a/catalog/plugins/swd146296-dsh-memos-bridge.yaml
+++ b/catalog/plugins/swd146296-dsh-memos-bridge.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: swd146296-dsh-memos-bridge
+name: dsh-memos-bridge
+description:
+  en: "DeepSeek Harness bundle that bridges the MemOS memory service into the agent over MCP: add, search, update and manage memories as native tools (mcp memos )."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - deepseek-harness
+  - memos
+  - memory
+  - mcp
+  - long-term-memory
+source:
+  repository: https://github.com/Swd146296/dsh-memos-bridge
+  repositoryNodeId: R_kgDOT-SwEQ
+  subpath: null
+  commit: 15fe5e381a9060d8688f9e612babe90d54b303c8
+creator:
+  github: Swd146296
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:00.438Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `swd146296-dsh-memos-bridge`
- Submission type: community curation
- Created by `Swd146296` — https://github.com/Swd146296
- Original source repository: https://github.com/Swd146296/dsh-memos-bridge
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.