### PR TITLE
catalog: add zuoguyoupan2023-adhdgofly-dsh-ext (community curation, created by @zuoguyoupan2023)

### DIFF
--- a/catalog/plugins/zuoguyoupan2023-adhdgofly-dsh-ext.yaml
+++ b/catalog/plugins/zuoguyoupan2023-adhdgofly-dsh-ext.yaml
@@ -1,0 +1,48 @@
+schemaVersion: 1
+id: zuoguyoupan2023-adhdgofly-dsh-ext
+name: adhdgofly-dsh-ext
+description:
+  en: "ADHDGoFly POS highlighting for DeepSeek Harness Web: nouns green, verbs red, adjectives/adverbs purple, others gray, in rendered Markdown (conversation messages, deliverables, etc.)"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: messaging-notifications
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - adhdgofly
+  - part-of-speech
+  - pos-tagging
+  - highlighting
+  - markdown
+source:
+  repository: https://github.com/zuoguyoupan2023/adhdgofly-dsh-ext
+  repositoryNodeId: R_kgDOT4BUSg
+  subpath: null
+  commit: afa2676fc18d13e25fbfeb901591118edd22e642
+creator:
+  github: zuoguyoupan2023
+package:
+  ecosystem: npm
+  name: adhdgofly-dsh-ext
+  version: 0.1.6
+  integrity: sha512-hheMznMrXneZuI18bk07zHhvkcGpyi3zpl8+GjT5pzMIJ4FUAJb8ie1T3W7w4bj8XEVECVxCBpeM5zEUNQuO6A==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T15:52:58.449Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zuoguyoupan2023-adhdgofly-dsh-ext`
- Submission type: community curation
- Created by `zuoguyoupan2023` — https://github.com/zuoguyoupan2023
- Original source repository: https://github.com/zuoguyoupan2023/adhdgofly-dsh-ext
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.