### PR TITLE
catalog: add wyzh0117-dsh-skill-select (community curation, created by @wyzh0117)

### DIFF
--- a/catalog/plugins/wyzh0117-dsh-skill-select.yaml
+++ b/catalog/plugins/wyzh0117-dsh-skill-select.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: wyzh0117-dsh-skill-select
+name: dsh-skill-select
+description:
+  en: "DSH web plugin: pick skills from a sidebar tab — list every installed skill with global/local badges, LLM-generated descriptions (cached, never touching skill files), and inject the /skill gesture into the current session composer on check."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - skill
+  - sidebar
+  - skill-select
+source:
+  repository: https://github.com/wyzh0117/dsh-skill-select
+  repositoryNodeId: R_kgDOT-rndQ
+  subpath: null
+  commit: f1834b3b0e1cf4ff2ff4b0642abce0711ce3a081
+creator:
+  github: wyzh0117
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:58.904Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/f1834b3b0e1cf4ff2ff4b0642abce0711ce3a081/assets/better-sidebar.png
+    alt: Skills tab inside dsh-better-sidebar
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/wyzh0117/dsh-skill-select/f1834b3b0e1cf4ff2ff4b0642abce0711ce3a081/assets/product.png
+    alt: dsh-SkillSelect — Pick skills from the sidebar.


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wyzh0117-dsh-skill-select`
- Submission type: community curation
- Created by `wyzh0117` — https://github.com/wyzh0117
- Original source repository: https://github.com/wyzh0117/dsh-skill-select
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.