### PR TITLE
catalog: add xiaoshihou514-dsh-weixin (community curation, created by @xiaoshihou514)

### DIFF
--- a/catalog/plugins/xiaoshihou514-dsh-weixin.yaml
+++ b/catalog/plugins/xiaoshihou514-dsh-weixin.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: xiaoshihou514-dsh-weixin
+name: dsh-weixin
+description:
+  en: Control DeepSeek Harness remotely through Weixin
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - deepseek-harness
+  - weixin
+  - wechat
+  - dsh
+source:
+  repository: https://github.com/xiaoshihou514/dsh-weixin
+  repositoryNodeId: R_kgDOT3e1uQ
+  subpath: null
+  commit: a83ecd355e751219c177f5e0e105075fd8680ac6
+creator:
+  github: xiaoshihou514
+package:
+  ecosystem: npm
+  name: dsh-weixin
+  version: 0.1.0
+  integrity: sha512-VY8zxXAIssGgXq61pWp6SSIkkiFv+g1eNnRcLNmAhRcZYDQT7bPHtEuwVFNJyajaMh9lxNqKNjTuFMqFdXpJPQ==
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:16.444Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 4
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xiaoshihou514-dsh-weixin`
- Submission type: community curation
- Created by `xiaoshihou514` — https://github.com/xiaoshihou514
- Original source repository: https://github.com/xiaoshihou514/dsh-weixin
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.