### PR TITLE
catalog: add mouliangyu-dsh-session-control (community curation, created by @mouliangyu)

### DIFF
--- a/catalog/plugins/mouliangyu-dsh-session-control.yaml
+++ b/catalog/plugins/mouliangyu-dsh-session-control.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: mouliangyu-dsh-session-control
+name: dsh-session-control
+description:
+  en: Global session and workspace management for DeepSeek Harness
+  evidencePath: packages/session-control/README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - global
+  - session
+  - workspace
+  - management
+  - dsh
+source:
+  repository: https://github.com/mouliangyu/dsh-plugins
+  repositoryNodeId: R_kgDOT395xQ
+  subpath: packages/session-control
+  commit: ad19451d8f5ec2286c358197b5fb6e137f0ba064
+creator:
+  github: mouliangyu
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/session-control/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:39.793Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `mouliangyu-dsh-session-control`
- Submission type: community curation
- Created by `mouliangyu` — https://github.com/mouliangyu
- Original source repository: https://github.com/mouliangyu/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.