### PR TITLE
catalog: add ylwl1997-dsh-browser-bsk (community curation, created by @ylwl1997)

### DIFF
--- a/catalog/plugins/ylwl1997-dsh-browser-bsk.yaml
+++ b/catalog/plugins/ylwl1997-dsh-browser-bsk.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: ylwl1997-dsh-browser-bsk
+name: dsh-browser-bsk
+description:
+  en: Browser automation for DeepSeek Harness via bsk — navigate, snapshot, click, fill, and screenshot the user's real browser.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - browser
+  - automation
+  - bsk
+  - dsh
+source:
+  repository: https://github.com/ylwl1997/dsh-browser
+  repositoryNodeId: R_kgDOT4V6KQ
+  subpath: null
+  commit: f612db958e7e10d06e90d13ed13738bef8c2be64
+creator:
+  github: ylwl1997
+package:
+  ecosystem: npm
+  name: dsh-browser-bsk
+  version: 0.1.0
+  integrity: sha512-qmCsnC8dBnhZhvDPgXehiPHUcuLpN7WfeajUGjQgTLyB71u8RtFysEvVFttLtH7GaHSjk5yXKNpg3q3eUKaOAQ==
+dsh:
+  profiles:
+    - default
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:31.880Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ylwl1997-dsh-browser-bsk`
- Submission type: community curation
- Created by `ylwl1997` — https://github.com/ylwl1997
- Original source repository: https://github.com/ylwl1997/dsh-browser
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.