### PR TITLE
catalog: add sakuraaa667-dsh-wallpaper-engine (community curation, created by @sakuraaa667)

### DIFF
--- a/catalog/plugins/sakuraaa667-dsh-wallpaper-engine.yaml
+++ b/catalog/plugins/sakuraaa667-dsh-wallpaper-engine.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1
+id: sakuraaa667-dsh-wallpaper-engine
+name: dsh-wallpaper-engine
+description:
+  en: Use wallpapers downloaded in Wallpaper Engine as the DeepSeek Harness web background. 将 Wallpaper Engine 中已下载的壁纸用作 DeepSeek Harness 的背景。
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - dsh
+  - dsh-plugin
+  - wallpaper-engine
+  - background
+  - theme
+source:
+  repository: https://github.com/sakuraaa667/dsh-wallpaper-engine
+  repositoryNodeId: R_kgDOT59U1A
+  subpath: null
+  commit: fba60078781763d80bb5b84b8f907ef98e3a632b
+creator:
+  github: sakuraaa667
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:13.438Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 7
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/sakuraaa667/dsh-wallpaper-engine/fba60078781763d80bb5b84b8f907ef98e3a632b/assets/screenshot.jpg
+    alt: DeepSeek Harness 壁纸背景效果


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `sakuraaa667-dsh-wallpaper-engine`
- Submission type: community curation
- Created by `sakuraaa667` — https://github.com/sakuraaa667
- Original source repository: https://github.com/sakuraaa667/dsh-wallpaper-engine
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.