### PR TITLE
catalog: add lxzy-7-dsh-plugin-guard (community curation, created by @lxzy-7)

### DIFF
--- a/catalog/plugins/lxzy-7-dsh-plugin-guard.yaml
+++ b/catalog/plugins/lxzy-7-dsh-plugin-guard.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: lxzy-7-dsh-plugin-guard
+name: dsh-plugin-guard
+description:
+  en: "A bad plugin install can leave the app unable to boot, and fixing it by hand usually means digging through config files. This plugin automates the whole chain:"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh
+  - cordis
+  - rollback
+  - snapshot
+  - guard
+source:
+  repository: https://github.com/lxzy-7/dsh-plugin-guard
+  repositoryNodeId: R_kgDOT56vtw
+  subpath: null
+  commit: c95036f33a2a10bb4c12d04a7f470747effe6532
+creator:
+  github: lxzy-7
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:13.409Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 36
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `lxzy-7-dsh-plugin-guard`
- Submission type: community curation
- Created by `lxzy-7` — https://github.com/lxzy-7
- Original source repository: https://github.com/lxzy-7/dsh-plugin-guard
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.