### PR TITLE
catalog: add zenjibad-skill-injector-plugin (community curation, created by @Zenjibad)

### DIFF
--- a/catalog/plugins/zenjibad-skill-injector-plugin.yaml
+++ b/catalog/plugins/zenjibad-skill-injector-plugin.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: zenjibad-skill-injector-plugin
+name: skill-injector-plugin
+description:
+  en: "Keywords : dsh-plugin · deepseek-harness-plugin · skills · skill-injection · caveman · ponytail"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - deepseek-harness-plugin
+  - skills
+  - skill-injection
+  - caveman
+  - ponytail
+  - ai-agent
+source:
+  repository: https://github.com/Zenjibad/skill-injector-plugin
+  repositoryNodeId: R_kgDOT6Gmww
+  subpath: null
+  commit: 3ac2cd002c05961e5d60070bb7a26b1d02d2395d
+creator:
+  github: Zenjibad
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:08.488Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zenjibad-skill-injector-plugin`
- Submission type: community curation
- Created by `Zenjibad` — https://github.com/Zenjibad
- Original source repository: https://github.com/Zenjibad/skill-injector-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.