### PR TITLE
catalog: add xing666173-dsh-bridge-preview (community curation, created by @xing666173)

### DIFF
--- a/catalog/plugins/xing666173-dsh-bridge-preview.yaml
+++ b/catalog/plugins/xing666173-dsh-bridge-preview.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1
+id: xing666173-dsh-bridge-preview
+name: dsh-bridge-preview
+description:
+  en: "[User sent an image (image.png), exported to: C:\\...\\dsh-vision-bridge\\image sha256:xxx.png. Inspect it with the inspect image tool to see its content.]"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: vision-audio-multimodal
+tags:
+  - dsh
+  - deepseek-harness
+  - dsh-plugin
+  - client-plugin
+  - ui
+  - vision
+  - image-preview
+  - tool-vision
+source:
+  repository: https://github.com/xing666173/dsh-bridge-preview
+  repositoryNodeId: R_kgDOT8Xqxw
+  subpath: null
+  commit: 94e7516906895de30652aea62fa4930cbdc53ae0
+creator:
+  github: xing666173
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:23.479Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/xing666173/dsh-bridge-preview/94e7516906895de30652aea62fa4930cbdc53ae0/assets/screenshots/screenshot-conversation.png
+    alt: 对话内联预览


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `xing666173-dsh-bridge-preview`
- Submission type: community curation
- Created by `xing666173` — https://github.com/xing666173
- Original source repository: https://github.com/xing666173/dsh-bridge-preview
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.