### PR TITLE
catalog: add yangbobo2021-relay-dsh-plugin-terminal (community curation, created by @yangbobo2021)

### DIFF
--- a/catalog/plugins/yangbobo2021-relay-dsh-plugin-terminal.yaml
+++ b/catalog/plugins/yangbobo2021-relay-dsh-plugin-terminal.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 1
+id: yangbobo2021-relay-dsh-plugin-terminal
+name: relay-dsh-plugin-terminal
+description:
+  en: Provider-neutral interactive terminal plugin for the Relay workbench in DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - provider
+  - neutral
+  - interactive
+  - terminal
+  - relay
+  - workbench
+  - dsh
+source:
+  repository: https://github.com/yangbobo2021/relay-dsh-plugin-terminal
+  repositoryNodeId: R_kgDOUCFi3A
+  subpath: null
+  commit: 09ed18a80284f8593140e579af05ee6dcd8f8d7b
+creator:
+  github: yangbobo2021
+package:
+  ecosystem: npm
+  name: relay-dsh-plugin-terminal
+  version: 0.1.0
+  integrity: sha512-ckSInQ21hgWxd30/xzv+5u3RuE9+8b8OHP2Z3bBh/1O2ZCmgtl9TxaTSprE6NdYfcYEA7b0K/WoxT/Kx/3YnKA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:31.576Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yangbobo2021/relay-dsh-plugin-terminal/09ed18a80284f8593140e579af05ee6dcd8f8d7b/docs/images/dsh-terminal-panel.png
+    alt: Relay Terminal bottom panel in DSH Web


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangbobo2021-relay-dsh-plugin-terminal`
- Submission type: community curation
- Created by `yangbobo2021` — https://github.com/yangbobo2021
- Original source repository: https://github.com/yangbobo2021/relay-dsh-plugin-terminal
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.