### PR TITLE
catalog: add x2802490130-prog-dsh-shield (community curation, created by @x2802490130-prog)

### DIFF
--- a/catalog/plugins/x2802490130-prog-dsh-shield.yaml
+++ b/catalog/plugins/x2802490130-prog-dsh-shield.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: x2802490130-prog-dsh-shield
+name: dsh-shield
+description:
+  en: "yaml - id: dsh-shield config: trashRoot: D:\\\\path\\\\to\\\\trash 默认 $DSH HOME/trash retentionDays: 14 maxTrashBytes: 5368709120 trashMode: dir dir system"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh
+  - deepseek-harness
+  - safety
+  - trash
+  - symlink
+  - rm
+source:
+  repository: https://github.com/x2802490130-prog/dsh-shield
+  repositoryNodeId: R_kgDOT43hww
+  subpath: null
+  commit: 56db93deae6ea2b7bf3722907501f5e8c282b6e3
+creator:
+  github: x2802490130-prog
+package:
+  ecosystem: npm
+  name: dsh-shield
+  version: 1.0.0
+  integrity: sha512-cYoU7T6G5Zd7S3dL1stYxrMNfJv4YT6v35o+UHSHXrfdJYA4FAUm/oiqbhNtQI3d9dprLML/1qvatoD2+o4WYA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:12.800Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `x2802490130-prog-dsh-shield`
- Submission type: community curation
- Created by `x2802490130-prog` — https://github.com/x2802490130-prog
- Original source repository: https://github.com/x2802490130-prog/dsh-shield
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.