### PR TITLE
catalog: add tetckx-deep-structural-analysis-skill (community curation, created by @tetckx)

### DIFF
--- a/catalog/plugins/tetckx-deep-structural-analysis-skill.yaml
+++ b/catalog/plugins/tetckx-deep-structural-analysis-skill.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: tetckx-deep-structural-analysis-skill
+name: deep-structural-analysis-skill
+description:
+  en: Opt-in DeepSeek Harness Skill-only bundle for the deep-structural-analysis multi-lens structural analysis skill.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-skill
+  - structural-analysis
+  - multi-lens
+  - dsh
+source:
+  repository: https://github.com/tetckx/deep-structural-analysis-skill
+  repositoryNodeId: R_kgDOTezLnQ
+  subpath: null
+  commit: 07b5ad8564cbbb352ad93e8a733ca835e43a448e
+creator:
+  github: tetckx
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:35:51.261Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tetckx-deep-structural-analysis-skill`
- Submission type: community curation
- Created by `tetckx` — https://github.com/tetckx
- Original source repository: https://github.com/tetckx/deep-structural-analysis-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.