### PR TITLE
catalog: add wodongx123-dsh-desktop-tray (community curation, created by @wodongx123)

### DIFF
--- a/catalog/plugins/wodongx123-dsh-desktop-tray.yaml
+++ b/catalog/plugins/wodongx123-dsh-desktop-tray.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wodongx123-dsh-desktop-tray
+name: dsh-desktop-tray
+description:
+  en: "System tray support for DSH Desktop: tray icon plus settings to hide the main window on minimize or close, with self-healing boot-time injection and an injection management panel."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - system
+  - tray
+  - desktop
+  - icon
+  - plus
+  - settings
+  - hide
+  - main
+  - window
+  - minimize
+  - close
+  - self
+  - healing
+  - boot
+  - time
+  - injection
+source:
+  repository: https://github.com/wodongx123/dsh-desktop-tray
+  repositoryNodeId: R_kgDOT7We0A
+  subpath: null
+  commit: 8f25fd2b600948b028733ef7f8e95f3dc5d74208
+creator:
+  github: wodongx123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:11.562Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wodongx123-dsh-desktop-tray`
- Submission type: community curation
- Created by `wodongx123` — https://github.com/wodongx123
- Original source repository: https://github.com/wodongx123/dsh-desktop-tray
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.