### PR TITLE
catalog: add realdanny-dsh-file-drop (community curation, created by @realdanny)

### DIFF
--- a/catalog/plugins/realdanny-dsh-file-drop.yaml
+++ b/catalog/plugins/realdanny-dsh-file-drop.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: realdanny-dsh-file-drop
+name: dsh-file-drop
+description:
+  en: sh dsh plugin --profile web add "link:/Users/fanxiaokang/dsh-file-drop"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - profile
+  - link
+  - users
+  - fanxiaokang
+  - file
+  - drop
+  - dsh
+source:
+  repository: https://github.com/dannyvan/dsh-file-drop
+  repositoryNodeId: R_kgDOT5u3TA
+  subpath: null
+  commit: afa3ce99a6a167fb17ff65a1a4030d887d2869db
+creator:
+  github: realdanny
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:13.373Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 5
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `realdanny-dsh-file-drop`
- Submission type: community curation
- Created by `realdanny` — https://github.com/realdanny
- Original source repository: https://github.com/dannyvan/dsh-file-drop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.