### PR TITLE
catalog: add waverly-w-dsh-scratchpad (community curation, created by @Waverly-W)

### DIFF
--- a/catalog/plugins/waverly-w-dsh-scratchpad.yaml
+++ b/catalog/plugins/waverly-w-dsh-scratchpad.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: waverly-w-dsh-scratchpad
+name: dsh-scratchpad
+description:
+  en: Quick temporary conversation & workspace manager for DeepSeek Harness (DSH) Web GUI
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - scratchpad
+  - temporary-session
+  - workspace
+  - web-ui
+source:
+  repository: https://github.com/Waverly-W/dsh-scratchpad
+  repositoryNodeId: R_kgDOT9Wxrg
+  subpath: null
+  commit: 6bc9fd6415a138e52c25164204c10238d3c93e11
+creator:
+  github: Waverly-W
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:03.312Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `waverly-w-dsh-scratchpad`
- Submission type: community curation
- Created by `Waverly-W` — https://github.com/Waverly-W
- Original source repository: https://github.com/Waverly-W/dsh-scratchpad
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.