### PR TITLE
catalog: add cerbur-clutch-dsh-fireworks (community curation, created by @Cerbur)

### DIFF
--- a/catalog/plugins/cerbur-clutch-dsh-fireworks.yaml
+++ b/catalog/plugins/cerbur-clutch-dsh-fireworks.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: cerbur-clutch-dsh-fireworks
+name: "@cerbur/clutch-dsh-fireworks"
+description:
+  en: Adds a celebratory fireworks overlay to the DSH Web UI through a happy fireworks agent tool.
+  evidencePath: packages/clutch-dsh-fireworks/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - fireworks
+  - celebration
+source:
+  repository: https://github.com/Cerbur/clutch-dsh
+  repositoryNodeId: R_kgDOT9QNJw
+  subpath: packages/clutch-dsh-fireworks
+  commit: e54f365ac0bf7c0bcc20fd3a448446e3aaca3ee5
+creator:
+  github: Cerbur
+package:
+  ecosystem: npm
+  name: "@cerbur/clutch-dsh-fireworks"
+  version: 0.1.0
+  integrity: sha512-m1qqd2MI9wm+8FqaMW5oAOre+70M0JHrGyUKWRxRFbaezm+UUdhzkTGyG4mTNvDZwPnWer3T2ClxupGp0svr9g==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/clutch-dsh-fireworks/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:16.499Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `cerbur-clutch-dsh-fireworks`
- Submission type: community curation
- Created by `Cerbur` — https://github.com/Cerbur
- Original source repository: https://github.com/Cerbur/clutch-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.