### PR TITLE
catalog: add plur9-dsh (community curation, created by @plur9)

### DIFF
--- a/catalog/plugins/plur9-dsh.yaml
+++ b/catalog/plugins/plur9-dsh.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: plur9-dsh
+name: "@plur-ai/dsh"
+description:
+  en: PLUR memory for DeepSeek Harness — engrams injected straight into the prompt, no tool call required
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - cordis
+  - agent-memory
+  - llm-memory
+  - persistent-memory
+  - local-first
+  - plur
+source:
+  repository: https://github.com/plur-ai/dsh-plugin
+  repositoryNodeId: R_kgDOT5Na4w
+  subpath: null
+  commit: 2c526f12fdb237ed3c303af96cbe2cdc93533d19
+creator:
+  github: plur9
+package:
+  ecosystem: npm
+  name: "@plur-ai/dsh"
+  version: 0.1.0
+  integrity: sha512-/imp3kMQ3ccPXMsSbEkhc9AStCWZRbk1yxS6zL24KApBuvRWrdfqs0z7T2NQMNDRw9xKTUuBIe5626X6u5DP5Q==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:23.217Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `plur9-dsh`
- Submission type: community curation
- Created by `plur9` — https://github.com/plur9
- Original source repository: https://github.com/plur-ai/dsh-plugin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.