### PR TITLE
catalog: add wydddddcool-dsh-hover-approve (community curation, created by @wydddddcool)

### DIFF
--- a/catalog/plugins/wydddddcool-dsh-hover-approve.yaml
+++ b/catalog/plugins/wydddddcool-dsh-hover-approve.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: wydddddcool-dsh-hover-approve
+name: dsh-hover-approve
+description:
+  en: '<p align="center" <strong Approve without opening the conversation.</strong <br An anchored sidebar bubble for DSH Web: sessions waiting for approval, questions, plan reviews or blocked goals — handled right at their list row. </p'
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - approval
+  - question
+  - plan-review
+  - hover
+  - sidebar
+source:
+  repository: https://github.com/wydddddcool/dsh-hover-approve
+  repositoryNodeId: R_kgDOT8GwVQ
+  subpath: null
+  commit: 70cd0c3176431eab98c8f8158f7381d7d7ecea2c
+creator:
+  github: wydddddcool
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:05.887Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wydddddcool/dsh-hover-approve/70cd0c3176431eab98c8f8158f7381d7d7ecea2c/assets/shot-approval.png
+    alt: 需要你授权：操作/智能体说明/写入文件高亮/一键拒绝或授权
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wydddddcool/dsh-hover-approve/70cd0c3176431eab98c8f8158f7381d7d7ecea2c/assets/shot-goal-blocked.png
+    alt: 目标已阻断：红色原因 + 目标内容 + 去会话查看


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wydddddcool-dsh-hover-approve`
- Submission type: community curation
- Created by `wydddddcool` — https://github.com/wydddddcool
- Original source repository: https://github.com/wydddddcool/dsh-hover-approve
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.