### PR TITLE
catalog: add wwweljf-dsh-wx-remote (community curation, created by @wwweljf)

### DIFF
--- a/catalog/plugins/wwweljf-dsh-wx-remote.yaml
+++ b/catalog/plugins/wwweljf-dsh-wx-remote.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: wwweljf-dsh-wx-remote
+name: dsh-wx-remote
+description:
+  en: "Permanent host plugin: continue an existing PC DSH session from WeChat (poll iLink, followup live session or resume closed one, send the reply back). Requires wechat-acp; only allowlisted WeChat senders are handled (empty allowlist denies everyone)."
+  evidencePath: plugins/dsh-wx-remote/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - permanent
+  - host
+  - continue
+  - existing
+  - session
+  - wechat
+  - poll
+  - ilink
+  - followup
+  - live
+  - resume
+  - closed
+  - send
+  - reply
+  - back
+  - requires
+source:
+  repository: https://github.com/wwweljf/dsh-plugins
+  repositoryNodeId: R_kgDOUADf_Q
+  subpath: plugins/dsh-wx-remote
+  commit: 13bd684e4ef1f76d38ff2fe1da99a4187cf00083
+creator:
+  github: wwweljf
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-wx-remote/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:25.752Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wwweljf-dsh-wx-remote`
- Submission type: community curation
- Created by `wwweljf` — https://github.com/wwweljf
- Original source repository: https://github.com/wwweljf/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.