### PR TITLE
docs(schema): mirror the kind:skill contract (SKL-01 phase 0)

### DIFF
--- a/cli/tests/skill-schema.test.ts
+++ b/cli/tests/skill-schema.test.ts
@@ -1,0 +1,170 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { ValidateFunction } from "ajv";
+import Ajv2020Module from "ajv/dist/2020.js";
+import addFormatsModule from "ajv-formats";
+import { describe, expect, it } from "vitest";
+
+import { parseSafeYamlData } from "../src/catalog/publicSchema.js";
+
+/**
+ * `schemas/skill.schema.yaml` is the public mirror of the catalog-core `kind: skill` contract
+ * (SKL-01 phase 0). The CLI does not load skill entries yet — that is phase 1 — but the mirror
+ * must already compile under the exact Ajv configuration the catalog loader uses, and must
+ * accept/reject the contract's canonical shapes, so the published schema never drifts into
+ * something the loader will later refuse.
+ */
+
+const publicRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+function compileSkillSchema(): ValidateFunction {
+  const schema = parseSafeYamlData(
+    readFileSync(join(publicRoot, "schemas/skill.schema.yaml"), "utf8"),
+  ) as Record<string, unknown>;
+  // Same options as createPublicEntryValidator in src/catalog/publicSchema.ts.
+  const ajv = new Ajv2020Module.default({ allErrors: true, strict: true, validateFormats: true });
+  addFormatsModule.default(ajv);
+  return ajv.compile(schema);
+}
+
+function subdirectorySkillEntry(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    id: "alice-dsh-commit-lint-skill",
+    name: "DSH Commit Lint Skill",
+    description: {
+      en:
+        "Loads a commit-message linting skill that checks Conventional Commit shape before " +
+        "the harness commits.",
+      evidencePath: "skills/commit-lint/SKILL.md",
+    },
+    unofficial: true,
+    kind: "skill",
+    skillScope: "subdirectory",
+    primaryCategory: "coding-developer-tools",
+    tags: ["git", "linting"],
+    triggers: ["When the user asks to commit staged work"],
+    source: {
+      repository: "https://github.com/alice/dsh-skills",
+      repositoryNodeId: "R_kgDOexample1",
+      subpath: "skills/commit-lint",
+      commit: "0123456789abcdef0123456789abcdef01234567",
+    },
+    creator: { github: "alice" },
+    usage: {
+      load: "dsh skill load skills/commit-lint",
+      evidencePath: "skills/commit-lint/SKILL.md",
+    },
+    compat: { harnessMin: "1.4.0" },
+    repositoryScope: "monorepo",
+    popularity: { starsPolicy: "undefined-parent-repository", stars: null },
+    license: { spdx: "MIT" },
+    verification: {
+      status: "eligible",
+      checkedAt: "2026-08-30T12:00:00Z",
+      repositoryIdentity: "resolved",
+      smokeTest: null,
+    },
+    provenance: { discussion: null, comment: null },
+  };
+}
+
+function repositorySkillEntry(): Record<string, unknown> {
+  const entry = subdirectorySkillEntry();
+  entry.skillScope = "repository";
+  entry.source = {
+    ...(entry.source as Record<string, unknown>),
+    subpath: null,
+  };
+  entry.repositoryScope = "dedicated";
+  entry.popularity = { starsPolicy: "exact-repository", stars: 12 };
+  return entry;
+}
+
+function messages(validate: ValidateFunction): string[] {
+  return (validate.errors ?? []).map((error) => `${error.instancePath} ${error.message ?? ""}`);
+}
+
+describe("public skill schema (kind: skill mirror)", () => {
+  it("accepts a subdirectory-scoped skill entry", () => {
+    const validate = compileSkillSchema();
+    expect(validate(subdirectorySkillEntry())).toBe(true);
+  });
+
+  it("accepts a whole-repository skill entry with a null subpath", () => {
+    const validate = compileSkillSchema();
+    expect(validate(repositorySkillEntry())).toBe(true);
+  });
+
+  it("rejects the plugin-only install and gallery fields", () => {
+    const validate = compileSkillSchema();
+    const entry = subdirectorySkillEntry();
+    entry.package = { ecosystem: "source" };
+    entry.dsh = { profiles: ["default"], evidencePath: "SKILL.md" };
+    entry.media = [];
+    expect(validate(entry)).toBe(false);
+    expect(messages(validate)).toContain(" must NOT have additional properties");
+  });
+
+  it("rejects a whole-repository skill that declares a subpath", () => {
+    const validate = compileSkillSchema();
+    const entry = repositorySkillEntry();
+    entry.source = {
+      ...(entry.source as Record<string, unknown>),
+      subpath: "skills/commit-lint",
+    };
+    expect(validate(entry)).toBe(false);
+    expect(messages(validate)).toContain("/source/subpath must be null");
+  });
+
+  it("rejects a subdirectory-scoped skill without a subpath", () => {
+    const validate = compileSkillSchema();
+    const entry = subdirectorySkillEntry();
+    entry.source = {
+      ...(entry.source as Record<string, unknown>),
+      subpath: null,
+    };
+    expect(validate(entry)).toBe(false);
+    expect(messages(validate)).toContain("/source/subpath must be string");
+  });
+
+  it("rejects an empty triggers list — absence is written by omitting the field", () => {
+    const validate = compileSkillSchema();
+    const entry = subdirectorySkillEntry();
+    entry.triggers = [];
+    expect(validate(entry)).toBe(false);
+  });
+
+  it("accepts an entry without triggers, the one optional field", () => {
+    const validate = compileSkillSchema();
+    const entry = subdirectorySkillEntry();
+    delete entry.triggers;
+    expect(validate(entry)).toBe(true);
+  });
+
+  it("rejects a SemVer range in compat.harnessMin", () => {
+    const validate = compileSkillSchema();
+    const entry = subdirectorySkillEntry();
+    entry.compat = { harnessMin: "^1.4.0" };
+    expect(validate(entry)).toBe(false);
+  });
+
+  it("rejects a non-null smoke test — content review is the admission gate", () => {
+    const validate = compileSkillSchema();
+    const entry = subdirectorySkillEntry();
+    entry.verification = {
+      status: "verified",
+      checkedAt: "2026-08-30T12:00:00Z",
+      repositoryIdentity: "resolved",
+      smokeTest: {
+        installTarget: "canonical-install-descriptor",
+        check: { name: "x", version: "1.0.0" },
+        result: "passed",
+      },
+    };
+    expect(validate(entry)).toBe(false);
+    expect(messages(validate)).toContain("/verification/smokeTest must be null");
+  });
+});

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -250,6 +250,112 @@ Omit the field entirely when there is nothing to show — `media: []` is not a v
 "no screenshots". The field is additive: entries published before it existed remain valid, and a
 consumer that ignores it reads every entry exactly as before.
 
