### PR TITLE
catalog: add vast-unhurried-dsh-softui-skin (community curation, created by @Vast-Unhurried)

### DIFF
--- a/catalog/plugins/vast-unhurried-dsh-softui-skin.yaml
+++ b/catalog/plugins/vast-unhurried-dsh-softui-skin.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: vast-unhurried-dsh-softui-skin
+name: dsh-softui-skin
+description:
+  en: "A collection of purely incremental native plugins for DeepSeek Harness: sticky notes , API balance & per-turn cost , reasoning levels , session deletion , conversation node navigation , and a soft-UI skin ."
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: entertainment-customization
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - theme
+  - skin
+  - neumorphism
+  - soft-ui
+  - web-ui
+source:
+  repository: https://github.com/Vast-Unhurried/dsh-toolkit
+  repositoryNodeId: R_kgDOT5-XIg
+  subpath: packages/dsh-softui-skin
+  commit: f86506fa5d1199cb21d3e49b6a1a850a6f1c9b11
+creator:
+  github: Vast-Unhurried
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-softui-skin/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:20.618Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Vast-Unhurried/dsh-toolkit/f86506fa5d1199cb21d3e49b6a1a850a6f1c9b11/packages/dsh-softui-skin/preview.jpg
+    alt: dsh-softui-skin 预览


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vast-unhurried-dsh-softui-skin`
- Submission type: community curation
- Created by `Vast-Unhurried` — https://github.com/Vast-Unhurried
- Original source repository: https://github.com/Vast-Unhurried/dsh-toolkit
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.