### PR TITLE
catalog: add blaczz-dsh-achievements (community curation, created by @Blaczz)

### DIFF
--- a/catalog/plugins/blaczz-dsh-achievements.yaml
+++ b/catalog/plugins/blaczz-dsh-achievements.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: blaczz-dsh-achievements
+name: dsh-achievements
+description:
+  en: "DeepSeek Harness achievement & gamification plugin: cross-session badges for turns, tool calls, sessions and daily streaks, with a badge panel, unlock toasts and a ctx.achievements service. Zero core changes."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cordis
+  - achievements
+  - gamification
+  - badges
+source:
+  repository: https://github.com/Blaczz/dsh-achievements
+  repositoryNodeId: R_kgDOT4MJKw
+  subpath: null
+  commit: 8c00e76de04498b743364bacd17888fe9a75f853
+creator:
+  github: Blaczz
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:24:19.840Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `blaczz-dsh-achievements`
- Submission type: community curation
- Created by `Blaczz` — https://github.com/Blaczz
- Original source repository: https://github.com/Blaczz/dsh-achievements
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.