### PR TITLE
catalog: add damonkoy-dsh-plugin-toggle (community curation, created by @DamonKoy)

### DIFF
--- a/catalog/plugins/damonkoy-dsh-plugin-toggle.yaml
+++ b/catalog/plugins/damonkoy-dsh-plugin-toggle.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: damonkoy-dsh-plugin-toggle
+name: dsh-plugin-toggle
+description:
+  en: "DSH plugin switchboard: a Settings → Plugins tab that lists every loaded plugin with its package.json description, fuzzy search, and runtime start/stop toggles (does not rewrite config files)."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - dsh
+  - dsh-plugin
+  - plugin-manager
+  - settings
+source:
+  repository: https://github.com/DamonKoy/dsh-plugin-toggle
+  repositoryNodeId: R_kgDOT5WaPw
+  subpath: null
+  commit: be4d811aebbc9aa972383dd713ed81b48195b181
+creator:
+  github: DamonKoy
+package:
+  ecosystem: npm
+  name: dsh-plugin-toggle
+  version: 0.1.0
+  integrity: sha512-ZMiMSmtpiVrfWq8u3DG/jYjEO5SD/ErJuTB9fgJ9Vlqpo9YKIwn2hS/gC9RSmzydZoQYwzOTzZytkdGXar+TQA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:24:16.264Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `damonkoy-dsh-plugin-toggle`
- Submission type: community curation
- Created by `DamonKoy` — https://github.com/DamonKoy
- Original source repository: https://github.com/DamonKoy/dsh-plugin-toggle
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.