+## `kind: skill` entries
+
+Schema version 1 also defines a second, self-contained entry contract for `kind: skill`,
+published as [`schemas/skill.schema.yaml`](../schemas/skill.schema.yaml) (SKL-01 phase 0). It
+never touches the plugin schema above: entries with `kind: plugin` keep validating exactly as
+before, and the skill schema file is the source of truth for skill entries the same way the
+plugin schema is for plugin entries.
+
+A skill is not installed, it is **loaded** by the harness, so the plugin-only install
+descriptors (`package`, `dsh`) do not exist on a skill entry and are replaced by `usage` +
+`compat`. A skill also frequently lives in a subdirectory of a repository that hosts many
+skills, so identity and dedupe is `source.repository` + `source.subpath` rather than the
+repository alone. A skill entry admits no `media` gallery: a skill is text the harness loads,
+so there is nothing to screenshot (`additionalProperties: false` is what enforces it).
+
+These fields keep exactly the shape and rules documented for plugin entries above:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Every field is required
+except `triggers`, the one optional skill field.
+
+### Skill-specific fields
+
+| Field                | Type   | Required | Rules                                                       |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   yes    | Must be exactly `skill`                                     |
+| `skillScope`         | enum   |   yes    | `repository` (the whole repository **is** the skill) or `subdirectory` (the skill lives at `source.subpath`) |
+| `triggers`           | array  |    no    | When the skill fires — the text a user evaluates before loading it. At least 1 unique string, each 3–200 characters; omit the field entirely when there are none (`triggers: []` is invalid) |
+| `usage.load`         | string |   yes    | How the harness loads the skill, 1–200 characters; a skill is loaded, never installed |
+| `usage.evidencePath` | string |   yes    | Safe relative path (same pattern as `description.evidencePath`) to the load evidence at `source.commit` |
+| `compat.harnessMin`  | string |   yes    | Minimum harness version the skill was verified against; exact `x.y.z` shape (optional prerelease/build), max 64 chars. Semantic layer additionally requires a parseable, exact SemVer |
+
+Conditional rules (enforced by the skill schema's `allOf` blocks):
+
+- `skillScope: subdirectory` **forces** `source.subpath` to be a safe relative path string —
+  a skill hosted in a subdirectory must pin that subdirectory.
+- `skillScope: repository` **forces** `source.subpath: null` — a whole-repository skill must
+  not declare a subpath.
+
+`verification` keeps the plugin shape (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), but `smokeTest` must be exactly `null`: a skill has no install smoke test, and
+content review is the admission gate. The skill schema carries no `status: verified` →
+`smokeTest` conditional and no `repositoryScope` → `popularity` conditionals; those couplings
+are plugin-schema rules only.
+
+### Semantic layer for skills
+
+On top of the schema, catalog validation applies the same mandatory semantic parsers as for
+plugins where the fields exist: `license.spdx` must parse as a valid SPDX expression
+(`invalid-spdx`), and `compat.harnessMin` must be an exact SemVer (`invalid-semver`). There is
+no `invalid-sri` case — a skill has no `package.integrity`.
+
+### Skill identity and dedupe
+
+The canonical key of a skill is `skill:<source.repositoryNodeId>:<normalized subpath>`. The
+subpath is normalized for identity purposes only: backslashes become `/`, empty and `.`
+segments are dropped, and an empty result (or `subpath: null`) becomes `.` — the whole
+repository. A subpath containing NUL bytes or `..` segments is rejected, never "cleaned". Two
+skills of the same repository are two entries; the same repository + subpath twice is a
+collision.
+
+### Minimal skill example
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## What the schema does not check
 
 The schema is intentionally local and structural. It does **not** verify that the repository

--- a/docs/i18n/ar/SCHEMA.md
+++ b/docs/i18n/ar/SCHEMA.md
@@ -221,6 +221,86 @@
 لقطات شاشة". الحقل إضافي: تظل الإدخالات المنشورة قبل وجوده صالحة، ويقرأ المستهلك الذي يتجاهله كل
 إدخال تمامًا كما كان.
 
+## إدخالات `kind: skill`
+
+يُعرِّف الإصدار 1 من المخطط أيضًا عقد إدخال ثانيًا قائمًا بذاته لـ `kind: skill`، منشورًا باسم [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (المرحلة 0 من SKL-01). وهو لا يمسّ أبدًا مخطط الإضافات أعلاه: تستمر الإدخالات ذات `kind: plugin` في التحقق تمامًا كما كانت من قبل، وملف مخطط المهارة (skill) هو مصدر الحقيقة لإدخالات المهارات بنفس الطريقة التي يكون بها مخطط الإضافات مصدر الحقيقة لإدخالات الإضافات.
+
+المهارة لا تُثبَّت، بل **تُحمَّل** بواسطة بيئة التشغيل (harness)، لذا فإن واصفات التثبيت الخاصة بالإضافات فقط (`package` و`dsh`) لا وجود لها في إدخال المهارة وتُستبدل بـ `usage` + `compat`. كما تعيش المهارة كثيرًا في مجلد فرعي من مستودع يستضيف مهارات عديدة، لذا فإن الهوية وإزالة التكرار (dedupe) هما `source.repository` + `source.subpath` وليس المستودع وحده. ولا يقبل إدخال المهارة معرض `media`: فالمهارة نص تُحمِّله بيئة التشغيل، فليس هناك ما يُلتقط له لقطة شاشة (`additionalProperties: false` هو ما يفرض ذلك).
+
+تحتفظ هذه الحقول تمامًا بالشكل والقواعد الموثَّقة لإدخالات الإضافات أعلاه: `schemaVersion`، و`id`، و`name`، و`description`، و`unofficial`، و`primaryCategory`، و`tags`، و`source`، و`creator`، و`repositoryScope`، و`license`، و`provenance`. كل حقل مطلوب باستثناء `triggers`، حقل المهارة الاختياري الوحيد.
+
+### الحقول الخاصة بالمهارة
+
+| الحقل                | النوع   | مطلوب | القواعد                                                       |
+| -------------------- | ------ | :------: | ------------------------------------------------------------- |
+| `kind`               | const  |   نعم    | يجب أن يكون `skill` بالضبط                                      |
+| `skillScope`         | enum   |   نعم    | `repository` (المستودع كله **هو** المهارة) أو `subdirectory` (المهارة تعيش في `source.subpath`) |
+| `triggers`           | array  |    لا    | متى تنطلق المهارة — النص الذي يُقيِّمه المستخدم قبل تحميلها. سلسلة نصية فريدة واحدة على الأقل، كل واحدة من 3 إلى 200 حرف؛ احذف الحقل بالكامل عندما لا يوجد أي منها (`triggers: []` غير صالح) |
+| `usage.load`         | string |   نعم    | كيف تُحمِّل بيئة التشغيل المهارة، من 1 إلى 200 حرف؛ المهارة تُحمَّل ولا تُثبَّت أبدًا |
+| `usage.evidencePath` | string |   نعم    | مسار نسبي آمن (نفس نمط `description.evidencePath`) إلى دليل التحميل عند `source.commit` |
+| `compat.harnessMin`  | string |   نعم    | الحد الأدنى لإصدار بيئة التشغيل الذي تم التحقق من المهارة مقابله؛ صيغة `x.y.z` دقيقة (prerelease/build اختياريان)، بحد أقصى 64 حرفًا. تشترط الطبقة الدلالية إضافيًا SemVer دقيقًا وقابلًا للتحليل |
+
+القواعد المشروطة (مفروضة بواسطة كتل `allOf` في مخطط المهارة):
+
+- يفرض `skillScope: subdirectory` أن يكون `source.subpath` سلسلة مسار نسبي آمن — المهارة المستضافة في مجلد فرعي يجب أن تُثبِّت ذلك المجلد الفرعي.
+- يفرض `skillScope: repository` القيمة `source.subpath: null` — مهارة المستودع الكامل يجب ألا تُعلن مسارًا فرعيًا.
+
+يحتفظ `verification` بشكل الإضافات (`status`، و`checkedAt`، و`repositoryIdentity`، و`smokeTest`)، لكن `smokeTest` يجب أن يكون `null` بالضبط: فالمهارة لا تملك اختبار تشغيل سريع للتثبيت، ومراجعة المحتوى هي بوابة القبول. لا يحمل مخطط المهارة شرط `status: verified` → `smokeTest` ولا شروط `repositoryScope` → `popularity`؛ فهذه الارتباطات قواعد خاصة بمخطط الإضافات فقط.
+
+### الطبقة الدلالية للمهارات
+
+فوق المخطط، يُطبِّق التحقق من الكتالوج نفس المُحلِّلات الدلالية الإلزامية المُطبَّقة على الإضافات حيثما وُجدت الحقول: يجب أن يُحلَّل `license.spdx` كتعبير SPDX صالح (`invalid-spdx`)، ويجب أن يكون `compat.harnessMin` بصيغة SemVer دقيقة (`invalid-semver`). ولا توجد حالة `invalid-sri` — فالمهارة لا تملك `package.integrity`.
+
+### هوية المهارة وإزالة التكرار
+
+المفتاح القانوني للمهارة هو `skill:<source.repositoryNodeId>:<normalized subpath>`. يُطبَّع المسار الفرعي لأغراض الهوية فقط: تتحول الشرطات المائلة العكسية إلى `/`، وتُحذف المقاطع الفارغة ومقاطع `.`، والنتيجة الفارغة (أو `subpath: null`) تصبح `.` — أي المستودع كله. أما المسار الفرعي الذي يحتوي على بايتات NUL أو مقاطع `..` فيُرفض ولا "يُنظَّف" أبدًا. مهارتان من نفس المستودع هما إدخالان؛ ونفس المستودع + المسار الفرعي مرتين هو تصادم.
+
+### مثال مهارة بالحد الأدنى
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## ما لا يفحصه المخطط
 
 المخطط محلي وبنيوي عمدًا. وهو لا يتحقق من وجود المستودع، أو تطابق معرّف العقدة مع عنوان URL، أو وجود مسارات الأدلة عند الالتزام المثبَّت، أو دقة عدد النجوم، أو ملكية المنشئ للمصدر. تنتمي تلك الفحوصات إلى بوابات مراجعة المشرفين الموصوفة في [CONTRIBUTING.md](../../CONTRIBUTING.md) و[docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).

--- a/docs/i18n/az/SCHEMA.md
+++ b/docs/i18n/az/SCHEMA.md
@@ -254,6 +254,112 @@ Göstəriləcək bir şey yoxdursa sahəni tamamilə buraxın — `media: []` "e
 demək üçün etibarlı yol deyil. Sahə əlavədir: o mövcud olmazdan əvvəl dərc edilmiş qeydlər
 etibarlı qalır və onu nəzərə almayan istehlakçı hər qeydi əvvəlki kimi oxuyur.
 
+## `kind: skill` qeydləri
+
+Sxem versiyası 1 həmçinin `kind: skill` üçün ikinci, özündə tam qeyd kontraktı müəyyən edir —
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) kimi dərc edilib (SKL-01 faza 0).
+O, yuxarıdakı plagin sxeminə heç vaxt toxunmur: `kind: plugin` olan qeydlər əvvəlki kimi dəqiq
+doğrulanmağa davam edir və skill sxem faylı skill qeydləri üçün həqiqət mənbəyidir — eynilə
+plagin sxeminin plagin qeydləri üçün olduğu kimi.
+
+Skill quraşdırılmır, harness tərəfindən **yüklənir**, buna görə də yalnız plaginlərə aid
+quraşdırma deskriptorları (`package`, `dsh`) skill qeydində mövcud deyil və `usage` + `compat`
+ilə əvəz olunur. Skill həmçinin tez-tez çoxlu skill saxlayan repozitoriyanın alt qovluğunda
+yaşayır, buna görə də kimlik və dedupe yalnız repozitoriya deyil, `source.repository` +
+`source.subpath`-dır. Skill qeydi heç bir `media` qalereyasına icazə vermir: skill harness-in
+yüklədiyi mətndir, yəni ekran görüntüsü alınacaq bir şey yoxdur (bunu tətbiq edən
+`additionalProperties: false`-dır).
+
+Bu sahələr yuxarıda plagin qeydləri üçün sənədləşdirilmiş forma və qaydaları dəqiq saxlayır:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Yeganə isteğe bağlı skill
+sahəsi olan `triggers` istisna olmaqla, hər sahə tələb olunur.
+
+### Skill-ə xas sahələr
+
+| Sahə                 | Növ    | Tələb olunur | Qaydalar                                                    |
+| -------------------- | ------ | :----------: | ----------------------------------------------------------- |
+| `kind`               | const  |     bəli     | Dəqiq `skill` olmalıdır                                     |
+| `skillScope`         | enum   |     bəli     | `repository` (bütün repozitoriya **elə** skill-dir) və ya `subdirectory` (skill `source.subpath` ünvanında yaşayır) |
+| `triggers`           | array  |     xeyr     | Skill-in nə vaxt işə düşdüyü — istifadəçinin onu yükləməzdən əvvəl qiymətləndirdiyi mətn. Ən azı 1 unikal string, hər biri 3–200 simvol; heç biri olmadıqda sahəni tamamilə buraxın (`triggers: []` etibarsızdır) |
+| `usage.load`         | string |     bəli     | Harness-in skill-i necə yüklədiyi, 1–200 simvol; skill yüklənir, heç vaxt quraşdırılmır |
+| `usage.evidencePath` | string |     bəli     | `source.commit` anında yükləmə sübutuna təhlükəsiz nisbi yol (`description.evidencePath` ilə eyni nümunə) |
+| `compat.harnessMin`  | string |     bəli     | Skill-in yoxlanıldığı minimal harness versiyası; dəqiq `x.y.z` forması (isteğe bağlı prerelease/build), maksimum 64 simvol. Semantik qat əlavə olaraq parser-lənə bilən, dəqiq SemVer tələb edir |
+
+Şərti qaydalar (skill sxeminin `allOf` blokları tərəfindən tətbiq edilir):
+
+- `skillScope: subdirectory` `source.subpath`-ın təhlükəsiz nisbi yol string-i olmasını
+  **məcbur edir** — alt qovluqda yerləşən skill həmin alt qovluğu sabitləməlidir.
+- `skillScope: repository` `source.subpath: null` dəyərini **məcbur edir** — bütöv
+  repozitoriya olan skill alt yol bəyan etməməlidir.
+
+`verification` plagin formasını saxlayır (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), lakin `smokeTest` dəqiq `null` olmalıdır: skill-in quraşdırma tüstü-sınağı
+yoxdur və qəbul qapısı məzmun baxışıdır. Skill sxemi heç bir `status: verified` → `smokeTest`
+şərtini və heç bir `repositoryScope` → `popularity` şərtlərini daşımır; bu bağlılıqlar yalnız
+plagin sxeminin qaydalarıdır.
+
+### Skill-lər üçün semantik qat
+
+Sxemin üstündə kataloq doğrulaması sahələr mövcud olduğu yerlərdə plaginlərdəki eyni məcburi
+semantik parser-ləri tətbiq edir: `license.spdx` etibarlı SPDX ifadəsi kimi parser-lənməlidir
+(`invalid-spdx`) və `compat.harnessMin` dəqiq SemVer olmalıdır (`invalid-semver`).
+`invalid-sri` halı mövcud deyil — skill-in `package.integrity` sahəsi yoxdur.
+
+### Skill kimliyi və dedupe
+
+Skill-in kanonik açarı `skill:<source.repositoryNodeId>:<normalized subpath>`-dır. Alt yol
+yalnız kimlik məqsədləri üçün normallaşdırılır: tərs çəp xətlər `/`-ə çevrilir, boş və `.`
+seqmentləri atılır və boş nəticə (və ya `subpath: null`) `.` olur — bütöv repozitoriya. NUL
+baytları və ya `..` seqmentləri olan alt yol rədd edilir, heç vaxt "təmizlənmir". Eyni
+repozitoriyanın iki skill-i iki qeyddir; eyni repozitoriya + alt yol iki dəfə isə kolliziyadır.
+
+### Minimal skill nümunəsi
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Sxemin yoxlamadığı şeylər
 
 Sxem qəsdən yerli və strukturaldır. O, repozitoriyanın mövcud olduğunu, node ID-nin URL-ə

--- a/docs/i18n/bg/SCHEMA.md
+++ b/docs/i18n/bg/SCHEMA.md
@@ -257,6 +257,113 @@ URL тук трябва да е също толкова непроменим, к
 каже „без екранни снимки“. Полето е добавъчно: записите, публикувани преди то да съществува,
 остават валидни, а потребител, който го игнорира, чете всеки запис точно както преди.
 
+## Записи `kind: skill`
+
+Схема версия 1 определя също втори, самостоятелен договор за запис за `kind: skill`,
+публикуван като [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01 фаза 0).
+Той никога не докосва схемата за плъгини по-горе: записите с `kind: plugin` продължават да се
+валидират точно както преди, а файлът на skill схемата е източникът на истина за записите на
+skill-ове по същия начин, по който схемата за плъгини е за записите на плъгини.
+
+Един skill не се инсталира, той се **зарежда** от harness-а, така че дескрипторите за
+инсталация само за плъгини (`package`, `dsh`) не съществуват върху запис на skill и се заменят
+от `usage` + `compat`. Един skill също често живее в поддиректория на хранилище, което
+приютява много skill-ове, така че идентичността и дедупликацията са `source.repository` +
+`source.subpath`, а не само хранилището. Запис на skill не допуска галерия `media`: skill-ът е
+текст, който harness-ът зарежда, така че няма какво да се снима
+(`additionalProperties: false` е това, което го налага).
+
+Тези полета запазват точно формата и правилата, документирани за записите на плъгини по-горе:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Всяко поле е задължително с
+изключение на `triggers`, единственото незадължително поле на skill.
+
+### Полета, специфични за skill
+
+| Поле                 | Тип    | Задължително | Правила                                                     |
+| -------------------- | ------ | :----------: | ----------------------------------------------------------- |
+| `kind`               | const  |      да      | Трябва да е точно `skill`                                   |
+| `skillScope`         | enum   |      да      | `repository` (цялото хранилище **е** skill-ът) или `subdirectory` (skill-ът живее в `source.subpath`) |
+| `triggers`           | array  |      не      | Кога skill-ът се задейства — текстът, който потребителят оценява, преди да го зареди. Поне 1 уникален низ, всеки от 3–200 символа; пропуснете полето изцяло, когато няма такива (`triggers: []` е невалидно) |
+| `usage.load`         | string |      да      | Как harness-ът зарежда skill-а, 1–200 символа; skill се зарежда, никога не се инсталира |
+| `usage.evidencePath` | string |      да      | Безопасен относителен път (същия образец като `description.evidencePath`) до доказателството за зареждане при `source.commit` |
+| `compat.harnessMin`  | string |      да      | Минимална версия на harness-а, срещу която skill-ът е бил верифициран; точна `x.y.z` форма (по избор prerelease/build), максимум 64 символа. Семантичният слой допълнително изисква разпознаваем точен SemVer |
+
+Условни правила (наложени от блоковете `allOf` на skill схемата):
+
+- `skillScope: subdirectory` **налага** `source.subpath` да е низ с безопасен относителен
+  път — skill, разположен в поддиректория, трябва да закрепи тази поддиректория.
+- `skillScope: repository` **налага** `source.subpath: null` — skill, обхващащ цяло хранилище,
+  не трябва да декларира подпът.
+
+`verification` запазва формата от плъгините (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), но `smokeTest` трябва да е точно `null`: skill няма инсталационен smoke test, а
+рецензията на съдържанието е gate-ът за допускане. Skill схемата не носи условието
+`status: verified` → `smokeTest`, нито условията `repositoryScope` → `popularity`; тези
+обвързвания са правила само на схемата за плъгини.
+
+### Семантичен слой за skill-ове
+
+Върху схемата валидацията на каталога прилага същите задължителни семантични парсери като при
+плъгините, там където полетата съществуват: `license.spdx` трябва да се разпознае като валиден
+SPDX израз (`invalid-spdx`), а `compat.harnessMin` трябва да е точен SemVer
+(`invalid-semver`). Няма случай `invalid-sri` — skill няма `package.integrity`.
+
+### Идентичност и дедупликация на skill
+
+Каноничният ключ на един skill е `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Подпътят се нормализира само за целите на идентичността: обратните наклонени черти стават `/`,
+празните и `.` сегментите се изхвърлят, а празен резултат (или `subpath: null`) става `.` —
+цялото хранилище. Подпът, съдържащ NUL байтове или `..` сегменти, се отхвърля, никога не се
+„почиства“. Два skill-а от едно и също хранилище са два записа; същото хранилище + подпът два
+пъти е колизия.
+
+### Минимален пример за skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Какво не проверява схемата
 
 Схемата е умишлено локална и структурна. Тя **не** проверява дали хранилището съществува, дали

--- a/docs/i18n/bn/SCHEMA.md
+++ b/docs/i18n/bn/SCHEMA.md
@@ -245,6 +245,110 @@
 উপায় নয়। ফিল্ডটি সংযোজনী: এটি থাকার আগে প্রকাশিত এন্ট্রিগুলো বৈধই থাকে, আর যে ভোক্তা এটি
 উপেক্ষা করে সে প্রতিটি এন্ট্রি আগের মতোই পড়ে।
 
+## `kind: skill` এন্ট্রি
+
+স্কিমা সংস্করণ ১ `kind: skill`-এর জন্য একটি দ্বিতীয়, স্বয়ংসম্পূর্ণ এন্ট্রি চুক্তিও সংজ্ঞায়িত করে, যা
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) হিসেবে প্রকাশিত (SKL-01 ফেজ ০)। এটি
+উপরের প্লাগইন স্কিমাকে কখনও স্পর্শ করে না: `kind: plugin`-সহ এন্ট্রিগুলি আগের মতোই ঠিক বৈধতা যাচাই
+হতে থাকে, এবং স্কিল স্কিমা ফাইলটি স্কিল এন্ট্রির জন্য সত্যের উৎস, ঠিক যেভাবে প্লাগইন স্কিমা প্লাগইন
+এন্ট্রির জন্য।
+
+একটি স্কিল ইনস্টল করা হয় না, এটি হারনেস দ্বারা **লোড** করা হয়, তাই শুধুমাত্র-প্লাগইনের ইনস্টল
+ডেস্ক্রিপ্টরগুলি (`package`, `dsh`) স্কিল এন্ট্রিতে বিদ্যমান নেই এবং `usage` + `compat` দ্বারা
+প্রতিস্থাপিত হয়। একটি স্কিল প্রায়ই এমন রিপোজিটরির একটি সাবডিরেক্টরিতে থাকে যেটি অনেক স্কিল ধারণ
+করে, তাই পরিচয় এবং ডিডুপ হলো `source.repository` + `source.subpath`, শুধু রিপোজিটরি নয়। একটি
+স্কিল এন্ট্রি কোনো `media` গ্যালারি গ্রহণ করে না: স্কিল হলো এমন টেক্সট যা হারনেস লোড করে, তাই
+স্ক্রিনশট নেওয়ার কিছু নেই (`additionalProperties: false`-ই এটি প্রয়োগ করে)।
+
+এই ফিল্ডগুলি উপরে প্লাগইন এন্ট্রির জন্য নথিভুক্ত আকার এবং নিয়ম ঠিক বজায় রাখে: `schemaVersion`,
+`id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`, `source`, `creator`,
+`repositoryScope`, `license`, `provenance`। প্রতিটি ফিল্ড প্রয়োজনীয়, কেবল `triggers` ছাড়া — একমাত্র
+ঐচ্ছিক স্কিল ফিল্ড।
+
+### স্কিল-নির্দিষ্ট ফিল্ড
+
+| ফিল্ড                | টাইপ   | প্রয়োজনীয় | নিয়ম                                                        |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   হ্যাঁ    | অবশ্যই ঠিক `skill` হতে হবে                                     |
+| `skillScope`         | enum   |   হ্যাঁ    | `repository` (সম্পূর্ণ রিপোজিটরিটিই **হলো** স্কিল) অথবা `subdirectory` (স্কিলটি `source.subpath`-এ থাকে) |
+| `triggers`           | array  |    না    | স্কিল কখন সক্রিয় হয় — যে টেক্সট একজন ব্যবহারকারী এটি লোড করার আগে মূল্যায়ন করেন। অন্তত ১টি অনন্য স্ট্রিং, প্রতিটি ৩–২০০ অক্ষর; কোনোটি না থাকলে ফিল্ডটি পুরোপুরি বাদ দিন (`triggers: []` অবৈধ) |
+| `usage.load`         | string |   হ্যাঁ    | হারনেস কীভাবে স্কিলটি লোড করে, ১–২০০ অক্ষর; স্কিল লোড করা হয়, কখনও ইনস্টল করা হয় না |
+| `usage.evidencePath` | string |   হ্যাঁ    | `source.commit`-এ লোড প্রমাণের নিরাপদ আপেক্ষিক পথ (`description.evidencePath`-এর মতো একই প্যাটার্ন) |
+| `compat.harnessMin`  | string |   হ্যাঁ    | স্কিলটি যে ন্যূনতম হারনেস সংস্করণের বিপরীতে যাচাই করা হয়েছে; সঠিক `x.y.z` আকার (ঐচ্ছিক prerelease/build), সর্বোচ্চ ৬৪ অক্ষর। সিমান্টিক স্তরে অতিরিক্তভাবে পার্সযোগ্য, সঠিক SemVer প্রয়োজন |
+
+শর্তসাপেক্ষ নিয়ম (স্কিল স্কিমার `allOf` ব্লক দ্বারা প্রয়োগকৃত):
+
+- `skillScope: subdirectory` **বাধ্য করে** `source.subpath`-কে একটি নিরাপদ আপেক্ষিক-পথ স্ট্রিং হতে —
+  সাবডিরেক্টরিতে হোস্ট করা স্কিলকে অবশ্যই সেই সাবডিরেক্টরি পিন করতে হবে।
+- `skillScope: repository` **বাধ্য করে** `source.subpath: null` — সম্পূর্ণ-রিপোজিটরি স্কিল কোনো
+  সাবপাথ ঘোষণা করতে পারবে না।
+
+`verification` প্লাগইনের আকার বজায় রাখে (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), কিন্তু `smokeTest`-কে অবশ্যই ঠিক `null` হতে হবে: স্কিলের কোনো ইনস্টল স্মোক টেস্ট নেই,
+এবং কনটেন্ট পর্যালোচনাই ভর্তির গেট। স্কিল স্কিমা কোনো `status: verified` → `smokeTest` শর্ত এবং
+কোনো `repositoryScope` → `popularity` শর্ত বহন করে না; সেই সংযোগগুলি কেবল প্লাগইন-স্কিমার নিয়ম।
+
+### স্কিলের জন্য সিমান্টিক স্তর
+
+স্কিমার উপরে, ক্যাটালগ বৈধতা যাচাইকরণ যেখানে ফিল্ডগুলি বিদ্যমান সেখানে প্লাগইনের মতো একই
+বাধ্যতামূলক সিমান্টিক পার্সার প্রয়োগ করে: `license.spdx`-কে অবশ্যই বৈধ SPDX এক্সপ্রেশন হিসেবে পার্স
+হতে হবে (`invalid-spdx`), এবং `compat.harnessMin`-কে অবশ্যই সঠিক SemVer হতে হবে
+(`invalid-semver`)। কোনো `invalid-sri` কেস নেই — স্কিলের কোনো `package.integrity` নেই।
+
+### স্কিলের পরিচয় এবং ডিডুপ
+
+একটি স্কিলের প্রামাণ্য কী হলো `skill:<source.repositoryNodeId>:<normalized subpath>`। সাবপাথটি
+কেবল পরিচয়ের উদ্দেশ্যে স্বাভাবিক করা হয়: ব্যাকস্ল্যাশ `/` হয়ে যায়, খালি এবং `.` সেগমেন্ট বাদ পড়ে,
+এবং একটি খালি ফলাফল (অথবা `subpath: null`) `.` হয়ে যায় — সম্পূর্ণ রিপোজিটরি। NUL বাইট বা `..`
+সেগমেন্ট ধারণকারী সাবপাথ প্রত্যাখ্যাত হয়, কখনও "পরিষ্কার" করা হয় না। একই রিপোজিটরির দুটি স্কিল
+দুটি এন্ট্রি; একই রিপোজিটরি + সাবপাথ দুইবার হলো একটি সংঘর্ষ।
+
+### ন্যূনতম স্কিল উদাহরণ
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## স্কিমা কী পরীক্ষা করে না
 
 স্কিমাটি ইচ্ছাকৃতভাবে স্থানীয় এবং স্ট্রাকচারাল। এটি রিপোজিটরিটি বিদ্যমান কিনা, নোড ID URL-এর সাথে মেলে

--- a/docs/i18n/cs/SCHEMA.md
+++ b/docs/i18n/cs/SCHEMA.md
@@ -252,6 +252,111 @@ Pole zcela vynechte, když není co ukázat — `media: []` není platný způso
 snímky obrazovky“. Pole je aditivní: záznamy zveřejněné dříve, než existovalo, zůstávají platné
 a konzument, který je ignoruje, čte každý záznam přesně jako dřív.
 
+## Záznamy `kind: skill`
+
+Schéma verze 1 definuje také druhý, samostatný kontrakt záznamu pro `kind: skill`, zveřejněný
+jako [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01 fáze 0). Nikdy se
+nedotýká výše uvedeného schématu pluginů: záznamy s `kind: plugin` se nadále validují přesně
+jako dřív a soubor skill schématu je zdrojem pravdy pro záznamy skillů stejně, jako je schéma
+pluginů zdrojem pravdy pro záznamy pluginů.
+
+Skill se neinstaluje, je harnessem **načítán**, takže instalační deskriptory určené pouze pro
+pluginy (`package`, `dsh`) na záznamu skillu neexistují a nahrazují je `usage` + `compat`.
+Skill také často žije v podadresáři repozitáře, který hostí mnoho skillů, takže identitou a
+deduplikací je `source.repository` + `source.subpath`, nikoli repozitář samotný. Záznam skillu
+nepřipouští žádnou galerii `media`: skill je text, který harness načítá, takže není co
+screenshotovat (je to `additionalProperties: false`, co to vynucuje).
+
+Tato pole si zachovávají přesně tvar a pravidla dokumentovaná výše pro záznamy pluginů:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Každé pole je povinné kromě
+`triggers`, jediného volitelného pole skillu.
+
+### Pole specifická pro skill
+
+| Pole                 | Typ    | Povinné | Pravidla                                                    |
+| -------------------- | ------ | :-----: | ----------------------------------------------------------- |
+| `kind`               | const  |   ano   | Musí být přesně `skill`                                     |
+| `skillScope`         | enum   |   ano   | `repository` (celý repozitář **je** skill) nebo `subdirectory` (skill žije na `source.subpath`) |
+| `triggers`           | array  |   ne    | Kdy se skill spouští — text, který uživatel vyhodnocuje před jeho načtením. Alespoň 1 jedinečný řetězec, každý 3–200 znaků; pokud žádné nejsou, pole zcela vynechte (`triggers: []` je neplatné) |
+| `usage.load`         | string |   ano   | Jak harness skill načítá, 1–200 znaků; skill se načítá, nikdy neinstaluje |
+| `usage.evidencePath` | string |   ano   | Bezpečná relativní cesta (stejný vzor jako `description.evidencePath`) k důkazu načtení v `source.commit` |
+| `compat.harnessMin`  | string |   ano   | Minimální verze harnessu, proti níž byl skill ověřen; tvar přesné verze `x.y.z` (volitelné prerelease/build), max. 64 znaků. Sémantická vrstva navíc vyžaduje rozparsovatelný, přesný SemVer |
+
+Podmíněná pravidla (vynucená bloky `allOf` skill schématu):
+
+- `skillScope: subdirectory` **vynucuje**, aby `source.subpath` byl řetězec s bezpečnou
+  relativní cestou — skill hostovaný v podadresáři musí tento podadresář fixovat.
+- `skillScope: repository` **vynucuje** `source.subpath: null` — skill tvořený celým
+  repozitářem nesmí deklarovat podcestu.
+
+`verification` si zachovává tvar z pluginů (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), ale `smokeTest` musí být přesně `null`: skill nemá žádný instalační smoke test a
+vstupní bránou je posouzení obsahu. Skill schéma nenese žádnou podmínku `status: verified` →
+`smokeTest` ani žádné podmínky `repositoryScope` → `popularity`; tyto vazby jsou výhradně
+pravidly schématu pluginů.
+
+### Sémantická vrstva pro skilly
+
+Nad schématem uplatňuje validace katalogu tytéž povinné sémantické parsery jako u pluginů tam,
+kde pole existují: `license.spdx` musí být rozparsovatelný jako platný výraz SPDX
+(`invalid-spdx`) a `compat.harnessMin` musí být přesný SemVer (`invalid-semver`). Neexistuje
+žádný případ `invalid-sri` — skill nemá `package.integrity`.
+
+### Identita a deduplikace skillu
+
+Kanonickým klíčem skillu je `skill:<source.repositoryNodeId>:<normalized subpath>`. Podcesta se
+normalizuje pouze pro účely identity: zpětná lomítka se mění na `/`, prázdné segmenty a
+segmenty `.` se zahazují a prázdný výsledek (nebo `subpath: null`) se stává `.` — celým
+repozitářem. Podcesta obsahující NUL bajty nebo segmenty `..` je odmítnuta, nikdy „vyčištěna".
+Dva skilly téhož repozitáře jsou dva záznamy; tentýž repozitář + podcesta dvakrát je kolize.
+
+### Minimální příklad skillu
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Co schéma nekontroluje
 
 Schéma je záměrně lokální a strukturální. **Neověřuje**, zda repozitář existuje, zda ID uzlu

--- a/docs/i18n/da/SCHEMA.md
+++ b/docs/i18n/da/SCHEMA.md
@@ -249,6 +249,114 @@ Udelad feltet helt, når der ikke er noget at vise — `media: []` er ikke en gy
 "ingen skærmbilleder" på. Feltet er additivt: poster, der blev udgivet, før det fandtes, er
 fortsat gyldige, og en forbruger, der ignorerer det, læser hver post præcis som før.
 
+## `kind: skill`-poster
+
+Schema-version 1 definerer også en anden, selvstændig postkontrakt for `kind: skill`,
+udgivet som [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01 fase 0). Den
+rører aldrig plugin-schemaet ovenfor: poster med `kind: plugin` bliver ved med at validere
+præcis som før, og skill-schema-filen er kilde til sandhed for skill-poster på samme måde, som
+plugin-schemaet er det for plugin-poster.
+
+En skill installeres ikke, den **indlæses** af harnesset, så de plugin-specifikke
+installationsdeskriptorer (`package`, `dsh`) findes ikke på en skill-post og erstattes af
+`usage` + `compat`. En skill bor desuden ofte i en undermappe af et repository, der huser mange
+skills, så identitet og deduplikering er `source.repository` + `source.subpath` frem for
+repositoryet alene. En skill-post tillader intet `media`-galleri: en skill er tekst, som
+harnesset indlæser, så der er intet at tage skærmbillede af (det er
+`additionalProperties: false`, der håndhæver det).
+
+Disse felter beholder præcis den form og de regler, der er dokumenteret for plugin-poster
+ovenfor: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Hvert felt er påkrævet undtagen
+`triggers`, det eneste valgfrie skill-felt.
+
+### Skill-specifikke felter
+
+| Felt                 | Type   | Påkrævet | Regler                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |    ja    | Skal være præcis `skill`                                    |
+| `skillScope`         | enum   |    ja    | `repository` (hele repositoryet **er** skillen) eller `subdirectory` (skillen bor på `source.subpath`) |
+| `triggers`           | array  |   nej    | Hvornår skillen udløses — den tekst, en bruger vurderer, før den indlæses. Mindst 1 unik streng, hver på 3–200 tegn; udelad feltet helt, når der ingen er (`triggers: []` er ugyldigt) |
+| `usage.load`         | string |    ja    | Hvordan harnesset indlæser skillen, 1–200 tegn; en skill indlæses, installeres aldrig |
+| `usage.evidencePath` | string |    ja    | Sikker relativ sti (samme mønster som `description.evidencePath`) til indlæsningsbeviset ved `source.commit` |
+| `compat.harnessMin`  | string |    ja    | Minimum harness-version, som skillen blev verificeret imod; præcis `x.y.z`-form (valgfri prerelease/build), maks. 64 tegn. Det semantiske lag kræver desuden en fortolkbar, præcis SemVer |
+
+Betingede regler (håndhævet af skill-schemaets `allOf`-blokke):
+
+- `skillScope: subdirectory` **tvinger** `source.subpath` til at være en streng med en sikker
+  relativ sti — en skill, der bor i en undermappe, skal fastlåse den undermappe.
+- `skillScope: repository` **tvinger** `source.subpath: null` — en skill, der udgør hele
+  repositoryet, må ikke erklære en understi.
+
+`verification` beholder plugin-formen (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), men `smokeTest` skal være præcis `null`: en skill har ingen
+installations-smoke-test, og indholdsgennemgang er adgangsgaten. Skill-schemaet bærer ingen
+`status: verified` → `smokeTest`-betingelse og ingen `repositoryScope` →
+`popularity`-betingelser; disse koblinger er udelukkende plugin-schema-regler.
+
+### Semantisk lag for skills
+
+Oven på schemaet anvender katalogvalideringen de samme obligatoriske semantiske fortolkere som
+for plugins, hvor felterne findes: `license.spdx` skal kunne fortolkes som et gyldigt
+SPDX-udtryk (`invalid-spdx`), og `compat.harnessMin` skal være en præcis SemVer
+(`invalid-semver`). Der findes intet `invalid-sri`-tilfælde — en skill har ingen
+`package.integrity`.
+
+### Skill-identitet og deduplikering
+
+Den kanoniske nøgle for en skill er `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Understien normaliseres kun til identitetsformål: backslashes bliver til `/`, tomme og
+`.`-segmenter droppes, og et tomt resultat (eller `subpath: null`) bliver til `.` — hele
+repositoryet. En understi, der indeholder NUL-bytes eller `..`-segmenter, afvises, aldrig
+"renset". To skills fra samme repository er to poster; samme repository + understi to gange er
+en kollision.
+
+### Minimalt skill-eksempel
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Hvad schemaet ikke kontrollerer
 
 Schemaet er med vilje lokalt og strukturelt. Det verificerer **ikke**, at repositoryet findes, at

--- a/docs/i18n/de/SCHEMA.md
+++ b/docs/i18n/de/SCHEMA.md
@@ -260,6 +260,114 @@ Lassen Sie das Feld ganz weg, wenn es nichts zu zeigen gibt — `media: []` ist 
 veröffentlicht wurden, bleiben gültig, und ein Konsument, der es ignoriert, liest jeden Eintrag
 genau wie zuvor.
 
+## `kind: skill`-Einträge
+
+Schema-Version 1 definiert außerdem einen zweiten, eigenständigen Eintragskontrakt für
+`kind: skill`, veröffentlicht als [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)
+(SKL-01 Phase 0). Er berührt das obige Plugin-Schema nie: Einträge mit `kind: plugin` validieren
+weiterhin exakt wie zuvor, und die Skill-Schema-Datei ist für Skill-Einträge die maßgebliche
+Quelle, genauso wie das Plugin-Schema es für Plugin-Einträge ist.
+
+Ein Skill wird nicht installiert, er wird vom Harness **geladen** — die Plugin-spezifischen
+Installationsdeskriptoren (`package`, `dsh`) existieren daher auf einem Skill-Eintrag nicht und
+werden durch `usage` + `compat` ersetzt. Ein Skill lebt außerdem häufig in einem
+Unterverzeichnis eines Repositorys, das viele Skills beherbergt, daher sind Identität und
+Deduplizierung `source.repository` + `source.subpath` statt des Repositorys allein. Ein
+Skill-Eintrag lässt keine `media`-Galerie zu: Ein Skill ist Text, den der Harness lädt, es gibt
+also nichts zu screenshotten (`additionalProperties: false` ist es, was das erzwingt).
+
+Diese Felder behalten exakt die Form und die Regeln, die oben für Plugin-Einträge dokumentiert
+sind: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Jedes Feld ist erforderlich
+außer `triggers`, dem einzigen optionalen Skill-Feld.
+
+### Skill-spezifische Felder
+
+| Feld                 | Typ    | Erforderlich | Regeln                                                      |
+| -------------------- | ------ | :----------: | ----------------------------------------------------------- |
+| `kind`               | const  |      ja      | Muss exakt `skill` sein                                     |
+| `skillScope`         | enum   |      ja      | `repository` (das gesamte Repository **ist** der Skill) oder `subdirectory` (der Skill lebt unter `source.subpath`) |
+| `triggers`           | array  |     nein     | Wann der Skill greift — der Text, den ein Benutzer vor dem Laden bewertet. Mindestens 1 eindeutiger String, jeder 3–200 Zeichen; das Feld ganz weglassen, wenn es keine gibt (`triggers: []` ist ungültig) |
+| `usage.load`         | string |      ja      | Wie der Harness den Skill lädt, 1–200 Zeichen; ein Skill wird geladen, nie installiert |
+| `usage.evidencePath` | string |      ja      | Sicherer relativer Pfad (gleiches Muster wie `description.evidencePath`) zum Ladebeleg bei `source.commit` |
+| `compat.harnessMin`  | string |      ja      | Minimale Harness-Version, gegen die der Skill verifiziert wurde; exakte `x.y.z`-Form (optional Prerelease/Build), max. 64 Zeichen. Die semantische Ebene verlangt zusätzlich ein parsebares, exaktes SemVer |
+
+Bedingte Regeln (erzwungen durch die `allOf`-Blöcke des Skill-Schemas):
+
+- `skillScope: subdirectory` **erzwingt**, dass `source.subpath` ein String mit einem sicheren
+  relativen Pfad ist — ein in einem Unterverzeichnis gehosteter Skill muss dieses
+  Unterverzeichnis fixieren.
+- `skillScope: repository` **erzwingt** `source.subpath: null` — ein Ganz-Repository-Skill
+  darf keinen Unterpfad deklarieren.
+
+`verification` behält die Plugin-Form (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), aber `smokeTest` muss exakt `null` sein: Ein Skill hat keinen
+Installations-Smoke-Test, und die inhaltliche Review ist das Zulassungs-Gate. Das Skill-Schema
+trägt keine Bedingung `status: verified` → `smokeTest` und keine Bedingungen
+`repositoryScope` → `popularity`; diese Kopplungen sind ausschließlich Plugin-Schema-Regeln.
+
+### Semantische Ebene für Skills
+
+Über dem Schema wendet die Katalogvalidierung dieselben verpflichtenden semantischen Parser wie
+bei Plugins an, wo die Felder existieren: `license.spdx` muss als gültiger SPDX-Ausdruck parsen
+(`invalid-spdx`), und `compat.harnessMin` muss ein exaktes SemVer sein (`invalid-semver`). Es
+gibt keinen `invalid-sri`-Fall — ein Skill hat kein `package.integrity`.
+
+### Skill-Identität und Deduplizierung
+
+Der kanonische Schlüssel eines Skills ist `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Der Unterpfad wird nur für Identitätszwecke normalisiert: Backslashes werden zu `/`, leere und
+`.`-Segmente werden verworfen, und ein leeres Ergebnis (oder `subpath: null`) wird zu `.` — das
+gesamte Repository. Ein Unterpfad mit NUL-Bytes oder `..`-Segmenten wird abgelehnt, nie
+„bereinigt". Zwei Skills desselben Repositorys sind zwei Einträge; dasselbe Repository +
+derselbe Unterpfad zweimal ist eine Kollision.
+
+### Minimales Skill-Beispiel
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Was das Schema nicht prüft
 
 Das Schema ist absichtlich lokal und strukturell. Es prüft **nicht**, ob das Repository

--- a/docs/i18n/es/SCHEMA.md
+++ b/docs/i18n/es/SCHEMA.md
@@ -256,6 +256,114 @@ Omite el campo por completo cuando no haya nada que mostrar: `media: []` no es u
 de decir "sin capturas". El campo es aditivo: las entradas publicadas antes de que existiera
 siguen siendo válidas, y un consumidor que lo ignora lee todas las entradas igual que antes.
 
+## Entradas `kind: skill`
+
+La versión 1 del schema también define un segundo contrato de entrada autocontenido para
+`kind: skill`, publicado como [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)
+(SKL-01 fase 0). Nunca toca el schema de plugin de arriba: las entradas con `kind: plugin`
+siguen validándose exactamente como antes, y el archivo de schema de skill es la fuente de la
+verdad para las entradas de skill igual que el schema de plugin lo es para las entradas de
+plugin.
+
+Una skill no se instala, la **carga** el harness, así que los descriptores de instalación
+exclusivos de plugin (`package`, `dsh`) no existen en una entrada de skill y se reemplazan por
+`usage` + `compat`. Una skill también vive con frecuencia en un subdirectorio de un repositorio
+que aloja muchas skills, por lo que la identidad y la deduplicación es `source.repository` +
+`source.subpath` en lugar del repositorio solo. Una entrada de skill no admite galería `media`:
+una skill es texto que el harness carga, así que no hay nada que capturar
+(`additionalProperties: false` es lo que lo hace cumplir).
+
+Estos campos mantienen exactamente la forma y las reglas documentadas arriba para las entradas
+de plugin: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Todos los campos son
+requeridos excepto `triggers`, el único campo opcional de skill.
+
+### Campos específicos de skill
+
+| Campo                | Tipo   | Requerido | Reglas                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   sí    | Debe ser exactamente `skill`                                |
+| `skillScope`         | enum   |   sí    | `repository` (el repositorio entero **es** la skill) o `subdirectory` (la skill vive en `source.subpath`) |
+| `triggers`           | array  |    no    | Cuándo se activa la skill — el texto que un usuario evalúa antes de cargarla. Al menos 1 string único, cada uno de 3–200 caracteres; omite el campo por completo cuando no haya ninguno (`triggers: []` es inválido) |
+| `usage.load`         | string |   sí    | Cómo el harness carga la skill, 1–200 caracteres; una skill se carga, nunca se instala |
+| `usage.evidencePath` | string |   sí    | Ruta relativa segura (el mismo patrón que `description.evidencePath`) a la evidencia de carga en `source.commit` |
+| `compat.harnessMin`  | string |   sí    | Versión mínima del harness contra la que se verificó la skill; forma exacta `x.y.z` (prerelease/build opcional), máx. 64 caracteres. La capa semántica exige además un SemVer exacto y parseable |
+
+Reglas condicionales (aplicadas por los bloques `allOf` del schema de skill):
+
+- `skillScope: subdirectory` **fuerza** que `source.subpath` sea un string de ruta relativa
+  segura — una skill alojada en un subdirectorio debe fijar ese subdirectorio.
+- `skillScope: repository` **fuerza** `source.subpath: null` — una skill de repositorio
+  completo no debe declarar un subpath.
+
+`verification` mantiene la forma de plugin (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), pero `smokeTest` debe ser exactamente `null`: una skill no tiene smoke test de
+instalación, y la revisión de contenido es la puerta de admisión. El schema de skill no lleva
+el condicional `status: verified` → `smokeTest` ni los condicionales `repositoryScope` →
+`popularity`; esos acoplamientos son reglas exclusivas del schema de plugin.
+
+### Capa semántica para skills
+
+Sobre el schema, la validación del catálogo aplica los mismos parsers semánticos obligatorios
+que para los plugins allí donde los campos existen: `license.spdx` debe parsear como una
+expresión SPDX válida (`invalid-spdx`), y `compat.harnessMin` debe ser un SemVer exacto
+(`invalid-semver`). No hay caso `invalid-sri` — una skill no tiene `package.integrity`.
+
+### Identidad y deduplicación de skills
+
+La clave canónica de una skill es `skill:<source.repositoryNodeId>:<normalized subpath>`. El
+subpath se normaliza solo a efectos de identidad: las barras invertidas se convierten en `/`,
+los segmentos vacíos y `.` se eliminan, y un resultado vacío (o `subpath: null`) se convierte
+en `.` — el repositorio completo. Un subpath que contenga bytes NUL o segmentos `..` se
+rechaza, nunca se "limpia". Dos skills del mismo repositorio son dos entradas; el mismo
+repositorio + subpath dos veces es una colisión.
+
+### Ejemplo mínimo de skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Lo que el schema no verifica
 
 El schema es intencionalmente local y estructural. **No** verifica que el repositorio exista, que

--- a/docs/i18n/fa/SCHEMA.md
+++ b/docs/i18n/fa/SCHEMA.md
@@ -249,6 +249,111 @@ URL پروفایل عمومی همیشه به‌صورت `https://github.com/<ha
 تصویر صفحه» نیست. این فیلد افزایشی است: ورودی‌هایی که پیش از وجود آن منتشر شده‌اند معتبر می‌مانند و
 مصرف‌کننده‌ای که آن را نادیده بگیرد هر ورودی را دقیقاً مثل گذشته می‌خواند.
 
+## ورودی‌های `kind: skill`
+
+نسخهٔ ۱ اسکیما همچنین یک قرارداد ورودی دومِ خودکفا برای `kind: skill` تعریف می‌کند که به‌صورت
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) منتشر شده است (SKL-01 فاز ۰).
+این قرارداد هرگز به اسکیمای پلاگین بالا دست نمی‌زند: ورودی‌های دارای `kind: plugin` دقیقاً مثل
+قبل اعتبارسنجی می‌شوند، و فایل اسکیمای اسکیل برای ورودی‌های اسکیل همان‌طور منبع حقیقت است که
+اسکیمای پلاگین برای ورودی‌های پلاگین است.
+
+اسکیل نصب نمی‌شود، بلکه هارنس آن را **بارگذاری** می‌کند؛ بنابراین توصیف‌گرهای نصبِ مخصوص
+پلاگین (`package`، `dsh`) روی ورودی اسکیل وجود ندارند و با `usage` + `compat` جایگزین می‌شوند.
+اسکیل همچنین اغلب در زیرشاخه‌ای از ریپازیتوری‌ای زندگی می‌کند که میزبان اسکیل‌های فراوانی است،
+پس هویت و حذف تکرار `source.repository` + `source.subpath` است، نه ریپازیتوری به‌تنهایی.
+ورودی اسکیل هیچ گالری `media` را نمی‌پذیرد: اسکیل متنی است که هارنس بارگذاری می‌کند، پس چیزی
+برای تصویربرداری وجود ندارد (`additionalProperties: false` همان چیزی است که این را الزام
+می‌کند).
+
+این فیلدها دقیقاً همان شکل و قواعدی را نگه می‌دارند که در بالا برای ورودی‌های پلاگین مستند
+شده است: `schemaVersion`، `id`، `name`، `description`، `unofficial`، `primaryCategory`،
+`tags`، `source`، `creator`، `repositoryScope`، `license`، `provenance`. همهٔ فیلدها الزامی
+هستند به‌جز `triggers`، تنها فیلد اختیاری اسکیل.
+
+### فیلدهای مخصوص اسکیل
+
+| فیلد                 | نوع    | الزامی | قواعد                                                       |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   بله    | باید دقیقاً `skill` باشد                                    |
+| `skillScope`         | enum   |   بله    | `repository` (کل ریپازیتوری **خودِ** اسکیل است) یا `subdirectory` (اسکیل در `source.subpath` زندگی می‌کند) |
+| `triggers`           | array  |    خیر    | کِی اسکیل فعال می‌شود — متنی که کاربر پیش از بارگذاری آن ارزیابی می‌کند. دست‌کم ۱ رشتهٔ یکتا، هرکدام ۳ تا ۲۰۰ کاراکتر؛ وقتی هیچ‌کدام وجود ندارد فیلد را کاملاً حذف کنید (`triggers: []` نامعتبر است) |
+| `usage.load`         | string |   بله    | این‌که هارنس اسکیل را چگونه بارگذاری می‌کند، ۱ تا ۲۰۰ کاراکتر؛ اسکیل بارگذاری می‌شود، هرگز نصب نمی‌شود |
+| `usage.evidencePath` | string |   بله    | مسیر نسبی امن (همان الگوی `description.evidencePath`) به شاهد بارگذاری در `source.commit` |
+| `compat.harnessMin`  | string |   بله    | حداقل نسخهٔ هارنسی که اسکیل در برابر آن راستی‌آزمایی شده است؛ شکل دقیق `x.y.z` (پیش‌انتشار/بیلد اختیاری)، حداکثر ۶۴ کاراکتر. لایهٔ معنایی علاوه بر این یک SemVer دقیق و قابل‌تجزیه الزام می‌کند |
+
+قواعد شرطی (که بلوک‌های `allOf` اسکیمای اسکیل الزام می‌کنند):
+
+- `skillScope: subdirectory` **الزام می‌کند** که `source.subpath` یک رشتهٔ مسیر نسبی امن
+  باشد — اسکیلی که در یک زیرشاخه میزبانی می‌شود باید آن زیرشاخه را سنجاق کند.
+- `skillScope: repository` **الزام می‌کند** `source.subpath: null` — اسکیلِ تمام‌ریپازیتوری
+  نباید subpath اعلام کند.
+
+`verification` شکل پلاگین را نگه می‌دارد (`status`، `checkedAt`، `repositoryIdentity`،
+`smokeTest`)، اما `smokeTest` باید دقیقاً `null` باشد: اسکیل تست دود نصب ندارد و بازبینی
+محتوا دروازهٔ پذیرش است. اسکیمای اسکیل شرطِ `status: verified` → `smokeTest` و شرط‌های
+`repositoryScope` → `popularity` را ندارد؛ آن پیوندها فقط قواعد اسکیمای پلاگین هستند.
+
+### لایهٔ معنایی برای اسکیل‌ها
+
+روی اسکیما، اعتبارسنجی کاتالوگ همان تجزیه‌گرهای معنایی اجباریِ پلاگین‌ها را هرجا فیلدها
+وجود دارند اعمال می‌کند: `license.spdx` باید به‌صورت یک عبارت SPDX معتبر تجزیه شود
+(`invalid-spdx`)، و `compat.harnessMin` باید یک SemVer دقیق باشد (`invalid-semver`). حالت
+`invalid-sri` وجود ندارد — اسکیل `package.integrity` ندارد.
+
+### هویت و حذف تکرار اسکیل
+
+کلید متعارف یک اسکیل `skill:<source.repositoryNodeId>:<normalized subpath>` است. subpath فقط
+برای هویت نرمال‌سازی می‌شود: بک‌اسلش‌ها `/` می‌شوند، بخش‌های خالی و `.` حذف می‌شوند، و نتیجهٔ
+خالی (یا `subpath: null`) به `.` تبدیل می‌شود — کل ریپازیتوری. subpath حاوی بایت NUL یا
+بخش‌های `..` رد می‌شود، هرگز «پاک‌سازی» نمی‌شود. دو اسکیل از یک ریپازیتوری دو ورودی هستند؛
+همان ریپازیتوری + subpath دو بار یک برخورد است.
+
+### حداقلی‌ترین مثال اسکیل
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## آنچه اسکیما بررسی نمی‌کند
 
 اسکیما عمداً محلی و ساختاری است. این **بررسی نمی‌کند** که ریپازیتوری وجود دارد، شناسهٔ گره با URL

--- a/docs/i18n/fi/SCHEMA.md
+++ b/docs/i18n/fi/SCHEMA.md
@@ -255,6 +255,113 @@ Jätä kenttä kokonaan pois, kun näytettävää ei ole — `media: []` ei ole 
 kuvakaappauksia". Kenttä on lisäävä: ennen sen olemassaoloa julkaistut merkinnät pysyvät
 pätevinä, ja kuluttaja, joka jättää sen huomiotta, lukee jokaisen merkinnän täsmälleen kuten ennen.
 
+## `kind: skill` -merkinnät
+
+Skeemaversio 1 määrittelee myös toisen, itsenäisen merkintäsopimuksen arvolle `kind: skill`,
+julkaistuna tiedostona [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01,
+vaihe 0). Se ei koskaan kosketa yllä olevaa plugin-skeemaa: merkinnät, joilla on
+`kind: plugin`, validoituvat täsmälleen kuten ennenkin, ja skill-skeematiedosto on totuuden
+lähde skill-merkinnöille samalla tavalla kuin plugin-skeema on plugin-merkinnöille.
+
+Skilliä ei asenneta, vaan harness **lataa** sen, joten vain plugineille kuuluvat
+asennuskuvaimet (`package`, `dsh`) eivät ole olemassa skill-merkinnässä, ja niiden tilalla ovat
+`usage` + `compat`. Skill asuu myös usein sellaisen repositorion alihakemistossa, joka isännöi
+monia skillejä, joten identiteetti ja deduplikointi on `source.repository` + `source.subpath`
+pelkän repositorion sijaan. Skill-merkintä ei salli `media`-galleriaa: skill on tekstiä, jonka
+harness lataa, joten kuvakaapattavaa ei ole (`additionalProperties: false` on se, mikä tämän
+pakottaa).
+
+Nämä kentät säilyttävät täsmälleen yllä plugin-merkinnöille dokumentoidun muodon ja säännöt:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Jokainen kenttä on vaadittu
+paitsi `triggers`, ainoa valinnainen skill-kenttä.
+
+### Skill-kohtaiset kentät
+
+| Kenttä               | Tyyppi | Vaadittu | Säännöt                                                     |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   kyllä  | On oltava täsmälleen `skill`                                |
+| `skillScope`         | enum   |   kyllä  | `repository` (koko repositorio **on** skilli) tai `subdirectory` (skill asuu polussa `source.subpath`) |
+| `triggers`           | array  |    ei    | Milloin skill laukeaa — teksti, jonka käyttäjä arvioi ennen sen lataamista. Vähintään 1 uniikki merkkijono, kukin 3–200 merkkiä; jätä kenttä kokonaan pois, kun laukaisimia ei ole (`triggers: []` on epäkelpo) |
+| `usage.load`         | string |   kyllä  | Miten harness lataa skillin, 1–200 merkkiä; skill ladataan, ei koskaan asenneta |
+| `usage.evidencePath` | string |   kyllä  | Turvallinen suhteellinen polku (sama kuvio kuin `description.evidencePath`) lataustodisteeseen commitissa `source.commit` |
+| `compat.harnessMin`  | string |   kyllä  | Harnessin vähimmäisversio, jota vasten skill varmistettiin; täsmällinen `x.y.z`-muoto (valinnainen prerelease/build), enintään 64 merkkiä. Semanttinen kerros vaatii lisäksi jäsennettävän, täsmällisen SemVerin |
+
+Ehdolliset säännöt (skill-skeeman `allOf`-lohkojen pakottamat):
+
+- `skillScope: subdirectory` **pakottaa** kentän `source.subpath` olemaan turvallinen
+  suhteellinen polkumerkkijono — alihakemistossa isännöidyn skillin on kiinnitettävä se
+  alihakemisto.
+- `skillScope: repository` **pakottaa** arvon `source.subpath: null` — koko repositorion
+  kattava skill ei saa ilmoittaa subpathia.
+
+`verification` säilyttää plugin-muodon (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), mutta `smokeTest`in on oltava täsmälleen `null`: skillillä ei ole asennuksen
+smoke-testiä, ja sisältökatselmointi on hyväksymisportti. Skill-skeema ei sisällä ehtoa
+`status: verified` → `smokeTest` eikä ehtoja `repositoryScope` → `popularity`; nuo kytkennät
+ovat vain plugin-skeeman sääntöjä.
+
+### Semanttinen kerros skilleille
+
+Skeeman päälle katalogin validointi soveltaa samoja pakollisia semanttisia jäsentimiä kuin
+plugineille siellä, missä kentät ovat olemassa: `license.spdx`in on jäsennyttävä kelvolliseksi
+SPDX-lausekkeeksi (`invalid-spdx`), ja `compat.harnessMin`in on oltava täsmällinen SemVer
+(`invalid-semver`). `invalid-sri`-tapausta ei ole — skillillä ei ole `package.integrity`ä.
+
+### Skillin identiteetti ja deduplikointi
+
+Skillin kanoninen avain on `skill:<source.repositoryNodeId>:<normalized subpath>`. Subpath
+normalisoidaan vain identiteettiä varten: kenoviivoista tulee `/`, tyhjät ja `.`-segmentit
+pudotetaan, ja tyhjästä tuloksesta (tai arvosta `subpath: null`) tulee `.` — koko repositorio.
+NUL-tavuja tai `..`-segmenttejä sisältävä subpath hylätään, ei koskaan "siivota". Kaksi saman
+repositorion skilliä ovat kaksi merkintää; sama repositorio + subpath kahdesti on törmäys.
+
+### Minimaalinen skill-esimerkki
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Mitä skeema ei tarkista
 
 Skeema on tarkoituksellisesti paikallinen ja rakenteellinen. Se **ei** varmista, että repositorio

