### PR TITLE
catalog: add vncntvx-dsh-zotero (community curation, created by @Vncntvx)

### DIFF
--- a/catalog/plugins/vncntvx-dsh-zotero.yaml
+++ b/catalog/plugins/vncntvx-dsh-zotero.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: vncntvx-dsh-zotero
+name: dsh-zotero
+description:
+  en: "Let agents search, read, and cite your local Zotero library: find papers, browse notes and annotations, pull evidence by question, open the source document, generate citations."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - zotero
+  - dsh
+  - deepseek-harness
+  - research
+  - literature
+source:
+  repository: https://github.com/Vncntvx/dsh-zotero
+  repositoryNodeId: R_kgDOT46EBA
+  subpath: null
+  commit: ae33e5b5332620a8307a789d75224c34577a0782
+creator:
+  github: Vncntvx
+package:
+  ecosystem: npm
+  name: dsh-zotero
+  version: 0.5.2
+  integrity: sha512-7HScAfmfkYYuI3ShB+hPev6fXaGVrGqgQ5d1UrmGHBttLcvsu0p7l+07k21Cv2txrfPfCzSFoKCbN1bIm1a/pA==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:13.528Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 10
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/Vncntvx/dsh-zotero/ae33e5b5332620a8307a789d75224c34577a0782/docs/images/header-collage.png
+    alt: dsh-zotero 界面：来源面板、证据提取、导出视图


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `vncntvx-dsh-zotero`
- Submission type: community curation
- Created by `Vncntvx` — https://github.com/Vncntvx
- Original source repository: https://github.com/Vncntvx/dsh-zotero
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.