### PR TITLE
catalog: add wyouwd1-dsh-opencode-models (community curation, created by @wyouwd1)

### DIFF
--- a/catalog/plugins/wyouwd1-dsh-opencode-models.yaml
+++ b/catalog/plugins/wyouwd1-dsh-opencode-models.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: wyouwd1-dsh-opencode-models
+name: dsh-opencode-models
+description:
+  en: "Manage OpenCode Zen free-tier and Go-tier models in settings.yaml: live model listings from opencode.ai, configured-versus-live drift per route, add/remove through four agent tools plus an OpenCode Models settings section."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - opencode
+  - zen
+  - models
+  - dsh
+source:
+  repository: https://github.com/wyouwd1/dsh-opencode-models
+  repositoryNodeId: R_kgDOUCKltg
+  subpath: null
+  commit: 9f6451ac58885b39d038e085d5475467f2746e97
+creator:
+  github: wyouwd1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:06.246Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wyouwd1-dsh-opencode-models`
- Submission type: community curation
- Created by `wyouwd1` — https://github.com/wyouwd1
- Original source repository: https://github.com/wyouwd1/dsh-opencode-models
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.