### PR TITLE
catalog: add yinhcao-yinchao-ai-music (community curation, created by @yinhcao)

### DIFF
--- a/catalog/plugins/yinhcao-yinchao-ai-music.yaml
+++ b/catalog/plugins/yinhcao-yinchao-ai-music.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: yinhcao-yinchao-ai-music
+name: yinchao-ai-music
+description:
+  en: Generate complete AI songs and BGM with YinChao, including lyrics-to-song, reference-audio creation, and song extension.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - agent-skills
+  - ai-music
+  - text-to-music
+  - lyrics-to-song
+  - song-extension
+  - yinchao
+  - dsh
+source:
+  repository: https://github.com/yinhcao/yinchao-ai-music-skill
+  repositoryNodeId: R_kgDOT-J7zQ
+  subpath: null
+  commit: 5f37cb9b6e4026114e9fb5531fce42e3128dde20
+creator:
+  github: yinhcao
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:53.077Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yinhcao-yinchao-ai-music`
- Submission type: community curation
- Created by `yinhcao` — https://github.com/yinhcao
- Original source repository: https://github.com/yinhcao/yinchao-ai-music-skill
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.