### PR TITLE
catalog: add zevorn-web (community curation, created by @zevorn)

### DIFF
--- a/catalog/plugins/zevorn-web.yaml
+++ b/catalog/plugins/zevorn-web.yaml
@@ -1,0 +1,55 @@
+schemaVersion: 1
+id: zevorn-web
+name: "@oh-dsh/web"
+description:
+  en: "Oh-DSH Web: a packaged DeepSeek Harness browser runtime with Oh-DSH plugin capabilities"
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: browser-automation
+tags:
+  - packaged
+  - browser
+  - runtime
+  - capabilities
+  - dsh
+source:
+  repository: https://github.com/hust-open-atom-club/oh-dsh
+  repositoryNodeId: R_kgDOT05OeQ
+  subpath: web
+  commit: d19353a3ecb4faabaf63bedd27a2dd0e6abd3b80
+creator:
+  github: zevorn
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: web/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:11:25.356Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/hust-open-atom-club/oh-dsh/d19353a3ecb4faabaf63bedd27a2dd0e6abd3b80/assets/oh-dsh-plugin-marketplace.png
+    alt: Oh-DSH 插件市场
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/hust-open-atom-club/oh-dsh/d19353a3ecb4faabaf63bedd27a2dd0e6abd3b80/assets/oh-dsh-desktop-skins.png
+    alt: Oh-DSH 跨界面皮肤
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/hust-open-atom-club/oh-dsh/d19353a3ecb4faabaf63bedd27a2dd0e6abd3b80/assets/dsh-whale.png
+    alt: Oh-DSH whale
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/hust-open-atom-club/oh-dsh/d19353a3ecb4faabaf63bedd27a2dd0e6abd3b80/assets/oh-dsh-desktop-readme.png
+    alt: Oh-DSH Desktop 界面展示


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zevorn-web`
- Submission type: community curation
- Created by `zevorn` — https://github.com/zevorn
- Original source repository: https://github.com/hust-open-atom-club/oh-dsh
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.