### PR TITLE
catalog: add yuuhann1999-dsh-bloub-mood (community curation, created by @Yuuhann1999)

### DIFF
--- a/catalog/plugins/yuuhann1999-dsh-bloub-mood.yaml
+++ b/catalog/plugins/yuuhann1999-dsh-bloub-mood.yaml
@@ -1,0 +1,62 @@
+schemaVersion: 1
+id: yuuhann1999-dsh-bloub-mood
+name: dsh-bloub-mood
+description:
+  en: bash dsh plugin --profile web add dsh-bloub-mood
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - web
+  - favicon
+  - logo
+  - animated
+  - bloub
+  - mood
+source:
+  repository: https://github.com/Yuuhann1999/dsh-bloub-mood
+  repositoryNodeId: R_kgDOT8CJqQ
+  subpath: null
+  commit: c626528b3d6c32669c265d7144e85f60f48570d2
+creator:
+  github: Yuuhann1999
+package:
+  ecosystem: npm
+  name: dsh-bloub-mood
+  version: 2.4.4
+  integrity: sha512-mShun0DJXAM4rBo+eKuPsfEXlK+oVvuJFag1bGA+HlX5xtoToCdYPJeVM4QWvbX96LxuaaOfy3+81jl9paisig==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:55.294Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Yuuhann1999/dsh-bloub-mood/c626528b3d6c32669c265d7144e85f60f48570d2/docs/settings-expressions.png
+    alt: 设置页 · 表情与形状颜色
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Yuuhann1999/dsh-bloub-mood/c626528b3d6c32669c265d7144e85f60f48570d2/docs/settings-desktop-launch.png
+    alt: 设置页 · 桌面启动
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Yuuhann1999/dsh-bloub-mood/c626528b3d6c32669c265d7144e85f60f48570d2/docs/dock-icon.png
+    alt: Dock · DSH Desktop
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Yuuhann1999/dsh-bloub-mood/c626528b3d6c32669c265d7144e85f60f48570d2/docs/desktop-app.png
+    alt: DSH Desktop 主界面


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yuuhann1999-dsh-bloub-mood`
- Submission type: community curation
- Created by `Yuuhann1999` — https://github.com/Yuuhann1999
- Original source repository: https://github.com/Yuuhann1999/dsh-bloub-mood
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.