### PR TITLE
catalog: add whiteicey-dsh-tool-calculator (community curation, created by @whiteicey)

### DIFF
--- a/catalog/plugins/whiteicey-dsh-tool-calculator.yaml
+++ b/catalog/plugins/whiteicey-dsh-tool-calculator.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: whiteicey-dsh-tool-calculator
+name: "@deepseek-ai/dsh-tool-calculator"
+description:
+  en: DSH Calculator tool plugin — a safe mathematical expression evaluator. Zero dependencies, zero processes, pure functions.
+  evidencePath: README.en.md
+unofficial: true
+kind: plugin
+primaryCategory: coding-developer-tools
+tags:
+  - calculator
+  - tool
+  - safe
+  - mathematical
+  - expression
+  - evaluator
+  - zero
+  - dependencies
+  - processes
+  - pure
+  - functions
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-tool-calculator
+  repositoryNodeId: R_kgDOTuNoQQ
+  subpath: null
+  commit: 9168c73ed58f79aa59e9a8921cff66ece3988e88
+creator:
+  github: whiteicey
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:13.362Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 8
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteicey-dsh-tool-calculator`
- Submission type: community curation
- Created by `whiteicey` — https://github.com/whiteicey
- Original source repository: https://github.com/omdsh-dev/dsh-tool-calculator
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.