### PR TITLE
catalog: add qingqingpi-dsh-design-qa (community curation, created by @sunxin-ai)

### DIFF
--- a/catalog/plugins/qingqingpi-dsh-design-qa.yaml
+++ b/catalog/plugins/qingqingpi-dsh-design-qa.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: qingqingpi-dsh-design-qa
+name: dsh-design-qa
+description:
+  en: Let text-only models in DeepSeek Harness read images.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh
+  - vision
+  - design-qa
+  - visual-regression
+  - design-review
+  - multimodal
+  - qwen-vl
+  - openai-compatible
+source:
+  repository: https://github.com/sunxin-ai/dsh-design-qa
+  repositoryNodeId: R_kgDOT7UkHQ
+  subpath: null
+  commit: a760f72e965e0a650fc03ba5df3802316f28756a
+creator:
+  github: qingqingpi
+package:
+  ecosystem: npm
+  name: dsh-design-qa
+  version: 0.1.4
+  integrity: sha512-lzOonhZMAIZ+mWgQ1x+9LG9h6PGkAtyOeDfF1kG5DeWjxLcJBh4k3l54tFCTzqKlk3x8BNxJ/TLbJDwdNGRyGw==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:20.315Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 2
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `qingqingpi-dsh-design-qa`
- Submission type: community curation
- Created by `sunxin-ai` — https://github.com/sunxin-ai
- Original source repository: https://github.com/sunxin-ai/dsh-design-qa
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.