### PR TITLE
catalog: add yuqingsh-dsh-image-subagent (community curation, created by @yuqingsh)

### DIFF
--- a/catalog/plugins/yuqingsh-dsh-image-subagent.yaml
+++ b/catalog/plugins/yuqingsh-dsh-image-subagent.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: yuqingsh-dsh-image-subagent
+name: dsh-image-subagent
+description:
+  en: sh dsh plugin --profile web add ./dsh-image-subagent
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - image
+  - vision
+  - subagent
+  - multimodal
+  - attachment
+source:
+  repository: https://github.com/yuqingsh/dsh-image-subagent
+  repositoryNodeId: R_kgDOT4QTng
+  subpath: null
+  commit: 289fdd85a94484ee938d15a497e5e0161d774702
+creator:
+  github: yuqingsh
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:57.569Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yuqingsh-dsh-image-subagent`
- Submission type: community curation
- Created by `yuqingsh` — https://github.com/yuqingsh
- Original source repository: https://github.com/yuqingsh/dsh-image-subagent
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.