### PR TITLE
catalog: add haozehua-sun-dsh-cli-store (community curation, created by @Harzva)

### DIFF
--- a/catalog/plugins/haozehua-sun-dsh-cli-store.yaml
+++ b/catalog/plugins/haozehua-sun-dsh-cli-store.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: haozehua-sun-dsh-cli-store
+name: dsh-cli-store
+description:
+  en: A security-conscious registry and installer for external CLI tools exposed through DeepSeek Harness.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - cli
+  - cli-manager
+  - developer-tools
+  - market
+source:
+  repository: https://github.com/Harzva/dsh-cli-store
+  repositoryNodeId: R_kgDOT-tJoA
+  subpath: null
+  commit: 9d9994817b97f22bfbda927a2f408ebdfea8ce61
+creator:
+  github: haozehua-sun
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:19.018Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haozehua-sun-dsh-cli-store`
- Submission type: community curation
- Created by `Harzva` — https://github.com/Harzva
- Original source repository: https://github.com/Harzva/dsh-cli-store
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.