### PR TITLE
catalog: add zsyu9779-dsh-subagent-max (community curation, created by @zsyu9779)

### DIFF
--- a/catalog/plugins/zsyu9779-dsh-subagent-max.yaml
+++ b/catalog/plugins/zsyu9779-dsh-subagent-max.yaml
@@ -1,0 +1,58 @@
+schemaVersion: 1
+id: zsyu9779-dsh-subagent-max
+name: "@aaravarr/dsh-subagent-max"
+description:
+  en: Subagent delegation with per-call model/provider override (host) + a live Subagents tab (client) — self-developed for dsh-desktop
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: models-providers-routing
+tags:
+  - subagent
+  - delegation
+  - call
+  - model
+  - provider
+  - override
+  - host
+  - live
+  - subagents
+  - client
+  - self
+  - developed
+  - desktop
+  - dsh
+source:
+  repository: https://github.com/zsyu9779/dsh-desktop
+  repositoryNodeId: R_kgDOT3kQCg
+  subpath: plugins/dsh-subagent-max
+  commit: f27fbd5ebdd8321754c02302e714e779016de75f
+creator:
+  github: zsyu9779
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: plugins/dsh-subagent-max/cordis.patch.yml
+repositoryScope: monorepo
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-01T03:12:17.372Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null
+media:
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zsyu9779/dsh-desktop/f27fbd5ebdd8321754c02302e714e779016de75f/assets/hero.jpg
+    alt: DeepSeek Harness Desktop：官网视觉背景上的原生应用窗口
+  - kind: screenshot
+    url: https://raw.githubusercontent.com/zsyu9779/dsh-desktop/f27fbd5ebdd8321754c02302e714e779016de75f/assets/remote-control.png
+    alt: DeepSeek Harness Desktop 局域网手机扫码远程控制


### PR DESCRIPTION
<!-- catalog-policy:one-plugin-per-branch-and-pr -->
<!-- creator-first:direct-pr-supersedes-curation-and-automation -->

## Plugin scope and source

- Plugin ID: `zsyu9779-dsh-subagent-max`
- Submission type: community curation
- Created by `zsyu9779` — https://github.com/zsyu9779
- Original source repository: https://github.com/zsyu9779/dsh-desktop
- The pinned commit, subpath, license, DSH integration evidence and install descriptor are all
  recorded in the entry file itself, rendered from the pinned clone by the canonical renderer.

## Checklist

- [x] One dedicated branch, exactly one plugin entry changed.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] Creator handle, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] No plugin or package lifecycle code was executed to prepare this contribution.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] A direct creator PR supersedes this curated one.
- [x] The entry is explicitly unofficial.