### PR TITLE
catalog: add tangzheng202202-dsh-voice-live (community curation, created by @tangzheng202202)

### DIFF
--- a/catalog/plugins/tangzheng202202-dsh-voice-live.yaml
+++ b/catalog/plugins/tangzheng202202-dsh-voice-live.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tangzheng202202-dsh-voice-live
+name: dsh-voice-live
+description:
+  en: "Real-time voice interaction for DSH: press the composer mic, speak, and the assistant replies aloud. The package ships two halves:"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - voice
+  - asr
+  - tts
+  - volcengine
+source:
+  repository: https://github.com/tangzheng202202/dsh-voice-live
+  repositoryNodeId: R_kgDOT6T11A
+  subpath: null
+  commit: 118f56353378421123481121228b8b4a78c05462
+creator:
+  github: tangzheng202202
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:05.464Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tangzheng202202-dsh-voice-live`
- Submission type: community curation
- Created by `tangzheng202202` — https://github.com/tangzheng202202
- Original source repository: https://github.com/tangzheng202202/dsh-voice-live
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.