### PR TITLE
catalog: add wmengxiang-dsh-any-skills (community curation, created by @wmengxiang)

### DIFF
--- a/catalog/plugins/wmengxiang-dsh-any-skills.yaml
+++ b/catalog/plugins/wmengxiang-dsh-any-skills.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: wmengxiang-dsh-any-skills
+name: dsh-any-skills
+description:
+  en: Import, install and invoke Agent Skills in DeepSeek Harness from Codex, Claude Code, OpenCode, GitHub or npm — with a composer-side skill picker. · 从 Codex / Claude Code / OpenCode / GitHub / npm 导入并安装技能到 ~/.dsh/skills，支持 composer 旁一键插入 /skill-name 调用。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - skills
+  - skill-manager
+  - codex
+  - claude-code
+  - opencode
+  - web-ui
+source:
+  repository: https://github.com/wmengxiang/dsh-any-skills
+  repositoryNodeId: R_kgDOT-oeOA
+  subpath: null
+  commit: d80a4f665a0926af9bf66579eebdc9c5c3f1751f
+creator:
+  github: wmengxiang
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:04.566Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wmengxiang-dsh-any-skills`
- Submission type: community curation
- Created by `wmengxiang` — https://github.com/wmengxiang
- Original source repository: https://github.com/wmengxiang/dsh-any-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.