### PR TITLE
catalog: add tancheng33-dsh-code-runtime-container (community curation, created by @tancheng33)

### DIFF
--- a/catalog/plugins/tancheng33-dsh-code-runtime-container.yaml
+++ b/catalog/plugins/tancheng33-dsh-code-runtime-container.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: tancheng33-dsh-code-runtime-container
+name: dsh-code-runtime-container
+description:
+  en: "Container-isolated backend for the DeepSeek Harness code-execution seam: Code Mode programs run in a fresh container with no network, a read-only rootfs, and kernel-enforced memory, CPU, and pid ceilings"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - code-runtime
+  - code-mode
+  - sandbox
+  - container
+  - docker
+  - isolation
+  - security
+source:
+  repository: https://github.com/tancheng33/dsh-code-runtime-container
+  repositoryNodeId: R_kgDOT5wWng
+  subpath: null
+  commit: 635a7ccd10f74010c4d249170a82cb4366203e1d
+creator:
+  github: tancheng33
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:16.026Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tancheng33-dsh-code-runtime-container`
- Submission type: community curation
- Created by `tancheng33` — https://github.com/tancheng33
- Original source repository: https://github.com/tancheng33/dsh-code-runtime-container
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.