### PR TITLE
catalog: add seaof0-dsh-auto-advance (community curation, created by @SeaOf0)

### DIFF
--- a/catalog/plugins/seaof0-dsh-auto-advance.yaml
+++ b/catalog/plugins/seaof0-dsh-auto-advance.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: seaof0-dsh-auto-advance
+name: "@dsh-external/dsh-auto-advance"
+description:
+  en: "Auto-advancer for the eight professional security presets: when a subagent-class executor returns and the intent ledger still has open directions, a followup nudge is injected carrying the ledger state — close the intent (done with output pointer / blocked with reason), then anchor-dispatch the next step or finish quie"
+  evidencePath: plugins/dsh-auto-advance/README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - dsh-bundle
+  - auto-advance
+  - intent-ledger
+  - dsh
+source:
+  repository: https://github.com/SeaOf0/dsh-redteam-model
+  repositoryNodeId: R_kgDOT67RoQ
+  subpath: plugins/dsh-auto-advance
+  commit: fdae3e964c6cdb7760970488c2841488a9ffcba8
+creator:
+  github: SeaOf0
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - default
+  evidencePath: plugins/dsh-auto-advance/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:41.889Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `seaof0-dsh-auto-advance`
- Submission type: community curation
- Created by `SeaOf0` — https://github.com/SeaOf0
- Original source repository: https://github.com/SeaOf0/dsh-redteam-model
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.