### PR TITLE
catalog: add x2802490130-prog-dsh-lan-pass (community curation, created by @x2802490130-prog)

### DIFF
--- a/catalog/plugins/x2802490130-prog-dsh-lan-pass.yaml
+++ b/catalog/plugins/x2802490130-prog-dsh-lan-pass.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: x2802490130-prog-dsh-lan-pass
+name: dsh-lan-pass
+description:
+  en: \ \ \ bash dsh plugin --profile web add link:/path/to/lan-pass \ \ \
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - lan
+  - auth
+  - password
+source:
+  repository: https://github.com/x2802490130-prog/dsh-lan-pass
+  repositoryNodeId: R_kgDOT4z5Ng
+  subpath: null
+  commit: 78022bd33cb8653e7d4c56b76f5a8921e3880371
+creator:
+  github: x2802490130-prog
+package:
+  ecosystem: npm
+  name: dsh-lan-pass
+  version: 1.0.1
+  integrity: sha512-oHppFB5rovHGWRkEK9xcvN5QNeGmGhAU+Ni/u2LUBNmjDZMauIBcx1bMEwTbE7iUnNiwKfLst3ETr/nkQjlPMg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:12.114Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `x2802490130-prog-dsh-lan-pass`
- Submission type: community curation
- Created by `x2802490130-prog` — https://github.com/x2802490130-prog
- Original source repository: https://github.com/x2802490130-prog/dsh-lan-pass
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.