### PR TITLE
catalog: add wuxiangru915-dsh-review-loop (community curation, created by @wuxiangru915)

### DIFF
--- a/catalog/plugins/wuxiangru915-dsh-review-loop.yaml
+++ b/catalog/plugins/wuxiangru915-dsh-review-loop.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: wuxiangru915-dsh-review-loop
+name: "@dsh-plugin/dsh-review-loop"
+description:
+  en: Incremental diff reviewer for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - incremental
+  - diff
+  - reviewer
+  - dsh
+source:
+  repository: https://github.com/wuxiangru915/dsh-review-loop
+  repositoryNodeId: R_kgDOT3i7nA
+  subpath: null
+  commit: eb4190498ef76daec21dfcf5c24c44f337a61ed3
+creator:
+  github: wuxiangru915
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:05.428Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wuxiangru915/dsh-review-loop/eb4190498ef76daec21dfcf5c24c44f337a61ed3/assets/review-panel.en.png
+    alt: Review panel (English)


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wuxiangru915-dsh-review-loop`
- Submission type: community curation
- Created by `wuxiangru915` — https://github.com/wuxiangru915
- Original source repository: https://github.com/wuxiangru915/dsh-review-loop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.