### PR TITLE
catalog: add zhaiyateng-dsh-design-skills (community curation, created by @zhaiyateng)

### DIFF
--- a/catalog/plugins/zhaiyateng-dsh-design-skills.yaml
+++ b/catalog/plugins/zhaiyateng-dsh-design-skills.yaml
@@ -1,0 +1,64 @@
+schemaVersion: 1
+id: zhaiyateng-dsh-design-skills
+name: dsh-design-skills
+description:
+  en: Design aesthetics skill pack for DeepSeek Harness (DSH) — keeps your vibe-coded websites away from the "AI look".
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh-plugin
+  - deepseek-harness
+  - design-system
+  - design-skills
+  - vibe-coding
+  - web-design
+  - ui
+  - dsh
+source:
+  repository: https://github.com/zhaiyateng/dsh-design-skills
+  repositoryNodeId: R_kgDOT4i62w
+  subpath: null
+  commit: 741272753c257c9b48fb60b015b4ecdb438d86e3
+creator:
+  github: zhaiyateng
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:52.655Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 20
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhaiyateng/dsh-design-skills/741272753c257c9b48fb60b015b4ecdb438d86e3/assets/dark-saas-landing.png
+    alt: dark-saas landing demo
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhaiyateng/dsh-design-skills/741272753c257c9b48fb60b015b4ecdb438d86e3/assets/apple-minimal-landing.png
+    alt: apple-minimal landing demo
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhaiyateng/dsh-design-skills/741272753c257c9b48fb60b015b4ecdb438d86e3/assets/neo-neumorphism-landing.png
+    alt: neo-neumorphism landing demo
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhaiyateng/dsh-design-skills/741272753c257c9b48fb60b015b4ecdb438d86e3/assets/brutalism-landing.png
+    alt: brutalism landing demo
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhaiyateng/dsh-design-skills/741272753c257c9b48fb60b015b4ecdb438d86e3/assets/glassmorphism-landing.png
+    alt: glassmorphism landing demo
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zhaiyateng/dsh-design-skills/741272753c257c9b48fb60b015b4ecdb438d86e3/assets/japanese-minimal-landing.png
+    alt: japanese-minimal landing demo


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhaiyateng-dsh-design-skills`
- Submission type: community curation
- Created by `zhaiyateng` — https://github.com/zhaiyateng
- Original source repository: https://github.com/zhaiyateng/dsh-design-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.