--- a/docs/i18n/fr/SCHEMA.md
+++ b/docs/i18n/fr/SCHEMA.md
@@ -257,6 +257,115 @@ Omettez entièrement le champ lorsqu'il n'y a rien à montrer — `media: []` n'
 valide de dire « aucune capture ». Le champ est additif : les entrées publiées avant son
 existence restent valides, et un consommateur qui l'ignore lit chaque entrée exactement comme avant.
 
+## Entrées `kind: skill`
+
+La version 1 du schéma définit aussi un second contrat d'entrée autonome pour `kind: skill`,
+publié en tant que [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01
+phase 0). Il ne touche jamais le schéma de plugin ci-dessus : les entrées avec `kind: plugin`
+continuent de se valider exactement comme avant, et le fichier de schéma de skill est la source
+de vérité pour les entrées de skill de la même manière que le schéma de plugin l'est pour les
+entrées de plugin.
+
+Une skill ne s'installe pas, elle est **chargée** par le harness ; les descripteurs
+d'installation propres aux plugins (`package`, `dsh`) n'existent donc pas sur une entrée de
+skill et sont remplacés par `usage` + `compat`. Une skill vit aussi fréquemment dans un
+sous-répertoire d'un dépôt hébergeant de nombreuses skills, l'identité et la déduplication
+reposent donc sur `source.repository` + `source.subpath` plutôt que sur le dépôt seul. Une
+entrée de skill n'admet aucune galerie `media` : une skill est du texte que le harness charge,
+il n'y a donc rien à capturer (`additionalProperties: false` est ce qui l'impose).
+
+Ces champs gardent exactement la forme et les règles documentées ci-dessus pour les entrées de
+plugin : `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Chaque champ est
+obligatoire sauf `triggers`, le seul champ de skill optionnel.
+
+### Champs spécifiques aux skills
+
+| Champ                | Type   | Obligatoire | Règles                                                    |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   oui    | Doit être exactement `skill`                                |
+| `skillScope`         | enum   |   oui    | `repository` (le dépôt entier **est** la skill) ou `subdirectory` (la skill vit à `source.subpath`) |
+| `triggers`           | array  |    non    | Quand la skill se déclenche — le texte qu'un utilisateur évalue avant de la charger. Au moins 1 chaîne unique, chacune de 3 à 200 caractères ; omettez entièrement le champ lorsqu'il n'y en a aucune (`triggers: []` est invalide) |
+| `usage.load`         | string |   oui    | Comment le harness charge la skill, 1 à 200 caractères ; une skill se charge, ne s'installe jamais |
+| `usage.evidencePath` | string |   oui    | Chemin relatif sûr (même motif que `description.evidencePath`) vers la preuve de chargement au `source.commit` |
+| `compat.harnessMin`  | string |   oui    | Version minimale du harness contre laquelle la skill a été vérifiée ; forme exacte `x.y.z` (prerelease/build optionnel), 64 caractères max. La couche sémantique exige en plus un SemVer exact et analysable |
+
+Règles conditionnelles (imposées par les blocs `allOf` du schéma de skill) :
+
+- `skillScope: subdirectory` **force** `source.subpath` à être une chaîne de chemin relatif
+  sûr — une skill hébergée dans un sous-répertoire doit épingler ce sous-répertoire.
+- `skillScope: repository` **force** `source.subpath: null` — une skill couvrant tout le dépôt
+  ne doit pas déclarer de subpath.
+
+`verification` garde la forme de plugin (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), mais `smokeTest` doit être exactement `null` : une skill n'a pas de smoke test
+d'installation, et la revue de contenu est la porte d'admission. Le schéma de skill ne porte
+pas le conditionnel `status: verified` → `smokeTest` ni les conditionnels `repositoryScope` →
+`popularity` ; ces couplages sont des règles propres au schéma de plugin.
+
+### Couche sémantique pour les skills
+
+Par-dessus le schéma, la validation du catalogue applique les mêmes analyseurs sémantiques
+obligatoires que pour les plugins là où les champs existent : `license.spdx` doit s'analyser
+comme une expression SPDX valide (`invalid-spdx`), et `compat.harnessMin` doit être un SemVer
+exact (`invalid-semver`). Il n'y a pas de cas `invalid-sri` — une skill n'a pas de
+`package.integrity`.
+
+### Identité et déduplication des skills
+
+La clé canonique d'une skill est `skill:<source.repositoryNodeId>:<normalized subpath>`. Le
+subpath n'est normalisé qu'à des fins d'identité : les antislashs deviennent `/`, les segments
+vides et `.` sont supprimés, et un résultat vide (ou `subpath: null`) devient `.` — le dépôt
+entier. Un subpath contenant des octets NUL ou des segments `..` est rejeté, jamais « nettoyé ».
+Deux skills du même dépôt sont deux entrées ; le même dépôt + subpath deux fois est une
+collision.
+
+### Exemple minimal de skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Ce que le schéma ne vérifie pas
 
 Le schéma est intentionnellement local et structurel. Il **ne** vérifie **pas** que le dépôt

--- a/docs/i18n/gu/SCHEMA.md
+++ b/docs/i18n/gu/SCHEMA.md
@@ -248,6 +248,111 @@
 માન્ય રીત નથી. આ ફીલ્ડ ઉમેરણરૂપ છે: તે અસ્તિત્વમાં આવ્યા પહેલાં પ્રકાશિત પ્રવેશો માન્ય રહે છે, અને
 તેને અવગણનાર ઉપભોક્તા દરેક પ્રવેશ પહેલાંની જેમ જ વાંચે છે.
 
+## `kind: skill` પ્રવેશો
+
+સ્કીમા વર્ઝન 1 `kind: skill` માટે બીજો, સ્વ-સમાવિષ્ટ પ્રવેશ કરાર પણ વ્યાખ્યાયિત કરે છે, જે
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) તરીકે પ્રકાશિત છે (SKL-01 ફેઝ 0).
+તે ઉપરના પ્લગિન સ્કીમાને ક્યારેય સ્પર્શતો નથી: `kind: plugin` વાળા પ્રવેશો પહેલાંની જેમ જ
+ચોક્કસ રીતે માન્ય થતા રહે છે, અને સ્કિલ સ્કીમા ફાઇલ સ્કિલ પ્રવેશો માટે એ જ રીતે સત્યનો સ્રોત છે
+જે રીતે પ્લગિન સ્કીમા પ્લગિન પ્રવેશો માટે છે.
+
+સ્કિલ ઇન્સ્ટોલ થતી નથી, હાર્નેસ તેને **લોડ** કરે છે, તેથી ફક્ત-પ્લગિન માટેના ઇન્સ્ટોલ
+ડિસ્ક્રિપ્ટર્સ (`package`, `dsh`) સ્કિલ પ્રવેશ પર અસ્તિત્વમાં નથી અને તેમની જગ્યાએ `usage` +
+`compat` આવે છે. સ્કિલ ઘણી વાર એવા રિપોઝિટરીના સબડિરેક્ટરીમાં પણ રહે છે જે ઘણી સ્કિલ્સ હોસ્ટ
+કરે છે, તેથી ઓળખ અને ડિડ્યુપ `source.repository` + `source.subpath` છે, ફક્ત રિપોઝિટરી નહીં.
+સ્કિલ પ્રવેશ કોઈ `media` ગેલેરી સ્વીકારતો નથી: સ્કિલ એ ટેક્સ્ટ છે જે હાર્નેસ લોડ કરે છે, તેથી
+સ્ક્રીનશોટ લેવા જેવું કંઈ નથી (`additionalProperties: false` જ તેને લાગુ કરે છે).
+
+આ ફિલ્ડ્સ ઉપર પ્લગિન પ્રવેશો માટે દસ્તાવેજિત સ્વરૂપ અને નિયમો બરાબર જાળવી રાખે છે:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. `triggers` સિવાય દરેક ફિલ્ડ
+જરૂરી છે — તે એકમાત્ર વૈકલ્પિક સ્કિલ ફિલ્ડ છે.
+
+### સ્કિલ-વિશિષ્ટ ફિલ્ડ્સ
+
+| ફિલ્ડ                | પ્રકાર | જરૂરી | નિયમો                                                        |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   હા    | બરાબર `skill` જ હોવું જોઈએ                                    |
+| `skillScope`         | enum   |   હા    | `repository` (આખું રિપોઝિટરી **જ** સ્કિલ છે) અથવા `subdirectory` (સ્કિલ `source.subpath` પર રહે છે) |
+| `triggers`           | array  |    ના    | સ્કિલ ક્યારે સક્રિય થાય છે — તે ટેક્સ્ટ જે વપરાશકર્તા લોડ કરતાં પહેલાં મૂલવે છે. ઓછામાં ઓછી 1 અનન્ય સ્ટ્રિંગ, દરેક 3–200 અક્ષરો; કંઈ ન હોય ત્યારે ફિલ્ડ સંપૂર્ણપણે છોડી દો (`triggers: []` અમાન્ય છે) |
+| `usage.load`         | string |   હા    | હાર્નેસ સ્કિલ કેવી રીતે લોડ કરે છે, 1–200 અક્ષરો; સ્કિલ લોડ થાય છે, ક્યારેય ઇન્સ્ટોલ થતી નથી |
+| `usage.evidencePath` | string |   હા    | `source.commit` પરના લોડ પુરાવા સુધીનો સુરક્ષિત સાપેક્ષ પાથ (`description.evidencePath` જેવો જ પેટર્ન) |
+| `compat.harnessMin`  | string |   હા    | લઘુતમ હાર્નેસ વર્ઝન જેની સામે સ્કિલ ચકાસાઈ હતી; ચોક્કસ `x.y.z` સ્વરૂપ (વૈકલ્પિક prerelease/build), મહત્તમ 64 અક્ષરો. સિમેન્ટિક લેયર વધારામાં પાર્સ થઈ શકે તેવું, ચોક્કસ SemVer માગે છે |
+
+શરતી નિયમો (સ્કિલ સ્કીમાના `allOf` બ્લોક્સ દ્વારા લાગુ):
+
+- `skillScope: subdirectory` `source.subpath` ને સુરક્ષિત સાપેક્ષ પાથ સ્ટ્રિંગ હોવા માટે
+  **ફરજ પાડે છે** — સબડિરેક્ટરીમાં હોસ્ટ થયેલી સ્કિલે તે સબડિરેક્ટરી પિન કરવી જ જોઈએ.
+- `skillScope: repository` `source.subpath: null` **ફરજ પાડે છે** — આખા-રિપોઝિટરીની સ્કિલે
+  subpath જાહેર કરવો ન જોઈએ.
+
+`verification` પ્લગિન સ્વરૂપ જાળવે છે (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), પણ `smokeTest` બરાબર `null` જ હોવું જોઈએ: સ્કિલ પાસે ઇન્સ્ટોલ સ્મોક ટેસ્ટ નથી,
+અને કન્ટેન્ટ રિવ્યૂ જ પ્રવેશ દ્વાર છે. સ્કિલ સ્કીમામાં `status: verified` → `smokeTest`
+શરત નથી અને `repositoryScope` → `popularity` શરતો પણ નથી; તે જોડાણો ફક્ત પ્લગિન-સ્કીમાના
+નિયમો છે.
+
+### સ્કિલ્સ માટે સિમેન્ટિક લેયર
+
+સ્કીમાની ઉપર, કેટલોગ વેલિડેશન જ્યાં ફિલ્ડ્સ અસ્તિત્વમાં હોય ત્યાં પ્લગિન્સ માટેના જ ફરજિયાત
+સિમેન્ટિક પાર્સર્સ લાગુ કરે છે: `license.spdx` માન્ય SPDX અભિવ્યક્તિ તરીકે પાર્સ થવું જોઈએ
+(`invalid-spdx`), અને `compat.harnessMin` ચોક્કસ SemVer હોવું જોઈએ (`invalid-semver`).
+`invalid-sri` કેસ નથી — સ્કિલ પાસે `package.integrity` નથી.
+
+### સ્કિલ ઓળખ અને ડિડ્યુપ
+
+સ્કિલની કેનોનિકલ કી `skill:<source.repositoryNodeId>:<normalized subpath>` છે. subpath ફક્ત
+ઓળખના હેતુઓ માટે નોર્મલાઇઝ થાય છે: બેકસ્લેશ `/` બને છે, ખાલી અને `.` સેગમેન્ટ્સ કાઢી નખાય
+છે, અને ખાલી પરિણામ (અથવા `subpath: null`) `.` બને છે — આખું રિપોઝિટરી. NUL બાઇટ્સ કે `..`
+સેગમેન્ટ્સ ધરાવતો subpath નકારાય છે, ક્યારેય "સાફ" થતો નથી. એક જ રિપોઝિટરીની બે સ્કિલ્સ બે
+પ્રવેશો છે; એ જ રિપોઝિટરી + subpath બે વાર એ ટકરાવ છે.
+
+### ન્યૂનતમ સ્કિલ ઉદાહરણ
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## સ્કીમા શું ચકાસતું નથી
 
 સ્કીમા જાણીજોઈને લોકલ અને સ્ટ્રક્ચરલ છે. તે રિપોઝિટરી અસ્તિત્વમાં છે કે નહીં, નોડ ID

--- a/docs/i18n/he/SCHEMA.md
+++ b/docs/i18n/he/SCHEMA.md
@@ -243,6 +243,111 @@ smoke test הניתנת לבדיקה משתמשות ב-`status: eligible` וב-`
 הוא תוספתי: רשומות שפורסמו לפני שהיה קיים נשארות תקפות, וצרכן שמתעלם ממנו קורא כל רשומה בדיוק
 כמקודם.
 
+## רשומות `kind: skill`
+
+גרסה 1 של הסכימה מגדירה גם חוזה רשומה שני ועצמאי עבור `kind: skill`, המפורסם בתור
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01 שלב 0). הוא לעולם
+אינו נוגע בסכימת הפלאגין שלמעלה: רשומות עם `kind: plugin` ממשיכות להיות מאומתות בדיוק
+כמקודם, וקובץ סכימת הסקיל הוא מקור האמת לרשומות סקיל באותו אופן שסכימת הפלאגין היא
+לרשומות פלאגין.
+
+סקיל אינו מותקן, הוא **נטען** על ידי ה-harness, ולכן מתארי ההתקנה הייחודיים לפלאגינים
+(`package`, `dsh`) אינם קיימים ברשומת סקיל ומוחלפים ב-`usage` + `compat`. סקיל גם חי לעתים
+קרובות בתת-ספרייה של מאגר המארח סקילים רבים, ולכן הזהות ומניעת הכפילויות הן
+`source.repository` + `source.subpath` ולא המאגר לבדו. רשומת סקיל אינה מתירה גלריית
+`media`: סקיל הוא טקסט שה-harness טוען, כך שאין מה לצלם (`additionalProperties: false` הוא
+מה שאוכף זאת).
+
+השדות הבאים שומרים בדיוק על הצורה והכללים שתועדו למעלה עבור רשומות פלאגין:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. כל שדה נדרש מלבד
+`triggers`, שדה הסקיל האופציונלי היחיד.
+
+### שדות ייחודיים לסקיל
+
+| שדה                  | סוג     | נדרש  | כללים                                                       |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | קבוע    |   כן    | חייב להיות בדיוק `skill`                                    |
+| `skillScope`         | enum   |   כן    | `repository` (המאגר כולו **הוא** הסקיל) או `subdirectory` (הסקיל חי ב-`source.subpath`) |
+| `triggers`           | array  |    לא    | מתי הסקיל מופעל — הטקסט שמשתמש מעריך לפני טעינתו. לפחות מחרוזת ייחודית אחת, כל אחת באורך 3–200 תווים; השמיטו את השדה לחלוטין כשאין אף אחת (`triggers: []` אינו תקף) |
+| `usage.load`         | מחרוזת |   כן    | כיצד ה-harness טוען את הסקיל, 1–200 תווים; סקיל נטען, לעולם אינו מותקן |
+| `usage.evidencePath` | מחרוזת |   כן    | מסלול יחסי בטוח (אותה תבנית כמו `description.evidencePath`) לראיית הטעינה ב-`source.commit` |
+| `compat.harnessMin`  | מחרוזת |   כן    | גרסת ה-harness המינימלית שמולה אומת הסקיל; צורת `x.y.z` מדויקת (prerelease/build אופציונלי), עד 64 תווים. השכבה הסמנטית דורשת בנוסף SemVer מדויק וניתן לניתוח |
+
+כללים מותנים (הנאכפים על ידי בלוקי ה-`allOf` של סכימת הסקיל):
+
+- `skillScope: subdirectory` **מכריח** את `source.subpath` להיות מחרוזת מסלול יחסי בטוח —
+  סקיל המתארח בתת-ספרייה חייב להצמיד את אותה תת-ספרייה.
+- `skillScope: repository` **מכריח** `source.subpath: null` — סקיל של מאגר שלם אסור לו
+  להצהיר על subpath.
+
+`verification` שומר על צורת הפלאגין (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), אבל `smokeTest` חייב להיות בדיוק `null`: לסקיל אין בדיקת עשן של התקנה,
+ובדיקת התוכן היא שער הקבלה. סכימת הסקיל אינה נושאת את התנאי `status: verified` →
+`smokeTest` ולא את התנאים `repositoryScope` → `popularity`; צימודים אלו הם כללים של סכימת
+הפלאגין בלבד.
+
+### שכבה סמנטית לסקילים
+
+מעל הסכימה, אימות הקטלוג מחיל את אותם מנתחים סמנטיים מחייבים כמו לפלאגינים היכן שהשדות
+קיימים: `license.spdx` חייב להתנתח כביטוי SPDX תקף (`invalid-spdx`), ו-`compat.harnessMin`
+חייב להיות SemVer מדויק (`invalid-semver`). אין מקרה `invalid-sri` — לסקיל אין
+`package.integrity`.
+
+### זהות סקיל ומניעת כפילויות
+
+המפתח הקנוני של סקיל הוא `skill:<source.repositoryNodeId>:<normalized subpath>`. ה-subpath
+מנורמל למטרות זהות בלבד: לוכסנים הפוכים הופכים ל-`/`, מקטעים ריקים ומקטעי `.` מושמטים,
+ותוצאה ריקה (או `subpath: null`) הופכת ל-`.` — המאגר כולו. subpath המכיל בייטי NUL או
+מקטעי `..` נדחה, לעולם אינו "מנוקה". שני סקילים של אותו מאגר הם שתי רשומות; אותו מאגר +
+subpath פעמיים הם התנגשות.
+
+### דוגמת סקיל מינימלית
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## מה הסכימה אינה בודקת
 
 הסכימה מכוונת להיות מקומית ומבנית. היא **אינה** מוודאת שהמאגר קיים, שמזהה ה-Node תואם

--- a/docs/i18n/hi/SCHEMA.md
+++ b/docs/i18n/hi/SCHEMA.md
@@ -244,6 +244,111 @@
 मान्य तरीका नहीं है। यह फ़ील्ड योगात्मक है: इसके अस्तित्व से पहले प्रकाशित प्रविष्टियाँ मान्य रहती
 हैं, और इसे अनदेखा करने वाला उपभोक्ता हर प्रविष्टि पहले जैसी ही पढ़ता है।
 
+## `kind: skill` प्रविष्टियाँ
+
+स्कीमा संस्करण 1 `kind: skill` के लिए एक दूसरा, स्व-निहित प्रविष्टि अनुबंध भी परिभाषित करता है, जो
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) के रूप में प्रकाशित है (SKL-01 फ़ेज़ 0)।
+यह ऊपर के प्लगइन स्कीमा को कभी नहीं छूता: `kind: plugin` वाली प्रविष्टियाँ ठीक पहले की तरह मान्य होती
+रहती हैं, और स्किल स्कीमा फ़ाइल स्किल प्रविष्टियों के लिए उसी तरह सत्य का स्रोत है जिस तरह प्लगइन
+स्कीमा प्लगइन प्रविष्टियों के लिए है।
+
+स्किल इंस्टॉल नहीं होती, उसे हार्नेस **लोड** करता है, इसलिए केवल-प्लगइन वाले इंस्टॉल डिस्क्रिप्टर
+(`package`, `dsh`) स्किल प्रविष्टि पर मौजूद नहीं होते और उनकी जगह `usage` + `compat` लेते हैं।
+स्किल अक्सर ऐसे रिपॉज़िटरी की सबडायरेक्टरी में भी रहती है जो कई स्किल्स होस्ट करता है, इसलिए पहचान
+और डीडुप्लीकेशन `source.repository` + `source.subpath` है, अकेला रिपॉज़िटरी नहीं। स्किल प्रविष्टि
+कोई `media` गैलरी स्वीकार नहीं करती: स्किल वह टेक्स्ट है जिसे हार्नेस लोड करता है, इसलिए स्क्रीनशॉट
+लेने के लिए कुछ नहीं है (`additionalProperties: false` ही इसे लागू करता है)।
+
+ये फ़ील्ड ऊपर प्लगइन प्रविष्टियों के लिए प्रलेखित आकार और नियम ठीक वैसे ही बनाए रखते हैं:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. `triggers` — एकमात्र वैकल्पिक
+स्किल फ़ील्ड — को छोड़कर हर फ़ील्ड आवश्यक है।
+
+### स्किल-विशिष्ट फ़ील्ड
+
+| फ़ील्ड                | प्रकार   | आवश्यक | नियम                                                        |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   हां    | ठीक `skill` होना चाहिए                                       |
+| `skillScope`         | enum   |   हां    | `repository` (पूरा रिपॉज़िटरी **ही** स्किल है) या `subdirectory` (स्किल `source.subpath` पर रहती है) |
+| `triggers`           | array  |    नहीं    | स्किल कब सक्रिय होती है — वह टेक्स्ट जिसे उपयोगकर्ता लोड करने से पहले आँकता है। कम से कम 1 अद्वितीय स्ट्रिंग, प्रत्येक 3–200 वर्ण; जब कोई न हो तो फ़ील्ड पूरी तरह छोड़ दें (`triggers: []` अमान्य है) |
+| `usage.load`         | string |   हां    | हार्नेस स्किल को कैसे लोड करता है, 1–200 वर्ण; स्किल लोड होती है, कभी इंस्टॉल नहीं होती |
+| `usage.evidencePath` | string |   हां    | `source.commit` पर लोड प्रमाण तक सुरक्षित सापेक्ष पथ (`description.evidencePath` जैसा ही पैटर्न) |
+| `compat.harnessMin`  | string |   हां    | न्यूनतम हार्नेस संस्करण जिसके विरुद्ध स्किल सत्यापित की गई; ठीक `x.y.z` आकार (वैकल्पिक prerelease/build), अधिकतम 64 वर्ण। सिमेंटिक परत अतिरिक्त रूप से एक पार्स करने योग्य, सटीक SemVer मांगती है |
+
+सशर्त नियम (स्किल स्कीमा के `allOf` ब्लॉकों द्वारा लागू):
+
+- `skillScope: subdirectory` `source.subpath` को सुरक्षित सापेक्ष पथ स्ट्रिंग होने के लिए
+  **बाध्य करता है** — सबडायरेक्टरी में होस्ट की गई स्किल को वह सबडायरेक्टरी पिन करनी ही होगी।
+- `skillScope: repository` `source.subpath: null` **बाध्य करता है** — पूरे-रिपॉज़िटरी वाली स्किल
+  को subpath घोषित नहीं करना चाहिए।
+
+`verification` प्लगइन आकार बनाए रखता है (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), लेकिन `smokeTest` ठीक `null` होना चाहिए: स्किल का कोई इंस्टॉल स्मोक टेस्ट नहीं
+होता, और सामग्री समीक्षा ही प्रवेश द्वार है। स्किल स्कीमा में `status: verified` → `smokeTest`
+शर्त नहीं है और `repositoryScope` → `popularity` शर्तें भी नहीं हैं; वे युग्मन केवल
+प्लगइन-स्कीमा के नियम हैं।
+
+### स्किल्स के लिए सिमेंटिक परत
+
+स्कीमा के ऊपर, कैटलॉग सत्यापन वहीं वही अनिवार्य सिमेंटिक पार्सर लागू करता है जो प्लगइनों के लिए
+हैं, जहाँ फ़ील्ड मौजूद हों: `license.spdx` को मान्य SPDX अभिव्यक्ति के रूप में पार्स होना चाहिए
+(`invalid-spdx`), और `compat.harnessMin` को सटीक SemVer होना चाहिए (`invalid-semver`)।
+कोई `invalid-sri` केस नहीं है — स्किल के पास `package.integrity` नहीं होता।
+
+### स्किल पहचान और डीडुप्लीकेशन
+
+स्किल की कैनोनिकल कुंजी `skill:<source.repositoryNodeId>:<normalized subpath>` है। subpath केवल
+पहचान के प्रयोजनों के लिए सामान्यीकृत होता है: बैकस्लैश `/` बन जाते हैं, खाली और `.` खंड हटा दिए
+जाते हैं, और खाली परिणाम (या `subpath: null`) `.` बन जाता है — पूरा रिपॉज़िटरी। NUL बाइट या `..`
+खंडों वाला subpath अस्वीकार किया जाता है, कभी "साफ़" नहीं किया जाता। एक ही रिपॉज़िटरी की दो
+स्किल्स दो प्रविष्टियाँ हैं; वही रिपॉज़िटरी + subpath दो बार एक टकराव है।
+
+### न्यूनतम स्किल उदाहरण
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## स्कीमा क्या जांच नहीं करती
 
 स्कीमा जानबूझकर स्थानीय और संरचनात्मक है। यह **यह सत्यापित नहीं करती** कि रिपॉज़िटरी मौजूद है, कि नोड ID URL से मेल

--- a/docs/i18n/hu/SCHEMA.md
+++ b/docs/i18n/hu/SCHEMA.md
@@ -260,6 +260,114 @@ Hagyja ki teljesen a mezőt, ha nincs mit mutatni — a `media: []` nem érvény
 „nincs képernyőkép”. A mező additív: a létezése előtt közzétett bejegyzések érvényesek maradnak,
 aki pedig figyelmen kívül hagyja, pontosan úgy olvas minden bejegyzést, mint korábban.
 
+## `kind: skill` bejegyzések
+
+Az 1-es sémaverzió egy második, önálló bejegyzés-kontraktust is definiál a `kind: skill`
+számára, amely [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) néven jelent meg
+(SKL-01, 0. fázis). Ez soha nem érinti a fenti bővítmény-sémát: a `kind: plugin` bejegyzések
+pontosan úgy validálódnak, mint eddig, és a skill-séma-fájl ugyanúgy a hiteles forrás a
+skill-bejegyzésekhez, ahogyan a bővítmény-séma a bővítmény-bejegyzésekhez.
+
+Egy skillt nem telepítenek: a harness **betölti**, ezért a csak bővítményekre vonatkozó
+telepítési deszkriptorok (`package`, `dsh`) nem léteznek egy skill-bejegyzésen, helyüket a
+`usage` + `compat` veszi át. Egy skill emellett gyakran egy olyan repository alkönyvtárában él,
+amely sok skillt tartalmaz, ezért az identitás és a deduplikáció a `source.repository` +
+`source.subpath` páros, nem pedig önmagában a repository. Egy skill-bejegyzés nem enged meg
+`media` galériát: a skill szöveg, amelyet a harness betölt, így nincs miről képernyőképet
+készíteni (ezt az `additionalProperties: false` kényszeríti ki).
+
+Ezek a mezők pontosan a fenti bővítmény-bejegyzéseknél dokumentált formát és szabályokat
+tartják meg: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Minden mező kötelező,
+kivéve a `triggers`-t, az egyetlen opcionális skill-mezőt.
+
+### Skill-specifikus mezők
+
+| Mező                 | Típus  | Kötelező | Szabályok                                                   |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   igen   | Pontosan `skill` kell legyen                                |
+| `skillScope`         | enum   |   igen   | `repository` (a teljes repository **maga** a skill) vagy `subdirectory` (a skill a `source.subpath` alatt él) |
+| `triggers`           | array  |    nem   | Mikor aktiválódik a skill — a szöveg, amelyet a felhasználó a betöltés előtt mérlegel. Legalább 1 egyedi string, mindegyik 3–200 karakter; ha nincs egy sem, a mezőt teljesen ki kell hagyni (a `triggers: []` érvénytelen) |
+| `usage.load`         | string |   igen   | Hogyan tölti be a harness a skillt, 1–200 karakter; egy skillt betöltenek, soha nem telepítenek |
+| `usage.evidencePath` | string |   igen   | Biztonságos relatív útvonal (ugyanaz a minta, mint a `description.evidencePath`) a betöltési bizonyítékhoz a `source.commit`-on |
+| `compat.harnessMin`  | string |   igen   | A legkisebb harness-verzió, amellyel a skillt ellenőrizték; pontos `x.y.z` forma (opcionális prerelease/build), max 64 karakter. A szemantikai réteg emellett megkövetel egy interpretálható, pontos SemVert |
+
+Feltételes szabályok (a skill-séma `allOf` blokkjai kényszerítik ki):
+
+- A `skillScope: subdirectory` **kikényszeríti**, hogy a `source.subpath` biztonságos relatív
+  útvonal-string legyen — egy alkönyvtárban élő skillnek rögzítenie kell azt az alkönyvtárat.
+- A `skillScope: repository` **kikényszeríti** a `source.subpath: null` értéket — egy
+  teljes-repository skill nem deklarálhat subpathot.
+
+A `verification` megtartja a bővítmény-formát (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), de a `smokeTest` pontosan `null` kell legyen: egy skillnek nincs telepítési
+smoke-tesztje, és a tartalmi átvizsgálás a befogadási kapu. A skill-séma nem hordoz
+`status: verified` → `smokeTest` feltételt, sem `repositoryScope` → `popularity` feltételeket;
+ezek a kapcsolások kizárólag a bővítmény-séma szabályai.
+
+### Szemantikai réteg a skillekhez
+
+A séma felett a katalógus-validáció ugyanazokat a kötelező szemantikai interpretálókat
+alkalmazza, mint a bővítményeknél, ahol a mezők léteznek: a `license.spdx`-nek érvényes
+SPDX-kifejezésként kell interpretálódnia (`invalid-spdx`), a `compat.harnessMin`-nek pedig
+pontos SemVernek kell lennie (`invalid-semver`). `invalid-sri` eset nincs — egy skillnek nincs
+`package.integrity`-je.
+
+### Skill-identitás és deduplikáció
+
+Egy skill kanonikus kulcsa: `skill:<source.repositoryNodeId>:<normalized subpath>`. A subpath
+kizárólag identitási célra normalizálódik: a backslash-ekből `/` lesz, az üres és `.`
+szegmensek kiesnek, az üres eredmény (vagy a `subpath: null`) pedig `.` lesz — a teljes
+repository. A NUL bájtokat vagy `..` szegmenseket tartalmazó subpath elutasításra kerül, soha
+nem „tisztítódik". Ugyanazon repository két skillje két bejegyzés; ugyanaz a repository +
+subpath kétszer viszont ütközés.
+
+### Minimális skill-példa
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Amit a séma nem ellenőriz
 
 A séma szándékosan helyi és strukturális. **Nem** ellenőrzi, hogy a repository létezik-e, hogy a

