### PR TITLE
catalog: add xiaofei-fei-dsh-prompt-history (community curation, created by @Xiaofei-fei)

### DIFF
--- a/catalog/plugins/xiaofei-fei-dsh-prompt-history.yaml
+++ b/catalog/plugins/xiaofei-fei-dsh-prompt-history.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: xiaofei-fei-dsh-prompt-history
+name: dsh-prompt-history
+description:
+  en: "DSH web plugin: terminal-style input for the composer — bash-like Up/Down prompt history with prefix search and Ctrl+R, selection toolbar with copy and quote (Codex-style blockquote), right-click paste, toggleable draggable chat TOC, fully internationalized (zh/en), with copy modes in Settings (history sourced from the"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - history
+  - composer
+  - input
+  - prompt
+source:
+  repository: https://github.com/Xiaofei-fei/dsh-prompt-history
+  repositoryNodeId: R_kgDOT9Gskg
+  subpath: null
+  commit: 557fe7e5373890c725d96a19320d472dab2c023d
+creator:
+  github: Xiaofei-fei
+package:
+  ecosystem: npm
+  name: dsh-prompt-history
+  version: 1.2.5
+  integrity: sha512-NnDUVUk8kNHhpxvQObO5K7OcjYGHHeZPkxSJC7FI3q6sDBkUg4Zr1KwognO9xdkH5CxmlidEiADmuNb8AEtE/A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:06.667Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaofei-fei-dsh-prompt-history`
- Submission type: community curation
- Created by `Xiaofei-fei` — https://github.com/Xiaofei-fei
- Original source repository: https://github.com/Xiaofei-fei/dsh-prompt-history
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.