### PR TITLE
catalog: add licyer-dsh-token-monitor (community curation, created by @licyer)

### DIFF
--- a/catalog/plugins/licyer-dsh-token-monitor.yaml
+++ b/catalog/plugins/licyer-dsh-token-monitor.yaml
@@ -1,0 +1,68 @@
+schemaVersion: 1
+id: licyer-dsh-token-monitor
+name: dsh-token-monitor
+description:
+  en: sh dsh plugin --profile web add dsh-token-monitor
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - dsh
+  - dsh-plugin
+  - deepseek-harness
+  - token-monitor
+  - usage
+  - quota
+  - kimi
+  - llm
+  - token-usage
+source:
+  repository: https://github.com/licyer/dsh-token-monitor
+  repositoryNodeId: R_kgDOT8OPcQ
+  subpath: null
+  commit: 2f1e265f37b67a75930bffe968ec391b9ce87b83
+creator:
+  github: licyer
+package:
+  ecosystem: npm
+  name: dsh-token-monitor
+  version: 1.0.2
+  integrity: sha512-TSd0f27KeEb0XQkkIQxEyoefpPlkZRhZhwp6DhGM3WURCPkQEQ/Y/hZetd50hp1Ld5Otgv/8bB3+buMm7pwYEw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:14.915Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/licyer/dsh-token-monitor/2f1e265f37b67a75930bffe968ec391b9ce87b83/docs/images/quota-popover.png
+    alt: 余量徽标与详情弹层
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/licyer/dsh-token-monitor/2f1e265f37b67a75930bffe968ec391b9ce87b83/docs/images/usage-trend.png
+    alt: 使用趋势
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/licyer/dsh-token-monitor/2f1e265f37b67a75930bffe968ec391b9ce87b83/docs/images/provider-bars.png
+    alt: 供应商消耗统计
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/licyer/dsh-token-monitor/2f1e265f37b67a75930bffe968ec391b9ce87b83/docs/images/heatmap.png
+    alt: 年度消耗热力图
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/licyer/dsh-token-monitor/2f1e265f37b67a75930bffe968ec391b9ce87b83/docs/images/usage-rank.png
+    alt: 使用排行
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/licyer/dsh-token-monitor/2f1e265f37b67a75930bffe968ec391b9ce87b83/docs/images/usage-records.png
+    alt: 请求记录


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `licyer-dsh-token-monitor`
- Submission type: community curation
- Created by `licyer` — https://github.com/licyer
- Original source repository: https://github.com/licyer/dsh-token-monitor
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.