### PR TITLE
catalog: add trench-xinxin-dsh-tool-lens (community curation, created by @trench-xinxin)

### DIFF
--- a/catalog/plugins/trench-xinxin-dsh-tool-lens.yaml
+++ b/catalog/plugins/trench-xinxin-dsh-tool-lens.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: trench-xinxin-dsh-tool-lens
+name: "@trench-xinxin/dsh-tool-lens"
+description:
+  en: "DeepSeek Lens: Deep AST code graph, symbol call hierarchies, and refactoring impact analysis tool plugin for DeepSeek Harness"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - lens
+  - deep
+  - code
+  - graph
+  - symbol
+  - call
+  - hierarchies
+  - refactoring
+  - impact
+  - analysis
+  - tool
+  - dsh
+source:
+  repository: https://github.com/trench-xinxin/dsh-tool-lens
+  repositoryNodeId: R_kgDOT7DF8A
+  subpath: null
+  commit: 4bf13121ef320584a9b75af42b95ad1147970370
+creator:
+  github: trench-xinxin
+package:
+  ecosystem: npm
+  name: "@trench-xinxin/dsh-tool-lens"
+  version: 2.0.5
+  integrity: sha512-emWZvgEbo4+gun1rBY2tF64QktSLIF9d0R5KIsjErTWTWr2lMmbcWmiP6m5CwY7owPksxcqF3rKDeHVR7BQHNQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:55.200Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `trench-xinxin-dsh-tool-lens`
- Submission type: community curation
- Created by `trench-xinxin` — https://github.com/trench-xinxin
- Original source repository: https://github.com/trench-xinxin/dsh-tool-lens
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.