### PR TITLE
catalog: add xu1132-dsh-plugin-browser (community curation, created by @xu1132)

### DIFF
--- a/catalog/plugins/xu1132-dsh-plugin-browser.yaml
+++ b/catalog/plugins/xu1132-dsh-plugin-browser.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: xu1132-dsh-plugin-browser
+name: dsh-plugin-browser
+description:
+  en: "A DeepSeek Harness community plugin that drives a headless Playwright browser: rendered page text, screenshots, and page automation"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - community
+  - drives
+  - headless
+  - playwright
+  - browser
+  - rendered
+  - page
+  - text
+  - screenshots
+  - automation
+  - dsh
+source:
+  repository: https://github.com/xu1132/dsh-plugin-browser
+  repositoryNodeId: R_kgDOT36X5Q
+  subpath: null
+  commit: 2ebc902ccbae2f2ffe9a334d04dc7f74757e56c8
+creator:
+  github: xu1132
+package:
+  ecosystem: npm
+  name: dsh-plugin-browser
+  version: 0.1.0
+  integrity: sha512-BOf6oHTizjfK0ykNfmc4P/OVfWN1IJv8f02iOYKgeBJW69pIhAvLArJcm+wKFcRJ3/cZ8zVj7ONlkiJgYGlN6Q==
+dsh:
+  profiles:
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:13.465Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xu1132-dsh-plugin-browser`
- Submission type: community curation
- Created by `xu1132` — https://github.com/xu1132
- Original source repository: https://github.com/xu1132/dsh-plugin-browser
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.