### PR TITLE
catalog: add xu1132-dsh-plugin-hello (community curation, created by @xu1132)

### DIFF
--- a/catalog/plugins/xu1132-dsh-plugin-hello.yaml
+++ b/catalog/plugins/xu1132-dsh-plugin-hello.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: xu1132-dsh-plugin-hello
+name: dsh-plugin-hello
+description:
+  en: A minimal DeepSeek Harness community plugin that adds a callable hello tool
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - minimal
+  - community
+  - adds
+  - callable
+  - hello
+  - tool
+  - dsh
+source:
+  repository: https://github.com/xu1132/dsh-plugin-hello
+  repositoryNodeId: R_kgDOT35gaQ
+  subpath: null
+  commit: 5ce5be43d40e1ba1b76751e23db301c44044dbf5
+creator:
+  github: xu1132
+package:
+  ecosystem: npm
+  name: dsh-plugin-hello
+  version: 0.1.0
+  integrity: sha512-dRN8i4CvUw9iD0XPTae9FfDwFHP1jpFcjY2oSpc6e8RBbJmLYya8hpYgChtohRpv9Fw8o46NRMv919zUMK6Niw==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:13.468Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xu1132-dsh-plugin-hello`
- Submission type: community curation
- Created by `xu1132` — https://github.com/xu1132
- Original source repository: https://github.com/xu1132/dsh-plugin-hello
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.