### PR TITLE
catalog: add hua1q1ng-dsh-prompt-self-client (community curation, created by @Hua1Q1nG)

### DIFF
--- a/catalog/plugins/hua1q1ng-dsh-prompt-self-client.yaml
+++ b/catalog/plugins/hua1q1ng-dsh-prompt-self-client.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: hua1q1ng-dsh-prompt-self-client
+name: dsh-prompt-self-client
+description:
+  en: "Personal prompt profile engine for DeepSeek Harness: message-level prompt rewriting and automatic profile learning with a bilingual settings panel and conversation dock."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - dsh
+  - dsh-plugin
+  - prompt
+  - prompt-optimizer
+  - profile
+  - memory
+source:
+  repository: https://github.com/Hua1Q1nG/dsh-prompt-self
+  repositoryNodeId: R_kgDOT5cLog
+  subpath: null
+  commit: aac7d4206a0f17a6cc5cf392408ee617f495fb6f
+creator:
+  github: Hua1Q1nG
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:24:21.481Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `hua1q1ng-dsh-prompt-self-client`
- Submission type: community curation
- Created by `Hua1Q1nG` — https://github.com/Hua1Q1nG
- Original source repository: https://github.com/Hua1Q1nG/dsh-prompt-self
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.