### PR TITLE
catalog: add songmiao-tech-dsh-prompt-optimizer (community curation, created by @SongMiao-tech)

### DIFF
--- a/catalog/plugins/songmiao-tech-dsh-prompt-optimizer.yaml
+++ b/catalog/plugins/songmiao-tech-dsh-prompt-optimizer.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: songmiao-tech-dsh-prompt-optimizer
+name: dsh-prompt-optimizer
+description:
+  en: "Prompt optimizer plugin for DeepSeek Harness: rewrite a composer draft into a clearer, more executable prompt with one click."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - prompt
+  - optimizer
+  - rewrite
+  - composer
+  - draft
+  - clearer
+  - executable
+  - click
+  - dsh
+source:
+  repository: https://github.com/SongMiao-tech/dsh-prompt-optimizer
+  repositoryNodeId: R_kgDOT5HIeQ
+  subpath: null
+  commit: 4e304b82f5fbf508346cd460c349f730f3b4ca6f
+creator:
+  github: SongMiao-tech
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:44:29.511Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `songmiao-tech-dsh-prompt-optimizer`
- Submission type: community curation
- Created by `SongMiao-tech` — https://github.com/SongMiao-tech
- Original source repository: https://github.com/SongMiao-tech/dsh-prompt-optimizer
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.