### PR TITLE
catalog: add xiamu-ssr-dsh-wind-aifin (community curation, created by @Xiamu-ssr)

### DIFF
--- a/catalog/plugins/xiamu-ssr-dsh-wind-aifin.yaml
+++ b/catalog/plugins/xiamu-ssr-dsh-wind-aifin.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: xiamu-ssr-dsh-wind-aifin
+name: "@xiamu-ssr/dsh-wind-aifin"
+description:
+  en: Credential-safe Wind AIFin MCP and Alice integration for DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - wind
+  - aifin
+  - mcp
+  - finance
+  - dsh
+source:
+  repository: https://github.com/Xiamu-ssr/snowmountain-market
+  repositoryNodeId: R_kgDOTXTu3A
+  subpath: null
+  commit: 0a05c84b8d631d3672e1857dd807691eee0150d0
+creator:
+  github: Xiamu-ssr
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:06.770Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiamu-ssr-dsh-wind-aifin`
- Submission type: community curation
- Created by `Xiamu-ssr` — https://github.com/Xiamu-ssr
- Original source repository: https://github.com/Xiamu-ssr/snowmountain-market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.