--- a/docs/i18n/id/SCHEMA.md
+++ b/docs/i18n/id/SCHEMA.md
@@ -257,6 +257,112 @@ untuk mengatakan "tanpa tangkapan layar". Bidang ini bersifat aditif: entri yang
 sebelum bidang ini ada tetap valid, dan konsumen yang mengabaikannya membaca setiap entri persis
 seperti sebelumnya.
 
+## Entri `kind: skill`
+
+Skema versi 1 juga mendefinisikan kontrak entri kedua yang mandiri untuk `kind: skill`,
+diterbitkan sebagai [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01
+fase 0). Kontrak ini tidak pernah menyentuh skema plugin di atas: entri dengan `kind: plugin`
+tetap tervalidasi persis seperti sebelumnya, dan file skema skill adalah sumber kebenaran
+untuk entri skill, sama seperti skema plugin untuk entri plugin.
+
+Sebuah skill tidak diinstal, melainkan **dimuat** oleh harness, sehingga deskriptor instalasi
+khusus plugin (`package`, `dsh`) tidak ada pada entri skill dan digantikan oleh `usage` +
+`compat`. Skill juga sering berada di subdirektori dari sebuah repositori yang menampung
+banyak skill, sehingga identitas dan dedupe adalah `source.repository` + `source.subpath`,
+bukan repositori saja. Entri skill tidak mengizinkan galeri `media`: skill adalah teks yang
+dimuat harness, jadi tidak ada yang perlu di-screenshot (`additionalProperties: false` yang
+menegakkannya).
+
+Bidang-bidang ini mempertahankan persis bentuk dan aturan yang didokumentasikan untuk entri
+plugin di atas: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Setiap bidang wajib
+kecuali `triggers`, satu-satunya bidang skill yang opsional.
+
+### Bidang khusus skill
+
+| Bidang               | Tipe   | Wajib | Aturan                                                         |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ya    | Harus persis `skill`                                          |
+| `skillScope`         | enum   |   ya    | `repository` (seluruh repositori **adalah** skill itu) atau `subdirectory` (skill berada di `source.subpath`) |
+| `triggers`           | array  |    tidak    | Kapan skill terpicu — teks yang dievaluasi pengguna sebelum memuatnya. Setidaknya 1 string unik, masing-masing 3–200 karakter; hilangkan bidang ini sepenuhnya bila tidak ada satu pun (`triggers: []` tidak valid) |
+| `usage.load`         | string |   ya    | Cara harness memuat skill, 1–200 karakter; skill dimuat, tidak pernah diinstal |
+| `usage.evidencePath` | string |   ya    | Jalur relatif aman (pola yang sama seperti `description.evidencePath`) ke bukti pemuatan pada `source.commit` |
+| `compat.harnessMin`  | string |   ya    | Versi harness minimum tempat skill diverifikasi; bentuk `x.y.z` yang tepat (prerelease/build opsional), maks 64 karakter. Lapisan semantik selanjutnya mewajibkan SemVer yang tepat dan dapat di-parsing |
+
+Aturan bersyarat (ditegakkan oleh blok `allOf` skema skill):
+
+- `skillScope: subdirectory` **mewajibkan** `source.subpath` berupa string jalur relatif aman —
+  skill yang di-host di subdirektori harus mematok subdirektori itu.
+- `skillScope: repository` **mewajibkan** `source.subpath: null` — skill seluruh-repositori
+  tidak boleh mendeklarasikan subpath.
+
+`verification` mempertahankan bentuk plugin (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), tetapi `smokeTest` harus persis `null`: skill tidak memiliki smoke test
+instalasi, dan tinjauan konten adalah gerbang penerimaannya. Skema skill tidak membawa
+kondisional `status: verified` → `smokeTest` maupun kondisional `repositoryScope` →
+`popularity`; keterkaitan itu adalah aturan skema plugin saja.
+
+### Lapisan semantik untuk skill
+
+Di atas skema, validasi katalog menerapkan parser semantik wajib yang sama seperti untuk
+plugin pada bidang yang ada: `license.spdx` harus dapat di-parsing sebagai ekspresi SPDX yang
+valid (`invalid-spdx`), dan `compat.harnessMin` harus berupa SemVer yang tepat
+(`invalid-semver`). Tidak ada kasus `invalid-sri` — skill tidak memiliki `package.integrity`.
+
+### Identitas dan dedupe skill
+
+Kunci kanonis sebuah skill adalah `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Subpath dinormalkan hanya untuk keperluan identitas: backslash menjadi `/`, segmen kosong dan
+`.` dibuang, dan hasil kosong (atau `subpath: null`) menjadi `.` — seluruh repositori. Subpath
+yang mengandung byte NUL atau segmen `..` ditolak, tidak pernah "dibersihkan". Dua skill dari
+repositori yang sama adalah dua entri; repositori + subpath yang sama dua kali adalah kolisi.
+
+### Contoh skill minimal
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Apa yang tidak diperiksa oleh skema
 
 Skema ini secara sengaja bersifat lokal dan struktural. Skema ini **tidak** memverifikasi bahwa

--- a/docs/i18n/in/SCHEMA.md
+++ b/docs/i18n/in/SCHEMA.md
@@ -253,6 +253,113 @@ Tautan provenance publik, masing-masing berupa URI atau `null`:
 मान्य तरीका नहीं है। यह फ़ील्ड योगात्मक है: इसके अस्तित्व से पहले प्रकाशित प्रविष्टियाँ मान्य रहती
 हैं, और इसे अनदेखा करने वाला उपभोक्ता हर प्रविष्टि पहले जैसी ही पढ़ता है।
 
+## Entri `kind: skill`
+
+Skema versi 1 juga mendefinisikan kontrak entri kedua yang mandiri untuk `kind: skill`,
+diterbitkan sebagai [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01
+fase 0). Kontrak itu tidak pernah menyentuh skema plugin di atas: entri dengan `kind: plugin`
+tetap tervalidasi persis seperti sebelumnya, dan file skema skill adalah sumber kebenaran
+untuk entri skill sama seperti skema plugin untuk entri plugin.
+
+Sebuah skill tidak diinstal, melainkan **dimuat** oleh harness, sehingga deskriptor instalasi
+khusus plugin (`package`, `dsh`) tidak ada pada entri skill dan digantikan oleh `usage` +
+`compat`. Skill juga sering berada di subdirektori dari sebuah repositori yang menampung
+banyak skill, sehingga identitas dan dedupe adalah `source.repository` + `source.subpath`,
+bukan repositori saja. Entri skill tidak mengizinkan galeri `media`: skill adalah teks yang
+dimuat harness, jadi tidak ada yang bisa di-screenshot (`additionalProperties: false` yang
+menegakkannya).
+
+Bidang-bidang ini mempertahankan persis bentuk dan aturan yang didokumentasikan untuk entri
+plugin di atas: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Setiap bidang wajib
+kecuali `triggers`, satu-satunya bidang skill yang opsional.
+
+### Bidang khusus skill
+
+| Bidang               | Tipe   | Wajib | Aturan                                                        |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ya    | Harus persis `skill`                                          |
+| `skillScope`         | enum   |   ya    | `repository` (seluruh repositori **adalah** skill itu) atau `subdirectory` (skill berada di `source.subpath`) |
+| `triggers`           | array  |    tidak    | Kapan skill terpicu — teks yang dievaluasi pengguna sebelum memuatnya. Setidaknya 1 string unik, masing-masing 3–200 karakter; hilangkan bidang ini sepenuhnya bila tidak ada satu pun (`triggers: []` tidak valid) |
+| `usage.load`         | string |   ya    | Cara harness memuat skill, 1–200 karakter; skill dimuat, tidak pernah diinstal |
+| `usage.evidencePath` | string |   ya    | Path relatif aman (pola yang sama seperti `description.evidencePath`) ke bukti pemuatan pada `source.commit` |
+| `compat.harnessMin`  | string |   ya    | Versi harness minimum tempat skill diverifikasi; bentuk `x.y.z` persis (prarilis/build opsional), maks 64 karakter. Lapisan semantik juga mewajibkan SemVer persis yang dapat di-parse |
+
+Aturan kondisional (diberlakukan oleh blok `allOf` skema skill):
+
+- `skillScope: subdirectory` **memaksa** `source.subpath` berupa string path relatif aman —
+  skill yang di-host di subdirektori harus mematok subdirektori itu.
+- `skillScope: repository` **memaksa** `source.subpath: null` — skill seluruh-repositori tidak
+  boleh mendeklarasikan subpath.
+
+`verification` mempertahankan bentuk plugin (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), tetapi `smokeTest` harus persis `null`: skill tidak punya smoke test instalasi,
+dan tinjauan konten adalah gerbang penerimaannya. Skema skill tidak membawa kondisional
+`status: verified` → `smokeTest` maupun kondisional `repositoryScope` → `popularity`;
+keterkaitan itu adalah aturan skema plugin saja.
+
+### Lapisan semantik untuk skill
+
+Di atas skema, validasi katalog menerapkan parser semantik wajib yang sama seperti untuk
+plugin pada bidang yang ada: `license.spdx` harus dapat di-parse sebagai ekspresi SPDX yang
+valid (`invalid-spdx`), dan `compat.harnessMin` harus berupa SemVer persis (`invalid-semver`).
+Tidak ada kasus `invalid-sri` — skill tidak memiliki `package.integrity`.
+
+### Identitas dan dedupe skill
+
+Kunci kanonis sebuah skill adalah `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Subpath dinormalisasi hanya untuk keperluan identitas: backslash menjadi `/`, segmen kosong
+dan `.` dibuang, dan hasil kosong (atau `subpath: null`) menjadi `.` — seluruh repositori.
+Subpath yang mengandung byte NUL atau segmen `..` ditolak, tidak pernah "dibersihkan". Dua
+skill dari repositori yang sama adalah dua entri; repositori + subpath yang sama dua kali
+adalah kolisi.
+
+### Contoh skill minimal
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Apa yang tidak diperiksa skema
 
 Skema sengaja bersifat lokal dan struktural. Ia **tidak** memverifikasi bahwa repositori itu

--- a/docs/i18n/it/SCHEMA.md
+++ b/docs/i18n/it/SCHEMA.md
@@ -256,6 +256,115 @@ Ometti del tutto il campo quando non c'è nulla da mostrare — `media: []` non 
 dire "nessuno screenshot". Il campo è additivo: le voci pubblicate prima che esistesse restano
 valide, e un consumatore che lo ignora legge ogni voce esattamente come prima.
 
+## Voci `kind: skill`
+
+Lo schema versione 1 definisce anche un secondo contratto di voce, autonomo, per
+`kind: skill`, pubblicato come [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)
+(SKL-01, fase 0). Non tocca mai lo schema dei plugin qui sopra: le voci con `kind: plugin`
+continuano a validarsi esattamente come prima, e il file dello schema delle skill è la fonte
+di verità per le voci skill, allo stesso modo in cui lo schema dei plugin lo è per le voci
+plugin.
+
+Una skill non si installa: viene **caricata** dall'harness, quindi i descrittori di
+installazione riservati ai plugin (`package`, `dsh`) non esistono su una voce skill e sono
+sostituiti da `usage` + `compat`. Una skill, inoltre, vive spesso in una sottodirectory di un
+repository che ospita molte skill, quindi l'identità e la deduplica sono `source.repository` +
+`source.subpath` anziché il solo repository. Una voce skill non ammette una galleria `media`:
+una skill è testo che l'harness carica, quindi non c'è nulla da catturare in uno screenshot
+(è `additionalProperties: false` a imporlo).
+
+Questi campi mantengono esattamente la forma e le regole documentate sopra per le voci plugin:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Ogni campo è obbligatorio
+tranne `triggers`, l'unico campo skill facoltativo.
+
+### Campi specifici delle skill
+
+| Campo                | Tipo   | Obbligatorio | Regole                                                  |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | costante  |   sì    | Deve essere esattamente `skill`                            |
+| `skillScope`         | enum   |   sì    | `repository` (l'intero repository **è** la skill) o `subdirectory` (la skill vive in `source.subpath`) |
+| `triggers`           | array  |    no    | Quando la skill si attiva — il testo che un utente valuta prima di caricarla. Almeno 1 stringa univoca, ciascuna di 3–200 caratteri; ometti del tutto il campo quando non ce ne sono (`triggers: []` non è valido) |
+| `usage.load`         | stringa |   sì    | Come l'harness carica la skill, 1–200 caratteri; una skill viene caricata, mai installata |
+| `usage.evidencePath` | stringa |   sì    | Percorso relativo sicuro (stesso pattern di `description.evidencePath`) alla prova di caricamento a `source.commit` |
+| `compat.harnessMin`  | stringa |   sì    | Versione minima dell'harness contro cui la skill è stata verificata; forma esatta `x.y.z` (prerelease/build opzionali), massimo 64 caratteri. Il livello semantico richiede inoltre un SemVer esatto e analizzabile |
+
+Regole condizionali (imposte dai blocchi `allOf` dello schema delle skill):
+
+- `skillScope: subdirectory` **impone** che `source.subpath` sia una stringa di percorso
+  relativo sicuro — una skill ospitata in una sottodirectory deve fissare quella
+  sottodirectory.
+- `skillScope: repository` **impone** `source.subpath: null` — una skill a repository intero
+  non deve dichiarare un subpath.
+
+`verification` mantiene la forma dei plugin (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), ma `smokeTest` deve essere esattamente `null`: una skill non ha uno smoke test
+di installazione, e la revisione dei contenuti è il gate di ammissione. Lo schema delle skill
+non porta il condizionale `status: verified` → `smokeTest` né i condizionali
+`repositoryScope` → `popularity`; quegli accoppiamenti sono regole del solo schema dei plugin.
+
+### Livello semantico per le skill
+
+Sopra lo schema, la validazione del catalogo applica gli stessi parser semantici obbligatori
+dei plugin dove i campi esistono: `license.spdx` deve essere analizzabile come espressione
+SPDX valida (`invalid-spdx`), e `compat.harnessMin` deve essere un SemVer esatto
+(`invalid-semver`). Non c'è un caso `invalid-sri` — una skill non ha `package.integrity`.
+
+### Identità e deduplica delle skill
+
+La chiave canonica di una skill è `skill:<source.repositoryNodeId>:<normalized subpath>`. Il
+subpath è normalizzato ai soli fini dell'identità: le backslash diventano `/`, i segmenti
+vuoti e `.` vengono eliminati, e un risultato vuoto (o `subpath: null`) diventa `.` —
+l'intero repository. Un subpath contenente byte NUL o segmenti `..` viene rifiutato, mai
+"ripulito". Due skill dello stesso repository sono due voci; lo stesso repository + subpath
+due volte è una collisione.
+
+### Esempio minimo di skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Cosa non controlla lo schema
 
 Lo schema è deliberatamente locale e strutturale. **Non** verifica che il repository esista, che

--- a/docs/i18n/ja/SCHEMA.md
+++ b/docs/i18n/ja/SCHEMA.md
@@ -241,6 +241,110 @@
 
 見せるものがない場合はフィールドごと省略してください — `media: []` は「スクリーンショットなし」を表す有効な書き方ではありません。このフィールドは追加的です: 存在する前に公開されたエントリは有効なままで、無視するコンシューマーはこれまでと全く同じようにすべてのエントリを読めます。
 
+## `kind: skill` エントリ
+
+スキーマバージョン1は、`kind: skill` 向けの、自己完結した第2のエントリ契約も定義しており、
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) として公開されています(SKL-01 フェーズ0)。
+これは上記のプラグインスキーマに一切触れません: `kind: plugin` のエントリはこれまでと全く同じように検証
+され続け、プラグインスキーマがプラグインエントリの信頼できる情報源であるのと同様に、スキルスキーマファ
+イルはスキルエントリの信頼できる情報源です。
+
+スキルはインストールされるのではなく、harnessによって**ロード**されます。そのため、プラグイン専用のイン
+ストール記述子(`package`、`dsh`)はスキルエントリには存在せず、`usage` + `compat` に置き換えられていま
+す。またスキルは、多くのスキルをホストするリポジトリのサブディレクトリに置かれることが多いため、識別と
+重複排除はリポジトリ単体ではなく `source.repository` + `source.subpath` で行われます。スキルエントリは
+`media` ギャラリーを認めません: スキルはharnessがロードするテキストであり、スクリーンショットに撮るもの
+が何もないからです(これを強制しているのが `additionalProperties: false` です)。
+
+以下のフィールドは、上記のプラグインエントリ向けに文書化された形状とルールをそのまま保ちます:
+`schemaVersion`、`id`、`name`、`description`、`unofficial`、`primaryCategory`、`tags`、
+`source`、`creator`、`repositoryScope`、`license`、`provenance`。唯一の任意スキルフィールドである
+`triggers` を除き、すべてのフィールドが必須です。
+
+### スキル固有のフィールド
+
+| フィールド             | 型    | 必須 | ルール                                                       |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   yes    | 正確に `skill` でなければならない                                |
+| `skillScope`         | enum   |   yes    | `repository`(リポジトリ全体**が**そのスキルである)または `subdirectory`(スキルは `source.subpath` に置かれている) |
+| `triggers`           | array  |    no    | スキルがいつ発火するか — ユーザーがロード前に評価するテキスト。少なくとも1つの一意な文字列で、それぞれ3〜200文字; 1つもない場合はフィールドごと省略する(`triggers: []` は無効) |
+| `usage.load`         | string |   yes    | harnessがスキルをどうロードするか、1〜200文字; スキルはロードされるものであり、決してインストールされない |
+| `usage.evidencePath` | string |   yes    | `source.commit` 時点のロードの証拠への安全な相対パス(`description.evidencePath` と同じパターン) |
+| `compat.harnessMin`  | string |   yes    | スキルが検証された最小のharnessバージョン; 正確な `x.y.z` 形式(オプションのプレリリース/ビルド)、最大64文字。セマンティック層は加えて、パース可能な正確なSemVerを要求する |
+
+条件付きルール(スキルスキーマの `allOf` ブロックによって強制されます):
+
+- `skillScope: subdirectory` は、`source.subpath` が安全な相対パス文字列であることを**強制します** —
+  サブディレクトリにホストされたスキルは、そのサブディレクトリを固定しなければなりません。
+- `skillScope: repository` は `source.subpath: null` を**強制します** — リポジトリ全体のスキルはサブパス
+  を宣言してはいけません。
+
+`verification` はプラグインの形状(`status`、`checkedAt`、`repositoryIdentity`、`smokeTest`)を保ちます
+が、`smokeTest` は正確に `null` でなければなりません: スキルにはインストールのスモークテストがなく、内容
+レビューが受け入れのゲートです。スキルスキーマは `status: verified` → `smokeTest` の条件も、
+`repositoryScope` → `popularity` の条件も持ちません。それらの結合はプラグインスキーマのみのルールです。
+
+### スキルのセマンティック層
+
+スキーマの上で、カタログの検証は、フィールドが存在する箇所についてプラグインと同じ必須のセマンティック
+パーサーを適用します: `license.spdx` は有効なSPDX表記としてパースできなければならず(`invalid-spdx`)、
+`compat.harnessMin` は正確なSemVerでなければなりません(`invalid-semver`)。`invalid-sri` のケースはあり
+ません — スキルには `package.integrity` がないからです。
+
+### スキルの識別と重複排除
+
+スキルの正規キーは `skill:<source.repositoryNodeId>:<normalized subpath>` です。サブパスは識別の目的で
+のみ正規化されます: バックスラッシュは `/` になり、空のセグメントと `.` セグメントは取り除かれ、空の結果
+(または `subpath: null`)は `.` — リポジトリ全体 — になります。NULバイトや `..` セグメントを含むサブパ
+スは拒否され、決して「クリーンアップ」されません。同じリポジトリの2つのスキルは2つのエントリですが、同じ
+リポジトリ + サブパスが2回現れれば衝突です。
+
+### 最小のスキル例
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## スキーマがチェックしないこと
 
 このスキーマは、意図的にローカルかつ構造的なものです。それは、リポジトリが存在すること、ノードIDがURL

--- a/docs/i18n/ko/SCHEMA.md
+++ b/docs/i18n/ko/SCHEMA.md
@@ -237,6 +237,111 @@ SPDX 표현식 파싱, 그리고 중복 키 거부. 값이 스키마 패턴과 �
 
 보여줄 것이 없으면 필드를 통째로 생략하세요 — `media: []`는 "스크린샷 없음"을 말하는 유효한 방법이 아닙니다. 이 필드는 추가적입니다: 필드가 생기기 전에 게시된 항목은 그대로 유효하며, 이를 무시하는 소비자는 모든 항목을 예전과 똑같이 읽습니다.
 
+## `kind: skill` 항목
+
+스키마 버전 1은 `kind: skill`을 위한 두 번째의 자기 완결적인 항목 계약도 정의하며,
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)로 게시되었습니다(SKL-01
+0단계). 이 계약은 위의 플러그인 스키마를 결코 건드리지 않습니다: `kind: plugin` 항목은
+이전과 정확히 동일하게 검증되며, 플러그인 스키마가 플러그인 항목의 원천인 것과 마찬가지로
+스킬 스키마 파일이 스킬 항목의 신뢰할 수 있는 원천입니다.
+
+스킬은 설치되는 것이 아니라 harness에 의해 **로드**되므로, 플러그인 전용 설치
+디스크립터(`package`, `dsh`)는 스킬 항목에 존재하지 않고 `usage` + `compat`로 대체됩니다.
+또한 스킬은 많은 스킬을 호스팅하는 저장소의 서브디렉터리에 있는 경우가 많으므로, 신원과
+중복 제거는 저장소 하나만이 아니라 `source.repository` + `source.subpath`로 이루어집니다.
+스킬 항목은 `media` 갤러리를 허용하지 않습니다: 스킬은 harness가 로드하는 텍스트이므로
+스크린샷으로 찍을 것이 없습니다(이를 강제하는 것이 `additionalProperties: false`입니다).
+
+다음 필드들은 위의 플러그인 항목에 문서화된 형태와 규칙을 정확히 그대로 유지합니다:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. 유일한 선택적 스킬 필드인
+`triggers`를 제외하고 모든 필드가 필수입니다.
+
+### 스킬 전용 필드
+
+| 필드                 | 유형   | 필수 | 규칙                                                          |
+| -------------------- | ------ | :--: | ------------------------------------------------------------- |
+| `kind`               | const  | 예   | 정확히 `skill`이어야 함                                        |
+| `skillScope`         | enum   | 예   | `repository`(저장소 전체**가** 스킬임) 또는 `subdirectory`(스킬이 `source.subpath`에 있음) |
+| `triggers`           | array  | 아니오 | 스킬이 언제 발동하는지 — 사용자가 로드하기 전에 평가하는 텍스트. 최소 1개의 고유한 문자열, 각각 3–200자; 하나도 없으면 필드를 통째로 생략하세요(`triggers: []`는 유효하지 않음) |
+| `usage.load`         | string | 예   | harness가 스킬을 로드하는 방법, 1–200자; 스킬은 로드되는 것이지 결코 설치되지 않음 |
+| `usage.evidencePath` | string | 예   | `source.commit` 시점의 로드 증거에 대한 안전한 상대 경로(`description.evidencePath`와 동일한 패턴) |
+| `compat.harnessMin`  | string | 예   | 스킬이 검증된 최소 harness 버전; 정확한 `x.y.z` 형태(선택적 prerelease/build), 최대 64자. 시맨틱 계층은 추가로 파싱 가능한 정확한 SemVer를 요구함 |
+
+조건부 규칙(스킬 스키마의 `allOf` 블록에 의해 강제됨):
+
+- `skillScope: subdirectory`는 `source.subpath`가 안전한 상대 경로 문자열이어야 함을
+  **강제합니다** — 서브디렉터리에 호스팅된 스킬은 그 서브디렉터리를 고정해야 합니다.
+- `skillScope: repository`는 `source.subpath: null`을 **강제합니다** — 저장소 전체 스킬은
+  서브패스를 선언해서는 안 됩니다.
+
+`verification`은 플러그인의 형태(`status`, `checkedAt`, `repositoryIdentity`, `smokeTest`)를
+유지하지만, `smokeTest`는 정확히 `null`이어야 합니다: 스킬에는 설치 스모크 테스트가 없으며,
+콘텐츠 검토가 승인 게이트입니다. 스킬 스키마는 `status: verified` → `smokeTest` 조건도,
+`repositoryScope` → `popularity` 조건도 갖지 않습니다; 그 결합들은 플러그인 스키마만의
+규칙입니다.
+
+### 스킬을 위한 시맨틱 계층
+
+스키마 위에서, 카탈로그 검증은 필드가 존재하는 곳에 플러그인과 동일한 필수 시맨틱 파서를
+적용합니다: `license.spdx`는 유효한 SPDX 표현식으로 파싱되어야 하고(`invalid-spdx`),
+`compat.harnessMin`은 정확한 SemVer여야 합니다(`invalid-semver`). `invalid-sri` 케이스는
+없습니다 — 스킬에는 `package.integrity`가 없기 때문입니다.
+
+### 스킬 신원과 중복 제거
+
+스킬의 정규 키는 `skill:<source.repositoryNodeId>:<normalized subpath>`입니다. 서브패스는
+오직 신원 목적을 위해서만 정규화됩니다: 백슬래시는 `/`가 되고, 빈 세그먼트와 `.` 세그먼트는
+버려지며, 빈 결과(또는 `subpath: null`)는 `.` — 저장소 전체 — 가 됩니다. NUL 바이트나 `..`
+세그먼트를 포함하는 서브패스는 거부되며, 결코 "정리"되지 않습니다. 같은 저장소의 두 스킬은
+두 개의 항목이지만, 같은 저장소 + 서브패스가 두 번 나오면 충돌입니다.
+
+### 최소 스킬 예시
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## 스키마가 검사하지 않는 것
 
 스키마는 의도적으로 로컬적이고 구조적입니다. 저장소가 존재하는지, 노드 ID가 URL과 일치하는지,

--- a/docs/i18n/mr/SCHEMA.md
+++ b/docs/i18n/mr/SCHEMA.md
@@ -249,6 +249,112 @@
 वैध मार्ग नाही. हे फील्ड वाढीव आहे: ते अस्तित्वात येण्यापूर्वी प्रकाशित झालेल्या नोंदी वैध राहतात,
 आणि त्याकडे दुर्लक्ष करणारा ग्राहक प्रत्येक नोंद पूर्वीसारखीच वाचतो.
 
+## `kind: skill` एंट्रीज
+
+स्कीमा आवृत्ती 1 `kind: skill` साठी दुसरा, स्वयंपूर्ण एंट्री करार देखील परिभाषित करते, जो
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) म्हणून प्रकाशित झाला आहे
+(SKL-01 टप्पा 0). तो वरील प्लगइन स्कीमाला कधीही स्पर्श करत नाही: `kind: plugin` असलेल्या
+एंट्रीज पूर्वीप्रमाणेच अचूक पडताळल्या जातात, आणि ज्याप्रमाणे प्लगइन स्कीमा प्लगइन एंट्रीजसाठी
+सत्याचा स्रोत आहे, त्याचप्रमाणे स्किल स्कीमा फाइल स्किल एंट्रीजसाठी सत्याचा स्रोत आहे.
+
+स्किल इंस्टॉल केली जात नाही, ती harness कडून **लोड** केली जाते, म्हणून फक्त-प्लगइनसाठीचे
+इंस्टॉल डिस्क्रिप्टर (`package`, `dsh`) स्किल एंट्रीवर अस्तित्वात नाहीत आणि त्यांची जागा
+`usage` + `compat` घेतात. स्किल अनेकदा अनेक स्किल्स असलेल्या रिपॉझिटरीच्या सबडिरेक्टरीत
+राहते, म्हणून ओळख आणि डिड्युप `source.repository` + `source.subpath` अशी आहे, केवळ
+रिपॉझिटरी नाही. स्किल एंट्रीला `media` गॅलरी मान्य नाही: स्किल हा harness लोड करत असलेला
+मजकूर आहे, त्यामुळे स्क्रीनशॉट घेण्यासारखे काहीही नाही (हे `additionalProperties: false`
+लागू करते).
+
+ही फील्ड्स वरील प्लगइन एंट्रीजसाठी दस्तऐवजीकृत आकार आणि नियम अगदी तसेच ठेवतात:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. `triggers` — एकमेव पर्यायी
+स्किल फील्ड — वगळता प्रत्येक फील्ड आवश्यक आहे.
+
+### स्किल-विशिष्ट फील्ड्स
+
+| फील्ड              | प्रकार  | आवश्यक | नियम                                                          |
+| -------------------- | ------ | :------: | ------------------------------------------------------------- |
+| `kind`               | const  |   होय    | नेमके `skill` असले पाहिजे                                     |
+| `skillScope`         | enum   |   होय    | `repository` (संपूर्ण रिपॉझिटरी **हीच** स्किल आहे) किंवा `subdirectory` (स्किल `source.subpath` वर राहते) |
+| `triggers`           | array  |    नाही    | स्किल केव्हा सक्रिय होते — लोड करण्यापूर्वी वापरकर्ता ज्या मजकुराचे मूल्यमापन करतो तो. किमान 1 अद्वितीय स्ट्रिंग, प्रत्येक 3–200 अक्षरे; एकही नसल्यास फील्ड पूर्णपणे वगळा (`triggers: []` अवैध आहे) |
+| `usage.load`         | string |   होय    | harness स्किल कशी लोड करते, 1–200 अक्षरे; स्किल लोड केली जाते, कधीही इंस्टॉल केली जात नाही |
+| `usage.evidencePath` | string |   होय    | `source.commit` वरील लोड पुराव्यासाठी सुरक्षित सापेक्ष पथ (`description.evidencePath` सारखाच पॅटर्न) |
+| `compat.harnessMin`  | string |   होय    | स्किल जिच्याविरुद्ध पडताळली गेली ती किमान harness आवृत्ती; अचूक `x.y.z` आकार (वैकल्पिक प्रिरिलीज/बिल्ड), कमाल 64 अक्षरे. सिमॅंटिक स्तर अतिरिक्तरित्या पार्स करता येणारी, अचूक SemVer आवश्यक करतो |
+
+सशर्त नियम (स्किल स्कीमाच्या `allOf` ब्लॉक्सद्वारे लागू):
+
+- `skillScope: subdirectory` हे `source.subpath` सुरक्षित सापेक्ष-पथ स्ट्रिंग असणे **सक्तीचे**
+  करते — सबडिरेक्टरीत होस्ट केलेल्या स्किलने ती सबडिरेक्टरी पिन केली पाहिजे.
+- `skillScope: repository` हे `source.subpath: null` **सक्तीचे** करते — संपूर्ण-रिपॉझिटरी
+  स्किलने सबपाथ जाहीर करू नये.
+
+`verification` प्लगइन आकार ठेवते (`status`, `checkedAt`, `repositoryIdentity`, `smokeTest`),
+पण `smokeTest` नेमके `null` असले पाहिजे: स्किलला इंस्टॉल स्मोक टेस्ट नाही, आणि आशय
+पुनरावलोकन हेच प्रवेशाचे गेट आहे. स्किल स्कीमामध्ये `status: verified` → `smokeTest` सशर्त
+नियम नाही आणि `repositoryScope` → `popularity` सशर्त नियमही नाहीत; त्या जोडण्या केवळ
+प्लगइन-स्कीमाचे नियम आहेत.
+
+### स्किल्ससाठी सिमॅंटिक स्तर
+
+स्कीमाच्या वर, कॅटलॉग पडताळणी — जिथे फील्ड्स अस्तित्वात आहेत तिथे — प्लगइनसाठी वापरले
+जाणारेच अनिवार्य सिमॅंटिक पार्सर्स लागू करते: `license.spdx` वैध SPDX अभिव्यक्ती म्हणून पार्स
+झाले पाहिजे (`invalid-spdx`), आणि `compat.harnessMin` अचूक SemVer असले पाहिजे
+(`invalid-semver`). `invalid-sri` केस नाही — स्किलला `package.integrity` नाही.
+
+### स्किल ओळख आणि डिड्युप
+
+स्किलची प्रामाणिक की `skill:<source.repositoryNodeId>:<normalized subpath>` आहे. सबपाथ केवळ
+ओळखीच्या हेतूने नॉर्मलाइझ केला जातो: बॅकस्लॅशचे `/` होतात, रिकामे आणि `.` विभाग टाकून दिले
+जातात, आणि रिकामा निकाल (किंवा `subpath: null`) `.` होतो — संपूर्ण रिपॉझिटरी. NUL बाइट्स
+किंवा `..` विभाग असलेला सबपाथ नाकारला जातो, कधीही "साफ" केला जात नाही. एकाच रिपॉझिटरीच्या
+दोन स्किल्स म्हणजे दोन एंट्रीज; तीच रिपॉझिटरी + सबपाथ दोनदा म्हणजे कोलिजन.
+
+### किमान स्किल उदाहरण
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## स्कीमा काय तपासत नाही
 
 स्कीमा जाणूनबुजून स्थानिक आणि संरचनात्मक आहे. ती रिपॉझिटरी अस्तित्वात आहे का, नोड ID

