### PR TITLE
catalog: add whiteplusms-dsh-git-graph (community curation, created by @WhitePlusMS)

### DIFF
--- a/catalog/plugins/whiteplusms-dsh-git-graph.yaml
+++ b/catalog/plugins/whiteplusms-dsh-git-graph.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: whiteplusms-dsh-git-graph
+name: dsh-git-graph
+description:
+  en: Standalone Git Graph conversation view for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - standalone
+  - graph
+  - conversation
+  - view
+  - dsh
+source:
+  repository: https://github.com/WhitePlusMS/dsh-git-graph
+  repositoryNodeId: R_kgDOT5AtZw
+  subpath: null
+  commit: 79af087915588bd91c699b221d81e624fe8ab453
+creator:
+  github: WhitePlusMS
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:59.726Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WhitePlusMS/dsh-git-graph/79af087915588bd91c699b221d81e624fe8ab453/docs/image1.png
+    alt: Git Graph view in the DeepSeek Harness web interface
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WhitePlusMS/dsh-git-graph/79af087915588bd91c699b221d81e624fe8ab453/docs/image2.png
+    alt: Uncommitted changes list and per-file diff preview


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteplusms-dsh-git-graph`
- Submission type: community curation
- Created by `WhitePlusMS` — https://github.com/WhitePlusMS
- Original source repository: https://github.com/WhitePlusMS/dsh-git-graph
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.