### PR TITLE
catalog: add tecfancy-dsh-auth-gate (community curation, created by @TecFancy)

### DIFF
--- a/catalog/plugins/tecfancy-dsh-auth-gate.yaml
+++ b/catalog/plugins/tecfancy-dsh-auth-gate.yaml
@@ -1,0 +1,60 @@
+schemaVersion: 1
+id: tecfancy-dsh-auth-gate
+name: dsh-auth-gate
+description:
+  en: Application-layer authentication plugin for the dsh web surface
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - auth
+  - authentication
+  - login
+  - password
+  - token
+  - security
+  - access-control
+  - rate-limiting
+source:
+  repository: https://github.com/TecFancy/dsh-auth-gate
+  repositoryNodeId: R_kgDOT4NVHQ
+  subpath: null
+  commit: 860834eea03c4be74760482aea977b936f903d9b
+creator:
+  github: TecFancy
+package:
+  ecosystem: npm
+  name: dsh-auth-gate
+  version: 0.11.0
+  integrity: sha512-a7qu3VcTsvD7IpjfoXER5QLV+2KbXSNRYHf29AaNYwlOaGGkWnWFKiO7D5LYPuvmNhweMhEEcJOPvZYVL5Zw4g==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-08-31T16:44:21.847Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/TecFancy/dsh-auth-gate/860834eea03c4be74760482aea977b936f903d9b/docs/demo/login-page.png
+    alt: Login page
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/TecFancy/dsh-auth-gate/860834eea03c4be74760482aea977b936f903d9b/docs/demo/totp-code.png
+    alt: TOTP verification step
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/TecFancy/dsh-auth-gate/860834eea03c4be74760482aea977b936f903d9b/docs/demo/dashboard.png
+    alt: dsh instance


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tecfancy-dsh-auth-gate`
- Submission type: community curation
- Created by `TecFancy` — https://github.com/TecFancy
- Original source repository: https://github.com/TecFancy/dsh-auth-gate
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.