### PR TITLE
catalog: add zdfb-dsh-plugin-diff-viewer (community curation, created by @zdfb)

### DIFF
--- a/catalog/plugins/zdfb-dsh-plugin-diff-viewer.yaml
+++ b/catalog/plugins/zdfb-dsh-plugin-diff-viewer.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: zdfb-dsh-plugin-diff-viewer
+name: dsh-plugin-diff-viewer
+description:
+  en: A diff plugin for DeepSeek Harness (DSH). Captures file write/edit operations, computes structured diff data, and provides a block-level diff renderer with syntax highlighting and dimmed deleted lines.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - diff
+  - code-review
+source:
+  repository: https://github.com/zdfb/dsh-plugin-diff-viewer
+  repositoryNodeId: R_kgDOT9f7zg
+  subpath: null
+  commit: f2fc696c691d6ebe2c8172232bc6ff4119dc2cf0
+creator:
+  github: zdfb
+package:
+  ecosystem: npm
+  name: dsh-plugin-diff-viewer
+  version: 0.1.1
+  integrity: sha512-uhhJ/wNv4jfyoRu4Z9r0ubZUB1ed4E5MOuop3+vJuEoSxRIjVrnmB/3zK2BCSZArZKh/ZhPcoKBVRDPLvosHUQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:15.111Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zdfb-dsh-plugin-diff-viewer`
- Submission type: community curation
- Created by `zdfb` — https://github.com/zdfb
- Original source repository: https://github.com/zdfb/dsh-plugin-diff-viewer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.