### PR TITLE
chore(ci): publish without the npm-release environment (plano B for trusted publishing)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -29,7 +29,6 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: npm-release
     defaults:
       run:
         working-directory: cli


### PR DESCRIPTION
Removes the \`environment: npm-release\` line from the \`publish\` job in \`.github/workflows/release-npm.yml\`.

Context: the npm trusted publisher for this repository will be configured with the **environment field left empty**, so the workflow must not claim a GitHub environment — otherwise the OIDC claim carries an environment the trusted publisher does not expect and the token exchange fails. Nothing else changes: the tag contract, main-ancestry guard, artifact-manifest verification, tarball smoke and the OIDC/token dual path are untouched.