### PR TITLE
catalog: add v-dev-388-dsh-host-plugin-market (community curation, created by @V-dev-388)

### DIFF
--- a/catalog/plugins/v-dev-388-dsh-host-plugin-market.yaml
+++ b/catalog/plugins/v-dev-388-dsh-host-plugin-market.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: v-dev-388-dsh-host-plugin-market
+name: "@deepseek-ai/dsh-host-plugin-market"
+description:
+  en: 'json { "version": 1, "plugins": [ { "id": "example-static", "name": "示例静态插件", "version": "1.0.0", "description": "一个经过校验的静态插件。", "type": "static", "downloadUrl": "https://example.com/plugins/example-static/index.js", "checksum": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "entry": "index.js", "p'
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - json
+  - version
+  - example
+  - static
+  - name
+  - description
+  - type
+  - downloadurl
+  - index
+  - checksum
+  - 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  - entry
+  - dsh
+source:
+  repository: https://github.com/V-dev-388/DSH-plugin-market
+  repositoryNodeId: R_kgDOT47kaA
+  subpath: null
+  commit: 0cc75c9d380af179fc4f576e4b3234b945541c08
+creator:
+  github: V-dev-388
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:25.705Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `v-dev-388-dsh-host-plugin-market`
- Submission type: community curation
- Created by `V-dev-388` — https://github.com/V-dev-388
- Original source repository: https://github.com/V-dev-388/DSH-plugin-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.