### PR TITLE
catalog: add wwweljf-dsh-wx-push (community curation, created by @wwweljf)

### DIFF
--- a/catalog/plugins/wwweljf-dsh-wx-push.yaml
+++ b/catalog/plugins/wwweljf-dsh-wx-push.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wwweljf-dsh-wx-push
+name: dsh-wx-push
+description:
+  en: "Permanent host plugin: auto-send every DSH turn result to WeChat via the wechat-acp iLink bridge (a separately installed WeChat daemon that must be logged in)."
+  evidencePath: plugins/dsh-wx-push/README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - permanent
+  - host
+  - auto
+  - send
+  - every
+  - turn
+  - result
+  - wechat
+  - ilink
+  - bridge
+  - separately
+  - installed
+  - daemon
+  - must
+  - logged
+  - dsh
+source:
+  repository: https://github.com/wwweljf/dsh-plugins
+  repositoryNodeId: R_kgDOUADf_Q
+  subpath: plugins/dsh-wx-push
+  commit: 13bd684e4ef1f76d38ff2fe1da99a4187cf00083
+creator:
+  github: wwweljf
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-wx-push/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:25.752Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wwweljf-dsh-wx-push`
- Submission type: community curation
- Created by `wwweljf` — https://github.com/wwweljf
- Original source repository: https://github.com/wwweljf/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.