### PR TITLE
catalog: add xiajiajun516-dsh-config-manager (community curation, created by @xiajiajun516)

### DIFF
--- a/catalog/plugins/xiajiajun516-dsh-config-manager.yaml
+++ b/catalog/plugins/xiajiajun516-dsh-config-manager.yaml
@@ -1,0 +1,72 @@
+schemaVersion: 1
+id: xiajiajun516-dsh-config-manager
+name: dsh-config-manager
+description:
+  en: "Backup, restore, export, import, migrate and sync your DeepSeek Harness (DSH) configuration: settings, plugins, MCP servers, skills, agent presets and workspaces. One-click migration to another machine. DSH 配置一键备份、恢复、导出、导入、迁移与同步插件。"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - cordis
+  - backup
+  - restore
+  - export
+  - import
+  - migration
+  - migrate
+  - sync
+  - webdav
+  - mcp
+  - skills
+  - configuration
+  - config-manager
+source:
+  repository: https://github.com/xiajiajun516/dsh-config-manager
+  repositoryNodeId: R_kgDOT4nZIQ
+  subpath: null
+  commit: 94a4ea5ac6432f708bbb4d448fe112df58b75d59
+creator:
+  github: xiajiajun516
+package:
+  ecosystem: npm
+  name: dsh-config-manager
+  version: 0.1.54
+  integrity: sha512-QOimBhlWzewClqK/25rrNQfNlAHicONw2Pdrt13ujfeN7y4nm+/HNPHXHAVg2F01Lv1g4LEbwuSCD3MDLGqoeQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:53.960Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 57
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/94a4ea5ac6432f708bbb4d448fe112df58b75d59/assets/screenshot-export.png
+    alt: One-click Export
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/94a4ea5ac6432f708bbb4d448fe112df58b75d59/assets/screenshot-import-preview.png
+    alt: Import Preview
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/94a4ea5ac6432f708bbb4d448fe112df58b75d59/assets/screenshot-snapshots.png
+    alt: Snapshot Restore
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/94a4ea5ac6432f708bbb4d448fe112df58b75d59/assets/screenshot-sync.png
+    alt: Remote Sync
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xiajiajun516/dsh-config-manager/94a4ea5ac6432f708bbb4d448fe112df58b75d59/assets/screenshot-market.png
+    alt: Configuration Market


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiajiajun516-dsh-config-manager`
- Submission type: community curation
- Created by `xiajiajun516` — https://github.com/xiajiajun516
- Original source repository: https://github.com/xiajiajun516/dsh-config-manager
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.