### PR TITLE
catalog: add michengai-dsh-codex-suite (community curation, created by @MichengAI)

### DIFF
--- a/catalog/plugins/michengai-dsh-codex-suite.yaml
+++ b/catalog/plugins/michengai-dsh-codex-suite.yaml
@@ -1,0 +1,53 @@
+schemaVersion: 1
+id: michengai-dsh-codex-suite
+name: "@michengai/dsh-codex-suite"
+description:
+  en: "@michengai/dsh-codex-suite is not recommended for new installations. It remains in source form only for compatibility and migration of existing profiles; no new versions are published."
+  evidencePath: packages/dsh-codex-suite/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - michengai
+  - codex
+  - suite
+  - recommended
+  - installations
+  - remains
+  - source
+  - form
+  - only
+  - compatibility
+  - migration
+  - existing
+  - profiles
+  - versions
+  - published
+  - dsh
+source:
+  repository: https://github.com/MichengAI/dsh-codex-ui
+  repositoryNodeId: R_kgDOT4iDRA
+  subpath: packages/dsh-codex-suite
+  commit: 4bfd4656d86a96363036ec1a205c3575bb88eae0
+creator:
+  github: MichengAI
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: packages/dsh-codex-suite/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:31.572Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `michengai-dsh-codex-suite`
- Submission type: community curation
- Created by `MichengAI` — https://github.com/MichengAI
- Original source repository: https://github.com/MichengAI/dsh-codex-ui
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.