### PR TITLE
catalog: add bbdaljc11-dsh-network-proxy (community curation, created by @bbdaljc11)

### DIFF
--- a/catalog/plugins/bbdaljc11-dsh-network-proxy.yaml
+++ b/catalog/plugins/bbdaljc11-dsh-network-proxy.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: bbdaljc11-dsh-network-proxy
+name: dsh-network-proxy
+description:
+  en: Network proxy management plugin for DeepSeek Harness. Switch between system / manual / direct proxy modes from the settings UI, applied live.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - proxy
+  - network
+source:
+  repository: https://github.com/kriskite/dsh-network-proxy
+  repositoryNodeId: R_kgDOT89unQ
+  subpath: null
+  commit: 4cc265a2115cffdcfbf4f74257243b12a98ac9e0
+creator:
+  github: bbdaljc11
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:24:14.466Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `bbdaljc11-dsh-network-proxy`
- Submission type: community curation
- Created by `bbdaljc11` — https://github.com/bbdaljc11
- Original source repository: https://github.com/kriskite/dsh-network-proxy
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.