### PR TITLE
catalog: add x2802490130-prog-dsh-balance-float (community curation, created by @x2802490130-prog)

### DIFF
--- a/catalog/plugins/x2802490130-prog-dsh-balance-float.yaml
+++ b/catalog/plugins/x2802490130-prog-dsh-balance-float.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: x2802490130-prog-dsh-balance-float
+name: dsh-balance-float
+description:
+  en: bash dsh plugin --profile web add dsh-balance-float
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - balance
+  - widget
+  - deepseek-api
+source:
+  repository: https://github.com/x2802490130-prog/dsh-balance-float
+  repositoryNodeId: R_kgDOT4r-WQ
+  subpath: null
+  commit: 14311f51e81b5b1fef335705d4e56c788d091979
+creator:
+  github: x2802490130-prog
+package:
+  ecosystem: npm
+  name: dsh-balance-float
+  version: 1.0.3
+  integrity: sha512-YdaUwFIdyfnztuNOjZm/gnKqS52dqlbcjh0RgoDP1VprUnDdMx4dvwII8ZhuxljV309DVizrOYPU/p2QxPTT4g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:56.873Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `x2802490130-prog-dsh-balance-float`
- Submission type: community curation
- Created by `x2802490130-prog` — https://github.com/x2802490130-prog
- Original source repository: https://github.com/x2802490130-prog/dsh-balance-float
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.