### PR TITLE
catalog: add ythfmc250415-byte-ai-company-framework (community curation, created by @yyyy231209)

### DIFF
--- a/catalog/plugins/ythfmc250415-byte-ai-company-framework.yaml
+++ b/catalog/plugins/ythfmc250415-byte-ai-company-framework.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: ythfmc250415-byte-ai-company-framework
+name: ai-company-framework
+description:
+  en: "Single-download DeepSeek Harness bundle: multi-agent company Skills, workflow templates, AgentTeams runtime, employee sidebar and Feishu bot bridge. v0.3.10: explicit memory-mode field (three-layer / single) in role skeletons. v0.3.9: full feishu scopes + extraScopes. v0.3.8: cross-group merge. v0.3.7: generic customer"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: data-external-services
+tags:
+  - deepseek-harness
+  - dsh
+  - dsh-plugin
+  - multi-agent
+  - workflow
+  - skills
+  - agent-teams
+  - feishu
+source:
+  repository: https://github.com/yyyy231209/ai-company-framework
+  repositoryNodeId: R_kgDOT8YlFA
+  subpath: null
+  commit: 465d08361dfcb03cf5958c648c4d3551189803e0
+creator:
+  github: ythfmc250415-byte
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:15.012Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 6
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yyyy231209/ai-company-framework/465d08361dfcb03cf5958c648c4d3551189803e0/assets/screenshots/agentteams-activity.png
+    alt: AgentTeams
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yyyy231209/ai-company-framework/465d08361dfcb03cf5958c648c4d3551189803e0/assets/screenshots/employee-sidebar.png
+    alt: Sidebar
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/yyyy231209/ai-company-framework/465d08361dfcb03cf5958c648c4d3551189803e0/assets/screenshots/company-created.png
+    alt: Company


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `ythfmc250415-byte-ai-company-framework`
- Submission type: community curation
- Created by `yyyy231209` — https://github.com/yyyy231209
- Original source repository: https://github.com/yyyy231209/ai-company-framework
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.