### PR TITLE
catalog: add zeng6125-rgb-dsh-llm-retry-settings (community curation, created by @zeng6125-rgb)

### DIFF
--- a/catalog/plugins/zeng6125-rgb-dsh-llm-retry-settings.yaml
+++ b/catalog/plugins/zeng6125-rgb-dsh-llm-retry-settings.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: zeng6125-rgb-dsh-llm-retry-settings
+name: dsh-llm-retry-settings
+description:
+  en: A settings card for the DSH LLM auto-retry engine ( @deepseek-ai/dsh-llm-retry ). Tune the retry count and backoff from Settings → General ; changes take effect immediately.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - settings
+  - card
+  - auto
+  - retry
+  - engine
+  - tune
+  - count
+  - backoff
+  - general
+  - changes
+  - take
+  - effect
+  - immediately
+  - dsh
+source:
+  repository: https://github.com/zeng6125-rgb/dsh-llm-retry-settings
+  repositoryNodeId: R_kgDOT7QYSA
+  subpath: null
+  commit: 083f84810998f6950f9282a10a39c25d150cc78b
+creator:
+  github: zeng6125-rgb
+package:
+  ecosystem: npm
+  name: dsh-llm-retry-settings
+  version: 0.1.4
+  integrity: sha512-HYdA6TtaNSzlgcFK719UUZJPpODzl3XixeePLupgzZj+DB5nLtgLimy1QJToGDY98uYfhOs3mLqnnGzPhO7URQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:01.522Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zeng6125-rgb-dsh-llm-retry-settings`
- Submission type: community curation
- Created by `zeng6125-rgb` — https://github.com/zeng6125-rgb
- Original source repository: https://github.com/zeng6125-rgb/dsh-llm-retry-settings
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.