### PR TITLE
catalog: add xjungit-dsh-connector (community curation, created by @XJungit)

### DIFF
--- a/catalog/plugins/xjungit-dsh-connector.yaml
+++ b/catalog/plugins/xjungit-dsh-connector.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: xjungit-dsh-connector
+name: "@omdp/dsh-connector"
+description:
+  en: "Unified DeepSeek Harness connector: edit MCP servers (cordis.patch.yml), user skills (~/.dsh/skills) and browse the ModelScope MCP/Skills marketplaces from one Web UI settings page."
+  evidencePath: dsh-connector/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - mcp
+  - skill
+  - cordis
+source:
+  repository: https://github.com/XJungit/omdp
+  repositoryNodeId: R_kgDOT4A-Tg
+  subpath: dsh-connector
+  commit: 47b09a75eeb3d40ac48d9c66b35c60c021ee832d
+creator:
+  github: XJungit
+package:
+  ecosystem: npm
+  name: "@omdp/dsh-connector"
+  version: 0.2.5
+  integrity: sha512-1vbWoq7PqIzLYEh8am+Q7yJVG77f63y0yRw3GpOOs9RwnrqSheIA8CflsTA5TfCT/d0x5sreMLKCtKlLyADq8Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-connector/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:27.441Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xjungit-dsh-connector`
- Submission type: community curation
- Created by `XJungit` — https://github.com/XJungit
- Original source repository: https://github.com/XJungit/omdp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.