### PR TITLE
catalog: add wzz3034026545-dsh-rule-manager (community curation, created by @wzz3034026545)

### DIFF
--- a/catalog/plugins/wzz3034026545-dsh-rule-manager.yaml
+++ b/catalog/plugins/wzz3034026545-dsh-rule-manager.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: wzz3034026545-dsh-rule-manager
+name: dsh-rule-manager
+description:
+  en: sh dsh plugin --profile web add dsh-rule-manager
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - agents
+  - instructions
+  - rules
+  - rule-splitter
+  - global-rules
+source:
+  repository: https://github.com/wzz3034026545/dsh-rule-manager
+  repositoryNodeId: R_kgDOT6Cg_A
+  subpath: null
+  commit: 1ec0f30b76c90af8360a67a20c033486a73c061b
+creator:
+  github: wzz3034026545
+package:
+  ecosystem: npm
+  name: dsh-rule-manager
+  version: 0.1.0
+  integrity: sha512-Zw7Qw9UiWeOaUJ5LVtJA2cY4paXeyhP6EmFTSUGrxc59yseJ6aAVKzDz2JOxVBWCPTucYJupPpEdoBZ1CjSVfA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:11.890Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wzz3034026545-dsh-rule-manager`
- Submission type: community curation
- Created by `wzz3034026545` — https://github.com/wzz3034026545
- Original source repository: https://github.com/wzz3034026545/dsh-rule-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.