### PR TITLE
catalog: add moon16u-dsh-plugin-web-search-tavily (community curation, created by @moon16u)

### DIFF
--- a/catalog/plugins/moon16u-dsh-plugin-web-search-tavily.yaml
+++ b/catalog/plugins/moon16u-dsh-plugin-web-search-tavily.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: moon16u-dsh-plugin-web-search-tavily
+name: "@moon16u/dsh-plugin-web-search-tavily"
+description:
+  en: Tavily-backed search provider for the DeepSeek Harness web capability seam (ctx.web)
+  evidencePath: packages/dsh-plugin-web-search-tavily/README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - tavily
+  - backed
+  - search
+  - provider
+  - capability
+  - seam
+  - dsh
+source:
+  repository: https://github.com/moon16u/dsh-pouch
+  repositoryNodeId: R_kgDOT-10Xw
+  subpath: packages/dsh-plugin-web-search-tavily
+  commit: b32d03cfc0a380af10dfabf6770407980f9f902d
+creator:
+  github: moon16u
+package:
+  ecosystem: npm
+  name: "@moon16u/dsh-plugin-web-search-tavily"
+  version: 0.2.0
+  integrity: sha512-19QVGJ07lNncr6z11fMw3jro7E7hGvWaRcIWzRzEXqKYF71hS8ztElWDtYyrDpNiDazRtEoOQo0G3gBVgmff8g==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-plugin-web-search-tavily/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:34.568Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `moon16u-dsh-plugin-web-search-tavily`
- Submission type: community curation
- Created by `moon16u` — https://github.com/moon16u
- Original source repository: https://github.com/moon16u/dsh-pouch
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.