### PR TITLE
catalog: add tttnny-dsh-a6api (community curation, created by @tttnny)

### DIFF
--- a/catalog/plugins/tttnny-dsh-a6api.yaml
+++ b/catalog/plugins/tttnny-dsh-a6api.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: tttnny-dsh-a6api
+name: "@lynn123411/dsh-a6api"
+description:
+  en: bash dsh plugin --profile web add @lynn123411/dsh-a6api
+  evidencePath: plugins/dsh-a6api/README.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - a6api
+  - llm-provider
+  - marketplace
+  - web-ui
+source:
+  repository: https://github.com/tttnny/my-dsh
+  repositoryNodeId: R_kgDOT91T7A
+  subpath: plugins/dsh-a6api
+  commit: d1ffda68c1016facc7d5b393f90eae1ec57b3cf3
+creator:
+  github: tttnny
+package:
+  ecosystem: npm
+  name: "@lynn123411/dsh-a6api"
+  version: 1.0.1
+  integrity: sha512-uafWfLLXoJ4AcXBDyzPYoE8B0ZH8Du8SrFRUxusnOv0L/pNJh8liCVSjrOOlc0M+WKmwJforvj1IIqVcI6P5NQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-a6api/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:12:07.958Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tttnny-dsh-a6api`
- Submission type: community curation
- Created by `tttnny` — https://github.com/tttnny
- Original source repository: https://github.com/tttnny/my-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.