### PR TITLE
catalog: add howe829-dsh-model-proxy (community curation, created by @Howe829)

### DIFF
--- a/catalog/plugins/howe829-dsh-model-proxy.yaml
+++ b/catalog/plugins/howe829-dsh-model-proxy.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: howe829-dsh-model-proxy
+name: "@awiki/dsh-model-proxy"
+description:
+  en: AWiki-authenticated model proxy and Quick Recharge UI for DeepSeek Harness
+  evidencePath: packages/dsh-model-proxy/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - awiki
+  - deepseek-harness
+  - dsh
+  - model-proxy
+source:
+  repository: https://github.com/AgentConnect/dsh-awiki
+  repositoryNodeId: R_kgDOT4nC7Q
+  subpath: packages/dsh-model-proxy
+  commit: a88e6750fc7a51387377a4e1322efefc3c280300
+creator:
+  github: Howe829
+package:
+  ecosystem: npm
+  name: "@awiki/dsh-model-proxy"
+  version: 0.1.4
+  integrity: sha512-fQUwoyUm8w5U90gr1QKfsS1vQ+ReTL4xuXjkaulJj4jRkkho+VyCXY5p6QeVW1lUxLa4oYFjyG78UPcAMNPHmg==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-model-proxy/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:15.618Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `howe829-dsh-model-proxy`
- Submission type: community curation
- Created by `Howe829` — https://github.com/Howe829
- Original source repository: https://github.com/AgentConnect/dsh-awiki
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.