### PR TITLE
catalog: add wbaifan-dsh-auto-archive (community curation, created by @wbaifan)

### DIFF
--- a/catalog/plugins/wbaifan-dsh-auto-archive.yaml
+++ b/catalog/plugins/wbaifan-dsh-auto-archive.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: wbaifan-dsh-auto-archive
+name: dsh-auto-archive
+description:
+  en: bash tail -f /tmp/dsh-web.log grep dsh-auto-archive
+  evidencePath: packages/dsh-auto-archive/README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - dsh
+  - deepseek-harness
+  - auto-archive
+  - session
+  - archive
+source:
+  repository: https://github.com/TZHR-invest/dsh-plugins
+  repositoryNodeId: R_kgDOT3_JbQ
+  subpath: packages/dsh-auto-archive
+  commit: 6654ad5a12d09b533ec49711616ac22a87324363
+creator:
+  github: wbaifan
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: packages/dsh-auto-archive/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:12:07.841Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wbaifan-dsh-auto-archive`
- Submission type: community curation
- Created by `wbaifan` — https://github.com/wbaifan
- Original source repository: https://github.com/TZHR-invest/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.