### PR TITLE
catalog: add leemancheung-dsh-skin-studio (community curation, created by @LeemanCheung)

### DIFF
--- a/catalog/plugins/leemancheung-dsh-skin-studio.yaml
+++ b/catalog/plugins/leemancheung-dsh-skin-studio.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: leemancheung-dsh-skin-studio
+name: dsh-skin-studio
+description:
+  en: A local token-safe DSH theme generator, editor, auditor, and exporter
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+source:
+  repository: https://github.com/LeemanCheung/dsh-skin-studio
+  repositoryNodeId: R_kgDOT5-fqw
+  subpath: null
+  commit: e855106bc832c9102bea265b039fa5572e5fa679
+creator:
+  github: LeemanCheung
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:19.107Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-skin-studio/e855106bc832c9102bea265b039fa5572e5fa679/assets/screenshots/overview.png
+    alt: Skin Studio token editor and preview


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leemancheung-dsh-skin-studio`
- Submission type: community curation
- Created by `LeemanCheung` — https://github.com/LeemanCheung
- Original source repository: https://github.com/LeemanCheung/dsh-skin-studio
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.