### PR TITLE
catalog: add leemancheung-dsh-vibe-pack (community curation, created by @LeemanCheung)

### DIFF
--- a/catalog/plugins/leemancheung-dsh-vibe-pack.yaml
+++ b/catalog/plugins/leemancheung-dsh-vibe-pack.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: leemancheung-dsh-vibe-pack
+name: dsh-vibe-pack
+description:
+  en: Transactional data-only DSH configuration packs with integrity, ownership, and rollback
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+source:
+  repository: https://github.com/LeemanCheung/dsh-vibe-pack
+  repositoryNodeId: R_kgDOT5-fsQ
+  subpath: null
+  commit: 3f348f8e6c07365f367375b012abb6bf61cfea8e
+creator:
+  github: LeemanCheung
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:19.703Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/LeemanCheung/dsh-vibe-pack/3f348f8e6c07365f367375b012abb6bf61cfea8e/assets/screenshots/overview.png
+    alt: Vibe Pack reviewed install plan


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `leemancheung-dsh-vibe-pack`
- Submission type: community curation
- Created by `LeemanCheung` — https://github.com/LeemanCheung
- Original source repository: https://github.com/LeemanCheung/dsh-vibe-pack
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.