### PR TITLE
catalog: add astra3294-dsh-doctor (community curation, created by @astra3294)

### DIFF
--- a/catalog/plugins/astra3294-dsh-doctor.yaml
+++ b/catalog/plugins/astra3294-dsh-doctor.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: astra3294-dsh-doctor
+name: dsh-doctor
+description:
+  en: Deterministic diagnostics and recovery for DeepSeek Harness
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - deepseek-harness
+  - dsh
+  - doctor
+  - diagnostics
+  - recovery
+source:
+  repository: https://github.com/astra3294/dsh-doctor
+  repositoryNodeId: R_kgDOT4orWw
+  subpath: null
+  commit: fa6128115e258782b6eba544b195095c06b1280a
+creator:
+  github: astra3294
+package:
+  ecosystem: npm
+  name: dsh-doctor
+  version: 0.4.3
+  integrity: sha512-awf+wye0mqvWtkT4Cndgu0Xczclc+Z9pr5mZbczYP5MKWWnN8VAemSM0aflrvH9g0cf2+ZV9nzz31RZK5eiToQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:24:16.277Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `astra3294-dsh-doctor`
- Submission type: community curation
- Created by `astra3294` — https://github.com/astra3294
- Original source repository: https://github.com/astra3294/dsh-doctor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.