### PR TITLE
catalog: add haozehua-sun-dsh-uvm (community curation, created by @Harzva)

### DIFF
--- a/catalog/plugins/haozehua-sun-dsh-uvm.yaml
+++ b/catalog/plugins/haozehua-sun-dsh-uvm.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: haozehua-sun-dsh-uvm
+name: "@harness-flow/dsh-uvm"
+description:
+  en: DSH-native uv environment manager with pip fallback and conda visibility
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - uv
+  - uvm
+  - venv
+  - virtualenv
+  - environment-management
+  - python
+source:
+  repository: https://github.com/Harzva/dsh-uvm
+  repositoryNodeId: R_kgDOT9eciQ
+  subpath: null
+  commit: f5bab7a5e2bb2a530e3b7dc1a89378dedbe0183f
+creator:
+  github: haozehua-sun
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:21.567Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `haozehua-sun-dsh-uvm`
- Submission type: community curation
- Created by `Harzva` — https://github.com/Harzva
- Original source repository: https://github.com/Harzva/dsh-uvm
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.