### PR TITLE
catalog: add zsyu9779-dsh-file-changes (community curation, created by @zsyu9779)

### DIFF
--- a/catalog/plugins/zsyu9779-dsh-file-changes.yaml
+++ b/catalog/plugins/zsyu9779-dsh-file-changes.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: zsyu9779-dsh-file-changes
+name: dsh-file-changes
+description:
+  en: Per-turn file-change panel with workspace-bound reveal (self-developed for dsh-desktop)
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - file-changes
+  - diff
+source:
+  repository: https://github.com/zsyu9779/dsh-desktop
+  repositoryNodeId: R_kgDOT3kQCg
+  subpath: plugins/file-changes
+  commit: f27fbd5ebdd8321754c02302e714e779016de75f
+creator:
+  github: zsyu9779
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/file-changes/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:53:31.926Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zsyu9779/dsh-desktop/f27fbd5ebdd8321754c02302e714e779016de75f/assets/hero.jpg
+    alt: DeepSeek Harness Desktop：官网视觉背景上的原生应用窗口
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zsyu9779/dsh-desktop/f27fbd5ebdd8321754c02302e714e779016de75f/assets/remote-control.png
+    alt: DeepSeek Harness Desktop 局域网手机扫码远程控制


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zsyu9779-dsh-file-changes`
- Submission type: community curation
- Created by `zsyu9779` — https://github.com/zsyu9779
- Original source repository: https://github.com/zsyu9779/dsh-desktop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.