### PR TITLE
catalog: add tuogusa-dsh-session-nav (community curation, created by @tuogusa)

### DIFF
--- a/catalog/plugins/tuogusa-dsh-session-nav.yaml
+++ b/catalog/plugins/tuogusa-dsh-session-nav.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1
+id: tuogusa-dsh-session-nav
+name: dsh-session-nav
+description:
+  en: bash dsh plugin --profile web add github:tuogusa/dsh-session-nav
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - bash
+  - profile
+  - tuogusa
+  - session
+  - dsh
+source:
+  repository: https://github.com/tuogusa/dsh-session-nav
+  repositoryNodeId: R_kgDOT5Bt-A
+  subpath: null
+  commit: 53ba777ca94a3dc03d4aec939f37acba62e0c445
+creator:
+  github: tuogusa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:23.273Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `tuogusa-dsh-session-nav`
- Submission type: community curation
- Created by `tuogusa` — https://github.com/tuogusa
- Original source repository: https://github.com/tuogusa/dsh-session-nav
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.