### PR TITLE
catalog: add void2anything-dsh-qingagent (community curation, created by @void2anything)

### DIFF
--- a/catalog/plugins/void2anything-dsh-qingagent.yaml
+++ b/catalog/plugins/void2anything-dsh-qingagent.yaml
@@ -1,0 +1,69 @@
+schemaVersion: 1
+id: void2anything-dsh-qingagent
+name: dsh-qingagent
+description:
+  en: QingAgent inside DeepSeek Harness
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - ai-writing
+  - writing-assistant
+  - qingml
+  - qingagent
+  - docs
+  - markdown
+source:
+  repository: https://github.com/void2anything/dsh-qingagent
+  repositoryNodeId: R_kgDOT6A0ng
+  subpath: null
+  commit: 56245b7709f13e1d285216a70695138f84f51617
+creator:
+  github: void2anything
+package:
+  ecosystem: npm
+  name: dsh-qingagent
+  version: 0.1.47
+  integrity: sha512-dTjAjq4tfRrO3wFY6CaYlR9gBUHFNav19vCmMjPj9oDSSiW5igMWBV+u1rKnWcmD0BoMnGguHulTqefLKxVsTg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:59.444Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/void2anything/dsh-qingagent/56245b7709f13e1d285216a70695138f84f51617/docs/assets/dsh-demo.gif
+    alt: 在 DSH 里一句话起草，右侧宣纸面板同步成文
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/void2anything/dsh-qingagent/56245b7709f13e1d285216a70695138f84f51617/docs/assets/dsh-diagram.webp
+    alt: DSH 对话与宣纸面板里的 Mermaid 流程图
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/void2anything/dsh-qingagent/56245b7709f13e1d285216a70695138f84f51617/docs/assets/dsh-table-math.webp
+    alt: 表格与行内、块级公式
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/void2anything/dsh-qingagent/56245b7709f13e1d285216a70695138f84f51617/docs/assets/dsh-review.webp
+    alt: 审阅态逐条裁决
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/void2anything/dsh-qingagent/56245b7709f13e1d285216a70695138f84f51617/docs/assets/dsh-onboarding.webp
+    alt: 未连接青简时的引导卡
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/void2anything/dsh-qingagent/56245b7709f13e1d285216a70695138f84f51617/docs/assets/wechat-group.png
+    alt: 青简用户交流群


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `void2anything-dsh-qingagent`
- Submission type: community curation
- Created by `void2anything` — https://github.com/void2anything
- Original source repository: https://github.com/void2anything/dsh-qingagent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.