### PR TITLE
catalog: add wenaixi-dsh-ponytail (community curation, created by @Wenaixi)

### DIFF
--- a/catalog/plugins/wenaixi-dsh-ponytail.yaml
+++ b/catalog/plugins/wenaixi-dsh-ponytail.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: wenaixi-dsh-ponytail
+name: "@wenaixi/dsh-ponytail"
+description:
+  en: <p align="center" <a href="CHANGELOG.md" Changelog</a · <a href="https://github.com/DietrichGebert/ponytail" 上游</a · <a href="https://www.npmjs.com/package/@wenaixi/dsh-ponytail" npm</a </p
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - ponytail
+  - yagni
+  - skills
+  - agent-skills
+  - claude-code
+  - lazy
+  - over-engineering
+source:
+  repository: https://github.com/Wenaixi/dsh-ponytail
+  repositoryNodeId: R_kgDOT_6Vsw
+  subpath: null
+  commit: 2db016c8f9a81bd80b24f906d49effb983a0e1b1
+creator:
+  github: Wenaixi
+package:
+  ecosystem: npm
+  name: "@wenaixi/dsh-ponytail"
+  version: 4.9.0-dsh.5
+  integrity: sha512-/HqepYWshx+2a7xLNsjwn/yWJVL/fMzPAb2PvbqAWz29SZdZSAyX/vlax4s1Iu2TuFV4GzX6Xcv49LjS6U9+Bw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:55.789Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Wenaixi/dsh-ponytail/2db016c8f9a81bd80b24f906d49effb983a0e1b1/assets/logo.png
+    alt: Ponytail


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wenaixi-dsh-ponytail`
- Submission type: community curation
- Created by `Wenaixi` — https://github.com/Wenaixi
- Original source repository: https://github.com/Wenaixi/dsh-ponytail
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.