### PR TITLE
catalog: add yangbobo2021-relay-dsh-plugin-workbench (community curation, created by @yangbobo2021)

### DIFF
--- a/catalog/plugins/yangbobo2021-relay-dsh-plugin-workbench.yaml
+++ b/catalog/plugins/yangbobo2021-relay-dsh-plugin-workbench.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: yangbobo2021-relay-dsh-plugin-workbench
+name: relay-dsh-plugin-workbench
+description:
+  en: Extensible workbench shell for DeepSeek Harness with generic side and bottom view registration.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - extensible
+  - workbench
+  - shell
+  - generic
+  - side
+  - bottom
+  - view
+  - registration
+  - dsh
+source:
+  repository: https://github.com/yangbobo2021/relay-dsh-plugin-workbench
+  repositoryNodeId: R_kgDOUCFi1A
+  subpath: null
+  commit: 07fa06d88942b14411cd0048a7f3dcfaa06dba92
+creator:
+  github: yangbobo2021
+package:
+  ecosystem: npm
+  name: relay-dsh-plugin-workbench
+  version: 0.1.0
+  integrity: sha512-1nvsO5kTrVineoe803hlvD28ixuN3E31gSPzl5W0qaH7emSyIPcOgUAXCmAFTS+GqOeWI289KDSDy9+hcm5JnQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:31.459Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yangbobo2021/relay-dsh-plugin-workbench/07fa06d88942b14411cd0048a7f3dcfaa06dba92/docs/images/dsh-workbench-files-panel.png
+    alt: Workbench hosting the Relay Files side panel in DSH Web


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangbobo2021-relay-dsh-plugin-workbench`
- Submission type: community curation
- Created by `yangbobo2021` — https://github.com/yangbobo2021
- Original source repository: https://github.com/yangbobo2021/relay-dsh-plugin-workbench
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.