--- a/docs/i18n/ms/SCHEMA.md
+++ b/docs/i18n/ms/SCHEMA.md
@@ -257,6 +257,113 @@ yang sah untuk berkata "tiada tangkapan skrin". Medan ini bersifat tambahan: ent
 diterbitkan sebelum ia wujud kekal sah, dan pengguna yang mengabaikannya membaca setiap entri
 tepat seperti dahulu.
 
+## Entri `kind: skill`
+
+Versi skema 1 juga mentakrifkan kontrak entri kedua yang berdiri sendiri untuk `kind: skill`,
+diterbitkan sebagai [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01
+fasa 0). Ia tidak sesekali menyentuh skema pemalam di atas: entri dengan `kind: plugin` terus
+disahkan tepat seperti sebelumnya, dan fail skema skill adalah sumber kebenaran untuk entri
+skill sama seperti skema pemalam bagi entri pemalam.
+
+Sesuatu skill tidak dipasang, ia **dimuatkan** oleh harness, jadi deskriptor pemasangan
+khusus-pemalam (`package`, `dsh`) tidak wujud pada entri skill dan digantikan oleh `usage` +
+`compat`. Skill juga kerap tinggal dalam subdirektori repositori yang menempatkan banyak
+skill, jadi identiti dan penyahduaan ialah `source.repository` + `source.subpath`, bukannya
+repositori sahaja. Entri skill tidak menerima galeri `media`: skill ialah teks yang dimuatkan
+oleh harness, jadi tiada apa-apa untuk ditangkap skrin (`additionalProperties: false` yang
+menguatkuasakannya).
+
+Medan-medan ini mengekalkan tepat bentuk dan peraturan yang didokumenkan untuk entri pemalam
+di atas: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Setiap medan adalah
+wajib kecuali `triggers`, satu-satunya medan skill pilihan.
+
+### Medan khusus skill
+
+| Medan                | Jenis  | Diperlukan | Peraturan                                                   |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | konstan  |   ya    | Mesti tepat `skill`                                     |
+| `skillScope`         | enum   |   ya    | `repository` (keseluruhan repositori **ialah** skill itu) atau `subdirectory` (skill tinggal di `source.subpath`) |
+| `triggers`           | tatasusunan  |    tidak    | Bila skill itu terpicu — teks yang dinilai pengguna sebelum memuatkannya. Sekurang-kurangnya 1 rentetan unik, setiap satu 3–200 aksara; tinggalkan medan ini sepenuhnya apabila tiada (`triggers: []` tidak sah) |
+| `usage.load`         | rentetan |   ya    | Cara harness memuatkan skill itu, 1–200 aksara; skill dimuatkan, tidak sesekali dipasang |
+| `usage.evidencePath` | rentetan |   ya    | Laluan relatif selamat (corak yang sama seperti `description.evidencePath`) kepada bukti muatan pada `source.commit` |
+| `compat.harnessMin`  | rentetan |   ya    | Versi harness minimum yang terhadapnya skill itu disahkan; bentuk `x.y.z` tepat (prarilis/binaan pilihan), maksimum 64 aksara. Lapisan semantik juga memerlukan SemVer yang boleh dihurai dan tepat |
+
+Peraturan bersyarat (dikuatkuasakan oleh blok `allOf` skema skill):
+
+- `skillScope: subdirectory` **memaksa** `source.subpath` menjadi rentetan laluan relatif
+  selamat — skill yang ditempatkan dalam subdirektori mesti memasak subdirektori itu.
+- `skillScope: repository` **memaksa** `source.subpath: null` — skill seluruh repositori
+  tidak boleh mengisytiharkan subpath.
+
+`verification` mengekalkan bentuk pemalam (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), tetapi `smokeTest` mesti tepat `null`: skill tiada ujian asap pemasangan, dan
+semakan kandungan ialah pintu kemasukannya. Skema skill tidak membawa syarat
+`status: verified` → `smokeTest` dan tiada syarat `repositoryScope` → `popularity`; gandingan
+tersebut adalah peraturan skema pemalam sahaja.
+
+### Lapisan semantik untuk skill
+
+Di atas skema itu, pengesahan katalog menggunakan penghurai semantik mandatori yang sama
+seperti untuk pemalam di mana medan itu wujud: `license.spdx` mesti dihurai sebagai ungkapan
+SPDX yang sah (`invalid-spdx`), dan `compat.harnessMin` mesti SemVer tepat
+(`invalid-semver`). Tiada kes `invalid-sri` — skill tiada `package.integrity`.
+
+### Identiti dan penyahduaan skill
+
+Kunci kanonik sesuatu skill ialah `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Subpath dinormalkan untuk tujuan identiti sahaja: garis miring terbalik menjadi `/`, segmen
+kosong dan `.` digugurkan, dan hasil kosong (atau `subpath: null`) menjadi `.` — keseluruhan
+repositori. Subpath yang mengandungi bait NUL atau segmen `..` ditolak, tidak sesekali
+"dibersihkan". Dua skill daripada repositori yang sama ialah dua entri; repositori + subpath
+yang sama dua kali ialah perlanggaran.
+
+### Contoh skill minimum
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Apa yang tidak disemak oleh skema
 
 Skema itu sengaja tempatan dan struktur. Ia **tidak** mengesahkan bahawa repositori itu

--- a/docs/i18n/nl/SCHEMA.md
+++ b/docs/i18n/nl/SCHEMA.md
@@ -256,6 +256,115 @@ Laat het veld helemaal weg als er niets te tonen valt — `media: []` is geen ge
 "geen schermafbeeldingen" te zeggen. Het veld is additief: items die vóór het bestond zijn
 gepubliceerd blijven geldig, en een consument die het negeert leest elk item precies als voorheen.
 
+## `kind: skill`-items
+
+Schemaversie 1 definieert ook een tweede, op zichzelf staand itemcontract voor `kind: skill`,
+gepubliceerd als [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01
+fase 0). Het raakt het pluginschema hierboven nooit: items met `kind: plugin` blijven exact
+valideren zoals voorheen, en het skill-schemabestand is de bron van waarheid voor skill-items
+op dezelfde manier als het pluginschema dat is voor plugin-items.
+
+Een skill wordt niet geïnstalleerd, hij wordt **geladen** door de harness, dus de
+plugin-specifieke installatiedescriptors (`package`, `dsh`) bestaan niet op een skill-item en
+worden vervangen door `usage` + `compat`. Een skill leeft bovendien vaak in een submap van
+een repository dat veel skills herbergt, dus identiteit en deduplicatie is
+`source.repository` + `source.subpath` in plaats van het repository alleen. Een skill-item
+laat geen `media`-galerij toe: een skill is tekst die de harness laadt, dus er valt niets te
+screenshotten (`additionalProperties: false` is wat dit afdwingt).
+
+Deze velden behouden exact de vorm en regels die hierboven voor plugin-items zijn
+gedocumenteerd: `schemaVersion`, `id`, `name`, `description`, `unofficial`,
+`primaryCategory`, `tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`.
+Elk veld is verplicht behalve `triggers`, het enige optionele skill-veld.
+
+### Skill-specifieke velden
+
+| Veld                 | Type   | Verplicht | Regels                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ja    | Moet exact `skill` zijn                                     |
+| `skillScope`         | enum   |   ja    | `repository` (het hele repository **is** de skill) of `subdirectory` (de skill leeft op `source.subpath`) |
+| `triggers`           | array  |    nee    | Wanneer de skill afgaat — de tekst die een gebruiker beoordeelt vóór het laden. Minstens 1 unieke string, elk 3–200 tekens; laat het veld helemaal weg als er geen zijn (`triggers: []` is ongeldig) |
+| `usage.load`         | string |   ja    | Hoe de harness de skill laadt, 1–200 tekens; een skill wordt geladen, nooit geïnstalleerd |
+| `usage.evidencePath` | string |   ja    | Veilig relatief pad (hetzelfde patroon als `description.evidencePath`) naar het laadbewijs op `source.commit` |
+| `compat.harnessMin`  | string |   ja    | Minimale harnessversie waartegen de skill is geverifieerd; exacte `x.y.z`-vorm (optioneel prerelease/build), max 64 tekens. De semantische laag vereist bovendien een parseerbare, exacte SemVer |
+
+Voorwaardelijke regels (afgedwongen door de `allOf`-blokken van het skill-schema):
+
+- `skillScope: subdirectory` **forceert** dat `source.subpath` een veilige
+  relatieve-padstring is — een skill die in een submap wordt gehost, moet die submap
+  vastpinnen.
+- `skillScope: repository` **forceert** `source.subpath: null` — een skill van het hele
+  repository mag geen subpad declareren.
+
+`verification` behoudt de pluginvorm (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), maar `smokeTest` moet exact `null` zijn: een skill heeft geen
+installatie-smoketest, en de inhoudsbeoordeling is de toelatingspoort. Het skill-schema
+draagt geen `status: verified` → `smokeTest`-conditie en geen `repositoryScope` →
+`popularity`-condities; die koppelingen zijn uitsluitend pluginschema-regels.
+
+### Semantische laag voor skills
+
+Bovenop het schema past catalogusvalidatie dezelfde verplichte semantische parsers toe als
+voor plugins waar de velden bestaan: `license.spdx` moet parsen als een geldige
+SPDX-expressie (`invalid-spdx`), en `compat.harnessMin` moet een exacte SemVer zijn
+(`invalid-semver`). Er is geen `invalid-sri`-geval — een skill heeft geen
+`package.integrity`.
+
+### Identiteit en deduplicatie van skills
+
+De canonieke sleutel van een skill is `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Het subpad wordt uitsluitend voor identiteitsdoeleinden genormaliseerd: backslashes worden
+`/`, lege en `.`-segmenten vervallen, en een leeg resultaat (of `subpath: null`) wordt `.` —
+het hele repository. Een subpad met NUL-bytes of `..`-segmenten wordt afgewezen, nooit
+"opgeschoond". Twee skills van hetzelfde repository zijn twee items; hetzelfde repository +
+subpad tweemaal is een botsing.
+
+### Minimaal skill-voorbeeld
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Wat het schema niet controleert
 
 Het schema is bewust lokaal en structureel. Het controleert **niet** of het repository bestaat,

--- a/docs/i18n/no/SCHEMA.md
+++ b/docs/i18n/no/SCHEMA.md
@@ -252,6 +252,113 @@ Utelat feltet helt når det ikke er noe å vise — `media: []` er ikke en gyldi
 skjermbilder" på. Feltet er additivt: oppføringer publisert før det fantes er fortsatt gyldige, og
 en konsument som ignorerer det leser hver oppføring nøyaktig som før.
 
+## `kind: skill`-oppføringer
+
+Skjemaversjon 1 definerer også en andre, selvstendig oppføringskontrakt for `kind: skill`,
+publisert som [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01
+fase 0). Den rører aldri plugin-skjemaet ovenfor: oppføringer med `kind: plugin` fortsetter å
+validere nøyaktig som før, og skill-skjemafilen er kilden til sannhet for skill-oppføringer
+på samme måte som plugin-skjemaet er det for plugin-oppføringer.
+
+En skill installeres ikke, den **lastes** av harnesset, så de plugin-spesifikke
+installasjonsdeskriptorene (`package`, `dsh`) finnes ikke på en skill-oppføring og erstattes
+av `usage` + `compat`. En skill bor dessuten ofte i en underkatalog av et repositorium som
+huser mange skills, så identitet og deduplisering er `source.repository` + `source.subpath`
+i stedet for repositoriet alene. En skill-oppføring tillater ikke noe `media`-galleri: en
+skill er tekst harnesset laster, så det finnes ingenting å ta skjermbilde av
+(`additionalProperties: false` er det som håndhever dette).
+
+Disse feltene beholder nøyaktig formen og reglene som er dokumentert for plugin-oppføringer
+ovenfor: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Hvert felt er
+påkrevd bortsett fra `triggers`, det eneste valgfrie skill-feltet.
+
+### Skill-spesifikke felter
+
+| Felt                 | Type   | Påkrevd | Regler                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ja    | Må være nøyaktig `skill`                                     |
+| `skillScope`         | enum   |   ja    | `repository` (hele repositoriet **er** skillen) eller `subdirectory` (skillen bor på `source.subpath`) |
+| `triggers`           | array  |    nei    | Når skillen utløses — teksten en bruker vurderer før den lastes. Minst 1 unik streng, hver 3–200 tegn; utelat feltet helt når det ikke finnes noen (`triggers: []` er ugyldig) |
+| `usage.load`         | string |   ja    | Hvordan harnesset laster skillen, 1–200 tegn; en skill lastes, installeres aldri |
+| `usage.evidencePath` | string |   ja    | Trygg relativsti (samme mønster som `description.evidencePath`) til lastebeviset ved `source.commit` |
+| `compat.harnessMin`  | string |   ja    | Minste harnessversjon skillen ble verifisert mot; eksakt `x.y.z`-form (valgfri prerelease/build), maks 64 tegn. Semantisk lag krever i tillegg en parserbar, eksakt SemVer |
+
+Betingede regler (håndhevet av skill-skjemaets `allOf`-blokker):
+
+- `skillScope: subdirectory` **tvinger** `source.subpath` til å være en trygg
+  relativsti-streng — en skill som bor i en underkatalog må feste den underkatalogen.
+- `skillScope: repository` **tvinger** `source.subpath: null` — en skill for hele
+  repositoriet må ikke deklarere en understi.
+
+`verification` beholder plugin-formen (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), men `smokeTest` må være nøyaktig `null`: en skill har ingen
+installasjons-smoketest, og innholdsgjennomgangen er adgangsporten. Skill-skjemaet bærer
+ingen `status: verified` → `smokeTest`-betingelse og ingen `repositoryScope` →
+`popularity`-betingelser; de koblingene er kun plugin-skjemaregler.
+
+### Semantisk lag for skills
+
+Oppå skjemaet anvender katalogvalideringen de samme obligatoriske semantiske parserne som
+for plugins der feltene finnes: `license.spdx` må parses som et gyldig SPDX-uttrykk
+(`invalid-spdx`), og `compat.harnessMin` må være en eksakt SemVer (`invalid-semver`). Det
+finnes ikke noe `invalid-sri`-tilfelle — en skill har ingen `package.integrity`.
+
+### Skill-identitet og deduplisering
+
+Den kanoniske nøkkelen til en skill er `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Understien normaliseres kun for identitetsformål: backslasher blir `/`, tomme segmenter og
+`.`-segmenter droppes, og et tomt resultat (eller `subpath: null`) blir `.` — hele
+repositoriet. En understi som inneholder NUL-byte eller `..`-segmenter avvises, "renses"
+aldri. To skills fra samme repositorium er to oppføringer; samme repositorium + understi to
+ganger er en kollisjon.
+
+### Minimalt skill-eksempel
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Hva skjemaet ikke sjekker
 
 Skjemaet er bevisst lokalt og strukturelt. Det verifiserer **ikke** at repositoriet finnes,

--- a/docs/i18n/phi/SCHEMA.md
+++ b/docs/i18n/phi/SCHEMA.md
@@ -265,6 +265,121 @@ sabihing "walang screenshot". Karagdagan ang field na ito: mananatiling wasto an
 nailathala bago ito umiral, at ang mambabasang hindi ito pinapansin ay babasahin ang bawat entry
 nang eksaktong tulad ng dati.
 
+## Mga entry na `kind: skill`
+
+Tinutukoy din ng bersyon 1 ng schema ang ikalawang, nakapag-iisang kontrata ng entry para sa
+`kind: skill`, na inilathala bilang
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01 phase 0). Hindi nito
+kailanman ginagalaw ang plugin schema sa itaas: ang mga entry na may `kind: plugin` ay
+patuloy na nava-validate nang eksaktong tulad ng dati, at ang skill schema file ang
+pinagmumulan ng katotohanan para sa mga skill entry sa parehong paraan na ang plugin schema
+ay para sa mga plugin entry.
+
+Ang isang skill ay hindi ini-install, ito ay **nilo-load** ng harness, kaya ang mga install
+descriptor na pang-plugin lamang (`package`, `dsh`) ay hindi umiiral sa isang skill entry at
+pinapalitan ng `usage` + `compat`. Madalas ding nakatira ang isang skill sa isang
+subdirectory ng repository na naglalaman ng maraming skill, kaya ang pagkakakilanlan at
+dedupe ay `source.repository` + `source.subpath` sa halip na ang repository lamang. Ang
+isang skill entry ay hindi tumatanggap ng `media` gallery: ang skill ay tekstong nilo-load
+ng harness, kaya walang maiscre-screenshot (`additionalProperties: false` ang nagpapatupad
+nito).
+
+Pinapanatili ng mga field na ito ang eksaktong hugis at mga tuntuning nakadokumento para sa
+mga plugin entry sa itaas: `schemaVersion`, `id`, `name`, `description`, `unofficial`,
+`primaryCategory`, `tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`.
+Lahat ng field ay kinakailangan maliban sa `triggers`, ang tanging opsyonal na field ng
+skill.
+
+### Mga field na tiyak sa skill
+
+| Field                | Uri    | Kinakailangan | Mga Tuntunin                                                |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   oo    | Dapat eksaktong `skill`                                     |
+| `skillScope`         | enum   |   oo    | `repository` (ang buong repository **ang** skill) o `subdirectory` (ang skill ay nakatira sa `source.subpath`) |
+| `triggers`           | array  |    hindi    | Kailan pumapasok ang skill — ang tekstong sinusuri ng user bago ito i-load. Hindi bababa sa 1 natatanging string, bawat isa 3–200 character; alisin nang buo ang field kapag wala (`triggers: []` ay hindi wasto) |
+| `usage.load`         | string |   oo    | Paano nilo-load ng harness ang skill, 1–200 character; ang skill ay nilo-load, hindi kailanman ini-install |
+| `usage.evidencePath` | string |   oo    | Ligtas na relative path (parehong pattern ng `description.evidencePath`) patungo sa ebidensya ng pag-load sa `source.commit` |
+| `compat.harnessMin`  | string |   oo    | Pinakamababang bersyon ng harness na pinatunayan laban sa skill; eksaktong hugis na `x.y.z` (opsyonal na prerelease/build), hanggang 64 character. Nangangailangan din ang semantic layer ng mapaparse at eksaktong SemVer |
+
+Mga kundisyonal na tuntunin (ipinapatupad ng mga `allOf` block ng skill schema):
+
+- **Pinipilit** ng `skillScope: subdirectory` na ang `source.subpath` ay isang ligtas na
+  relative-path string — ang skill na naka-host sa isang subdirectory ay dapat mag-pin ng
+  subdirectory na iyon.
+- **Pinipilit** ng `skillScope: repository` ang `source.subpath: null` — ang skill na
+  buong-repository ay hindi dapat magdeklara ng subpath.
+
+Pinapanatili ng `verification` ang hugis ng plugin (`status`, `checkedAt`,
+`repositoryIdentity`, `smokeTest`), ngunit ang `smokeTest` ay dapat eksaktong `null`: walang
+install smoke test ang isang skill, at ang pagsusuri ng nilalaman ang gate ng pagtanggap.
+Walang dala ang skill schema na kundisyong `status: verified` → `smokeTest` at walang mga
+kundisyong `repositoryScope` → `popularity`; ang mga pagkakaugnay na iyon ay mga tuntunin
+lamang ng plugin schema.
+
+### Semantic layer para sa mga skill
+
+Sa ibabaw ng schema, ginagamit ng catalog validation ang parehong mga sapilitang semantic
+parser tulad ng sa mga plugin kung saan umiiral ang mga field: ang `license.spdx` ay dapat
+ma-parse bilang wastong SPDX expression (`invalid-spdx`), at ang `compat.harnessMin` ay
+dapat eksaktong SemVer (`invalid-semver`). Walang kasong `invalid-sri` — walang
+`package.integrity` ang isang skill.
+
+### Pagkakakilanlan at dedupe ng skill
+
+Ang canonical na key ng isang skill ay `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Ang subpath ay nino-normalize para lamang sa layunin ng pagkakakilanlan: ang mga backslash ay
+nagiging `/`, ang mga walang laman at `.` na segment ay inaalis, at ang walang laman na
+resulta (o `subpath: null`) ay nagiging `.` — ang buong repository. Ang subpath na may mga
+NUL byte o `..` na segment ay tinatanggihan, hindi kailanman "nililinis". Ang dalawang skill
+ng parehong repository ay dalawang entry; ang parehong repository + subpath nang dalawang
+beses ay isang banggaan.
+
+### Minimal na halimbawa ng skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Ano ang hindi sinusuri ng schema
 
 Ang schema ay sinasadyang lokal at structural. **Hindi** nito biniberipika na umiiral ang

--- a/docs/i18n/pl/SCHEMA.md
+++ b/docs/i18n/pl/SCHEMA.md
@@ -223,6 +223,114 @@ Pomiń pole w całości, gdy nie ma czego pokazywać — `media: []` nie jest po
 powiedzenia „brak zrzutów ekranu”. Pole jest addytywne: wpisy opublikowane przed jego istnieniem
 pozostają poprawne, a konsument, który je ignoruje, czyta każdy wpis dokładnie jak wcześniej.
 
+## Wpisy `kind: skill`
+
+Wersja 1 schematu definiuje również drugi, samodzielny kontrakt wpisu dla `kind: skill`,
+opublikowany jako [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01,
+faza 0). Nigdy nie dotyka on powyższego schematu wtyczek: wpisy z `kind: plugin` walidują
+się dokładnie tak jak dotychczas, a plik schematu skilla jest źródłem prawdy dla wpisów
+skilli w ten sam sposób, w jaki schemat wtyczek jest nim dla wpisów wtyczek.
+
+Skill nie jest instalowany, jest **ładowany** przez harness, więc deskryptory instalacji
+właściwe tylko wtyczkom (`package`, `dsh`) nie istnieją we wpisie skilla i są zastąpione
+przez `usage` + `compat`. Skill często mieszka też w podkatalogu repozytorium goszczącego
+wiele skilli, więc tożsamość i deduplikacja to `source.repository` + `source.subpath`, a nie
+samo repozytorium. Wpis skilla nie dopuszcza galerii `media`: skill to tekst, który ładuje
+harness, więc nie ma czego uwiecznić na zrzucie ekranu (wymusza to
+`additionalProperties: false`).
+
+Te pola zachowują dokładnie kształt i zasady udokumentowane powyżej dla wpisów wtyczek:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Każde pole jest wymagane z
+wyjątkiem `triggers` — jedynego opcjonalnego pola skilla.
+
+### Pola specyficzne dla skilla
+
+| Pole                 | Typ    | Wymagane | Zasady                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   tak    | Musi być dokładnie `skill`                                  |
+| `skillScope`         | enum   |   tak    | `repository` (całe repozytorium **jest** skillem) lub `subdirectory` (skill mieszka pod `source.subpath`) |
+| `triggers`           | array  |    nie    | Kiedy skill się uruchamia — tekst, który użytkownik ocenia przed jego załadowaniem. Co najmniej 1 unikalny ciąg znaków, każdy 3–200 znaków; pomiń pole w całości, gdy nie ma żadnych (`triggers: []` jest nieprawidłowe) |
+| `usage.load`         | string |   tak    | Jak harness ładuje skilla, 1–200 znaków; skill jest ładowany, nigdy instalowany |
+| `usage.evidencePath` | string |   tak    | Bezpieczna względna ścieżka (ten sam wzorzec co `description.evidencePath`) do dowodu ładowania przy `source.commit` |
+| `compat.harnessMin`  | string |   tak    | Minimalna wersja harnessa, względem której skill został zweryfikowany; dokładny kształt `x.y.z` (opcjonalny prerelease/build), maks. 64 znaki. Warstwa semantyczna dodatkowo wymaga parsowalnego, dokładnego SemVer |
+
+Zasady warunkowe (wymuszane przez bloki `allOf` schematu skilla):
+
+- `skillScope: subdirectory` **wymusza**, aby `source.subpath` był ciągiem znaków będącym
+  bezpieczną ścieżką względną — skill goszczony w podkatalogu musi przypiąć ten podkatalog.
+- `skillScope: repository` **wymusza** `source.subpath: null` — skill obejmujący całe
+  repozytorium nie może deklarować podścieżki.
+
+`verification` zachowuje kształt z wtyczek (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), ale `smokeTest` musi być dokładnie `null`: skill nie ma instalacyjnego smoke
+testu, a bramką dopuszczenia jest recenzja treści. Schemat skilla nie niesie warunku
+`status: verified` → `smokeTest` ani warunków `repositoryScope` → `popularity`; te
+powiązania są zasadami wyłącznie schematu wtyczek.
+
+### Warstwa semantyczna dla skilli
+
+Na tej podstawie walidacja katalogu stosuje te same obowiązkowe parsery semantyczne co dla
+wtyczek tam, gdzie pola istnieją: `license.spdx` musi być parsowalne jako prawidłowe
+wyrażenie SPDX (`invalid-spdx`), a `compat.harnessMin` musi być dokładnym SemVer
+(`invalid-semver`). Nie istnieje przypadek `invalid-sri` — skill nie ma
+`package.integrity`.
+
+### Tożsamość i deduplikacja skilla
+
+Kanonicznym kluczem skilla jest `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Podścieżka jest normalizowana wyłącznie na potrzeby tożsamości: ukośniki wsteczne stają się
+`/`, puste segmenty i segmenty `.` są usuwane, a pusty wynik (lub `subpath: null`) staje się
+`.` — całym repozytorium. Podścieżka zawierająca bajty NUL lub segmenty `..` jest odrzucana,
+nigdy „czyszczona". Dwa skille tego samego repozytorium to dwa wpisy; to samo repozytorium +
+podścieżka dwa razy to kolizja.
+
+### Minimalny przykład skilla
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Czego schemat nie sprawdza
 
 Schemat jest celowo lokalny i strukturalny. **Nie** weryfikuje, czy repozytorium istnieje, czy node ID pasuje do URL, czy ścieżki dowodowe istnieją w przypiętym commicie, czy liczba gwiazdek jest dokładna, ani czy twórca jest właścicielem źródła. Te sprawdzenia należą do bramek recenzji maintainerów opisanych w [CONTRIBUTING.md](../../CONTRIBUTING.md) i [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md).

--- a/docs/i18n/pt-BR/SCHEMA.md
+++ b/docs/i18n/pt-BR/SCHEMA.md
@@ -255,6 +255,115 @@ Omita o campo inteiro quando não houver nada a mostrar — `media: []` não é 
 dizer "sem capturas de tela". O campo é aditivo: entradas publicadas antes de ele existir
 continuam válidas, e um consumidor que o ignora lê todas as entradas exatamente como antes.
 
+## Entradas `kind: skill`
+
+A versão 1 do schema também define um segundo contrato de entrada, autocontido, para
+`kind: skill`, publicado como
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01, fase 0). Ele nunca
+toca no schema de plugins acima: entradas com `kind: plugin` continuam validando exatamente
+como antes, e o arquivo de schema de skill é a fonte da verdade para entradas de skill da
+mesma forma que o schema de plugins é para entradas de plugin.
+
+Uma skill não é instalada, ela é **carregada** pelo harness, então os descritores de
+instalação exclusivos de plugins (`package`, `dsh`) não existem em uma entrada de skill e
+são substituídos por `usage` + `compat`. Uma skill também vive com frequência em um
+subdiretório de um repositório que hospeda muitas skills, então a identidade e a
+desduplicação são `source.repository` + `source.subpath`, em vez do repositório sozinho.
+Uma entrada de skill não admite galeria `media`: uma skill é texto que o harness carrega,
+então não há nada para capturar (`additionalProperties: false` é o que impõe isso).
+
+Estes campos mantêm exatamente o formato e as regras documentados acima para as entradas de
+plugin: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Todos os campos são
+obrigatórios exceto `triggers`, o único campo opcional de skill.
+
+### Campos específicos de skill
+
+| Campo                | Tipo   | Obrigatório | Regras                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   sim    | Deve ser exatamente `skill`                                 |
+| `skillScope`         | enum   |   sim    | `repository` (o repositório inteiro **é** a skill) ou `subdirectory` (a skill vive em `source.subpath`) |
+| `triggers`           | array  |    não    | Quando a skill dispara — o texto que um usuário avalia antes de carregá-la. Pelo menos 1 string única, cada uma com 3–200 caracteres; omita o campo inteiro quando não houver nenhum (`triggers: []` é inválido) |
+| `usage.load`         | string |   sim    | Como o harness carrega a skill, 1–200 caracteres; uma skill é carregada, nunca instalada |
+| `usage.evidencePath` | string |   sim    | Caminho relativo seguro (mesmo padrão que `description.evidencePath`) para a evidência de carregamento em `source.commit` |
+| `compat.harnessMin`  | string |   sim    | Versão mínima do harness contra a qual a skill foi verificada; formato exato `x.y.z` (prerelease/build opcionais), máximo de 64 caracteres. A camada semântica ainda exige um SemVer exato interpretável |
+
+Regras condicionais (aplicadas pelos blocos `allOf` do schema de skill):
+
+- `skillScope: subdirectory` **força** `source.subpath` a ser uma string de caminho relativo
+  seguro — uma skill hospedada em um subdiretório deve fixar esse subdiretório.
+- `skillScope: repository` **força** `source.subpath: null` — uma skill de repositório
+  inteiro não pode declarar um subcaminho.
+
+`verification` mantém o formato dos plugins (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), mas `smokeTest` deve ser exatamente `null`: uma skill não tem smoke test de
+instalação, e a revisão de conteúdo é o gate de admissão. O schema de skill não carrega a
+condição `status: verified` → `smokeTest` nem as condições `repositoryScope` →
+`popularity`; esses acoplamentos são regras exclusivas do schema de plugins.
+
+### Camada semântica para skills
+
+Sobre o schema, a validação do catálogo aplica os mesmos interpretadores semânticos
+obrigatórios que para os plugins onde os campos existem: `license.spdx` deve ser
+interpretado como uma expressão SPDX válida (`invalid-spdx`), e `compat.harnessMin` deve ser
+um SemVer exato (`invalid-semver`). Não existe o caso `invalid-sri` — uma skill não tem
+`package.integrity`.
+
+### Identidade e desduplicação de skills
+
+A chave canônica de uma skill é `skill:<source.repositoryNodeId>:<normalized subpath>`. O
+subcaminho é normalizado apenas para fins de identidade: barras invertidas viram `/`,
+segmentos vazios e `.` são descartados, e um resultado vazio (ou `subpath: null`) vira `.` —
+o repositório inteiro. Um subcaminho contendo bytes NUL ou segmentos `..` é rejeitado, nunca
+"limpo". Duas skills do mesmo repositório são duas entradas; o mesmo repositório +
+subcaminho duas vezes é uma colisão.
+
+### Exemplo mínimo de skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## O que o schema não verifica
 
 O schema é intencionalmente local e estrutural. Ele **não** verifica se o repositório existe, se

--- a/docs/i18n/pt/SCHEMA.md
+++ b/docs/i18n/pt/SCHEMA.md
@@ -255,6 +255,115 @@ Omita o campo por completo quando não houver nada a mostrar — `media: []` nã
 de dizer "sem capturas de ecrã". O campo é aditivo: as entradas publicadas antes de ele existir
 mantêm-se válidas, e um consumidor que o ignora lê todas as entradas exatamente como antes.
 
+## Entradas `kind: skill`
+
+A versão 1 do esquema também define um segundo contrato de entrada, autónomo, para
+`kind: skill`, publicado como
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01, fase 0). Nunca toca
+no esquema de plugins acima: as entradas com `kind: plugin` continuam a validar exatamente
+como antes, e o ficheiro de esquema de skill é a fonte da verdade para entradas de skill da
+mesma forma que o esquema de plugins o é para entradas de plugin.
+
+Uma skill não é instalada, é **carregada** pelo harness, pelo que os descritores de
+instalação exclusivos de plugins (`package`, `dsh`) não existem numa entrada de skill e são
+substituídos por `usage` + `compat`. Uma skill também vive frequentemente num subdiretório
+de um repositório que aloja muitas skills, pelo que a identidade e a desduplicação são
+`source.repository` + `source.subpath`, em vez do repositório sozinho. Uma entrada de skill
+não admite galeria `media`: uma skill é texto que o harness carrega, pelo que não há nada
+para capturar (é `additionalProperties: false` que o impõe).
+
+Estes campos mantêm exatamente a forma e as regras documentadas acima para as entradas de
+plugin: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Todos os campos são
+obrigatórios exceto `triggers`, o único campo opcional de skill.
+
+### Campos específicos de skill
+
+| Campo                | Tipo   | Obrigatório | Regras                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   sim    | Tem de ser exatamente `skill`                               |
+| `skillScope`         | enum   |   sim    | `repository` (o repositório inteiro **é** a skill) ou `subdirectory` (a skill vive em `source.subpath`) |
+| `triggers`           | array  |    não    | Quando a skill dispara — o texto que um utilizador avalia antes de a carregar. Pelo menos 1 string única, cada uma com 3–200 carateres; omita o campo por completo quando não houver nenhum (`triggers: []` é inválido) |
+| `usage.load`         | string |   sim    | Como o harness carrega a skill, 1–200 carateres; uma skill é carregada, nunca instalada |
+| `usage.evidencePath` | string |   sim    | Caminho relativo seguro (mesmo padrão que `description.evidencePath`) para a prova de carregamento em `source.commit` |
+| `compat.harnessMin`  | string |   sim    | Versão mínima do harness contra a qual a skill foi verificada; forma exata `x.y.z` (pré-lançamento/build opcional), máx. 64 carateres. A camada semântica exige adicionalmente um SemVer exato e analisável |
+
+Regras condicionais (impostas pelos blocos `allOf` do esquema de skill):
+
+- `skillScope: subdirectory` **obriga** a que `source.subpath` seja uma string de caminho
+  relativo seguro — uma skill alojada num subdiretório tem de fixar esse subdiretório.
+- `skillScope: repository` **obriga** a `source.subpath: null` — uma skill de repositório
+  inteiro não pode declarar um subcaminho.
+
+`verification` mantém a forma dos plugins (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), mas `smokeTest` tem de ser exatamente `null`: uma skill não tem teste de fumo
+de instalação, e a revisão de conteúdo é o controlo de admissão. O esquema de skill não
+transporta a condição `status: verified` → `smokeTest` nem as condições `repositoryScope` →
+`popularity`; esses acoplamentos são regras exclusivas do esquema de plugins.
+
+### Camada semântica para skills
+
+Por cima do esquema, a validação do catálogo aplica os mesmos analisadores semânticos
+obrigatórios que para os plugins onde os campos existem: `license.spdx` tem de ser analisado
+como uma expressão SPDX válida (`invalid-spdx`), e `compat.harnessMin` tem de ser um SemVer
+exato (`invalid-semver`). Não existe o caso `invalid-sri` — uma skill não tem
+`package.integrity`.
+
+### Identidade e desduplicação de skills
+
+A chave canónica de uma skill é `skill:<source.repositoryNodeId>:<normalized subpath>`. O
+subcaminho é normalizado apenas para fins de identidade: as barras invertidas tornam-se `/`,
+os segmentos vazios e `.` são descartados, e um resultado vazio (ou `subpath: null`)
+torna-se `.` — o repositório inteiro. Um subcaminho contendo bytes NUL ou segmentos `..` é
+rejeitado, nunca "limpo". Duas skills do mesmo repositório são duas entradas; o mesmo
+repositório + subcaminho duas vezes é uma colisão.
+
+### Exemplo mínimo de skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## O que o esquema não verifica
 
 O esquema é intencionalmente local e estrutural. **Não** verifica se o repositório existe, se o

--- a/docs/i18n/ro/SCHEMA.md
+++ b/docs/i18n/ro/SCHEMA.md
@@ -253,6 +253,113 @@ Omite complet câmpul când nu este nimic de arătat — `media: []` nu este o m
 spune "fără capturi". Câmpul este aditiv: intrările publicate înainte ca el să existe rămân
 valide, iar un consumator care îl ignoră citește fiecare intrare exact ca înainte.
 
+## Intrări `kind: skill`
+
+Versiunea 1 a schemei definește și un al doilea contract de intrare, de sine stătător, pentru
+`kind: skill`, publicat ca [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)
+(SKL-01 faza 0). El nu atinge niciodată schema de plugin de mai sus: intrările cu `kind: plugin`
+continuă să se valideze exact ca înainte, iar fișierul schemei de skill este sursa de adevăr
+pentru intrările de skill în același fel în care schema de plugin este pentru intrările de plugin.
+
+Un skill nu se instalează, ci este **încărcat** de harness, astfel încât descriptorii de instalare
+exclusiv de plugin (`package`, `dsh`) nu există pe o intrare de skill și sunt înlocuiți de
+`usage` + `compat`. Un skill trăiește de asemenea frecvent într-un subdirector al unui repository
+care găzduiește multe skill-uri, deci identitatea și deduplicarea sunt `source.repository` +
+`source.subpath`, nu repository-ul singur. O intrare de skill nu admite o galerie `media`: un
+skill este text pe care harness-ul îl încarcă, deci nu există nimic de capturat
+(`additionalProperties: false` este ceea ce impune asta).
+
+Aceste câmpuri păstrează exact forma și regulile documentate pentru intrările de plugin de mai
+sus: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Fiecare câmp este obligatoriu,
+cu excepția lui `triggers`, singurul câmp opțional de skill.
+
+### Câmpuri specifice skill-urilor
+
+| Câmp                 | Tip    | Obligatoriu | Reguli                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   da    | Trebuie să fie exact `skill`                                     |
+| `skillScope`         | enum   |   da    | `repository` (întregul repository **este** skill-ul) sau `subdirectory` (skill-ul trăiește la `source.subpath`) |
+| `triggers`           | array  |    nu    | Când se declanșează skill-ul — textul pe care un utilizator îl evaluează înainte de a-l încărca. Cel puțin 1 string unic, fiecare de 3–200 de caractere; omite complet câmpul când nu există niciunul (`triggers: []` este invalid) |
+| `usage.load`         | string |   da    | Cum încarcă harness-ul skill-ul, 1–200 de caractere; un skill este încărcat, niciodată instalat |
+| `usage.evidencePath` | string |   da    | Cale relativă sigură (același tipar ca `description.evidencePath`) către dovada de încărcare la `source.commit` |
+| `compat.harnessMin`  | string |   da    | Versiunea minimă de harness față de care skill-ul a fost verificat; formă exactă `x.y.z` (prerelease/build opționale), max 64 de caractere. Stratul semantic cere în plus un SemVer exact, parsabil |
+
+Reguli condiționale (impuse de blocurile `allOf` ale schemei de skill):
+
+- `skillScope: subdirectory` **forțează** ca `source.subpath` să fie un string de cale relativă
+  sigură — un skill găzduit într-un subdirector trebuie să fixeze acel subdirector.
+- `skillScope: repository` **forțează** `source.subpath: null` — un skill de repository întreg
+  nu trebuie să declare un subpath.
+
+`verification` păstrează forma de plugin (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), dar `smokeTest` trebuie să fie exact `null`: un skill nu are smoke-test de
+instalare, iar revizuirea conținutului este poarta de admitere. Schema de skill nu poartă
+condiționala `status: verified` → `smokeTest` și nici condiționalele `repositoryScope` →
+`popularity`; acele cuplaje sunt reguli exclusiv ale schemei de plugin.
+
+### Stratul semantic pentru skill-uri
+
+Deasupra schemei, validarea catalogului aplică aceleași parsere semantice obligatorii ca pentru
+pluginuri, acolo unde câmpurile există: `license.spdx` trebuie să se parseze ca o expresie SPDX
+validă (`invalid-spdx`), iar `compat.harnessMin` trebuie să fie un SemVer exact
+(`invalid-semver`). Nu există cazul `invalid-sri` — un skill nu are `package.integrity`.
+
+### Identitatea și deduplicarea skill-urilor
+
+Cheia canonică a unui skill este `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Subpath-ul este normalizat doar în scopuri de identitate: backslash-urile devin `/`, segmentele
+goale și `.` sunt eliminate, iar un rezultat gol (sau `subpath: null`) devine `.` — întregul
+repository. Un subpath care conține octeți NUL sau segmente `..` este respins, niciodată
+„curățat". Două skill-uri ale aceluiași repository sunt două intrări; același repository +
+subpath de două ori este o coliziune.
+
+### Exemplu minim de skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Ce nu verifică schema
 
 Schema este intenționat locală și structurală. **Nu** verifică faptul că repository-ul există, că

