### PR TITLE
catalog: add pasumao-dsh-notify (community curation, created by @Pasumao)

### DIFF
--- a/catalog/plugins/pasumao-dsh-notify.yaml
+++ b/catalog/plugins/pasumao-dsh-notify.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: pasumao-dsh-notify
+name: dsh-notify
+description:
+  en: "Native Windows toast + system tray for DeepSeek Harness (dsh): the only dsh plugin with a tray icon. Pops the moment the agent stops running — finished / aborted / error / output limit / waiting for your choice / session closed — body labeled with workspace · session, so you can switch windows during long tasks and gla"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - dsh
+  - dsh-plugin
+  - cordis
+  - notify
+  - notification
+  - toast
+  - windows-toast
+  - tray
+  - system-tray
+  - windows
+  - long-running
+  - agent-monitor
+source:
+  repository: https://github.com/Pasumao/dsh-plugin-notify
+  repositoryNodeId: R_kgDOT4amnw
+  subpath: null
+  commit: f0ee902be68f2b201ba45012844ee8dd9ac84eb8
+creator:
+  github: Pasumao
+package:
+  ecosystem: npm
+  name: dsh-notify
+  version: 0.1.6
+  integrity: sha512-iMAAIvnAO/KNAdk/QHUXOeSfjg6iP6STnOhJ3Eghk5umoFAFd4rclgfSsVEXZrcCISGLGItM9ItZD6DQt+OqnQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:16.663Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Pasumao/dsh-plugin-notify/f0ee902be68f2b201ba45012844ee8dd9ac84eb8/docs/notify-toast.png
+    alt: dsh-notify 实机截图：Windows 原生 Toast 通知


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `pasumao-dsh-notify`
- Submission type: community curation
- Created by `Pasumao` — https://github.com/Pasumao
- Original source repository: https://github.com/Pasumao/dsh-plugin-notify
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.