### PR TITLE
catalog: add max-null-dsh-ssid-panels (community curation, created by @Max-Null)

### DIFF
--- a/catalog/plugins/max-null-dsh-ssid-panels.yaml
+++ b/catalog/plugins/max-null-dsh-ssid-panels.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: max-null-dsh-ssid-panels
+name: "@max-null/dsh-ssid-panels"
+description:
+  en: "SSiD (思灵) panels for dsh-better-sidebar: memory / guardian state / habit candidates / API balances as sidebar tabs"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: user-interface-dashboards
+tags:
+  - ssid
+  - panels
+  - better
+  - sidebar
+  - memory
+  - guardian
+  - state
+  - habit
+  - candidates
+  - balances
+  - tabs
+  - dsh
+source:
+  repository: https://github.com/Max-Null/seek-soul-in-darkness
+  repositoryNodeId: R_kgDOT5byLA
+  subpath: plugins/dsh-ssid-panels
+  commit: 0fdb24d6bb2f10df4d7e3f00f0dc8e5ed890de9f
+creator:
+  github: Max-Null
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-ssid-panels/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:27.757Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Max-Null/seek-soul-in-darkness/0fdb24d6bb2f10df4d7e3f00f0dc8e5ed890de9f/assets/logo.png
+    alt: SSiD logo — Si 原子，原子核是瞳孔


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `max-null-dsh-ssid-panels`
- Submission type: community curation
- Created by `Max-Null` — https://github.com/Max-Null
- Original source repository: https://github.com/Max-Null/seek-soul-in-darkness
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.