### PR TITLE
catalog: add yumm007-dsh-reveal-files (community curation, created by @yumm007)

### DIFF
--- a/catalog/plugins/yumm007-dsh-reveal-files.yaml
+++ b/catalog/plugins/yumm007-dsh-reveal-files.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: yumm007-dsh-reveal-files
+name: dsh-reveal-files
+description:
+  en: "DeepSeek Harness plugin: adds a folder icon next to the produced-files row that reveals the files in the native file browser (macOS Finder / Linux file manager)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - cordis
+  - finder
+  - reveal
+  - files
+source:
+  repository: https://github.com/yumm007/dsh-reveal-files
+  repositoryNodeId: R_kgDOUBqiGA
+  subpath: null
+  commit: 328917ff210ed2ec7f674dda386f2de39fd59bfb
+creator:
+  github: yumm007
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:14.894Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yumm007-dsh-reveal-files`
- Submission type: community curation
- Created by `yumm007` — https://github.com/yumm007
- Original source repository: https://github.com/yumm007/dsh-reveal-files
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.