### PR TITLE
catalog: add wade20250715-dsh-pubmed (community curation, created by @wade20250715)

### DIFF
--- a/catalog/plugins/wade20250715-dsh-pubmed.yaml
+++ b/catalog/plugins/wade20250715-dsh-pubmed.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: wade20250715-dsh-pubmed
+name: dsh-pubmed
+description:
+  en: sh dsh plugin --profile web add <本仓库地址或 npm 包名
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - profile
+  - dsh
+source:
+  repository: https://github.com/wade20250715/dsh-pubmed
+  repositoryNodeId: R_kgDOT5LqqA
+  subpath: null
+  commit: fa92128836d19e8bacb5aafa58e7160bd706fbe3
+creator:
+  github: wade20250715
+package:
+  ecosystem: npm
+  name: dsh-pubmed
+  version: 0.1.0
+  integrity: sha512-5XW5kZVQxAQ+BHkJM3invQnpCW+HThmId4yomAfQMoV/9QF1FJSjvaEj9Jmc8nvp+RvpTziRVjn/bZ7hkPuPZQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:10.450Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wade20250715-dsh-pubmed`
- Submission type: community curation
- Created by `wade20250715` — https://github.com/wade20250715
- Original source repository: https://github.com/wade20250715/dsh-pubmed
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.