### PR TITLE
catalog: add xiaheng1-dsh-turn-nav (community curation, created by @xiaheng1)

### DIFF
--- a/catalog/plugins/xiaheng1-dsh-turn-nav.yaml
+++ b/catalog/plugins/xiaheng1-dsh-turn-nav.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: xiaheng1-dsh-turn-nav
+name: dsh-turn-nav
+description:
+  en: Turn histogram navigation rail for DeepSeek Harness Web with mixed, DeepSeek, and Codex visual variants. Hover/focus reveals a wave or highlight and a message preview; click jumps to that turn. Visual behavior is configurable through DSH settings.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - turn-navigation
+  - histogram
+  - conversation-ui
+  - dsh
+source:
+  repository: https://github.com/xiaheng1/dsh-turn-nav
+  repositoryNodeId: R_kgDOT74dzw
+  subpath: null
+  commit: 74b128343ddb6d33014bdbeb77c9b1d0c0491026
+creator:
+  github: xiaheng1
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:13.226Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaheng1-dsh-turn-nav`
- Submission type: community curation
- Created by `xiaheng1` — https://github.com/xiaheng1
- Original source repository: https://github.com/xiaheng1/dsh-turn-nav
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.