### PR TITLE
catalog: add weijiafu14-dsh-work-x (community curation, created by @weijiafu14)

### DIFF
--- a/catalog/plugins/weijiafu14-dsh-work-x.yaml
+++ b/catalog/plugins/weijiafu14-dsh-work-x.yaml
@@ -1,0 +1,47 @@
+schemaVersion: 1
+id: weijiafu14-dsh-work-x
+name: dsh-work-x
+description:
+  en: "Batteries-included capability suite for DeepSeek Harness: MCP manager with lazy proxy + OAuth, parallel steerable subagents, side conversations, image generation — one install, every piece verified end to end."
+  evidencePath: dsh-x/README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - mcp
+  - subagents
+  - pi2dsh
+source:
+  repository: https://github.com/weijiafu14/pi2dsh
+  repositoryNodeId: R_kgDOT3reRg
+  subpath: dsh-x
+  commit: f200553784f3e594acefcd8a653161b70f20cc70
+creator:
+  github: weijiafu14
+package:
+  ecosystem: npm
+  name: dsh-work-x
+  version: 0.3.0
+  integrity: sha512-fAPH3NVPk5sfJpcg0YaTi1RxlDJXXBZbewJ911B1dqbxgwoKXl3zSxpRqVt0LBtC9RkDWEo95iTkWil6mFsyMQ==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: dsh-x/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:12:15.461Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `weijiafu14-dsh-work-x`
- Submission type: community curation
- Created by `weijiafu14` — https://github.com/weijiafu14
- Original source repository: https://github.com/weijiafu14/pi2dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.