### PR TITLE
catalog: add shaoshi20-malicious-manifest-obfuscation (community curation, created by @shaoshi20)

### DIFF
--- a/catalog/plugins/shaoshi20-malicious-manifest-obfuscation.yaml
+++ b/catalog/plugins/shaoshi20-malicious-manifest-obfuscation.yaml
@@ -1,0 +1,57 @@
+schemaVersion: 1
+id: shaoshi20-malicious-manifest-obfuscation
+name: malicious-manifest-obfuscation
+description:
+  en: "Security scanner for DSH plugins: static and semantic passes over plugin source, DSH-specific attack-surface rules, npm audit, batch scanning, and an HTML report with per-finding severity and evidence."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - security
+  - scanner
+  - static
+  - semantic
+  - passes
+  - over
+  - source
+  - specific
+  - attack
+  - surface
+  - rules
+  - audit
+  - batch
+  - scanning
+  - html
+  - report
+source:
+  repository: https://github.com/shaoshi20/dshscan
+  repositoryNodeId: R_kgDOT8KcWw
+  subpath: benchmark/cases/malicious-manifest-obfuscation
+  commit: 0633b01b2cdfa778b308b273580d4dffee28f661
+creator:
+  github: shaoshi20
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: benchmark/cases/malicious-manifest-obfuscation/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:43.009Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/shaoshi20/dshscan/0633b01b2cdfa778b308b273580d4dffee28f661/docs/demo-report.png
+    alt: DShScan Demo Report


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `shaoshi20-malicious-manifest-obfuscation`
- Submission type: community curation
- Created by `shaoshi20` — https://github.com/shaoshi20
- Original source repository: https://github.com/shaoshi20/dshscan
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.