### PR TITLE
catalog: add whiteicey-dsh-tool-time (community curation, created by @whiteicey)

### DIFF
--- a/catalog/plugins/whiteicey-dsh-tool-time.yaml
+++ b/catalog/plugins/whiteicey-dsh-tool-time.yaml
@@ -1,0 +1,41 @@
+schemaVersion: 1
+id: whiteicey-dsh-tool-time
+name: "@deepseek-ai/dsh-tool-time"
+description:
+  en: DSH time tool plugin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: diagnostics-observability
+tags:
+  - time
+  - tool
+  - dsh
+source:
+  repository: https://github.com/omdsh-dev/dsh-tool-time
+  repositoryNodeId: R_kgDOTvRiZQ
+  subpath: null
+  commit: 1c6b8b2602294082b14a3c4a932f1686169f423c
+creator:
+  github: whiteicey
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - headless
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:16.443Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `whiteicey-dsh-tool-time`
- Submission type: community curation
- Created by `whiteicey` — https://github.com/whiteicey
- Original source repository: https://github.com/omdsh-dev/dsh-tool-time
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.