### PR TITLE
catalog: add wulusai2333-mimo-vision (community curation, created by @wulusai2333)

### DIFF
--- a/catalog/plugins/wulusai2333-mimo-vision.yaml
+++ b/catalog/plugins/wulusai2333-mimo-vision.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: wulusai2333-mimo-vision
+name: mimo-vision
+description:
+  en: "DeepSeek Harness (DSH) native plugin: the describe image tool, a vision bridge (image - mimo-v2.5 - text description) over the ctx.fs / ctx.credentials seams"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - vision
+  - multimodal
+  - image
+  - describe-image
+  - agent
+  - typescript
+source:
+  repository: https://github.com/wulusai2333/mimo-vision
+  repositoryNodeId: R_kgDOT1Y8fw
+  subpath: null
+  commit: 9a6bacab4119158f1dbe4c24e70f14fb8b15fbec
+creator:
+  github: wulusai2333
+package:
+  ecosystem: npm
+  name: mimo-vision
+  version: 0.1.0
+  integrity: sha512-KLZB3misghS5jDhf0ocWXUIUayX3n8icp4IvZ7LjfcUB5l8tJ3AtnSQjhE2NBitAwYoBgwjFt5D0Q3FKvkXCeA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:05.192Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wulusai2333-mimo-vision`
- Submission type: community curation
- Created by `wulusai2333` — https://github.com/wulusai2333
- Original source repository: https://github.com/wulusai2333/mimo-vision
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.