### PR TITLE
catalog: add zhenhuanglab-dsh-sync (community curation, created by @ZhenHuangLab)

### DIFF
--- a/catalog/plugins/zhenhuanglab-dsh-sync.yaml
+++ b/catalog/plugins/zhenhuanglab-dsh-sync.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: zhenhuanglab-dsh-sync
+name: dsh-sync
+description:
+  en: Git sync for DeepSeek Harness settings and profile configuration.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - configuration
+  - git
+  - sync
+source:
+  repository: https://github.com/ZhenHuangLab/dsh-sync
+  repositoryNodeId: R_kgDOT4_Lqg
+  subpath: null
+  commit: d474556c55a85095169d55ab0ba976af568fae5b
+creator:
+  github: ZhenHuangLab
+package:
+  ecosystem: npm
+  name: dsh-sync
+  version: 0.1.3
+  integrity: sha512-NvP6mzfqJ0TNCva42WKBdgkkx27CVnFO4frbGwTpS+eIh1uYUmndi9zvnbVnYrl3jhGv9Phr9HJJWkmKtWEuug==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:15.176Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zhenhuanglab-dsh-sync`
- Submission type: community curation
- Created by `ZhenHuangLab` — https://github.com/ZhenHuangLab
- Original source repository: https://github.com/ZhenHuangLab/dsh-sync
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.