### PR TITLE
catalog: add ch4acko3-dsh-structured-render (community curation, created by @CH4ACKO3)

### DIFF
--- a/catalog/plugins/ch4acko3-dsh-structured-render.yaml
+++ b/catalog/plugins/ch4acko3-dsh-structured-render.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ch4acko3-dsh-structured-render
+name: "@ch4acko3/dsh-structured-render"
+description:
+  en: Safe expandable structured data rendering service for DeepSeek Harness Web plugins
+  evidencePath: packages/structured-render/README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - json
+  - structured-data
+  - tree-view
+source:
+  repository: https://github.com/CH4ACKO3/dsh-render-engine
+  repositoryNodeId: R_kgDOT_CyLg
+  subpath: packages/structured-render
+  commit: cca409bdfbcdb58e20267f970744d9b2918d218a
+creator:
+  github: CH4ACKO3
+package:
+  ecosystem: npm
+  name: "@ch4acko3/dsh-structured-render"
+  version: 0.1.2
+  integrity: sha512-vLiwUzBkF16Tq3y6fcb7AL1KNjTxIexm2SjBB4Dek6xXoq58CwAfyQ4ojOlpYLDOulETajF8iJ+jWyHFUbst6A==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/structured-render/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:16.709Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ch4acko3-dsh-structured-render`
- Submission type: community curation
- Created by `CH4ACKO3` — https://github.com/CH4ACKO3
- Original source repository: https://github.com/CH4ACKO3/dsh-render-engine
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.