### PR TITLE
catalog: add wefio-dsh-cache-miss (community curation, created by @wefio)

### DIFF
--- a/catalog/plugins/wefio-dsh-cache-miss.yaml
+++ b/catalog/plugins/wefio-dsh-cache-miss.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: wefio-dsh-cache-miss
+name: dsh-cache-miss
+description:
+  en: "DSH web plugin: a yellow one-line cache-miss notice under the first assistant reply of each turn, when that turn's first request rebuilt the prompt cache."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - prompt-cache
+source:
+  repository: https://github.com/wefio/dsh-cache-miss
+  repositoryNodeId: R_kgDOT6IBbw
+  subpath: null
+  commit: ccfcf3dbdc676dd01f0d40f06b9164e3cbef94da
+creator:
+  github: wefio
+package:
+  ecosystem: npm
+  name: dsh-cache-miss
+  version: 0.1.5
+  integrity: sha512-RZlJGIdktkrFhgtZZcYHosTDfAn3qRQYR4Map6g6wmV5OuyhxxOzjKpFZXh20aQ9Btg2HNq2jHoVy/Rqm6iW0A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:04.010Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wefio/dsh-cache-miss/ccfcf3dbdc676dd01f0d40f06b9164e3cbef94da/cache-miss.png
+    alt: 缓存未命中提示


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wefio-dsh-cache-miss`
- Submission type: community curation
- Created by `wefio` — https://github.com/wefio
- Original source repository: https://github.com/wefio/dsh-cache-miss
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.