### PR TITLE
catalog: add lilming123-dsh-api (community curation, created by @lilming123)

### DIFF
--- a/catalog/plugins/lilming123-dsh-api.yaml
+++ b/catalog/plugins/lilming123-dsh-api.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: lilming123-dsh-api
+name: dsh-api
+description:
+  en: HTTP control-plane plugin for DeepSeek Harness — exposes dsh internals (language, workspace registry, agent-status/approval events) over /dsh-api on the local loopback socket dsh already listens on.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - dsh
+  - dsh-plugin
+  - sse
+  - control-plane
+source:
+  repository: https://github.com/lilming123/dsh-api
+  repositoryNodeId: R_kgDOT7ORRg
+  subpath: null
+  commit: 30f1e917711e5eb5bb90d4ec61f374c8be7edb8e
+creator:
+  github: lilming123
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:19.793Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lilming123-dsh-api`
- Submission type: community curation
- Created by `lilming123` — https://github.com/lilming123
- Original source repository: https://github.com/lilming123/dsh-api
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.