### PR TITLE
catalog: add whiteplusms-dsh-input-plus (community curation, created by @WhitePlusMS)

### DIFF
--- a/catalog/plugins/whiteplusms-dsh-input-plus.yaml
+++ b/catalog/plugins/whiteplusms-dsh-input-plus.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: whiteplusms-dsh-input-plus
+name: dsh-input-plus
+description:
+  en: "DSH 输入框强化 (DSH Input+): @ file/directory reference and native composer status for the DeepSeek Harness Web UI."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - web-ui
+  - input-enhancement
+  - file-reference
+  - dsh-plugin
+source:
+  repository: https://github.com/WhitePlusMS/dsh-input-plus
+  repositoryNodeId: R_kgDOT4jVZQ
+  subpath: null
+  commit: cee1c7907e7f5ad1b38971d316d39c07d787967d
+creator:
+  github: WhitePlusMS
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:58.461Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WhitePlusMS/dsh-input-plus/cee1c7907e7f5ad1b38971d316d39c07d787967d/docs/image1.png
+    alt: File reference candidate menu
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/WhitePlusMS/dsh-input-plus/cee1c7907e7f5ad1b38971d316d39c07d787967d/docs/image2.png
+    alt: Input history menu


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteplusms-dsh-input-plus`
- Submission type: community curation
- Created by `WhitePlusMS` — https://github.com/WhitePlusMS
- Original source repository: https://github.com/WhitePlusMS/dsh-input-plus
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.