### PR TITLE
catalog: add tinqiao-oss-dsh-engramory (community curation, created by @tinqiao-oss)

### DIFF
--- a/catalog/plugins/tinqiao-oss-dsh-engramory.yaml
+++ b/catalog/plugins/tinqiao-oss-dsh-engramory.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: tinqiao-oss-dsh-engramory
+name: dsh-engramory
+description:
+  en: Curated file-based long-term memory for DeepSeek Harness — human-readable markdown notes, one plain-file store shared across hosts (git-ignored when it lives inside a project repo), and a deterministic index cap enforced by ctx.tools.guard()
+  evidencePath: adapters/dsh/plugin/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - dsh
+  - memory
+  - agent-memory
+  - long-term-memory
+  - engramory
+  - markdown
+source:
+  repository: https://github.com/tinqiao-oss/engramory
+  repositoryNodeId: R_kgDOS5qe6g
+  subpath: adapters/dsh/plugin
+  commit: 39efc183a55cb3d2c56e11a42b2b5e059a193ce3
+creator:
+  github: tinqiao-oss
+package:
+  ecosystem: npm
+  name: dsh-engramory
+  version: 0.2.3
+  integrity: sha512-2THdPKjjj3w5ROFwH312ArioEdLEp0JX54azd4AfJ6Tcz3vc8ATiyDrpECsFxSiaHDectR+HAI2PnkUxCp41+A==
+dsh:
+  profiles:
+    - web
+  evidencePath: adapters/dsh/plugin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:16.056Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tinqiao-oss-dsh-engramory`
- Submission type: community curation
- Created by `tinqiao-oss` — https://github.com/tinqiao-oss
- Original source repository: https://github.com/tinqiao-oss/engramory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.