### PR TITLE
catalog: add tancheng33-dsh-credentials-vault (community curation, created by @tancheng33)

### DIFF
--- a/catalog/plugins/tancheng33-dsh-credentials-vault.yaml
+++ b/catalog/plugins/tancheng33-dsh-credentials-vault.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: tancheng33-dsh-credentials-vault
+name: dsh-credentials-vault
+description:
+  en: "HashiCorp Vault backend for the DeepSeek Harness credential seam: central secrets, AppRole machine auth, rotation without restart, and no long-lived provider key on the agent host"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - vault
+  - hashicorp-vault
+  - credentials
+  - secrets
+  - approle
+  - security
+source:
+  repository: https://github.com/tancheng33/dsh-credentials-vault
+  repositoryNodeId: R_kgDOT5wWbg
+  subpath: null
+  commit: 5aba0e64569913103e686f658ca6a09b011aa254
+creator:
+  github: tancheng33
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:04.949Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tancheng33-dsh-credentials-vault`
- Submission type: community curation
- Created by `tancheng33` — https://github.com/tancheng33
- Original source repository: https://github.com/tancheng33/dsh-credentials-vault
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.