### PR TITLE
catalog: add huhoo-dsh-cue-data-mcp (community curation, created by @huhoo)

### DIFF
--- a/catalog/plugins/huhoo-dsh-cue-data-mcp.yaml
+++ b/catalog/plugins/huhoo-dsh-cue-data-mcp.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: huhoo-dsh-cue-data-mcp
+name: "@cueai/dsh-cue-data-mcp"
+description:
+  en: "DSH bundle: exposes Cue's public data MCP services (regulatory, macro, disclosures, market data, statute, holdings, entity, academic, IPO, ESOP, buyback, footnote, fact index) as native mcp cue <domain tools."
+  evidencePath: dsh/cue-data-mcp/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - deepseek-harness
+  - mcp
+  - cue
+  - data
+  - finance
+source:
+  repository: https://github.com/sensedeal/cue-skills
+  repositoryNodeId: R_kgDOSigUuw
+  subpath: dsh/cue-data-mcp
+  commit: 5b5b8005dfa51aca0b56028d2bc6ccbfcd266d6b
+creator:
+  github: huhoo
+package:
+  ecosystem: npm
+  name: "@cueai/dsh-cue-data-mcp"
+  version: 0.1.2
+  integrity: sha512-nwYPyxzLp5Ykg8il+oUArLQ651LerU1ItbXaaQnuKnmg3JGQMzX40TH5GRJ5rcBwQgZqktkmEFaJniq3YJ+mBQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: dsh/cue-data-mcp/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:24:45.377Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huhoo-dsh-cue-data-mcp`
- Submission type: community curation
- Created by `huhoo` — https://github.com/huhoo
- Original source repository: https://github.com/sensedeal/cue-skills
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.