### PR TITLE
catalog: add zfu691531-hash-dsh-realtime-voice (community curation, created by @zfu691531-hash)

### DIFF
--- a/catalog/plugins/zfu691531-hash-dsh-realtime-voice.yaml
+++ b/catalog/plugins/zfu691531-hash-dsh-realtime-voice.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: zfu691531-hash-dsh-realtime-voice
+name: dsh-realtime-voice
+description:
+  en: Lightweight realtime speech-to-speech for DeepSeek Harness with Qwen and OpenAI providers.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - realtime-voice
+  - asr
+  - tts
+  - qwen
+  - openai
+source:
+  repository: https://github.com/zfu691531-hash/dsh-realtime-voice
+  repositoryNodeId: R_kgDOT5VQ_Q
+  subpath: null
+  commit: 91aae229357e647964bbf2e50ec7602c4ce55d4a
+creator:
+  github: zfu691531-hash
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:08.691Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zfu691531-hash/dsh-realtime-voice/91aae229357e647964bbf2e50ec7602c4ce55d4a/screenshots/settings.png
+    alt: DeepSeek Harness 实时语音插件设置


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zfu691531-hash-dsh-realtime-voice`
- Submission type: community curation
- Created by `zfu691531-hash` — https://github.com/zfu691531-hash
- Original source repository: https://github.com/zfu691531-hash/dsh-realtime-voice
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.