### PR TITLE
catalog: add noirbright-pairing (community curation, created by @NOirBRight)

### DIFF
--- a/catalog/plugins/noirbright-pairing.yaml
+++ b/catalog/plugins/noirbright-pairing.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: noirbright-pairing
+name: "@dsh-mobile/pairing"
+description:
+  en: "DSH Mobile Remote plugin: Host Gateway, Public Endpoint pairing, WebRTC Direct, encrypted Tunnel Fallback"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - mobile
+  - remote
+  - host
+  - gateway
+  - public
+  - endpoint
+  - pairing
+  - webrtc
+  - direct
+  - encrypted
+  - tunnel
+  - fallback
+  - dsh
+source:
+  repository: https://github.com/NOirBRight/dsh-mobile-pairing
+  repositoryNodeId: R_kgDOT_TNiw
+  subpath: null
+  commit: 279ec4ddd133104acaf54eb65558059ed3704a58
+creator:
+  github: NOirBRight
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:41.400Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `noirbright-pairing`
- Submission type: community curation
- Created by `NOirBRight` — https://github.com/NOirBRight
- Original source repository: https://github.com/NOirBRight/dsh-mobile-pairing
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.