### PR TITLE
catalog: add haozehua-sun-dsh-control-plane (community curation, created by @Harzva)

### DIFF
--- a/catalog/plugins/haozehua-sun-dsh-control-plane.yaml
+++ b/catalog/plugins/haozehua-sun-dsh-control-plane.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: haozehua-sun-dsh-control-plane
+name: dsh-control-plane
+description:
+  en: A local-first developer control plane for multiple DeepSeek Harness runtimes.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - developer-tools
+  - agent-runtime
+  - control-plane
+source:
+  repository: https://github.com/Harzva/dsh-control-plane
+  repositoryNodeId: R_kgDOT_cY2w
+  subpath: null
+  commit: 238b79d02a3b71d34d8eb68229eed161e32d4283
+creator:
+  github: haozehua-sun
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:21.031Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haozehua-sun-dsh-control-plane`
- Submission type: community curation
- Created by `Harzva` — https://github.com/Harzva
- Original source repository: https://github.com/Harzva/dsh-control-plane
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.