--- a/docs/i18n/ru/SCHEMA.md
+++ b/docs/i18n/ru/SCHEMA.md
@@ -251,6 +251,113 @@ URL здесь должен быть таким же неизменяемым, �
 сказать «скриншотов нет». Поле аддитивно: записи, опубликованные до его появления, остаются
 действительными, а потребитель, который его игнорирует, читает каждую запись ровно как прежде.
 
+## Записи `kind: skill`
+
+Версия 1 схемы также определяет второй, самостоятельный контракт записи для `kind: skill`,
+опубликованный как [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01,
+фаза 0). Он никогда не затрагивает схему плагинов выше: записи с `kind: plugin` продолжают
+валидироваться ровно как прежде, а файл схемы скиллов — источник истины для записей скиллов так
+же, как схема плагинов — для записей плагинов.
+
+Скилл не устанавливается, он **загружается** харнесом, поэтому дескрипторы установки, присущие
+только плагинам (`package`, `dsh`), отсутствуют в записи скилла и заменены на `usage` +
+`compat`. Скилл также часто живёт в подкаталоге репозитория, содержащего много скиллов, поэтому
+идентичность и дедупликация — это `source.repository` + `source.subpath`, а не репозиторий сам
+по себе. Запись скилла не допускает галереи `media`: скилл — это текст, который загружает
+харнес, поэтому снимать на скриншот нечего (именно `additionalProperties: false` это и
+обеспечивает).
+
+Эти поля сохраняют ровно ту форму и правила, что задокументированы для записей плагинов выше:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Каждое поле обязательно, кроме
+`triggers` — единственного необязательного поля скилла.
+
+### Поля, специфичные для скиллов
+
+| Поле                 | Тип    | Обязательно | Правила                                                     |
+| -------------------- | ------ | :---------: | ----------------------------------------------------------- |
+| `kind`               | const  |     да      | Должно быть точно `skill`                                   |
+| `skillScope`         | enum   |     да      | `repository` (весь репозиторий **является** скиллом) или `subdirectory` (скилл живёт по пути `source.subpath`) |
+| `triggers`           | array  |     нет     | Когда скилл срабатывает — текст, который пользователь оценивает перед загрузкой. Не менее 1 уникальной строки, каждая 3–200 символов; полностью опускайте поле, когда их нет (`triggers: []` недопустимо) |
+| `usage.load`         | string |     да      | Как харнес загружает скилл, 1–200 символов; скилл загружается, никогда не устанавливается |
+| `usage.evidencePath` | string |     да      | Безопасный относительный путь (тот же паттерн, что у `description.evidencePath`) к доказательству загрузки на `source.commit` |
+| `compat.harnessMin`  | string |     да      | Минимальная версия харнеса, с которой скилл был проверен; точная форма `x.y.z` (опциональные prerelease/build), не более 64 символов. Семантический уровень дополнительно требует разбираемого точного SemVer |
+
+Условные правила (применяются блоками `allOf` схемы скиллов):
+
+- `skillScope: subdirectory` **вынуждает** `source.subpath` быть строкой безопасного
+  относительного пути — скилл, размещённый в подкаталоге, обязан закрепить этот подкаталог.
+- `skillScope: repository` **вынуждает** `source.subpath: null` — скилл на весь репозиторий не
+  должен объявлять подпуть.
+
+`verification` сохраняет форму плагина (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), но `smokeTest` должен быть точно `null`: у скилла нет установочного smoke-теста,
+а барьером допуска служит ревью содержимого. Схема скиллов не несёт условного правила
+`status: verified` → `smokeTest` и условных правил `repositoryScope` → `popularity`; эти связки
+— правила только схемы плагинов.
+
+### Семантический уровень для скиллов
+
+Поверх схемы проверка каталога применяет те же обязательные семантические парсеры, что и для
+плагинов, там, где поля существуют: `license.spdx` должно разбираться как валидное
+SPDX-выражение (`invalid-spdx`), а `compat.harnessMin` должно быть точным SemVer
+(`invalid-semver`). Случая `invalid-sri` не существует — у скилла нет `package.integrity`.
+
+### Идентичность и дедупликация скиллов
+
+Канонический ключ скилла — `skill:<source.repositoryNodeId>:<normalized subpath>`. Подпуть
+нормализуется только для целей идентичности: обратные слэши становятся `/`, пустые сегменты и
+сегменты `.` отбрасываются, а пустой результат (или `subpath: null`) становится `.` — весь
+репозиторий. Подпуть, содержащий NUL-байты или сегменты `..`, отклоняется, а не «очищается».
+Два скилла одного репозитория — это две записи; один и тот же репозиторий + подпуть дважды —
+это коллизия.
+
+### Минимальный пример скилла
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Что схема не проверяет
 
 Схема намеренно локальна и структурна. Она **не** проверяет, существует ли репозиторий, совпадает

--- a/docs/i18n/sk/SCHEMA.md
+++ b/docs/i18n/sk/SCHEMA.md
@@ -247,6 +247,111 @@ Pole úplne vynechajte, keď niet čo ukázať — `media: []` nie je platný sp
 snímky obrazovky“. Pole je aditívne: záznamy zverejnené predtým, než existovalo, zostávajú platné
 a konzument, ktorý ho ignoruje, číta každý záznam presne ako predtým.
 
+## Záznamy `kind: skill`
+
+Verzia 1 schémy definuje aj druhý, samostatný kontrakt záznamu pre `kind: skill`, zverejnený
+ako [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01, fáza 0). Nikdy sa
+nedotýka vyššie uvedenej schémy pluginov: záznamy s `kind: plugin` sa naďalej validujú presne
+ako doteraz a súbor schémy skillov je zdrojom pravdy pre záznamy skillov rovnako, ako je schéma
+pluginov pre záznamy pluginov.
+
+Skill sa neinštaluje, harness ho **načítava**, takže inštalačné deskriptory určené len pre
+pluginy (`package`, `dsh`) na zázname skillu neexistujú a nahrádzajú ich `usage` + `compat`.
+Skill navyše často žije v podadresári repozitára, ktorý hostí mnoho skillov, takže identita a
+deduplikácia je `source.repository` + `source.subpath`, nie samotný repozitár. Záznam skillu
+nepripúšťa galériu `media`: skill je text, ktorý harness načítava, takže nie je čo odfotiť
+(vynucuje to práve `additionalProperties: false`).
+
+Tieto polia si zachovávajú presne tvar a pravidlá zdokumentované pre záznamy pluginov vyššie:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Každé pole je povinné okrem
+`triggers`, jediného voliteľného poľa skillu.
+
+### Polia špecifické pre skill
+
+| Pole                 | Typ    | Povinné | Pravidlá                                                    |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   áno    | Musí byť presne `skill`                                     |
+| `skillScope`         | enum   |   áno    | `repository` (celý repozitár **je** skill) alebo `subdirectory` (skill žije na `source.subpath`) |
+| `triggers`           | array  |    nie    | Kedy sa skill spúšťa — text, ktorý používateľ posudzuje pred jeho načítaním. Aspoň 1 unikátny reťazec, každý 3–200 znakov; pole úplne vynechajte, keď žiadne nie sú (`triggers: []` je neplatné) |
+| `usage.load`         | string |   áno    | Ako harness skill načítava, 1–200 znakov; skill sa načítava, nikdy neinštaluje |
+| `usage.evidencePath` | string |   áno    | Bezpečná relatívna cesta (rovnaký regulárny výraz ako `description.evidencePath`) k dôkazu načítania na `source.commit` |
+| `compat.harnessMin`  | string |   áno    | Minimálna verzia harnessu, voči ktorej bol skill overený; presný tvar `x.y.z` (voliteľný prerelease/build), max. 64 znakov. Sémantická vrstva navyše vyžaduje parsovateľné, presné SemVer |
+
+Podmienené pravidlá (vynucované blokmi `allOf` schémy skillov):
+
+- `skillScope: subdirectory` **vynucuje**, aby `source.subpath` bol reťazec bezpečnej relatívnej
+  cesty — skill hosťovaný v podadresári musí tento podadresár pripnúť.
+- `skillScope: repository` **vynucuje** `source.subpath: null` — skill pokrývajúci celý
+  repozitár nesmie deklarovať podcestu.
+
+`verification` si zachováva tvar z pluginov (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), ale `smokeTest` musí byť presne `null`: skill nemá inštalačný smoke test a bránou
+prijatia je posúdenie obsahu. Schéma skillov nenesie podmienku `status: verified` → `smokeTest`
+ani podmienky `repositoryScope` → `popularity`; tieto väzby sú pravidlami výlučne schémy
+pluginov.
+
+### Sémantická vrstva pre skilly
+
+Nad schémou uplatňuje validácia katalógu rovnaké povinné sémantické parsery ako pri pluginoch
+tam, kde polia existujú: `license.spdx` sa musí dať spracovať ako platný SPDX výraz
+(`invalid-spdx`) a `compat.harnessMin` musí byť presné SemVer (`invalid-semver`). Prípad
+`invalid-sri` neexistuje — skill nemá `package.integrity`.
+
+### Identita a deduplikácia skillov
+
+Kanonickým kľúčom skillu je `skill:<source.repositoryNodeId>:<normalized subpath>`. Podcesta sa
+normalizuje len na účely identity: spätné lomky sa menia na `/`, prázdne segmenty a segmenty
+`.` sa zahadzujú a prázdny výsledok (alebo `subpath: null`) sa stáva `.` — celým repozitárom.
+Podcesta obsahujúca bajty NUL alebo segmenty `..` sa odmieta, nikdy sa „nečistí“. Dva skilly
+toho istého repozitára sú dva záznamy; ten istý repozitár + podcesta dvakrát je kolízia.
+
+### Minimálny príklad skillu
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Čo schéma nekontroluje
 
 Schéma je zámerne lokálna a štrukturálna. **Neoveruje**, že repozitár existuje, že ID uzla sa

--- a/docs/i18n/sv/SCHEMA.md
+++ b/docs/i18n/sv/SCHEMA.md
@@ -250,6 +250,113 @@ Utelämna fältet helt när det inte finns något att visa — `media: []` är i
 säga "inga skärmbilder". Fältet är additivt: poster som publicerades innan det fanns är fortfarande
 giltiga, och en konsument som ignorerar det läser varje post precis som förut.
 
+## Poster med `kind: skill`
+
+Schemaversion 1 definierar också ett andra, självständigt postkontrakt för `kind: skill`,
+publicerat som [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01 fas 0).
+Det rör aldrig pluginschemat ovan: poster med `kind: plugin` fortsätter att valideras exakt som
+förut, och skillschemafilen är sanningskällan för skillposter på samma sätt som pluginschemat
+är det för pluginposter.
+
+En skill installeras inte, den **läses in** av harnesset, så de installationsdeskriptorer som
+bara finns för plugins (`package`, `dsh`) existerar inte på en skillpost och ersätts av
+`usage` + `compat`. En skill lever också ofta i en underkatalog av ett repository som rymmer
+många skills, så identitet och dedupe är `source.repository` + `source.subpath` snarare än
+repositoryt ensamt. En skillpost tillåter inget `media`-galleri: en skill är text som harnesset
+läser in, så det finns inget att ta skärmbild av (det är `additionalProperties: false` som
+upprätthåller detta).
+
+Dessa fält behåller exakt den form och de regler som dokumenteras för pluginposter ovan:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Varje fält är obligatoriskt
+utom `triggers`, det enda valfria skillfältet.
+
+### Skillspecifika fält
+
+| Fält                 | Typ    | Obligatoriskt | Regler                                              |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ja     | Måste vara exakt `skill`                                    |
+| `skillScope`         | enum   |   ja     | `repository` (hela repositoryt **är** skillen) eller `subdirectory` (skillen lever vid `source.subpath`) |
+| `triggers`           | array  |    nej    | När skillen utlöses — texten en användare bedömer innan den läses in. Minst 1 unik sträng, vardera 3–200 tecken; utelämna fältet helt när inga finns (`triggers: []` är ogiltigt) |
+| `usage.load`         | string |   ja     | Hur harnesset läser in skillen, 1–200 tecken; en skill läses in, installeras aldrig |
+| `usage.evidencePath` | string |   ja     | Säker relativ stig (samma mönster som `description.evidencePath`) till inläsningsbeviset vid `source.commit` |
+| `compat.harnessMin`  | string |   ja     | Lägsta harnessversion som skillen verifierades mot; exakt `x.y.z`-form (valfri prerelease/build), högst 64 tecken. Det semantiska lagret kräver dessutom en parsbar, exakt SemVer |
+
+Villkorade regler (upprätthålls av skillschemats `allOf`-block):
+
+- `skillScope: subdirectory` **tvingar** `source.subpath` att vara en säker relativ stigsträng —
+  en skill som finns i en underkatalog måste fästa den underkatalogen.
+- `skillScope: repository` **tvingar** `source.subpath: null` — en skill som omfattar hela
+  repositoryt får inte deklarera en understig.
+
+`verification` behåller pluginformen (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), men `smokeTest` måste vara exakt `null`: en skill har inget installationsröktest,
+och innehållsgranskning är antagningsgrinden. Skillschemat bär inte villkoret
+`status: verified` → `smokeTest` och inte heller villkoren `repositoryScope` → `popularity`;
+de kopplingarna är regler enbart i pluginschemat.
+
+### Semantiskt lager för skills
+
+Ovanpå schemat tillämpar katalogvalideringen samma obligatoriska semantiska parsers som för
+plugins där fälten finns: `license.spdx` måste parsas som ett giltigt SPDX-uttryck
+(`invalid-spdx`), och `compat.harnessMin` måste vara en exakt SemVer (`invalid-semver`). Det
+finns inget `invalid-sri`-fall — en skill har ingen `package.integrity`.
+
+### Skillidentitet och dedupe
+
+Den kanoniska nyckeln för en skill är `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Understigen normaliseras endast för identitetsändamål: omvända snedstreck blir `/`, tomma
+segment och `.`-segment tas bort, och ett tomt resultat (eller `subpath: null`) blir `.` — hela
+repositoryt. En understig som innehåller NUL-byte eller `..`-segment avvisas, "städas" aldrig.
+Två skills i samma repository är två poster; samma repository + understig två gånger är en
+kollision.
+
+### Minimalt skillexempel
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Vad schemat inte kontrollerar
 
 Schemat är avsiktligt lokalt och strukturellt. Det verifierar **inte** att repositoryt finns, att

--- a/docs/i18n/sw/SCHEMA.md
+++ b/docs/i18n/sw/SCHEMA.md
@@ -247,6 +247,113 @@ Acha sehemu hii kabisa wakati hakuna cha kuonyesha — `media: []` si njia halal
 picha za skrini". Sehemu hii ni ya nyongeza: maingizo yaliyochapishwa kabla haijakuwepo yanabaki
 halali, na mtumiaji anayeipuuza husoma kila ingizo kama zamani kabisa.
 
+## Viingilio vya `kind: skill`
+
+Toleo la 1 la schema pia linafafanua mkataba wa pili wa kiingilio unaojitegemea kwa
+`kind: skill`, uliochapishwa kama [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)
+(SKL-01 awamu ya 0). Kamwe haugusi schema ya programu-jalizi hapo juu: viingilio vyenye
+`kind: plugin` vinaendelea kuthibitishwa kama zamani kabisa, na faili la schema ya skill ndilo
+chanzo cha ukweli kwa viingilio vya skill kama vile schema ya programu-jalizi ilivyo kwa
+viingilio vya programu-jalizi.
+
+Skill haisakinishwi, bali **inapakiwa** na harness, kwa hivyo vielezi vya usakinishaji vya
+programu-jalizi pekee (`package`, `dsh`) havipo kwenye kiingilio cha skill na vinabadilishwa na
+`usage` + `compat`. Skill pia mara nyingi huishi katika saraka ndogo ya hazina inayohifadhi
+skill nyingi, kwa hivyo utambulisho na uondoaji-nakala ni `source.repository` + `source.subpath`
+badala ya hazina pekee. Kiingilio cha skill hakiruhusu maonyesho ya `media`: skill ni maandishi
+ambayo harness hupakia, kwa hivyo hakuna cha kupiga picha ya skrini
+(`additionalProperties: false` ndiyo inayolazimisha hilo).
+
+Sehemu hizi zinahifadhi haswa umbo na kanuni zilizoandikwa kwa viingilio vya programu-jalizi
+hapo juu: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. Kila sehemu ni ya
+lazima isipokuwa `triggers`, sehemu pekee ya hiari ya skill.
+
+### Sehemu mahususi za skill
+
+| Sehemu               | Aina   | Inahitajika | Kanuni                                                      |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ndiyo    | Lazima iwe `skill` haswa                                     |
+| `skillScope`         | enum   |   ndiyo    | `repository` (hazina nzima **ndiyo** skill) au `subdirectory` (skill inaishi kwenye `source.subpath`) |
+| `triggers`           | array  |    hapana    | Wakati skill inapowashwa — maandishi ambayo mtumiaji hutathmini kabla ya kuipakia. Angalau string 1 ya kipekee, kila moja herufi 3–200; acha sehemu hii kabisa wakati hakuna zozote (`triggers: []` ni batili) |
+| `usage.load`         | string |   ndiyo    | Jinsi harness inavyopakia skill, herufi 1–200; skill hupakiwa, kamwe haisakinishwi |
+| `usage.evidencePath` | string |   ndiyo    | Njia salama ya uwiano (pattern ile ile kama `description.evidencePath`) ya ushahidi wa upakiaji kwenye `source.commit` |
+| `compat.harnessMin`  | string |   ndiyo    | Toleo la chini la harness ambalo skill ilithibitishwa dhidi yake; umbo halisi la `x.y.z` (prerelease/build ya hiari), hadi herufi 64. Tabaka la kisemantiki pia linahitaji SemVer halisi inayoweza kuchambuliwa |
+
+Kanuni za masharti (zinazotekelezwa na vitalu vya `allOf` vya schema ya skill):
+
+- `skillScope: subdirectory` **hulazimisha** `source.subpath` kuwa string ya njia salama ya
+  uwiano — skill inayoishi katika saraka ndogo lazima ibandike saraka ndogo hiyo.
+- `skillScope: repository` **hulazimisha** `source.subpath: null` — skill ya hazina nzima
+  haipaswi kutangaza subpath.
+
+`verification` inahifadhi umbo la programu-jalizi (`status`, `checkedAt`,
+`repositoryIdentity`, `smokeTest`), lakini `smokeTest` lazima iwe `null` haswa: skill haina
+jaribio la moshi la usakinishaji, na ukaguzi wa maudhui ndilo lango la kukubaliwa. Schema ya
+skill haibebi sharti la `status: verified` → `smokeTest` wala masharti ya `repositoryScope` →
+`popularity`; miunganisho hiyo ni kanuni za schema ya programu-jalizi pekee.
+
+### Tabaka la kisemantiki kwa skill
+
+Juu ya schema, uthibitishaji wa katalogi hutumia vichambuzi vile vile vya kisemantiki vya
+lazima kama kwa programu-jalizi pale sehemu zilipo: `license.spdx` lazima ichambuliwe kama
+usemi halali wa SPDX (`invalid-spdx`), na `compat.harnessMin` lazima iwe SemVer halisi
+(`invalid-semver`). Hakuna kesi ya `invalid-sri` — skill haina `package.integrity`.
+
+### Utambulisho na uondoaji-nakala wa skill
+
+Ufunguo rasmi wa skill ni `skill:<source.repositoryNodeId>:<normalized subpath>`. Subpath
+husanifishwa kwa madhumuni ya utambulisho pekee: backslash huwa `/`, sehemu tupu na za `.`
+huondolewa, na matokeo matupu (au `subpath: null`) huwa `.` — hazina nzima. Subpath yenye baiti
+za NUL au sehemu za `..` hukataliwa, kamwe "haisafishwi". Skill mbili za hazina ile ile ni
+viingilio viwili; hazina ile ile + subpath mara mbili ni mgongano.
+
+### Mfano mdogo wa skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Schema haikague nini
 
 Schema kwa makusudi ni ya kienyeji na kimuundo. **Hai**thibitishi kwamba hazina ipo, kwamba ID ya node

--- a/docs/i18n/ta/SCHEMA.md
+++ b/docs/i18n/ta/SCHEMA.md
@@ -261,6 +261,116 @@ commit-இல் ஆதாரப்படுத்தப்பட்ட மு�
 வெளியிடப்பட்ட பதிவுகள் செல்லுபடியாகவே இருக்கும், இதைப் புறக்கணிக்கும் நுகர்வோர் ஒவ்வொரு பதிவையும்
 முன்பு போலவே படிப்பார்.
 
+## `kind: skill` பதிவுகள்
+
+திட்டவரைவு பதிப்பு 1, `kind: skill`-க்கான இரண்டாவது, தன்னிறைவான பதிவு ஒப்பந்தத்தையும்
+வரையறுக்கிறது; அது [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) ஆக
+வெளியிடப்பட்டுள்ளது (SKL-01 கட்டம் 0). இது மேலே உள்ள செருகுநிரல் திட்டவரைவை ஒருபோதும்
+தொடுவதில்லை: `kind: plugin` கொண்ட பதிவுகள் முன்பு போலவே சரிபார்க்கப்படுகின்றன, மேலும்
+செருகுநிரல் திட்டவரைவு செருகுநிரல் பதிவுகளுக்கு எப்படியோ அப்படியே skill திட்டவரைவுக்
+கோப்பு skill பதிவுகளுக்கு உண்மையின் மூலம்.
+
+ஒரு skill நிறுவப்படுவதில்லை, அது ஹார்னெஸால் **ஏற்றப்படுகிறது**; எனவே செருகுநிரலுக்கு
+மட்டுமே உரிய நிறுவல் விவரிப்பான்கள் (`package`, `dsh`) skill பதிவில் இல்லை, அவற்றுக்குப்
+பதிலாக `usage` + `compat` உள்ளன. ஒரு skill பல skill-களை வைத்திருக்கும் களஞ்சியத்தின் துணை
+அடைவில் அடிக்கடி வாழ்கிறது; எனவே அடையாளமும் நகல்நீக்கமும் களஞ்சியம் மட்டுமன்றி
+`source.repository` + `source.subpath` ஆகும். skill பதிவு `media` காட்சியகத்தை
+அனுமதிப்பதில்லை: skill என்பது ஹார்னெஸ் ஏற்றும் உரை; எனவே திரைப்பிடிக்க எதுவும் இல்லை
+(`additionalProperties: false` தான் இதை அமல்படுத்துகிறது).
+
+இந்தப் புலங்கள் மேலே செருகுநிரல் பதிவுகளுக்கு ஆவணப்படுத்தப்பட்ட வடிவத்தையும் விதிகளையும்
+அப்படியே வைத்திருக்கின்றன: `schemaVersion`, `id`, `name`, `description`, `unofficial`,
+`primaryCategory`, `tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`.
+ஒரே விருப்ப skill புலமான `triggers` தவிர ஒவ்வொரு புலமும் கட்டாயம்.
+
+### skill-க்குரிய புலங்கள்
+
+| புலம்             | வகை    | தேவை | விதிகள்                                                       |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ஆம்    | சரியாக `skill` ஆக இருக்க வேண்டும்                                     |
+| `skillScope`         | enum   |   ஆம்    | `repository` (முழு களஞ்சியமும் skill **ஆகும்**) அல்லது `subdirectory` (skill `source.subpath`-இல் வாழ்கிறது) |
+| `triggers`           | array  |    இல்லை    | skill எப்போது தூண்டப்படுகிறது — ஏற்றுவதற்கு முன் பயனர் மதிப்பிடும் உரை. குறைந்தது 1 தனித்துவமான சரம், ஒவ்வொன்றும் 3–200 எழுத்துகள்; எதுவும் இல்லாதபோது புலத்தை முழுவதுமாக விட்டுவிடுங்கள் (`triggers: []` செல்லாது) |
+| `usage.load`         | string |   ஆம்    | ஹார்னெஸ் skill-ஐ எப்படி ஏற்றுகிறது, 1–200 எழுத்துகள்; skill ஏற்றப்படுகிறது, ஒருபோதும் நிறுவப்படுவதில்லை |
+| `usage.evidencePath` | string |   ஆம்    | `source.commit`-இல் ஏற்றல் ஆதாரத்திற்கான பாதுகாப்பான தொடர்புடைய பாதை (`description.evidencePath` போன்ற அதே முறை) |
+| `compat.harnessMin`  | string |   ஆம்    | skill சரிபார்க்கப்பட்ட குறைந்தபட்ச ஹார்னெஸ் பதிப்பு; சரியான `x.y.z` வடிவம் (விருப்ப prerelease/build), அதிகபட்சம் 64 எழுத்துகள். சொற்பொருள் அடுக்கு கூடுதலாகப் பாகுபடுத்தக்கூடிய, சரியான SemVer-ஐக் கோருகிறது |
+
+நிபந்தனை விதிகள் (skill திட்டவரைவின் `allOf` தொகுதிகளால் அமல்படுத்தப்படுகின்றன):
+
+- `skillScope: subdirectory` `source.subpath` ஒரு பாதுகாப்பான தொடர்புடைய-பாதை சரமாக இருக்க
+  வேண்டும் என **கட்டாயப்படுத்துகிறது** — துணை அடைவில் வாழும் skill அந்தத் துணை அடைவைப்
+  பின்னிணைக்க வேண்டும்.
+- `skillScope: repository` `source.subpath: null`-ஐ **கட்டாயப்படுத்துகிறது** — முழு-களஞ்சிய
+  skill துணைப்பாதையை அறிவிக்கக்கூடாது.
+
+`verification` செருகுநிரல் வடிவத்தையே (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`) வைத்திருக்கிறது, ஆனால் `smokeTest` சரியாக `null` ஆக இருக்க வேண்டும்: skill-க்கு
+நிறுவல் புகை சோதனை இல்லை; உள்ளடக்க மதிப்பாய்வே அனுமதி நுழைவாயில். skill திட்டவரைவில்
+`status: verified` → `smokeTest` நிபந்தனையும் `repositoryScope` → `popularity`
+நிபந்தனைகளும் இல்லை; அந்த இணைப்புகள் செருகுநிரல்-திட்டவரைவு விதிகள் மட்டுமே.
+
+### skill-களுக்கான சொற்பொருள் அடுக்கு
+
+திட்டவரைவின் மீது, புலங்கள் இருக்கும் இடங்களில் பட்டியல் சரிபார்ப்பு செருகுநிரல்களுக்குப்
+பயன்படுத்தும் அதே கட்டாய சொற்பொருள் பாகுபடுத்திகளையே பயன்படுத்துகிறது: `license.spdx`
+செல்லுபடியாகும் SPDX கோவையாகப் பாகுபடுத்தப்பட வேண்டும் (`invalid-spdx`), மேலும்
+`compat.harnessMin` சரியான SemVer ஆக இருக்க வேண்டும் (`invalid-semver`). `invalid-sri`
+நிகழ்வு இல்லை — skill-க்கு `package.integrity` இல்லை.
+
+### skill அடையாளமும் நகல்நீக்கமும்
+
+ஒரு skill-இன் அதிகாரப்பூர்வ விசை `skill:<source.repositoryNodeId>:<normalized subpath>`.
+துணைப்பாதை அடையாள நோக்கங்களுக்காக மட்டுமே இயல்பாக்கப்படுகிறது: பின்சாய்வுகள் `/`
+ஆகின்றன, காலி மற்றும் `.` பிரிவுகள் நீக்கப்படுகின்றன, காலி முடிவு (அல்லது `subpath: null`)
+`.` ஆகிறது — முழு களஞ்சியம். NUL பைட்டுகள் அல்லது `..` பிரிவுகளைக் கொண்ட துணைப்பாதை
+நிராகரிக்கப்படுகிறது, ஒருபோதும் "சுத்தம்" செய்யப்படாது. ஒரே களஞ்சியத்தின் இரண்டு skill-கள்
+இரண்டு பதிவுகள்; ஒரே களஞ்சியம் + துணைப்பாதை இருமுறை என்பது மோதல்.
+
+### குறைந்தபட்ச skill எடுத்துக்காட்டு
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## திட்டவரைவு என்ன சோதிப்பதில்லை
 
 திட்டவரைவு வேண்டுமென்றே உள்ளூர் மற்றும் கட்டமைப்பு சார்ந்தது. களஞ்சியம் உள்ளதா, நோட் ID

