### PR TITLE
catalog: add zem17-dsh-subagent-antigravity (community curation, created by @ZEM17)

### DIFF
--- a/catalog/plugins/zem17-dsh-subagent-antigravity.yaml
+++ b/catalog/plugins/zem17-dsh-subagent-antigravity.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: zem17-dsh-subagent-antigravity
+name: "@dsh-external/dsh-subagent-antigravity"
+description:
+  en: Delegate tasks to Google Antigravity CLI (agy) as a DSH subagent — no Gemini API key needed, uses your Antigravity login
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - antigravity
+  - agy
+  - gemini
+  - subagent
+source:
+  repository: https://github.com/ZEM17/dsh-subagent-agy
+  repositoryNodeId: R_kgDOT5gMiw
+  subpath: null
+  commit: d520b9f690dbba9f8dafac09ebc79a5e1c5a8c8e
+creator:
+  github: ZEM17
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:59.032Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zem17-dsh-subagent-antigravity`
- Submission type: community curation
- Created by `ZEM17` — https://github.com/ZEM17
- Original source repository: https://github.com/ZEM17/dsh-subagent-agy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.