### PR TITLE
catalog: add neomei-dsh-roundtable (community curation, created by @NeoMei)

### DIFF
--- a/catalog/plugins/neomei-dsh-roundtable.yaml
+++ b/catalog/plugins/neomei-dsh-roundtable.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: neomei-dsh-roundtable
+name: dsh-roundtable
+description:
+  en: Roundtable (圆桌讨论) multi-agent discussion plugin for DeepSeek Harness — host engine, model-facing tool, and web sidebar entry.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - roundtable
+  - multi
+  - agent
+  - discussion
+  - host
+  - engine
+  - model
+  - facing
+  - tool
+  - sidebar
+  - entry
+  - dsh
+source:
+  repository: https://github.com/NeoMei/dsh-roundtable
+  repositoryNodeId: R_kgDOT8Xbqg
+  subpath: null
+  commit: 6c251e61e5acedda329df799013c84e1b8bd1e68
+creator:
+  github: NeoMei
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:22.834Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `neomei-dsh-roundtable`
- Submission type: community curation
- Created by `NeoMei` — https://github.com/NeoMei
- Original source repository: https://github.com/NeoMei/dsh-roundtable
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.