### PR TITLE
catalog: add z-6354-dsh-mobile-hanui (community curation, created by @Z-6354)

### DIFF
--- a/catalog/plugins/z-6354-dsh-mobile-hanui.yaml
+++ b/catalog/plugins/z-6354-dsh-mobile-hanui.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: z-6354-dsh-mobile-hanui
+name: dsh-mobile-hanui
+description:
+  en: Standalone mobile UI shell for the DeepSeek Harness web GUI (phone layout, drawers, FAB, mobile composer fixes)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - standalone
+  - mobile
+  - shell
+  - phone
+  - layout
+  - drawers
+  - composer
+  - fixes
+  - dsh
+source:
+  repository: https://github.com/Z-6354/dsh-mobile-hanui
+  repositoryNodeId: R_kgDOT5Tj2g
+  subpath: null
+  commit: 27f11e7b7925fafcd63926dfefde11cfc1197cf3
+creator:
+  github: Z-6354
+package:
+  ecosystem: npm
+  name: dsh-mobile-hanui
+  version: 0.2.5
+  integrity: sha512-M2EMyZYrc8tyccSHEeOSiFJ/paJecOPcbq9fIaBG+FjpiBgISwFHvjFkD5r/WYRvGNVLIBFfPIFnObOVtpqxyg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:52.658Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 16
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `z-6354-dsh-mobile-hanui`
- Submission type: community curation
- Created by `Z-6354` — https://github.com/Z-6354
- Original source repository: https://github.com/Z-6354/dsh-mobile-hanui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.