### PR TITLE
catalog: add wbaifan-dsh-vision-tool (community curation, created by @wbaifan)

### DIFF
--- a/catalog/plugins/wbaifan-dsh-vision-tool.yaml
+++ b/catalog/plugins/wbaifan-dsh-vision-tool.yaml
@@ -1,0 +1,56 @@
+schemaVersion: 1
+id: wbaifan-dsh-vision-tool
+name: dsh-vision-tool
+description:
+  en: "vision tool for DeepSeek Harness agents: describe local images via any OpenAI-compatible vision endpoint you configure (no built-in keys, optional multi-model cross-check)"
+  evidencePath: packages/dsh-vision/README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - vision
+  - tool
+  - agents
+  - describe
+  - local
+  - images
+  - openai
+  - compatible
+  - endpoint
+  - configure
+  - built
+  - keys
+  - optional
+  - multi
+  - model
+  - cross
+source:
+  repository: https://github.com/TZHR-invest/dsh-plugins
+  repositoryNodeId: R_kgDOT3_JbQ
+  subpath: packages/dsh-vision
+  commit: 6654ad5a12d09b533ec49711616ac22a87324363
+creator:
+  github: wbaifan
+package:
+  ecosystem: npm
+  name: dsh-vision-tool
+  version: 0.1.1
+  integrity: sha512-Yh5cNZDx+gcjboc8StC4tPLO8/laBWcYDkhSFY25UZhYjfzj/O9bzd/HykAIJ+2KpnUgdQx+tkPwjFZjLRr8wA==
+dsh:
+  profiles:
+    - web
+  evidencePath: packages/dsh-vision/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:12:07.841Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `wbaifan-dsh-vision-tool`
- Submission type: community curation
- Created by `wbaifan` — https://github.com/wbaifan
- Original source repository: https://github.com/TZHR-invest/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.