### PR TITLE
catalog: add maxnull-dsh-capture (community curation, created by @maxnull)

### DIFF
--- a/catalog/plugins/maxnull-dsh-capture.yaml
+++ b/catalog/plugins/maxnull-dsh-capture.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: maxnull-dsh-capture
+name: "@max-null/dsh-capture"
+description:
+  en: "SSiD (思灵) quick screenshot capture: tray/hotkey → fullscreen box-select overlay → cropped image into the current conversation composer"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - ssid
+  - quick
+  - screenshot
+  - capture
+  - tray
+  - hotkey
+  - fullscreen
+  - select
+  - overlay
+  - cropped
+  - image
+  - current
+  - conversation
+  - composer
+  - dsh
+source:
+  repository: https://github.com/Max-Null/dsh-capture
+  repositoryNodeId: R_kgDOUA8lJw
+  subpath: null
+  commit: afc803e92cce0242e10735aa07d2efaa9769ad28
+creator:
+  github: maxnull
+package:
+  ecosystem: npm
+  name: "@max-null/dsh-capture"
+  version: 0.2.1
+  integrity: sha512-hPDsRsvDug0dsLsXWqN5UPdlo/vdrPkYi0asYMqMDgktATFCsrHKJMQFtbxXYnbAYZcrncqe6pAXim4ms0SXCg==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:22.560Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `maxnull-dsh-capture`
- Submission type: community curation
- Created by `maxnull` — https://github.com/maxnull
- Original source repository: https://github.com/Max-Null/dsh-capture
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.