--- a/docs/i18n/te/SCHEMA.md
+++ b/docs/i18n/te/SCHEMA.md
@@ -247,6 +247,113 @@
 అని చెప్పడానికి చెల్లుబాటు అయ్యే మార్గం కాదు. ఈ ఫీల్డ్ అదనపుది: ఇది ఉనికిలోకి రాకముందు ప్రచురించిన
 ఎంట్రీలు చెల్లుబాటులోనే ఉంటాయి, దీన్ని విస్మరించే వినియోగదారు ప్రతి ఎంట్రీని మునుపటిలాగే చదువుతారు.
 
+## `kind: skill` ఎంట్రీలు
+
+స్కీమా వెర్షన్ 1, `kind: skill` కోసం రెండవ, స్వతంత్ర ఎంట్రీ కాంట్రాక్ట్‌ను కూడా నిర్వచిస్తుంది; ఇది
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)గా ప్రచురించబడింది (SKL-01 దశ 0).
+ఇది పైన ఉన్న ప్లగిన్ స్కీమాను ఎప్పుడూ తాకదు: `kind: plugin` ఉన్న ఎంట్రీలు మునుపటిలాగే ఖచ్చితంగా
+వాలిడేట్ అవుతూనే ఉంటాయి, మరియు ప్లగిన్ ఎంట్రీలకు ప్లగిన్ స్కీమా ఎలాగో అలాగే స్కిల్ ఎంట్రీలకు స్కిల్
+స్కీమా ఫైల్ మూలం (సోర్స్ ఆఫ్ ట్రూత్).
+
+స్కిల్ ఇన్‌స్టాల్ చేయబడదు, హార్నెస్ దాన్ని **లోడ్ చేస్తుంది**; కాబట్టి ప్లగిన్-మాత్రమే ఇన్‌స్టాల్
+డిస్క్రిప్టర్‌లు (`package`, `dsh`) స్కిల్ ఎంట్రీపై ఉండవు, వాటి స్థానంలో `usage` + `compat`
+ఉంటాయి. స్కిల్ తరచుగా అనేక స్కిల్స్‌ను హోస్ట్ చేసే రిపాజిటరీ యొక్క సబ్‌డైరెక్టరీలో కూడా
+నివసిస్తుంది; కాబట్టి ఐడెంటిటీ మరియు డీడూప్ రిపాజిటరీ మాత్రమే కాకుండా `source.repository` +
+`source.subpath`. స్కిల్ ఎంట్రీ `media` గ్యాలరీని అనుమతించదు: స్కిల్ అనేది హార్నెస్ లోడ్ చేసే
+టెక్స్ట్, కాబట్టి స్క్రీన్‌షాట్ తీయడానికి ఏమీ లేదు (దీన్ని అమలు చేసేది
+`additionalProperties: false`).
+
+ఈ ఫీల్డ్‌లు పైన ప్లగిన్ ఎంట్రీలకు డాక్యుమెంట్ చేసిన రూపం మరియు నియమాలను ఖచ్చితంగా
+ఉంచుకుంటాయి: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`,
+`tags`, `source`, `creator`, `repositoryScope`, `license`, `provenance`. ఏకైక ఐచ్ఛిక స్కిల్
+ఫీల్డ్ అయిన `triggers` తప్ప ప్రతి ఫీల్డ్ తప్పనిసరి.
+
+### స్కిల్-ప్రత్యేక ఫీల్డ్‌లు
+
+| ఫీల్డ్               | రకం    | అవసరం | నియమాలు                                                       |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   అవును    | ఖచ్చితంగా `skill` అయి ఉండాలి                                     |
+| `skillScope`         | enum   |   అవును    | `repository` (రిపాజిటరీ మొత్తం **స్కిల్లే**) లేదా `subdirectory` (స్కిల్ `source.subpath` వద్ద నివసిస్తుంది) |
+| `triggers`           | array  |    కాదు    | స్కిల్ ఎప్పుడు ప్రేరేపితమవుతుందో — లోడ్ చేసే ముందు వినియోగదారు అంచనా వేసే టెక్స్ట్. కనీసం 1 ప్రత్యేకమైన స్ట్రింగ్, ప్రతిదీ 3–200 అక్షరాలు; ఏవీ లేనప్పుడు ఫీల్డ్‌ను పూర్తిగా వదిలేయండి (`triggers: []` చెల్లదు) |
+| `usage.load`         | string |   అవును    | హార్నెస్ స్కిల్‌ను ఎలా లోడ్ చేస్తుందో, 1–200 అక్షరాలు; స్కిల్ లోడ్ చేయబడుతుంది, ఎప్పుడూ ఇన్‌స్టాల్ చేయబడదు |
+| `usage.evidencePath` | string |   అవును    | `source.commit` వద్ద లోడ్ ఎవిడెన్స్‌కు సేఫ్ రిలేటివ్ పాత్ (`description.evidencePath` వలె అదే ప్యాటర్న్) |
+| `compat.harnessMin`  | string |   అవును    | స్కిల్ ధృవీకరించబడిన కనీస హార్నెస్ వెర్షన్; ఖచ్చితమైన `x.y.z` రూపం (ఐచ్ఛిక ప్రీరిలీజ్/బిల్డ్), గరిష్టంగా 64 అక్షరాలు. సెమాంటిక్ పొర అదనంగా పార్స్ చేయదగిన, ఖచ్చితమైన SemVerను అవసరం చేస్తుంది |
+
+ఆధారిత నియమాలు (స్కిల్ స్కీమా యొక్క `allOf` బ్లాక్‌ల ద్వారా అమలు చేయబడతాయి):
+
+- `skillScope: subdirectory` `source.subpath` సేఫ్ రిలేటివ్-పాత్ స్ట్రింగ్ అయి ఉండాలని
+  **బలవంతం** చేస్తుంది — సబ్‌డైరెక్టరీలో హోస్ట్ అయిన స్కిల్ ఆ సబ్‌డైరెక్టరీని పిన్ చేయాలి.
+- `skillScope: repository` `source.subpath: null`ను **బలవంతం** చేస్తుంది — మొత్తం-రిపాజిటరీ
+  స్కిల్ సబ్‌పాత్‌ను ప్రకటించకూడదు.
+
+`verification` ప్లగిన్ రూపాన్నే (`status`, `checkedAt`, `repositoryIdentity`, `smokeTest`)
+ఉంచుకుంటుంది, కానీ `smokeTest` ఖచ్చితంగా `null` అయి ఉండాలి: స్కిల్‌కు ఇన్‌స్టాల్ స్మోక్ టెస్ట్
+లేదు, కంటెంట్ సమీక్షే ప్రవేశ గేట్. స్కిల్ స్కీమా `status: verified` → `smokeTest` షరతును గానీ
+`repositoryScope` → `popularity` షరతులను గానీ మోయదు; ఆ బంధాలు ప్లగిన్-స్కీమా నియమాలు
+మాత్రమే.
+
+### స్కిల్స్ కోసం సెమాంటిక్ పొర
+
+స్కీమాపై, ఫీల్డ్‌లు ఉన్న చోట ప్లగిన్‌ల కోసం ఉపయోగించే అవే తప్పనిసరి సెమాంటిక్ పార్సర్‌లను
+కేటలాగ్ వాలిడేషన్ వర్తింపజేస్తుంది: `license.spdx` చెల్లుబాటు అయ్యే SPDX ఎక్స్‌ప్రెషన్‌గా పార్స్
+కావాలి (`invalid-spdx`), మరియు `compat.harnessMin` ఖచ్చితమైన SemVer అయి ఉండాలి
+(`invalid-semver`). `invalid-sri` కేసు లేదు — స్కిల్‌కు `package.integrity` లేదు.
+
+### స్కిల్ ఐడెంటిటీ మరియు డీడూప్
+
+స్కిల్ యొక్క కానానికల్ కీ `skill:<source.repositoryNodeId>:<normalized subpath>`. సబ్‌పాత్
+ఐడెంటిటీ ప్రయోజనాల కోసం మాత్రమే నార్మలైజ్ చేయబడుతుంది: బ్యాక్‌స్లాష్‌లు `/` అవుతాయి, ఖాళీ
+మరియు `.` సెగ్మెంట్‌లు తొలగించబడతాయి, మరియు ఖాళీ ఫలితం (లేదా `subpath: null`) `.` అవుతుంది —
+రిపాజిటరీ మొత్తం. NUL బైట్‌లు లేదా `..` సెగ్మెంట్‌లు ఉన్న సబ్‌పాత్ తిరస్కరించబడుతుంది, ఎప్పుడూ
+"శుభ్రం" చేయబడదు. ఒకే రిపాజిటరీకి చెందిన రెండు స్కిల్స్ రెండు ఎంట్రీలు; అదే రిపాజిటరీ +
+సబ్‌పాత్ రెండుసార్లు ఉంటే అది ఘర్షణ.
+
+### కనిష్ఠ స్కిల్ ఉదాహరణ
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## స్కీమా తనిఖీ చేయనిది
 
 స్కీమా ఉద్దేశపూర్వకంగా లోకల్ మరియు స్ట్రక్చరల్. ఇది రిపాజిటరీ ఉనికిలో ఉందో లేదో, నోడ్ IDతో URL

--- a/docs/i18n/th/SCHEMA.md
+++ b/docs/i18n/th/SCHEMA.md
@@ -241,6 +241,107 @@ URL ที่นี่ต้องเปลี่ยนแปลงไม่ไ�
 ให้ละฟิลด์นี้ทั้งหมดเมื่อไม่มีอะไรจะแสดง — `media: []` ไม่ใช่วิธีที่ถูกต้องในการบอกว่า "ไม่มีภาพหน้าจอ"
 ฟิลด์นี้เป็นส่วนเพิ่ม: รายการที่เผยแพร่ก่อนที่ฟิลด์นี้จะมีอยู่ยังคงใช้ได้ และผู้บริโภคที่ละเลยมันจะอ่านทุกรายการเหมือนเดิมทุกประการ
 
+## รายการ `kind: skill`
+
+สคีมาเวอร์ชัน 1 ยังกำหนดสัญญารายการชุดที่สองที่เป็นอิสระในตัวเองสำหรับ `kind: skill`
+ซึ่งเผยแพร่เป็น [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01 เฟส 0)
+มันไม่แตะต้องสคีมาปลั๊กอินด้านบนเลย: รายการที่มี `kind: plugin` ยังคงผ่านการตรวจสอบเหมือนเดิมทุกประการ
+และไฟล์สคีมาสกิลเป็นแหล่งความจริงสำหรับรายการสกิล เช่นเดียวกับที่สคีมาปลั๊กอินเป็นสำหรับรายการปลั๊กอิน
+
+สกิลไม่ได้ถูกติดตั้ง แต่ถูก**โหลด**โดย harness ดังนั้นตัวระบุการติดตั้งเฉพาะปลั๊กอิน
+(`package`, `dsh`) จึงไม่มีอยู่ในรายการสกิล และถูกแทนที่ด้วย `usage` + `compat`
+สกิลยังมักอยู่ในไดเรกทอรีย่อยของรีโพซิทอรีที่โฮสต์สกิลจำนวนมาก ดังนั้นอัตลักษณ์และการขจัดข้อมูลซ้ำจึงเป็น
+`source.repository` + `source.subpath` ไม่ใช่รีโพซิทอรีเพียงอย่างเดียว รายการสกิลไม่รับแกลเลอรี `media`:
+สกิลคือข้อความที่ harness โหลด จึงไม่มีอะไรให้จับภาพหน้าจอ (`additionalProperties: false` คือสิ่งที่บังคับเรื่องนี้)
+
+ฟิลด์เหล่านี้คงรูปแบบและกฎตามที่บันทึกไว้สำหรับรายการปลั๊กอินด้านบนทุกประการ:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance` ทุกฟิลด์จำเป็นทั้งหมด
+ยกเว้น `triggers` ซึ่งเป็นฟิลด์สกิลเดียวที่ไม่บังคับ
+
+### ฟิลด์เฉพาะของสกิล
+
+| ฟิลด์                | ชนิด   | จำเป็น | กฎ                                                          |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ใช่    | ต้องเป็น `skill` เท่านั้น                                     |
+| `skillScope`         | enum   |   ใช่    | `repository` (รีโพซิทอรีทั้งหมด**คือ**สกิล) หรือ `subdirectory` (สกิลอยู่ที่ `source.subpath`) |
+| `triggers`           | array  |   ไม่    | เมื่อใดสกิลจะทำงาน — ข้อความที่ผู้ใช้ประเมินก่อนโหลดมัน อย่างน้อย 1 สตริงที่ไม่ซ้ำกัน แต่ละสตริงยาว 3–200 อักขระ ให้ละฟิลด์นี้ทั้งหมดเมื่อไม่มีเลย (`triggers: []` ไม่ถูกต้อง) |
+| `usage.load`         | string |   ใช่    | วิธีที่ harness โหลดสกิล ยาว 1–200 อักขระ สกิลถูกโหลด ไม่เคยถูกติดตั้ง |
+| `usage.evidencePath` | string |   ใช่    | เส้นทางสัมพัทธ์ที่ปลอดภัย (แพตเทิร์นเดียวกับ `description.evidencePath`) ไปยังหลักฐานการโหลด ณ `source.commit` |
+| `compat.harnessMin`  | string |   ใช่    | เวอร์ชัน harness ต่ำสุดที่สกิลได้รับการตรวจสอบด้วย รูปแบบ `x.y.z` แบบตรงตัว (prerelease/build ไม่บังคับ) สูงสุด 64 อักขระ ชั้นเชิงความหมายยังกำหนดเพิ่มว่าต้องเป็น SemVer ตรงตัวที่แยกวิเคราะห์ได้ |
+
+กฎแบบมีเงื่อนไข (บังคับโดยบล็อก `allOf` ของสคีมาสกิล):
+
+- `skillScope: subdirectory` **บังคับ**ให้ `source.subpath` เป็นสตริงเส้นทางสัมพัทธ์ที่ปลอดภัย —
+  สกิลที่โฮสต์ในไดเรกทอรีย่อยต้องตรึงไดเรกทอรีย่อยนั้นไว้
+- `skillScope: repository` **บังคับ**ให้ `source.subpath: null` — สกิลแบบทั้งรีโพซิทอรีต้องไม่ประกาศ subpath
+
+`verification` คงรูปแบบของปลั๊กอิน (`status`, `checkedAt`, `repositoryIdentity`, `smokeTest`)
+แต่ `smokeTest` ต้องเป็น `null` เท่านั้น: สกิลไม่มี smoke test ของการติดตั้ง และการตรวจทานเนื้อหาคือด่านรับเข้า
+สคีมาสกิลไม่มีเงื่อนไข `status: verified` → `smokeTest` และไม่มีเงื่อนไข `repositoryScope` → `popularity`
+การเชื่อมโยงเหล่านั้นเป็นกฎของสคีมาปลั๊กอินเท่านั้น
+
+### ชั้นเชิงความหมายสำหรับสกิล
+
+นอกเหนือจากสคีมา การตรวจสอบแคตาล็อกใช้ตัวแยกวิเคราะห์เชิงความหมายภาคบังคับชุดเดียวกับของปลั๊กอิน
+ในฟิลด์ที่มีอยู่: `license.spdx` ต้องแยกวิเคราะห์เป็นนิพจน์ SPDX ที่ถูกต้อง (`invalid-spdx`)
+และ `compat.harnessMin` ต้องเป็น SemVer ตรงตัว (`invalid-semver`) ไม่มีกรณี `invalid-sri` —
+สกิลไม่มี `package.integrity`
+
+### อัตลักษณ์และการขจัดข้อมูลซ้ำของสกิล
+
+คีย์มาตรฐานของสกิลคือ `skill:<source.repositoryNodeId>:<normalized subpath>` โดย subpath
+จะถูกทำให้เป็นรูปแบบมาตรฐานเพื่อวัตถุประสงค์ด้านอัตลักษณ์เท่านั้น: แบ็กสแลชกลายเป็น `/`
+เซกเมนต์ว่างและ `.` ถูกตัดทิ้ง และผลลัพธ์ที่ว่างเปล่า (หรือ `subpath: null`) กลายเป็น `.` —
+รีโพซิทอรีทั้งหมด subpath ที่มีไบต์ NUL หรือเซกเมนต์ `..` จะถูกปฏิเสธ ไม่มีวัน "ถูกทำความสะอาด"
+สกิลสองตัวของรีโพซิทอรีเดียวกันคือสองรายการ ส่วนรีโพซิทอรี + subpath เดียวกันซ้ำสองครั้งคือการชนกัน
+
+### ตัวอย่างสกิลแบบน้อยที่สุด
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## สิ่งที่สคีมาไม่ตรวจสอบ
 
 สคีมาตั้งใจให้เป็นการตรวจสอบเชิงโครงสร้างและภายในเครื่องเท่านั้น มัน**ไม่**ตรวจสอบว่ารีโพซิทอรีมีอยู่จริง ว่า

--- a/docs/i18n/tr/SCHEMA.md
+++ b/docs/i18n/tr/SCHEMA.md
@@ -249,6 +249,112 @@ Gösterilecek bir şey yoksa alanı tamamen atlayın — `media: []`, "ekran gö
 geçerli bir yolu değildir. Alan eklemelidir: o var olmadan önce yayımlanmış girdiler geçerli
 kalır ve alanı yok sayan bir tüketici her girdiyi tam olarak eskisi gibi okur.
 
