### PR TITLE
catalog: add wangyihao0001-oss-dsh-task-memory (community curation, created by @wangyihao0001-oss)

### DIFF
--- a/catalog/plugins/wangyihao0001-oss-dsh-task-memory.yaml
+++ b/catalog/plugins/wangyihao0001-oss-dsh-task-memory.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wangyihao0001-oss-dsh-task-memory
+name: dsh-task-memory
+description:
+  en: "Task-isolated long-term memory for DeepSeek Harness: remember / recall / search stay inside one task boundary, with optional prompt injection."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - memory
+  - task-memory
+  - long-term-memory
+  - isolation
+source:
+  repository: https://github.com/wangyihao0001-oss/dsh-task-memory
+  repositoryNodeId: R_kgDOT-K88Q
+  subpath: null
+  commit: 96e6552a26b11b6430e48cbd37755bb40f1a13dc
+creator:
+  github: wangyihao0001-oss
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:55.597Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wangyihao0001-oss-dsh-task-memory`
- Submission type: community curation
- Created by `wangyihao0001-oss` — https://github.com/wangyihao0001-oss
- Original source repository: https://github.com/wangyihao0001-oss/dsh-task-memory
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.