### PR TITLE
catalog: add kaziii-dsh-ui-github (community curation, created by @kaziii)

### DIFF
--- a/catalog/plugins/kaziii-dsh-ui-github.yaml
+++ b/catalog/plugins/kaziii-dsh-ui-github.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: kaziii-dsh-ui-github
+name: dsh-ui-github
+description:
+  en: GitHub workflow UI for the DeepSeek Harness web client — the Connect GitHub settings section and the conversation PR status bar (create / AI-review / merge), driven entirely by dsh-github-connect's @Remote methods and forwarded events, bound to the client shell through a narrow injected port
+  evidencePath: packages/github/ui-github/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - workflow
+  - client
+  - connect
+  - settings
+  - section
+  - conversation
+  - status
+  - create
+  - review
+  - merge
+  - driven
+  - entirely
+  - remote
+  - methods
+  - forwarded
+  - events
+source:
+  repository: https://github.com/kaziii/dsh-github-connector
+  repositoryNodeId: R_kgDOT3ijLg
+  subpath: packages/github/ui-github
+  commit: 34117bfad325e47a30c5146d4b7c2421d07594b5
+creator:
+  github: kaziii
+package:
+  ecosystem: npm
+  name: dsh-ui-github
+  version: 0.1.4
+  integrity: sha512-WEidaLwUXTRYzVoGEbm2Cp+NQxveXSoQvRJ4kEoGaBMOwJeewv50MmEKF16TdFAKS+4ifrsCZB8Hwvw9ira4NQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/github/ui-github/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:26.476Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `kaziii-dsh-ui-github`
- Submission type: community curation
- Created by `kaziii` — https://github.com/kaziii
- Original source repository: https://github.com/kaziii/dsh-github-connector
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.