+## `kind: skill` girdileri
+
+Şema sürüm 1, `kind: skill` için ikinci, kendi başına yeterli bir girdi sözleşmesi de tanımlar;
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) olarak yayımlanmıştır (SKL-01
+faz 0). Yukarıdaki eklenti şemasına asla dokunmaz: `kind: plugin` girdileri tam olarak eskisi
+gibi doğrulanmaya devam eder ve skill şema dosyası, eklenti şemasının eklenti girdileri için
+olduğu gibi, skill girdileri için doğruluk kaynağıdır.
+
+Bir skill kurulmaz, harness tarafından **yüklenir**; bu yüzden yalnızca eklentiye özgü kurulum
+tanımlayıcıları (`package`, `dsh`) bir skill girdisinde yoktur ve yerlerini `usage` + `compat`
+alır. Bir skill ayrıca sıkça, çok sayıda skill barındıran bir deponun alt dizininde yaşar; bu
+yüzden kimlik ve yinelenme ayıklama, tek başına depo yerine `source.repository` +
+`source.subpath` ikilisidir. Bir skill girdisi `media` galerisi kabul etmez: skill, harness'ın
+yüklediği metindir, dolayısıyla ekran görüntüsü alınacak bir şey yoktur (bunu zorunlu kılan
+`additionalProperties: false`'tur).
+
+Şu alanlar, yukarıda eklenti girdileri için belgelenen şekil ve kuralları tam olarak korur:
+`schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Tek isteğe bağlı skill alanı
+olan `triggers` dışında her alan zorunludur.
+
+### Skill'e özgü alanlar
+
+| Alan                 | Tür    | Zorunlu | Kurallar                                                    |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   evet    | Tam olarak `skill` olmalıdır                                |
+| `skillScope`         | enum   |   evet    | `repository` (tüm depo skill'in **kendisidir**) veya `subdirectory` (skill `source.subpath` konumunda yaşar) |
+| `triggers`           | array  |   hayır    | Skill'in ne zaman tetiklendiği — kullanıcının onu yüklemeden önce değerlendirdiği metin. En az 1 benzersiz dize, her biri 3–200 karakter; hiç yoksa alanı tamamen atlayın (`triggers: []` geçersizdir) |
+| `usage.load`         | string |   evet    | Harness'ın skill'i nasıl yüklediği, 1–200 karakter; bir skill yüklenir, asla kurulmaz |
+| `usage.evidencePath` | string |   evet    | `source.commit`teki yükleme kanıtına giden güvenli göreli yol (`description.evidencePath` ile aynı desen) |
+| `compat.harnessMin`  | string |   evet    | Skill'in doğrulandığı en düşük harness sürümü; tam `x.y.z` şekli (isteğe bağlı prerelease/build), en fazla 64 karakter. Anlamsal katman ayrıca ayrıştırılabilir, tam bir SemVer gerektirir |
+
+Koşullu kurallar (skill şemasının `allOf` blokları tarafından zorunlu kılınır):
+
+- `skillScope: subdirectory`, `source.subpath`in güvenli bir göreli yol dizesi olmasını
+  **zorlar** — bir alt dizinde barındırılan skill o alt dizini sabitlemek zorundadır.
+- `skillScope: repository`, `source.subpath: null` olmasını **zorlar** — tüm depoyu kapsayan
+  bir skill alt yol bildirmemelidir.
+
+`verification`, eklenti şeklini korur (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), ancak `smokeTest` tam olarak `null` olmalıdır: bir skill'in kurulum smoke
+test'i yoktur ve kabul kapısı içerik incelemesidir. Skill şeması, `status: verified` →
+`smokeTest` koşulunu ve `repositoryScope` → `popularity` koşullarını taşımaz; bu bağlantılar
+yalnızca eklenti şeması kurallarıdır.
+
+### Skill'ler için anlamsal katman
+
+Şemanın üzerine, katalog doğrulaması, alanların var olduğu yerlerde eklentilerle aynı zorunlu
+anlamsal ayrıştırıcıları uygular: `license.spdx` geçerli bir SPDX ifadesi olarak
+ayrıştırılmalıdır (`invalid-spdx`) ve `compat.harnessMin` tam bir SemVer olmalıdır
+(`invalid-semver`). `invalid-sri` durumu yoktur — bir skill'in `package.integrity`si yoktur.
+
+### Skill kimliği ve yinelenme ayıklama
+
+Bir skill'in kanonik anahtarı `skill:<source.repositoryNodeId>:<normalized subpath>`tır. Alt
+yol yalnızca kimlik amaçlı normalize edilir: ters eğik çizgiler `/` olur, boş ve `.`
+parçaları atılır ve boş bir sonuç (veya `subpath: null`) `.` olur — yani tüm depo. NUL bayt
+veya `..` parçaları içeren bir alt yol reddedilir, asla "temizlenmez". Aynı deponun iki
+skill'i iki girdidir; aynı depo + alt yolun iki kez geçmesi ise bir çakışmadır.
+
+### Asgari skill örneği
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Şemanın denetlemediği
 
 Şema kasıtlı olarak yerel ve yapısaldır. Deponun var olduğunu, düğüm kimliğinin URL ile

--- a/docs/i18n/uk-UA/SCHEMA.md
+++ b/docs/i18n/uk-UA/SCHEMA.md
@@ -249,6 +249,112 @@ URL тут має бути таким самим незмінним, як `sourc
 «немає знімків екрана». Поле є адитивним: записи, опубліковані до його появи, залишаються
 дійсними, а споживач, який його ігнорує, читає кожен запис точно як раніше.
 
+## Записи `kind: skill`
+
+Схема версії 1 також визначає другий, самодостатній контракт запису для `kind: skill`,
+опублікований як [`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01
+фаза 0). Він ніколи не торкається схеми плагінів вище: записи з `kind: plugin` продовжують
+валідуватися точно як раніше, а файл схеми skill є джерелом істини для записів skill так
+само, як схема плагінів — для записів плагінів.
+
+Skill не встановлюється, а **завантажується** harness-ом, тож суто плагінні інсталяційні
+дескриптори (`package`, `dsh`) не існують на записі skill і замінені на `usage` + `compat`.
+Skill також часто живе в підкаталозі репозиторію, що хостить багато skill-ів, тому
+ідентичність і дедуплікація — це `source.repository` + `source.subpath`, а не сам лише
+репозиторій. Запис skill не допускає галереї `media`: skill — це текст, який завантажує
+harness, тож знімати нема чого (саме `additionalProperties: false` це забезпечує).
+
+Ці поля зберігають точно ту саму форму та правила, задокументовані для записів плагінів
+вище: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Кожне поле обов'язкове,
+окрім `triggers` — єдиного необов'язкового поля skill.
+
+### Поля, специфічні для skill
+
+| Поле                 | Тип    | Обов'язкове | Правила                                                  |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   так    | Має бути рівно `skill`                                      |
+| `skillScope`         | enum   |   так    | `repository` (увесь репозиторій **і є** skill) або `subdirectory` (skill живе за `source.subpath`) |
+| `triggers`           | array  |   ні    | Коли skill спрацьовує — текст, який користувач оцінює перед його завантаженням. Щонайменше 1 унікальний рядок, кожен 3–200 символів; коли їх немає, повністю пропускайте поле (`triggers: []` є недійсним) |
+| `usage.load`         | string |   так    | Як harness завантажує skill, 1–200 символів; skill завантажується, ніколи не встановлюється |
+| `usage.evidencePath` | string |   так    | Безпечний відносний шлях (той самий патерн, що й `description.evidencePath`) до доказу завантаження на `source.commit` |
+| `compat.harnessMin`  | string |   так    | Мінімальна версія harness, з якою skill було перевірено; точна форма `x.y.z` (необов'язковий prerelease/build), максимум 64 символи. Семантичний шар додатково вимагає розбірного, точного SemVer |
+
+Умовні правила (забезпечуються блоками `allOf` схеми skill):
+
+- `skillScope: subdirectory` **змушує** `source.subpath` бути рядком безпечного відносного
+  шляху — skill, розміщений у підкаталозі, має закріпити цей підкаталог.
+- `skillScope: repository` **змушує** `source.subpath: null` — skill на весь репозиторій не
+  повинен оголошувати субшлях.
+
+`verification` зберігає плагінну форму (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), але `smokeTest` має бути рівно `null`: skill не має інсталяційного smoke
+test-у, а шлюзом допуску є перегляд вмісту. Схема skill не несе умови `status: verified` →
+`smokeTest` і умов `repositoryScope` → `popularity`; ці зв'язки є правилами лише схеми
+плагінів.
+
+### Семантичний шар для skill-ів
+
+Понад схемою валідація каталогу застосовує ті самі обов'язкові семантичні парсери, що й для
+плагінів, там, де поля існують: `license.spdx` має розбиратися як дійсний вираз SPDX
+(`invalid-spdx`), а `compat.harnessMin` має бути точним SemVer (`invalid-semver`). Випадку
+`invalid-sri` немає — skill не має `package.integrity`.
+
+### Ідентичність skill і дедуплікація
+
+Канонічний ключ skill — `skill:<source.repositoryNodeId>:<normalized subpath>`. Субшлях
+нормалізується лише для цілей ідентичності: зворотні скісні риски стають `/`, порожні
+сегменти та `.` відкидаються, а порожній результат (або `subpath: null`) стає `.` — увесь
+репозиторій. Субшлях із байтами NUL або сегментами `..` відхиляється, ніколи не
+«очищується». Два skill-и одного репозиторію — це два записи; той самий репозиторій +
+субшлях двічі — це колізія.
+
+### Мінімальний приклад skill
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Чого схема не перевіряє
 
 Схема навмисно локальна та структурна. Вона **не** перевіряє, що репозиторій існує, що вузловий

--- a/docs/i18n/ur/SCHEMA.md
+++ b/docs/i18n/ur/SCHEMA.md
@@ -223,6 +223,111 @@
 کا درست طریقہ نہیں ہے۔ یہ فیلڈ اضافی ہے: اس کے وجود سے پہلے شائع ہونے والے اندراجات درست رہتے
 ہیں، اور اسے نظرانداز کرنے والا صارف ہر اندراج بالکل پہلے کی طرح پڑھتا ہے۔
 
+## `kind: skill` اندراجات
+
+اسکیما ورژن 1 `kind: skill` کے لیے ایک دوسرا، خودمکتفی اندراجی معاہدہ بھی متعین کرتی ہے، جو
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) کے طور پر شائع ہے (SKL-01 فیز 0)۔
+یہ اوپر والی پلگ ان اسکیما کو کبھی نہیں چھیڑتا: `kind: plugin` والے اندراجات بالکل پہلے کی طرح
+ویلیڈیٹ ہوتے رہتے ہیں، اور اسکل اسکیما فائل اسکل اندراجات کے لیے اسی طرح سچائی کا ماخذ ہے جس
+طرح پلگ ان اسکیما پلگ ان اندراجات کے لیے ہے۔
+
+اسکل انسٹال نہیں ہوتی، اسے harness کے ذریعے **لوڈ** کیا جاتا ہے، لہٰذا صرف-پلگ ان انسٹال
+ڈسکرپٹرز (`package`, `dsh`) اسکل اندراج پر موجود نہیں ہوتے اور ان کی جگہ `usage` + `compat`
+لیتے ہیں۔ اسکل اکثر ایسی ریپوزٹری کی ذیلی ڈائریکٹری میں بھی رہتی ہے جو بہت سی اسکلز کی میزبانی
+کرتی ہے، اس لیے شناخت اور ڈی ڈیوپ صرف ریپوزٹری کے بجائے `source.repository` + `source.subpath`
+ہے۔ اسکل اندراج کوئی `media` گیلری قبول نہیں کرتا: اسکل وہ متن ہے جسے harness لوڈ کرتی ہے، لہٰذا
+اسکرین شاٹ لینے کو کچھ نہیں (`additionalProperties: false` ہی اسے نافذ کرتا ہے)۔
+
+یہ فیلڈز بالکل وہی شکل اور قواعد برقرار رکھتی ہیں جو اوپر پلگ ان اندراجات کے لیے دستاویز کیے
+گئے ہیں: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`۔ ہر فیلڈ درکار ہے سوائے
+`triggers` کے، جو واحد اختیاری اسکل فیلڈ ہے۔
+
+### اسکل مخصوص فیلڈز
+
+| فیلڈ                | قسم   | درکار | قواعد                                                       |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   ہاں    | لازمی طور پر بالکل `skill`                                   |
+| `skillScope`         | enum   |   ہاں    | `repository` (پوری ریپوزٹری **ہی** اسکل ہے) یا `subdirectory` (اسکل `source.subpath` پر رہتی ہے) |
+| `triggers`           | array  |   نہیں    | اسکل کب فائر ہوتی ہے — وہ متن جسے صارف اسے لوڈ کرنے سے پہلے پرکھتا ہے۔ کم از کم 1 منفرد سٹرنگ، ہر ایک 3–200 حروف؛ جب کوئی نہ ہو تو فیلڈ کو مکمل طور پر چھوڑ دیں (`triggers: []` غیر درست ہے) |
+| `usage.load`         | string |   ہاں    | harness اسکل کو کیسے لوڈ کرتی ہے، 1–200 حروف؛ اسکل لوڈ ہوتی ہے، کبھی انسٹال نہیں |
+| `usage.evidencePath` | string |   ہاں    | `source.commit` پر لوڈ ثبوت تک محفوظ نسبتی راستہ (وہی pattern جو `description.evidencePath` کا ہے) |
+| `compat.harnessMin`  | string |   ہاں    | کم از کم harness ورژن جس کے خلاف اسکل کی تصدیق کی گئی؛ بالکل `x.y.z` شکل (اختیاری prerelease/build)، زیادہ سے زیادہ 64 حروف۔ معنوی تہہ اضافی طور پر ایک پارس ہونے کے قابل، بالکل درست SemVer کا تقاضا کرتی ہے |
+
+مشروط قواعد (اسکل اسکیما کے `allOf` بلاکس کے ذریعے نافذ):
+
+- `skillScope: subdirectory` `source.subpath` کو ایک محفوظ نسبتی راستے کی سٹرنگ ہونے پر
+  **مجبور** کرتا ہے — ذیلی ڈائریکٹری میں میزبان اسکل کو وہ ذیلی ڈائریکٹری پن کرنی ہوگی۔
+- `skillScope: repository` `source.subpath: null` پر **مجبور** کرتا ہے — پوری ریپوزٹری والی
+  اسکل کو subpath کا اعلان نہیں کرنا چاہیے۔
+
+`verification` پلگ ان والی شکل برقرار رکھتا ہے (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`)، مگر `smokeTest` لازمی طور پر بالکل `null` ہونا چاہیے: اسکل کا کوئی انسٹال
+smoke test نہیں ہوتا، اور مواد کا جائزہ ہی داخلے کا گیٹ ہے۔ اسکل اسکیما میں کوئی
+`status: verified` → `smokeTest` شرط نہیں اور کوئی `repositoryScope` → `popularity` شرائط
+نہیں؛ وہ جوڑ صرف پلگ ان اسکیما کے قواعد ہیں۔
+
+### اسکلز کے لیے معنوی تہہ
+
+اسکیما کے اوپر، کیٹلاگ ویلیڈیشن وہی لازمی معنوی پارسرز لاگو کرتی ہے جو پلگ انز کے لیے ہیں،
+جہاں فیلڈز موجود ہوں: `license.spdx` کو ایک درست SPDX اظہار کے طور پر پارس ہونا چاہیے
+(`invalid-spdx`)، اور `compat.harnessMin` کو بالکل درست SemVer ہونا چاہیے (`invalid-semver`)۔
+کوئی `invalid-sri` کیس نہیں — اسکل کے پاس `package.integrity` نہیں ہوتا۔
+
+### اسکل کی شناخت اور ڈی ڈیوپ
+
+اسکل کی معیاری کلید `skill:<source.repositoryNodeId>:<normalized subpath>` ہے۔ subpath صرف
+شناختی مقاصد کے لیے نارملائز کیا جاتا ہے: بیک سلیشز `/` بن جاتے ہیں، خالی اور `.` سیگمنٹس
+گرا دیے جاتے ہیں، اور خالی نتیجہ (یا `subpath: null`) `.` بن جاتا ہے — یعنی پوری ریپوزٹری۔
+NUL بائٹس یا `..` سیگمنٹس رکھنے والا subpath مسترد ہوتا ہے، کبھی "صاف" نہیں کیا جاتا۔ ایک ہی
+ریپوزٹری کی دو اسکلز دو اندراجات ہیں؛ وہی ریپوزٹری + subpath دو بار ایک ٹکراؤ ہے۔
+
+### کم سے کم اسکل مثال
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## اسکیما کیا چیک نہیں کرتی
 
 اسکیما جان بوجھ کر مقامی اور ساختی ہے۔ یہ تصدیق **نہیں** کرتی کہ ریپوزٹری موجود ہے، node ID URL سے مطابقت رکھتا ہے، ثبوت کے راستے پن شدہ کمٹ پر موجود ہیں، ستاروں کی تعداد درست ہے، یا تخلیق کار سورس کا مالک ہے۔ وہ چیکس [CONTRIBUTING.md](../../CONTRIBUTING.md) اور [docs/GOVERNANCE.md](../../docs/GOVERNANCE.md) میں بیان کردہ مینٹینر جائزہ گیٹس سے تعلق رکھتی ہیں۔

--- a/docs/i18n/vi/SCHEMA.md
+++ b/docs/i18n/vi/SCHEMA.md
@@ -245,6 +245,113 @@ Hãy bỏ hẳn trường này khi không có gì để hiển thị — `media:
 "không có ảnh chụp màn hình". Trường này mang tính bổ sung: các mục được công bố trước khi nó tồn
 tại vẫn hợp lệ, và một bên tiêu thụ bỏ qua nó vẫn đọc mọi mục y như trước.
 
+## Mục nhập `kind: skill`
+
+Schema phiên bản 1 cũng định nghĩa một hợp đồng mục nhập thứ hai, khép kín, dành cho
+`kind: skill`, được công bố dưới dạng
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml) (SKL-01 giai đoạn 0). Nó không
+bao giờ chạm vào schema plugin ở trên: các mục nhập với `kind: plugin` tiếp tục được xác thực
+y như trước, và file schema skill là nguồn chân lý cho các mục nhập skill giống như cách
+schema plugin là nguồn chân lý cho các mục nhập plugin.
+
+Một skill không được cài đặt, nó được harness **tải**, nên các bộ mô tả cài đặt chỉ dành cho
+plugin (`package`, `dsh`) không tồn tại trên mục nhập skill và được thay bằng `usage` +
+`compat`. Một skill cũng thường sống trong thư mục con của một repository chứa nhiều skill,
+nên danh tính và khử trùng lặp là `source.repository` + `source.subpath` thay vì chỉ riêng
+repository. Mục nhập skill không chấp nhận thư viện `media`: skill là văn bản mà harness tải,
+nên không có gì để chụp màn hình (`additionalProperties: false` chính là thứ bắt buộc điều đó).
+
+Các trường sau giữ nguyên chính xác hình dạng và quy tắc đã được ghi cho mục nhập plugin ở
+trên: `schemaVersion`, `id`, `name`, `description`, `unofficial`, `primaryCategory`, `tags`,
+`source`, `creator`, `repositoryScope`, `license`, `provenance`. Mọi trường đều bắt buộc,
+ngoại trừ `triggers`, trường skill duy nhất mang tính tùy chọn.
+
+### Các trường riêng của skill
+
+| Trường               | Kiểu   | Bắt buộc | Quy tắc                                                     |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | hằng số  |   có    | Phải chính xác bằng `skill`                                 |
+| `skillScope`         | enum   |   có    | `repository` (toàn bộ repository **chính là** skill) hoặc `subdirectory` (skill nằm tại `source.subpath`) |
+| `triggers`           | mảng  |   không    | Khi nào skill kích hoạt — văn bản mà người dùng đánh giá trước khi tải nó. Ít nhất 1 chuỗi duy nhất, mỗi chuỗi 3–200 ký tự; hãy bỏ hẳn trường này khi không có gì (`triggers: []` là không hợp lệ) |
+| `usage.load`         | chuỗi |   có    | Cách harness tải skill, 1–200 ký tự; một skill được tải, không bao giờ được cài đặt |
+| `usage.evidencePath` | chuỗi |   có    | Đường dẫn tương đối an toàn (cùng mẫu như `description.evidencePath`) tới bằng chứng tải tại `source.commit` |
+| `compat.harnessMin`  | chuỗi |   có    | Phiên bản harness tối thiểu mà skill đã được kiểm chứng; hình dạng `x.y.z` chính xác (prerelease/build tùy chọn), tối đa 64 ký tự. Tầng ngữ nghĩa còn yêu cầu thêm một SemVer chính xác, phân tích được |
+
+Các quy tắc có điều kiện (được các khối `allOf` của schema skill bắt buộc):
+
+- `skillScope: subdirectory` **buộc** `source.subpath` phải là một chuỗi đường dẫn tương đối
+  an toàn — skill được lưu trong thư mục con phải ghim thư mục con đó.
+- `skillScope: repository` **buộc** `source.subpath: null` — skill toàn-repository không được
+  khai báo subpath.
+
+`verification` giữ nguyên hình dạng của plugin (`status`, `checkedAt`, `repositoryIdentity`,
+`smokeTest`), nhưng `smokeTest` phải chính xác bằng `null`: skill không có smoke test cài
+đặt, và việc xét duyệt nội dung chính là cổng tiếp nhận. Schema skill không mang điều kiện
+`status: verified` → `smokeTest` và không mang các điều kiện `repositoryScope` →
+`popularity`; những ràng buộc đó chỉ là quy tắc của schema plugin.
+
+### Tầng ngữ nghĩa cho skill
+
+Bên trên schema, việc xác thực catalog áp dụng cùng các bộ phân tích ngữ nghĩa bắt buộc như
+với plugin ở những trường tồn tại: `license.spdx` phải phân tích được thành một biểu thức
+SPDX hợp lệ (`invalid-spdx`), và `compat.harnessMin` phải là một SemVer chính xác
+(`invalid-semver`). Không có trường hợp `invalid-sri` — skill không có `package.integrity`.
+
+### Danh tính skill và khử trùng lặp
+
+Khóa chính tắc của một skill là `skill:<source.repositoryNodeId>:<normalized subpath>`.
+Subpath chỉ được chuẩn hóa cho mục đích danh tính: dấu gạch chéo ngược trở thành `/`, các
+phân đoạn rỗng và `.` bị loại bỏ, và kết quả rỗng (hoặc `subpath: null`) trở thành `.` —
+toàn bộ repository. Subpath chứa byte NUL hoặc phân đoạn `..` sẽ bị từ chối, không bao giờ
+được "làm sạch". Hai skill của cùng một repository là hai mục nhập; cùng repository +
+subpath xuất hiện hai lần là một va chạm.
+
+### Ví dụ skill tối thiểu
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## Những gì schema không kiểm tra
 
 Schema được thiết kế cố ý mang tính cục bộ và cấu trúc. Nó **không** xác minh repository có tồn tại hay không, ID

--- a/docs/i18n/zh-CN/SCHEMA.md
+++ b/docs/i18n/zh-CN/SCHEMA.md
@@ -232,6 +232,105 @@ schema 只保证安全形状（主机、40 位十六进制引用、长度上限�
 
 没有可展示的内容时请完全省略该字段——`media: []` 不是表达“没有截图”的有效方式。该字段是增量的：在它出现之前发布的条目依然有效，忽略它的消费者读取每个条目的方式与以前完全相同。
 
+## `kind: skill` 条目
+
+模式版本 1 还为 `kind: skill` 定义了第二份自成一体的条目契约，发布为
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)（SKL-01 第 0 阶段）。它完全
+不触及上面的插件模式：`kind: plugin` 的条目继续按原样通过校验，而技能模式文件对技能条目而言
+是真实来源，正如插件模式之于插件条目。
+
+技能不是被安装的，而是由 harness **加载**的，因此仅插件才有的安装描述符（`package`、`dsh`）
+在技能条目上不存在，取而代之的是 `usage` + `compat`。技能也经常位于托管多个技能的仓库的
+子目录中，因此身份与去重依据是 `source.repository` + `source.subpath`，而不只是仓库本身。
+技能条目不接受 `media` 图库：技能是 harness 加载的文本，没有可截图的内容
+（正是 `additionalProperties: false` 强制了这一点）。
+
+以下字段完全保持上面为插件条目记录的形状和规则：
+`schemaVersion`、`id`、`name`、`description`、`unofficial`、`primaryCategory`、`tags`、
+`source`、`creator`、`repositoryScope`、`license`、`provenance`。除 `triggers`（唯一可选的
+技能字段）外，每个字段都是必需的。
+
+### 技能特有字段
+
+| 字段                 | 类型   | 是否必需 | 规则                                                        |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   是    | 必须精确等于 `skill`                                        |
+| `skillScope`         | enum   |   是    | `repository`（整个仓库**就是**技能）或 `subdirectory`（技能位于 `source.subpath`） |
+| `triggers`           | array  |   否    | 技能何时触发——用户在加载它之前评估的文本。至少 1 个唯一字符串，每个 3–200 个字符；没有触发条件时请完全省略该字段（`triggers: []` 是无效的） |
+| `usage.load`         | string |   是    | harness 如何加载该技能，1–200 个字符；技能只会被加载，绝不会被安装 |
+| `usage.evidencePath` | string |   是    | 指向 `source.commit` 处加载证据的安全相对路径（与 `description.evidencePath` 相同的模式） |
+| `compat.harnessMin`  | string |   是    | 技能经过验证的最低 harness 版本；精确的 `x.y.z` 形状（可选的 prerelease/build），最长 64 个字符。语义层还额外要求一个可解析的、精确的 SemVer |
+
+条件规则（由技能模式的 `allOf` 块强制执行）：
+
+- `skillScope: subdirectory` **强制** `source.subpath` 为安全相对路径字符串——托管在
+  子目录中的技能必须固定该子目录。
+- `skillScope: repository` **强制** `source.subpath: null`——整仓库技能不得声明子路径。
+
+`verification` 保持插件的形状（`status`、`checkedAt`、`repositoryIdentity`、`smokeTest`），
+但 `smokeTest` 必须精确等于 `null`：技能没有安装冒烟测试，内容审查才是准入门禁。技能模式
+不携带 `status: verified` → `smokeTest` 条件，也不携带 `repositoryScope` → `popularity`
+条件；这些耦合仅是插件模式的规则。
+
+### 技能的语义层
+
+在模式之上，目录校验在字段存在时应用与插件相同的强制语义解析器：`license.spdx` 必须解析为
+有效的 SPDX 表达式（`invalid-spdx`），`compat.harnessMin` 必须是精确的 SemVer
+（`invalid-semver`）。不存在 `invalid-sri` 情形——技能没有 `package.integrity`。
+
+### 技能身份与去重
+
+技能的规范键是 `skill:<source.repositoryNodeId>:<normalized subpath>`。子路径仅出于身份
+目的进行规范化：反斜杠变为 `/`，空段和 `.` 段被丢弃，空结果（或 `subpath: null`）变为
+`.`——即整个仓库。包含 NUL 字节或 `..` 段的子路径会被拒绝，绝不会被"清理"。同一仓库的
+两个技能是两个条目；相同的仓库 + 子路径出现两次则是冲突。
+
+### 最小技能示例
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## 模式不检查的内容
 
 该模式在设计上只做本地和结构性检查。它**不会**验证仓库是否存在、节点 ID 是否与 URL 匹配、证据路径

--- a/docs/i18n/zh-TW/SCHEMA.md
+++ b/docs/i18n/zh-TW/SCHEMA.md
@@ -234,6 +234,105 @@ schema 只保證安全形狀（主機、40 位十六進位參考、長度上限�
 
 沒有可展示的內容時請完全省略此欄位——`media: []` 不是表達「沒有螢幕截圖」的有效方式。此欄位是增量的：在它出現之前發布的條目仍然有效，忽略它的消費者讀取每個條目的方式與以往完全相同。
 
+## `kind: skill` 條目
+
+結構描述版本 1 也為 `kind: skill` 定義了第二份自成一體的條目契約，發布為
+[`schemas/skill.schema.yaml`](../../schemas/skill.schema.yaml)（SKL-01 第 0 階段）。它完全
+不觸及上面的外掛結構描述：`kind: plugin` 的條目繼續照原樣通過驗證，而技能結構描述檔案對
+技能條目而言是真實來源，正如外掛結構描述之於外掛條目。
+
+技能不是被安裝的，而是由 harness **載入**的，因此僅外掛才有的安裝描述子（`package`、`dsh`）
+在技能條目上不存在，取而代之的是 `usage` + `compat`。技能也經常位於託管多個技能的儲存庫的
+子目錄中，因此身分與去重依據是 `source.repository` + `source.subpath`，而不只是儲存庫本身。
+技能條目不接受 `media` 圖庫：技能是 harness 載入的文字，沒有可截圖的內容
+（正是 `additionalProperties: false` 強制了這一點）。
+
+以下欄位完全保持上面為外掛條目記錄的形狀和規則：
+`schemaVersion`、`id`、`name`、`description`、`unofficial`、`primaryCategory`、`tags`、
+`source`、`creator`、`repositoryScope`、`license`、`provenance`。除 `triggers`（唯一可選的
+技能欄位）外，每個欄位都是必要的。
+
+### 技能特有欄位
+
+| 欄位                 | 型別   | 是否必要 | 規則                                                        |
+| -------------------- | ------ | :------: | ----------------------------------------------------------- |
+| `kind`               | const  |   是    | 必須恰好等於 `skill`                                        |
+| `skillScope`         | enum   |   是    | `repository`（整個儲存庫**就是**技能）或 `subdirectory`（技能位於 `source.subpath`） |
+| `triggers`           | array  |   否    | 技能何時觸發——使用者在載入它之前評估的文字。至少 1 個唯一字串，每個 3–200 個字元；沒有觸發條件時請完全省略此欄位（`triggers: []` 是無效的） |
+| `usage.load`         | string |   是    | harness 如何載入該技能，1–200 個字元；技能只會被載入，絕不會被安裝 |
+| `usage.evidencePath` | string |   是    | 指向 `source.commit` 處載入證據的安全相對路徑（與 `description.evidencePath` 相同的格式） |
+| `compat.harnessMin`  | string |   是    | 技能經過驗證的最低 harness 版本；恰好的 `x.y.z` 形狀（可選的 prerelease/build），最長 64 個字元。語意層還額外要求一個可解析的、精確的 SemVer |
+
+條件規則（由技能結構描述的 `allOf` 區塊強制執行）：
+
+- `skillScope: subdirectory` **強制** `source.subpath` 為安全相對路徑字串——託管在
+  子目錄中的技能必須釘選該子目錄。
+- `skillScope: repository` **強制** `source.subpath: null`——整儲存庫技能不得宣告子路徑。
+
+`verification` 保持外掛的形狀（`status`、`checkedAt`、`repositoryIdentity`、`smokeTest`），
+但 `smokeTest` 必須恰好等於 `null`：技能沒有安裝煙霧測試，內容審查才是准入關卡。技能結構
+描述不帶 `status: verified` → `smokeTest` 條件，也不帶 `repositoryScope` → `popularity`
+條件；這些耦合僅是外掛結構描述的規則。
+
+### 技能的語意層
+
+在結構描述之上，目錄驗證在欄位存在時套用與外掛相同的強制語意解析器：`license.spdx` 必須
+解析為有效的 SPDX 表達式（`invalid-spdx`），`compat.harnessMin` 必須是精確的 SemVer
+（`invalid-semver`）。不存在 `invalid-sri` 情形——技能沒有 `package.integrity`。
+
+### 技能身分與去重
+
+技能的規範鍵是 `skill:<source.repositoryNodeId>:<normalized subpath>`。子路徑僅出於身分
+目的進行正規化：反斜線變為 `/`，空段和 `.` 段被捨棄，空結果（或 `subpath: null`）變為
+`.`——即整個儲存庫。包含 NUL 位元組或 `..` 段的子路徑會被拒絕，絕不會被「清理」。同一
+儲存庫的兩個技能是兩個條目；相同的儲存庫 + 子路徑出現兩次則是衝突。
+
+### 最小技能範例
+
+```yaml
+schemaVersion: 1
+id: alice-dsh-commit-lint-skill
+name: DSH Commit Lint Skill
+description:
+  en: Loads a commit-message linting skill that checks Conventional Commit shape before the harness commits.
+  evidencePath: skills/commit-lint/SKILL.md
+unofficial: true
+kind: skill
+skillScope: subdirectory
+primaryCategory: coding-developer-tools
+tags:
+  - git
+  - linting
+triggers:
+  - When the user asks to commit staged work
+source:
+  repository: https://github.com/alice/dsh-skills
+  repositoryNodeId: R_kgDOexample1
+  subpath: skills/commit-lint
+  commit: 0123456789abcdef0123456789abcdef01234567
+creator:
+  github: alice
+usage:
+  load: dsh skill load skills/commit-lint
+  evidencePath: skills/commit-lint/SKILL.md
+compat:
+  harnessMin: 1.4.0
+repositoryScope: monorepo
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-30T12:00:00Z
+  repositoryIdentity: resolved
+  smokeTest: null
+provenance:
+  discussion: null
+  comment: null
+```
+
 ## 結構描述不檢查的事
 
 此結構描述在設計上僅做本機與結構性檢查。它**不會**驗證儲存庫是否存在、節點 ID 是否與網址相

--- a/schemas/skill.schema.yaml
+++ b/schemas/skill.schema.yaml
@@ -1,0 +1,258 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: Awesome Omni DSH Skill Entry
+description: Public schema version 1 for one creator-sourced DSH skill catalog artifact.
+$comment: >-
+  Phase-0 decision: a skill admits no media[] gallery. A skill is text the harness loads,
+  so there is nothing to screenshot; additionalProperties:false is what enforces it.
+type: object
+additionalProperties: false
+required:
+  - schemaVersion
+  - id
+  - name
+  - description
+  - unofficial
+  - kind
+  - skillScope
+  - primaryCategory
+  - tags
+  - source
+  - creator
+  - usage
+  - compat
+  - repositoryScope
+  - popularity
+  - license
+  - verification
+  - provenance
+properties:
+  schemaVersion:
+    const: 1
+  id:
+    type: string
+    pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+  name:
+    type: string
+    minLength: 1
+    maxLength: 120
+  description:
+    type: object
+    additionalProperties: false
+    required:
+      - en
+      - evidencePath
+    properties:
+      en:
+        type: string
+        minLength: 20
+        maxLength: 320
+      evidencePath:
+        type: string
+        pattern: '^(?!/)(?!.*\\)(?!\.{1,2}(?:/|$))(?!.*(?:/\.{1,2})(?:/|$))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$'
+  unofficial:
+    const: true
+  kind:
+    const: skill
+  skillScope:
+    enum:
+      - repository
+      - subdirectory
+  primaryCategory:
+    enum:
+      - user-interface-dashboards
+      - memory-rag
+      - search-research
+      - coding-developer-tools
+      - browser-automation
+      - vision-audio-multimodal
+      - sessions-productivity
+      - security-permissions-approvals
+      - diagnostics-observability
+      - models-providers-routing
+      - messaging-notifications
+      - data-external-services
+      - entertainment-customization
+      - finance-trading
+  tags:
+    type: array
+    uniqueItems: true
+    items:
+      type: string
+      pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+  triggers:
+    description: When the skill fires — the text a user evaluates before loading it.
+    type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: string
+      minLength: 3
+      maxLength: 200
+  source:
+    type: object
+    additionalProperties: false
+    required:
+      - repository
+      - repositoryNodeId
+      - subpath
+      - commit
+    properties:
+      repository:
+        type: string
+        pattern: '^https://github\.com/[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/(?!\.{1,2}$)(?![A-Za-z0-9._-]*\.git$)[A-Za-z0-9._-]{1,100}$'
+      repositoryNodeId:
+        type: string
+        minLength: 1
+      subpath:
+        oneOf:
+          - type: string
+            pattern: '^(?!/)(?!.*\\)(?!\.{1,2}(?:/|$))(?!.*(?:/\.{1,2})(?:/|$))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$'
+          - type: "null"
+      commit:
+        type: string
+        pattern: '^[0-9a-fA-F]{40}$'
+  creator:
+    type: object
+    additionalProperties: false
+    required:
+      - github
+    properties:
+      github:
+        type: string
+        pattern: '^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$'
+  usage:
+    description: How the harness loads the skill; a skill is loaded, never installed.
+    type: object
+    additionalProperties: false
+    required:
+      - load
+      - evidencePath
+    properties:
+      load:
+        type: string
+        minLength: 1
+        maxLength: 200
+      evidencePath:
+        type: string
+        pattern: '^(?!/)(?!.*\\)(?!\.{1,2}(?:/|$))(?!.*(?:/\.{1,2})(?:/|$))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$'
+  compat:
+    type: object
+    additionalProperties: false
+    required:
+      - harnessMin
+    properties:
+      harnessMin:
+        type: string
+        maxLength: 64
+        pattern: '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$'
+        $comment: Safe shape only; catalog-core parses it with an exact SemVer parser.
+  repositoryScope:
+    enum:
+      - dedicated
+      - monorepo
+  popularity:
+    type: object
+    additionalProperties: false
+    required:
+      - starsPolicy
+      - stars
+    properties:
+      starsPolicy:
+        enum:
+          - exact-repository
+          - undefined-parent-repository
+      stars:
+        oneOf:
+          - type: integer
+            minimum: 0
+          - type: "null"
+  license:
+    description: 'Mandatory: a repository without an explicit license is ineligible.'
+    type: object
+    additionalProperties: false
+    required:
+      - spdx
+    properties:
+      spdx:
+        type: string
+        minLength: 2
+        maxLength: 256
+        pattern: '^(?!-)[A-Za-z0-9.+(): -]+$'
+  verification:
+    type: object
+    additionalProperties: false
+    required:
+      - status
+      - checkedAt
+      - repositoryIdentity
+      - smokeTest
+    properties:
+      status:
+        enum:
+          - eligible
+          - verified
+          - stale
+          - unavailable
+          - archived
+          - quarantined
+      checkedAt:
+        type: string
+        format: date-time
+      repositoryIdentity:
+        const: resolved
+      smokeTest:
+        type: "null"
+        $comment: A skill has no install smoke test; content review is the admission gate.
+  provenance:
+    type: object
+    additionalProperties: false
+    required:
+      - discussion
+      - comment
+    properties:
+      discussion:
+        oneOf:
+          - type: string
+            format: uri
+          - type: "null"
+      comment:
+        oneOf:
+          - type: string
+            format: uri
+          - type: "null"
+allOf:
+  - if:
+      type: object
+      required:
+        - skillScope
+      properties:
+        skillScope:
+          const: subdirectory
+    then:
+      type: object
+      properties:
+        source:
+          type: object
+          required:
+            - subpath
+          properties:
+            subpath:
+              type: string
+              pattern: '^(?!/)(?!.*\\)(?!\.{1,2}(?:/|$))(?!.*(?:/\.{1,2})(?:/|$))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$'
+  - if:
+      type: object
+      required:
+        - skillScope
+      properties:
+        skillScope:
+          const: repository
+    then:
+      type: object
+      properties:
+        source:
+          type: object
+          required:
+            - subpath
+          properties:
+            subpath:
+              type: "null"


### PR DESCRIPTION
Mirrors the approved catalog-core `kind: skill` contract (SKL-01 phase 0) into the public repository, so contributors and the public CLI can see the skill contract without depending on the private repo. Prerequisite for SKL-01 phase 1.

## What this adds

- **`schemas/skill.schema.yaml`** — the public JSON Schema (draft 2020-12) for one `kind: skill` catalog entry. It is a 1:1 mirror of the catalog-core `SKILL_ENTRY_SCHEMA` constant: a deep structural comparison between this YAML (parsed) and the TS constant (exported to JSON) reports zero differences — every `required` list, pattern, enum, length bound, `$comment` and both `allOf` conditionals (`skillScope: subdirectory` ⇒ `source.subpath` is a safe relative path; `skillScope: repository` ⇒ `source.subpath: null`) are identical.
- **`docs/SCHEMA.md`** — new "`kind: skill` entries" section: which fields keep the plugin shape, the skill-specific fields (`kind`, `skillScope`, `triggers`, `usage`, `compat`), the conditional rules, the semantic layer (SPDX + exact SemVer for `compat.harnessMin`), skill identity/dedupe (`repository + subpath`), and a minimal valid example.
- **All 41 `docs/i18n/*/SCHEMA.md` translations** — the same section translated per locale, keeping the shape parity `catalog docs-check` enforces (sections=3, subsections=22, table rows=81, matching the English file). Same approach as the `media[]` addition (26d0480e).
- **`cli/tests/skill-schema.test.ts`** — a vitest guard that compiles the mirror under the exact Ajv configuration the catalog loader uses (Ajv 2020-12, `strict: true`, `allErrors`, `validateFormats`, ajv-formats) and pins the contract's canonical accept/reject shapes (9 tests), so the published mirror cannot drift.

## Form decision: separate `schemas/skill.schema.yaml`, plugin schema untouched

Three reasons, in order of weight:

1. **The contract's own design.** The catalog-core module is deliberately self-contained — its header states the schema is owned there "so the very same document can later be mirrored into the public repository as `schemas/skill.schema.yaml`" and that it "never touches the plugin schema". Entries with `kind: plugin` keep validating exactly as before.
2. **The contracts are structurally incompatible inside one schema.** A skill has no `package`, no `dsh`, no `media` (all enforced by `additionalProperties: false`), replaces them with `usage`/`compat`, adds `skillScope` + `triggers`, and pins `verification.smokeTest` to `null`. Folding that into `plugin.schema.yaml` would mean a top-level `oneOf` discriminated on `kind` — a rewrite of the file every published entry validates against, for zero benefit.
3. **What the public validation supports.** The CLI's hardened schema loader (`createPublicEntryValidator`) loads any local YAML schema under the catalog root, so a sibling schema file is first-class. `catalog validate` and the docs-check parity gate read only `schemas/plugin.schema.yaml` (whose `kind` enum already lists `skill`), so a sibling file changes no behavior for the 3420 published entries.

## Known TS ↔ YAML divergences (all deliberate, none structural)

- **Semantic layer is not expressible in JSON Schema** — same two-layer split the plugin schema already documents: catalog-core additionally parses `license.spdx` with a real SPDX parser (`invalid-spdx`) and requires `compat.harnessMin` to be an exact SemVer (`invalid-semver`). The schema carries only the bounded safe shapes; docs state this explicitly.
- **Dedupe/identity is code, not schema** — the canonical key `skill:<repositoryNodeId>:<normalized subpath>` (backslash→`/`, empty/`.` segments dropped, `null`/empty → `.`, NUL and `..` rejected) and collision detection live in catalog-core functions. Documented in the new SCHEMA.md subsection; not enforceable in YAML.
- **The public CLI does not load `kind: skill` entries yet** — `catalog/plugins/` entries still validate against the plugin schema only. Wiring the loader/dedupe for skill entries is phase 1; this PR is the contract mirror that phase 1 builds on.

Nothing else diverges: the schema document itself is byte-faithful (verified by deep comparison, key order aside).

## Validation

- `node cli/dist/bin.js catalog validate --catalog .` → `3420 entries valid` (exit 0).
- `node cli/dist/bin.js catalog docs-check . --skip-count` (the PR-mode gate) → passes.
- `cd cli && npm test` → all suites green, including the 9 new skill-schema tests; `npm run typecheck` clean.
- Fixture demonstration with the loader's exact Ajv options: a valid subdirectory skill entry → **VALID**; an entry carrying `package`/`media`, a smoke-test object, a `^1.4.0` range and `skillScope: repository` with a subpath → **INVALID** with the expected errors (`must NOT have additional properties`, `/verification/smokeTest must be null`, `/compat/harnessMin must match pattern …`, `/source/subpath must be null`).
