### PR TITLE
catalog: add waknow-dsh-web-icon-indicator (community curation, created by @waknow)

### DIFF
--- a/catalog/plugins/waknow-dsh-web-icon-indicator.yaml
+++ b/catalog/plugins/waknow-dsh-web-icon-indicator.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: waknow-dsh-web-icon-indicator
+name: dsh-web-icon-indicator
+description:
+  en: Browser tab favicon reflects the current DSH session state — idle / running / asking / done — so you can see at a glance whether a session needs your attention, even when the tab is in the background.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - dsh-plugin
+  - favicon
+  - icon-indicator
+  - browser-tab
+source:
+  repository: https://github.com/waknow/dsh-web-icon-indicator
+  repositoryNodeId: R_kgDOT9QbRQ
+  subpath: null
+  commit: e3dd29806413ea5f33dd36077caa340c24e8c70c
+creator:
+  github: waknow
+package:
+  ecosystem: npm
+  name: dsh-web-icon-indicator
+  version: 0.2.3
+  integrity: sha512-1rsjXbwX0zAyC2s9YVZ8pvcbTYBdOQFaKRfYf4kO954B/TmbTU9vvT+gCcckXQt3fknC8JglsBr2UxoUCaW3dA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:03.653Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `waknow-dsh-web-icon-indicator`
- Submission type: community curation
- Created by `waknow` — https://github.com/waknow
- Original source repository: https://github.com/waknow/dsh-web-icon-indicator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.