### PR TITLE
catalog: add wally8-8-dsh-done-whale (community curation, created by @wally8-8)

### DIFF
--- a/catalog/plugins/wally8-8-dsh-done-whale.yaml
+++ b/catalog/plugins/wally8-8-dsh-done-whale.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: wally8-8-dsh-done-whale
+name: dsh-done-whale
+description:
+  en: sh dsh plugin --profile web add dsh-done-whale
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - favicon
+  - whale
+source:
+  repository: https://github.com/wally8-8/dsh-done-whale
+  repositoryNodeId: R_kgDOT6LhVw
+  subpath: null
+  commit: f27878701aa9d48bbfedeef7d6bbcd949832f105
+creator:
+  github: wally8-8
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:53.097Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 9
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wally8-8-dsh-done-whale`
- Submission type: community curation
- Created by `wally8-8` — https://github.com/wally8-8
- Original source repository: https://github.com/wally8-8/dsh-done-whale
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.