### PR TITLE
catalog: add xiaoshenming-dsh-session-surgeon (community curation, created by @xiaoshenming)

### DIFF
--- a/catalog/plugins/xiaoshenming-dsh-session-surgeon.yaml
+++ b/catalog/plugins/xiaoshenming-dsh-session-surgeon.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: xiaoshenming-dsh-session-surgeon
+name: dsh-session-surgeon
+description:
+  en: Repair DeepSeek Harness sessions that refuse to load (seq gap, torn zstd frames, lone surrogates).
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - session
+  - jsonl
+  - repair
+  - dsh
+source:
+  repository: https://github.com/xiaoshenming/dsh-session-surgeon
+  repositoryNodeId: R_kgDOT79N8w
+  subpath: null
+  commit: e7af94ea0c2c06f8edd3adc61a2dcce1219dd78c
+creator:
+  github: xiaoshenming
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:00.040Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaoshenming-dsh-session-surgeon`
- Submission type: community curation
- Created by `xiaoshenming` — https://github.com/xiaoshenming
- Original source repository: https://github.com/xiaoshenming/dsh-session-surgeon
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.