### PR TITLE
catalog: add whiteicey-dsh-tool-diff (community curation, created by @whiteicey)

### DIFF
--- a/catalog/plugins/whiteicey-dsh-tool-diff.yaml
+++ b/catalog/plugins/whiteicey-dsh-tool-diff.yaml
@@ -1,0 +1,54 @@
+schemaVersion: 1
+id: whiteicey-dsh-tool-diff
+name: "@deepseek-ai/dsh-tool-diff"
+description:
+  en: "DSH diff tool: structured comparison of text/JSON/CSV/Markdown plus unified diff generation and in-memory patch validation. Zero-dependency, read-only."
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - diff
+  - tool
+  - structured
+  - comparison
+  - text
+  - json
+  - markdown
+  - plus
+  - unified
+  - generation
+  - memory
+  - patch
+  - validation
+  - zero
+  - dependency
+  - read
+source:
+  repository: https://github.com/omdsh-dev/dsh-tool-diff
+  repositoryNodeId: R_kgDOTy7pLQ
+  subpath: null
+  commit: 596c6f2bcbbfeab9eadacacc2a80a09d1f5d897d
+creator:
+  github: whiteicey
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:15.318Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteicey-dsh-tool-diff`
- Submission type: community curation
- Created by `whiteicey` — https://github.com/whiteicey
- Original source repository: https://github.com/omdsh-dev/dsh-tool-diff
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.