### PR TITLE
catalog: add xanthanl-dsh-plugin-uisfx (community curation, created by @XanthanL)

### DIFF
--- a/catalog/plugins/xanthanl-dsh-plugin-uisfx.yaml
+++ b/catalog/plugins/xanthanl-dsh-plugin-uisfx.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: xanthanl-dsh-plugin-uisfx
+name: dsh-plugin-uisfx
+description:
+  en: "dsh plugin: semantic UI sound effects powered by uisfx — per-scenario cues with a settings UI"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - dsh
+  - uisfx
+  - web-audio
+  - sound-effects
+  - ui-sfx
+source:
+  repository: https://github.com/XanthanL/dsh-plugin-uisfx
+  repositoryNodeId: R_kgDOT5Gp3w
+  subpath: null
+  commit: f020972c3291abcbd84b99c6355953866e045b5c
+creator:
+  github: XanthanL
+package:
+  ecosystem: npm
+  name: dsh-plugin-uisfx
+  version: 0.1.1
+  integrity: sha512-xODTvOVU2XxN0cFsNjHcjdsaK6JZhQcK2qUG7H8f+sI+yYlm0UkuZL/vtTr3IU9Oalva5Faoq+hTqavbUdnApw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:57.349Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/XanthanL/dsh-plugin-uisfx/f020972c3291abcbd84b99c6355953866e045b5c/docs/settings-sound-effects.png
+    alt: dsh-plugin-uisfx settings page


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xanthanl-dsh-plugin-uisfx`
- Submission type: community curation
- Created by `XanthanL` — https://github.com/XanthanL
- Original source repository: https://github.com/XanthanL/dsh-plugin-uisfx
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.