### PR TITLE
catalog: add htommr-dsh-appserver (community curation, created by @htommr)

### DIFF
--- a/catalog/plugins/htommr-dsh-appserver.yaml
+++ b/catalog/plugins/htommr-dsh-appserver.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: htommr-dsh-appserver
+name: dsh-appserver
+description:
+  en: Codex app-server-shaped protocol adapter for DeepSeek Harness
+  evidencePath: dsh-appserver/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - codex
+  - server
+  - shaped
+  - protocol
+  - adapter
+  - dsh
+source:
+  repository: https://github.com/text2future/flowix
+  repositoryNodeId: R_kgDOSm7IOg
+  subpath: dsh-appserver
+  commit: 8876781829f0ce2163b1736fbe41e344a9cf11a1
+creator:
+  github: htommr
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+  evidencePath: dsh-appserver/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:25:04.727Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `htommr-dsh-appserver`
- Submission type: community curation
- Created by `htommr` — https://github.com/htommr
- Original source repository: https://github.com/text2future/flowix
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.