### PR TITLE
catalog: add tangwenhao616-netizen-dsh-clawbot (community curation, created by @tangwenhao616-netizen)

### DIFF
--- a/catalog/plugins/tangwenhao616-netizen-dsh-clawbot.yaml
+++ b/catalog/plugins/tangwenhao616-netizen-dsh-clawbot.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: tangwenhao616-netizen-dsh-clawbot
+name: dsh-clawbot
+description:
+  en: Turn your WeChat into an AI agent command center. Scan a QR code, chat with DeepSeek Harness directly from WeChat — no extra apps, no servers, no bridges.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - deepseek-harness
+  - weixin
+  - wechat
+  - ilink
+  - clawbot
+  - bundle
+  - dsh
+source:
+  repository: https://github.com/tangwenhao616-netizen/dsh-clawbot
+  repositoryNodeId: R_kgDOT75jZQ
+  subpath: null
+  commit: 77748ea665e215aab9f9e7f9890802441af5b92e
+creator:
+  github: tangwenhao616-netizen
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:48.240Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tangwenhao616-netizen-dsh-clawbot`
- Submission type: community curation
- Created by `tangwenhao616-netizen` — https://github.com/tangwenhao616-netizen
- Original source repository: https://github.com/tangwenhao616-netizen/dsh-clawbot
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.