### PR TITLE
catalog: add wulun811-dsh-plugin-vet (community curation, created by @wulun811)

### DIFF
--- a/catalog/plugins/wulun811-dsh-plugin-vet.yaml
+++ b/catalog/plugins/wulun811-dsh-plugin-vet.yaml
@@ -1,0 +1,63 @@
+schemaVersion: 1
+id: wulun811-dsh-plugin-vet
+name: "@jieai/dsh-plugin-vet"
+description:
+  en: Audit deepseek-harness (DSH) plugins before install, guard them at runtime. Static verdict + pre-install audit protocol; supply-chain checks (typosquat, OSV); exfiltration & ransomware detection, honeypot canaries, integrity baseline. Alarm-only; blocks confirmed destructive ops.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - security
+  - trust
+  - audit
+  - guard
+  - vet
+  - static-analysis
+  - sandbox
+  - supply-chain
+  - vulnerability
+  - malware-detection
+  - typosquat
+  - runtime-protection
+  - exfiltration-detection
+  - ransomware
+source:
+  repository: https://github.com/wulun811/dsh-plugin-vet
+  repositoryNodeId: R_kgDOT5VRhg
+  subpath: null
+  commit: c23b6feef46270ff785c485c5294d32037cc057f
+creator:
+  github: wulun811
+package:
+  ecosystem: npm
+  name: "@jieai/dsh-plugin-vet"
+  version: 0.3.3
+  integrity: sha512-2qC/dIG6VlxrD/cKjndUmJ/GlKeNTTujczvMZfHKf7H7RSNNsEh639HvEWRxvf5QP6cImLZQvEdRk2pC88ymCA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:00.070Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wulun811/dsh-plugin-vet/c23b6feef46270ff785c485c5294d32037cc057f/assets/white.jpg
+    alt: vet shield panel (light theme)
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wulun811/dsh-plugin-vet/c23b6feef46270ff785c485c5294d32037cc057f/assets/dark.jpg
+    alt: vet shield panel (dark theme)


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wulun811-dsh-plugin-vet`
- Submission type: community curation
- Created by `wulun811` — https://github.com/wulun811
- Original source repository: https://github.com/wulun811/dsh-plugin-vet
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.