### PR TITLE
catalog: add yifanxuaaa-dsh-sidechat (community curation, created by @yifanxuaaa)

### DIFF
--- a/catalog/plugins/yifanxuaaa-dsh-sidechat.yaml
+++ b/catalog/plugins/yifanxuaaa-dsh-sidechat.yaml
@@ -1,0 +1,43 @@
+schemaVersion: 1
+id: yifanxuaaa-dsh-sidechat
+name: dsh-sidechat
+description:
+  en: Memory-only read-only side chats for DeepSeek Harness
+  evidencePath: sidechat/README.md
+unofficial: true
+kind: plugin
+primaryCategory: memory-rag
+tags:
+  - memory
+  - only
+  - read
+  - side
+  - chats
+  - dsh
+source:
+  repository: https://github.com/Ephemeral-AI-Lab/dsh-plugins
+  repositoryNodeId: R_kgDOT5uUvw
+  subpath: sidechat
+  commit: 05c50f3a54fff7bed7ee6325dc322a9b5ea20460
+creator:
+  github: yifanxuaaa
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: sidechat/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:24.314Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `yifanxuaaa-dsh-sidechat`
- Submission type: community curation
- Created by `yifanxuaaa` — https://github.com/yifanxuaaa
- Original source repository: https://github.com/Ephemeral-AI-Lab/dsh-plugins
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.