### PR TITLE
catalog: add xjungit-dsh-key-fallback (community curation, created by @XJungit)

### DIFF
--- a/catalog/plugins/xjungit-dsh-key-fallback.yaml
+++ b/catalog/plugins/xjungit-dsh-key-fallback.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: xjungit-dsh-key-fallback
+name: "@omdp/dsh-key-fallback"
+description:
+  en: "Multi-key API key pool with automatic rotation for DeepSeek Harness (DSH) — sits between the LLM adapter and the credential store. Before each request the plugin picks a key from the per-provider pool and pre-writes it into the provider's credential reference; when a configured trigger error occurs it marks the failed "
+  evidencePath: dsh-key-fallback/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - multi
+  - pool
+  - automatic
+  - rotation
+  - sits
+  - between
+  - adapter
+  - credential
+  - store
+  - before
+  - each
+  - request
+  - picks
+  - provider
+  - writes
+  - reference
+source:
+  repository: https://github.com/XJungit/omdp
+  repositoryNodeId: R_kgDOT4A-Tg
+  subpath: dsh-key-fallback
+  commit: 47b09a75eeb3d40ac48d9c66b35c60c021ee832d
+creator:
+  github: XJungit
+package:
+  ecosystem: npm
+  name: "@omdp/dsh-key-fallback"
+  version: 3.1.1
+  integrity: sha512-E2XVFnpjXYLBGdNZ6pZVGDw/449EmvUHSB5/uA8N543rXq1moWCI/SdMiEtY1r0MFmc6ruDja0wCoSJKhk+1Fg==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh-key-fallback/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:27.441Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xjungit-dsh-key-fallback`
- Submission type: community curation
- Created by `XJungit` — https://github.com/XJungit
- Original source repository: https://github.com/XJungit/omdp
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.