### PR TITLE
catalog: add ttb-eng-dsh-github-search (community curation, created by @ttb-eng)

### DIFF
--- a/catalog/plugins/ttb-eng-dsh-github-search.yaml
+++ b/catalog/plugins/ttb-eng-dsh-github-search.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: ttb-eng-dsh-github-search
+name: dsh-github-search
+description:
+  en: English overview — full 中文说明 below.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - english
+  - overview
+  - full
+  - below
+  - dsh
+source:
+  repository: https://github.com/ttb-eng/dsh-github-search
+  repositoryNodeId: R_kgDOT8_3SQ
+  subpath: null
+  commit: b9c5c14c6fd33f77fab1b1a5c224a9cd53fde400
+creator:
+  github: ttb-eng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:10.448Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ttb-eng-dsh-github-search`
- Submission type: community curation
- Created by `ttb-eng` — https://github.com/ttb-eng
- Original source repository: https://github.com/ttb-eng/dsh-github-search
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.