### PR TITLE
catalog: add yangshen830-eng-dsh-editor (community curation, created by @yangshen830-eng)

### DIFF
--- a/catalog/plugins/yangshen830-eng-dsh-editor.yaml
+++ b/catalog/plugins/yangshen830-eng-dsh-editor.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: yangshen830-eng-dsh-editor
+name: dsh-editor
+description:
+  en: "DSH web plugin: a VS Code-style code editor view (file tree, Monaco, ripgrep search/replace, Markdown preview, git diff)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - code
+  - style
+  - editor
+  - view
+  - file
+  - tree
+  - monaco
+  - ripgrep
+  - search
+  - replace
+  - markdown
+  - preview
+  - diff
+  - dsh
+source:
+  repository: https://github.com/yangshen830-eng/dsh-editor
+  repositoryNodeId: R_kgDOT8IH4g
+  subpath: null
+  commit: dafd1d6a91366e37a53844e3d3ef35e34dd30dd9
+creator:
+  github: yangshen830-eng
+package:
+  ecosystem: npm
+  name: dsh-editor
+  version: 0.2.3
+  integrity: sha512-rtuV3tl/z+GjLZ95eX1lDUZpX+Sv76Llb5HfeOxRVQn0hzDOSq5IixbEUzD04WYn3zJkvtabsi2aJVi/ii+JzQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:13.632Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yangshen830-eng-dsh-editor`
- Submission type: community curation
- Created by `yangshen830-eng` — https://github.com/yangshen830-eng
- Original source repository: https://github.com/yangshen830-eng/dsh-editor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.