### PR TITLE
catalog: add leemancheung-dsh-agent-arena (community curation, created by @LeemanCheung)

### DIFF
--- a/catalog/plugins/leemancheung-dsh-agent-arena.yaml
+++ b/catalog/plugins/leemancheung-dsh-agent-arena.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: leemancheung-dsh-agent-arena
+name: dsh-agent-arena
+description:
+  en: Isolated multi-model coding matches with deterministic verification, scoring, and reports
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+source:
+  repository: https://github.com/LeemanCheung/dsh-agent-arena
+  repositoryNodeId: R_kgDOT5-frQ
+  subpath: null
+  commit: 2b494d2462244eb2565ac80aa44c0ce0f70ff311
+creator:
+  github: LeemanCheung
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:16.803Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 3
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-agent-arena/2b494d2462244eb2565ac80aa44c0ce0f70ff311/assets/screenshots/overview.png
+    alt: Agent Arena results and diff review


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leemancheung-dsh-agent-arena`
- Submission type: community curation
- Created by `LeemanCheung` — https://github.com/LeemanCheung
- Original source repository: https://github.com/LeemanCheung/dsh-agent-arena
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.