### PR TITLE
catalog: add jo32-dsh-provider-aware-web (community curation, created by @jo32)

### DIFF
--- a/catalog/plugins/jo32-dsh-provider-aware-web.yaml
+++ b/catalog/plugins/jo32-dsh-provider-aware-web.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: jo32-dsh-provider-aware-web
+name: "@deepdeck/dsh-provider-aware-web"
+description:
+  en: This Cordis service replacement keeps the Harness ctx.web contract while selecting search through the provider used by the current agent request.
+  evidencePath: plugins/provider-aware-web/README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - cordis
+  - service
+  - replacement
+  - keeps
+  - contract
+  - while
+  - selecting
+  - search
+  - through
+  - provider
+  - used
+  - current
+  - agent
+  - request
+  - dsh
+source:
+  repository: https://github.com/jo32/DeepDeck
+  repositoryNodeId: R_kgDOT6sjUA
+  subpath: plugins/provider-aware-web
+  commit: 01e4b6c1f5c17ba60c5fd8b3e2ec588d5741ea5c
+creator:
+  github: jo32
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/provider-aware-web/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:25.863Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `jo32-dsh-provider-aware-web`
- Submission type: community curation
- Created by `jo32` — https://github.com/jo32
- Original source repository: https://github.com/jo32/DeepDeck
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.