### PR TITLE
catalog: add x2802490130-prog-dsh-client-ui-writing (community curation, created by @x2802490130-prog)

### DIFF
--- a/catalog/plugins/x2802490130-prog-dsh-client-ui-writing.yaml
+++ b/catalog/plugins/x2802490130-prog-dsh-client-ui-writing.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: x2802490130-prog-dsh-client-ui-writing
+name: dsh-client-ui-writing
+description:
+  en: "Client-side writing panel for the DeepSeek Harness: project volumes, library, search, and evolution tab with inline version-chain diff and SVG thread graph."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - deepseek-harness
+  - client-plugin
+  - panel
+  - svg-graph
+  - dsh
+source:
+  repository: https://github.com/x2802490130-prog/dsh-client-ui-writing
+  repositoryNodeId: R_kgDOT45r3Q
+  subpath: null
+  commit: a7b759a110ee1cc4056e7726d31ccb0cb5fd577b
+creator:
+  github: x2802490130-prog
+package:
+  ecosystem: npm
+  name: dsh-client-ui-writing
+  version: 0.6.2
+  integrity: sha512-/Z8x3ybBcwsYNqQIxaDJ3PagrZ73EdTI10i9m4yNIY7UqGfVGKs4fbgfeYGmXHS0y7kLDIF0/QLQKFGhe0jxCw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:56.907Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `x2802490130-prog-dsh-client-ui-writing`
- Submission type: community curation
- Created by `x2802490130-prog` — https://github.com/x2802490130-prog
- Original source repository: https://github.com/x2802490130-prog/dsh-client-ui-writing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.