### PR TITLE
catalog: add v587d-dsh-ocgo-usage (community curation, created by @v587d)

### DIFF
--- a/catalog/plugins/v587d-dsh-ocgo-usage.yaml
+++ b/catalog/plugins/v587d-dsh-ocgo-usage.yaml
@@ -1,0 +1,58 @@
+schemaVersion: 1
+id: v587d-dsh-ocgo-usage
+name: dsh-ocgo-usage
+description:
+  en: "OpenCode Go subscription usage readout for the dsh web GUI: rolling (5h), weekly, and monthly usage windows with reset countdowns in the composer dock."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - deepseek-harness
+  - bundle
+  - opencode
+  - opencode-go
+  - usage
+  - subscription
+  - composer-dock
+source:
+  repository: https://github.com/v587d/dsh-opencode-go-usage
+  repositoryNodeId: R_kgDOT4GNbA
+  subpath: null
+  commit: 682a7872e6a3bf9313f08b9337319678b8a25895
+creator:
+  github: v587d
+package:
+  ecosystem: npm
+  name: dsh-ocgo-usage
+  version: 0.1.1
+  integrity: sha512-c26g0aWiObPEu9B8IjQbg/s2zIFkfG0Phm/WIKEKWB2qLWweJ98Zgpmo1XFLC02U2eYS2twXReq8vytKVQD28g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:53.074Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/682a7872e6a3bf9313f08b9337319678b8a25895/assets/custom-footer.png
+    alt: Footer demo
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/682a7872e6a3bf9313f08b9337319678b8a25895/assets/set-cookie-wid.png
+    alt: Set editor
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/v587d/dsh-opencode-go-usage/682a7872e6a3bf9313f08b9337319678b8a25895/assets/usage-detail.png
+    alt: Usage detail


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `v587d-dsh-ocgo-usage`
- Submission type: community curation
- Created by `v587d` — https://github.com/v587d
- Original source repository: https://github.com/v587d/dsh-opencode-go-usage
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.