### PR TITLE
catalog: add whiteicey-dsh-tool-csv (community curation, created by @whiteicey)

### DIFF
--- a/catalog/plugins/whiteicey-dsh-tool-csv.yaml
+++ b/catalog/plugins/whiteicey-dsh-tool-csv.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 1
+id: whiteicey-dsh-tool-csv
+name: "@deepseek-ai/dsh-tool-csv"
+description:
+  en: "DSH CSV data tool: parse/query/stats over RFC 4180 CSV text, zero-dependency state-machine parser"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: search-research
+tags:
+  - data
+  - tool
+  - parse
+  - query
+  - stats
+  - over
+  - "4180"
+  - text
+  - zero
+  - dependency
+  - state
+  - machine
+  - parser
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-tool-csv
+  repositoryNodeId: R_kgDOTxXM_w
+  subpath: null
+  commit: a882f555b2f81a2129f8c051d99be8f15008c6b0
+creator:
+  github: whiteicey
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:15.261Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteicey-dsh-tool-csv`
- Submission type: community curation
- Created by `whiteicey` — https://github.com/whiteicey
- Original source repository: https://github.com/omdsh-dev/dsh-tool-csv
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.