### PR TITLE
catalog: add huiliyi37-dsh-lsp (community curation, created by @huiliyi37)

### DIFF
--- a/catalog/plugins/huiliyi37-dsh-lsp.yaml
+++ b/catalog/plugins/huiliyi37-dsh-lsp.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: huiliyi37-dsh-lsp
+name: "@huiliyi37/dsh-lsp"
+description:
+  en: "dsh-lsp: LSP model tool surface for the DeepSeek Harness — goto-definition / find-references / diagnostics tools + a shared 'lsp' service consumed by the dsh-tianshu-tui display bridge (single LSP server set, no double spawn)"
+  evidencePath: lsp/README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - model
+  - tool
+  - surface
+  - goto
+  - definition
+  - find
+  - references
+  - diagnostics
+  - tools
+  - shared
+  - service
+  - consumed
+  - tianshu
+  - display
+  - bridge
+  - single
+source:
+  repository: https://github.com/huiliyi37/dsh-tianshu-tui
+  repositoryNodeId: R_kgDOT29GJw
+  subpath: lsp
+  commit: da5833e3b5ed5e6c94dfe092e898c53ee41014ee
+creator:
+  github: huiliyi37
+package:
+  ecosystem: npm
+  name: "@huiliyi37/dsh-lsp"
+  version: 0.1.0-rc.1
+  integrity: sha512-N+7wVgpOBNOYCJaH3uI3GyXjdChIdv17BhTUWGzUI5zsKvpOQgoD3VZeA3s3i4n/fV4ASMxi2JvttHRBdqRjyw==
+dsh:
+  profiles:
+    - default
+  evidencePath: lsp/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:24:28.095Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `huiliyi37-dsh-lsp`
- Submission type: community curation
- Created by `huiliyi37` — https://github.com/huiliyi37
- Original source repository: https://github.com/huiliyi37/dsh-tianshu-tui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.