### PR TITLE
catalog: add xuhurdern-beep-dsh-live-reload (community curation, created by @xuhurdern-beep)

### DIFF
--- a/catalog/plugins/xuhurdern-beep-dsh-live-reload.yaml
+++ b/catalog/plugins/xuhurdern-beep-dsh-live-reload.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: xuhurdern-beep-dsh-live-reload
+name: dsh-live-reload
+description:
+  en: One-click hot reload of the running DSH plugin composition — without restarting the process.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - hot-reload
+  - live-reload
+  - plugin-manager
+  - reload
+source:
+  repository: https://github.com/xuhurdern-beep/dsh-live-reload
+  repositoryNodeId: R_kgDOT4yV5A
+  subpath: null
+  commit: 5b4513183a27752777de9441980bd3f489bedf54
+creator:
+  github: xuhurdern-beep
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:07.265Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xuhurdern-beep-dsh-live-reload`
- Submission type: community curation
- Created by `xuhurdern-beep` — https://github.com/xuhurdern-beep
- Original source repository: https://github.com/xuhurdern-beep/dsh-live-reload
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.