### PR TITLE
catalog: add ylwl1997-noatmark-dsh-plugin (community curation, created by @ylwl1997)

### DIFF
--- a/catalog/plugins/ylwl1997-noatmark-dsh-plugin.yaml
+++ b/catalog/plugins/ylwl1997-noatmark-dsh-plugin.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: ylwl1997-noatmark-dsh-plugin
+name: noatmark-dsh-plugin
+description:
+  en: NoAtMark text hygiene as a DeepSeek Harness (dsh) plugin — sanitize untrusted text, scan invisible characters, clean LLM formatting, and escape CSV formula injection.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - dsh-plugin
+  - text-hygiene
+  - sanitize
+  - prompt-injection
+  - dsh
+source:
+  repository: https://github.com/ylwl1997/noatmark-dsh-plugin
+  repositoryNodeId: R_kgDOT35xlg
+  subpath: null
+  commit: 0e28246d0208e11b7d6ca0883af4722d5ef58bb4
+creator:
+  github: ylwl1997
+package:
+  ecosystem: npm
+  name: noatmark-dsh-plugin
+  version: 0.1.0
+  integrity: sha512-n3hbkFLva/oo+Fn6zpHvp4AobmQceeSwx2VyshgY2EjZ00+4FU6rJ4gmJOA7m0M+ZQMMuOGhDLO0VxxNLutMrw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:07.832Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ylwl1997-noatmark-dsh-plugin`
- Submission type: community curation
- Created by `ylwl1997` — https://github.com/ylwl1997
- Original source repository: https://github.com/ylwl1997/noatmark-dsh-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.