### PR TITLE
catalog: add haozehua-sun-dsh-agent-project-sync (community curation, created by @Harzva)

### DIFF
--- a/catalog/plugins/haozehua-sun-dsh-agent-project-sync.yaml
+++ b/catalog/plugins/haozehua-sun-dsh-agent-project-sync.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: haozehua-sun-dsh-agent-project-sync
+name: dsh-agent-project-sync
+description:
+  en: Discover Codex and Claude project directories and register them as shared DeepSeek Harness workspaces.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - codex
+  - claude-code
+  - workspace
+  - project-sync
+source:
+  repository: https://github.com/Harzva/dsh-agent-project-sync
+  repositoryNodeId: R_kgDOUBUrmg
+  subpath: null
+  commit: 5ff9b30f5a3cc4d798af7288920c539ac2d84515
+creator:
+  github: haozehua-sun
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:18.890Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haozehua-sun-dsh-agent-project-sync`
- Submission type: community curation
- Created by `Harzva` — https://github.com/Harzva
- Original source repository: https://github.com/Harzva/dsh-agent-project-sync
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.