### PR TITLE
catalog: add tancheng33-dsh-spill-s3 (community curation, created by @tancheng33)

### DIFF
--- a/catalog/plugins/tancheng33-dsh-spill-s3.yaml
+++ b/catalog/plugins/tancheng33-dsh-spill-s3.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: tancheng33-dsh-spill-s3
+name: dsh-spill-s3
+description:
+  en: "S3-compatible spill backend for DeepSeek Harness: oversized tool output goes to object storage (AWS S3, MinIO, R2) instead of the agent's local disk"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - spill
+  - s3
+  - minio
+  - object-storage
+  - r2
+source:
+  repository: https://github.com/tancheng33/dsh-spill-s3
+  repositoryNodeId: R_kgDOT5wWRg
+  subpath: null
+  commit: 9125bbb93e97c5535d9c0953c125dbf08acb2f94
+creator:
+  github: tancheng33
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:05.170Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tancheng33-dsh-spill-s3`
- Submission type: community curation
- Created by `tancheng33` — https://github.com/tancheng33
- Original source repository: https://github.com/tancheng33/dsh-spill-s3
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.