### PR TITLE
catalog: add trank-dtk-dsh-skill-import (community curation, created by @Trank-DTK)

### DIFF
--- a/catalog/plugins/trank-dtk-dsh-skill-import.yaml
+++ b/catalog/plugins/trank-dtk-dsh-skill-import.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: trank-dtk-dsh-skill-import
+name: dsh-skill-import
+description:
+  en: "Skill-import plugin for DeepSeek Harness: a slash-menu entry that imports local skill folders and switches them per skill (off = no autonomous model invocation, the /name user gesture still works)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - skill
+  - import
+  - slash
+  - menu
+  - entry
+  - imports
+  - local
+  - folders
+  - switches
+  - autonomous
+  - model
+  - invocation
+  - name
+  - user
+  - gesture
+  - still
+source:
+  repository: https://github.com/Trank-DTK/dsh-skill-import
+  repositoryNodeId: R_kgDOT48Bdg
+  subpath: null
+  commit: 68b56106e232aa15e206483d184150b144c13180
+creator:
+  github: Trank-DTK
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T22:36:05.261Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `trank-dtk-dsh-skill-import`
- Submission type: community curation
- Created by `Trank-DTK` — https://github.com/Trank-DTK
- Original source repository: https://github.com/Trank-DTK/dsh-skill-import
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.