### PR TITLE
catalog: add woshishadowhunter-dsh-seed-society (community curation, created by @woshishadowhunter)

### DIFF
--- a/catalog/plugins/woshishadowhunter-dsh-seed-society.yaml
+++ b/catalog/plugins/woshishadowhunter-dsh-seed-society.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: woshishadowhunter-dsh-seed-society
+name: dsh-seed-society
+description:
+  en: "Yogacara eight-consciousness agent society for DeepSeek Harness: auditable double-loop runtime bridge, mneme memory consolidation tuning, MCP society tools, and six seed skills"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - dsh-plugin
+  - memory
+  - agents
+  - yogacara
+  - mneme
+  - dsh
+source:
+  repository: https://github.com/woshishadowhunter/dsh-seed-society
+  repositoryNodeId: R_kgDOUDcH4w
+  subpath: null
+  commit: ed95419f71e7fcd723e510d319cf1f3b0f348f91
+creator:
+  github: woshishadowhunter
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:12:15.034Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 0
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `woshishadowhunter-dsh-seed-society`
- Submission type: community curation
- Created by `woshishadowhunter` — https://github.com/woshishadowhunter
- Original source repository: https://github.com/woshishadowhunter/dsh-seed-society
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.