### PR TITLE
catalog: add nanshan1995-dsh-plugin-market (community curation, created by @nanshan1995)

### DIFF
--- a/catalog/plugins/nanshan1995-dsh-plugin-market.yaml
+++ b/catalog/plugins/nanshan1995-dsh-plugin-market.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: nanshan1995-dsh-plugin-market
+name: dsh-plugin-market
+description:
+  en: "Plugin market inside DeepSeek Harness: browse, search, one-click install — every install/update passes a static security audit gate first."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - marketplace
+  - plugin-manager
+  - security
+  - audit
+source:
+  repository: https://github.com/nanshan1995/DSH-Plugin-Market
+  repositoryNodeId: R_kgDOT4edCQ
+  subpath: null
+  commit: cb79579df4f41be8902d53a64221e21367b46652
+creator:
+  github: nanshan1995
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:44:26.644Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `nanshan1995-dsh-plugin-market`
- Submission type: community curation
- Created by `nanshan1995` — https://github.com/nanshan1995
- Original source repository: https://github.com/nanshan1995/DSH-Plugin-Market
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.