### PR TITLE
catalog: add vvvspec-better-reasoning-slider (community curation, created by @vvvspec)

### DIFF
--- a/catalog/plugins/vvvspec-better-reasoning-slider.yaml
+++ b/catalog/plugins/vvvspec-better-reasoning-slider.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: vvvspec-better-reasoning-slider
+name: better-reasoning-slider
+description:
+  en: "DeepSeek Harness WebUI plugin: official-style composer model trigger with a floating reasoning-effort slider popup"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - webui
+  - official
+  - style
+  - composer
+  - model
+  - trigger
+  - floating
+  - reasoning
+  - effort
+  - slider
+  - popup
+  - dsh
+source:
+  repository: https://github.com/vvvspec/better-reasoning-slider
+  repositoryNodeId: R_kgDOT5gWdA
+  subpath: null
+  commit: ba879cf9668a9aad3dd488565634740a9faf8ffe
+creator:
+  github: vvvspec
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:10.448Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vvvspec-better-reasoning-slider`
- Submission type: community curation
- Created by `vvvspec` — https://github.com/vvvspec
- Original source repository: https://github.com/vvvspec/better-reasoning-slider
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.