### PR TITLE
fix(cli): refuse a manifest that cannot name the published version

### DIFF
--- a/cli/src/app.ts
+++ b/cli/src/app.ts
@@ -85,11 +85,23 @@ function addMutationOptions(command: Command): Command {
 // such a release can never be corrected, only superseded. Both the bundled entrypoint
 // (dist/bin.js) and this module sit exactly one directory below the package root, so the same
 // relative path resolves in the published artifact and under the test runner.
+// Exported to be tested in process: the failure modes below otherwise need a relocated bundle in
+// a subprocess, and those spawns are pure load on an already timing-sensitive suite.
+export function parseManifestVersion(raw: string): string {
+  const manifest = JSON.parse(raw) as { version?: unknown };
+  // The read can succeed against the wrong file: a relocated bundle resolves `../package.json`
+  // onto whatever package root sits above it. Announcing that file's version — or `undefined`,
+  // which crashes commander several calls later — is worse than refusing, so require the exact
+  // semver a published release always carries.
+  const version = manifest.version;
+  if (typeof version !== "string" || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u.test(version)) {
+    throw new Error("the package manifest does not declare an exact version");
+  }
+  return version;
+}
+
 function publishedVersion(): string {
-  const manifest = JSON.parse(
-    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-  ) as { version: string };
-  return manifest.version;
+  return parseManifestVersion(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 }
 
 export async function runCli(
@@ -97,9 +109,20 @@ export async function runCli(
   dependencies: CliDependencies = defaultDependencies,
 ): Promise<number> {
   let result = 0;
+  // Reading the manifest is file I/O where a string literal used to be, and it runs while the
+  // command tree is built — outside the parse try/catch below. Guard it here so an unreadable
+  // manifest still honours the sanitized failure contract instead of printing a V8 stack.
+  let version: string;
+  try {
+    version = publishedVersion();
+  } catch (error) {
+    dependencies.stderr(`${sanitizedErrorMessage(error)}\n`);
+    dependencies.stderr("Command failed safely; no changes were made.\n");
+    return 1;
+  }
   const program = new Command()
     .name("dsh-plugins")
-    .version(publishedVersion())
+    .version(version)
     .description("Unofficial catalog and safe installer for DeepSeek Harness plugins.")
     .addHelpText(
       "after",

--- a/cli/tests/package-contents.test.ts
+++ b/cli/tests/package-contents.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -40,7 +40,14 @@ function npmPack(args: readonly string[]): PackResult {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
-  return (JSON.parse(raw) as PackResult[])[0] as PackResult;
+  // npm 11 emits an array of reports; npm 12 keys the same reports by package name. Accept both,
+  // or every contributor whose npm is one major ahead of CI's starts from a red baseline.
+  const parsed = JSON.parse(raw) as PackResult[] | Record<string, PackResult>;
+  const report = Array.isArray(parsed) ? parsed[0] : Object.values(parsed)[0];
+  if (report === undefined) {
+    throw new Error(`npm pack --json returned no report: ${raw.slice(0, 200)}`);
+  }
+  return report;
 }
 
 // The build + double npm pack competes with the rest of the suite for CPU;
@@ -132,4 +139,47 @@ describe("packed public CLI", () => {
     }
     expect(help).toContain("Unofficial community project");
   });
+
+  // Reading the version from the manifest replaced a string literal, which could not fail, with
+  // file I/O, which can — and it runs while the command tree is built, outside the parse
+  // try/catch. Lives here rather than beside the other version assertions because it needs
+  // dist/bin.js, and this file already owns the single build. One spawn, not one per failure
+  // mode: the content cases (missing/invalid version) are covered in process against
+  // parseManifestVersion in reported-version.test.ts, and extra subprocesses are pure concurrent
+  // load on an already timing-sensitive suite.
+  it("fails sanitized, not with a raw stack, when the manifest cannot be read", () => {
+    // The bundle goes one level below a temp root we own, mirroring its real dist/ position, so
+    // the parent it resolves is ours and never a real package root above the OS temp dir.
+    const orphan = mkdtempSync(join(tmpdir(), "dsh-plugins-orphan-"));
+    const nested = join(orphan, "dist");
+    mkdirSync(nested);
+    const bin = join(nested, "bin.js");
+    copyFileSync(join(cliRoot, "dist/bin.js"), bin);
+
+    // stderr and status keep their initial values when the command does not throw; stdout is
+    // overwritten by the first statement either way, so it starts undeclared.
+    let stdout: string;
+    let stderr = "";
+    let status: number | null = 0;
+    try {
+      stdout = execFileSync(process.execPath, [bin, "--help"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 30_000,
+      });
+    } catch (error) {
+      const failure = error as { stderr?: string; stdout?: string; status?: number };
+      stderr = failure.stderr ?? "";
+      stdout = failure.stdout ?? "";
+      status = failure.status ?? null;
+    }
+    rmSync(orphan, { recursive: true, force: true });
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("Command failed safely; no changes were made.");
+    // Stack-frame marker: a leaked V8 stack always renders " at /abs/path".
+    expect(stderr).not.toContain(" at /");
+    expect(stdout).not.toContain(" at /");
+    expect(stderr).not.toContain("ENOENT");
+  }, 60_000);
 });

--- a/cli/tests/reported-version.test.ts
+++ b/cli/tests/reported-version.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
-import { runCli, type CliDependencies } from "../src/app.js";
+import { parseManifestVersion, runCli, type CliDependencies } from "../src/app.js";
 import { loadDefaultCatalog } from "../src/catalogSource.js";
 
 const manifestVersion = (
@@ -48,4 +48,27 @@ describe("the version the CLI reports", () => {
 
     expect(output().stdout).not.toMatch(/v?\d+\.\d+\.\d+/u);
   });
+
+  // A relocated bundle resolves `../package.json` onto whatever package root sits above it, so the
+  // read can succeed against the wrong file — while developing this suite it hit /tmp/package.json.
+  // Announcing that file's version, or `undefined` (which crashed commander several calls later,
+  // far from the cause), is worse than refusing.
+  it.each([
+    { label: "no version field", raw: '{"name":"unrelated"}' },
+    { label: "a range instead of an exact version", raw: '{"version":"^1.2.3"}' },
+    { label: "a non-string version", raw: '{"version":100}' },
+    { label: "a truncated version", raw: '{"version":"1.2"}' },
+  ])("refuses a manifest with $label", ({ raw }) => {
+    expect(() => parseManifestVersion(raw)).toThrow(/exact version/u);
+  });
+
+  it("accepts the exact and prerelease forms a release can carry", () => {
+    expect(parseManifestVersion('{"version":"1.0.2"}')).toBe("1.0.2");
+    expect(parseManifestVersion('{"version":"1.1.0-rc.1"}')).toBe("1.1.0-rc.1");
+  });
+
+  // The end-to-end contract — an unreadable manifest still failing sanitized rather than printing
+  // a V8 stack — needs the real bundle, so it lives in package-contents.test.ts, which already
+  // owns dist/. Rebuilding it from here races that suite's `npm pack` (`build` starts with
+  // `rm -rf dist`) and drops dist/bin.js from the packed set mid-run.
 });


### PR DESCRIPTION
## Why

When the CLI moved into this repository, it was carried over from a snapshot taken **before** the last hardening landed in the source tree — so a guard and its tests were silently dropped in the migration. This restores them, plus one forward-compatibility fix found while validating.

`publishedVersion()` reads `../package.json` at startup. That replaced a string literal, which could not fail, with file I/O, which can — and it runs while the command tree is built, *outside* the parse `try/catch`. Two failure modes, both reachable from a relocated bundle:

| | current behavior | with this PR |
| --- | --- | --- |
| manifest absent next to the bundle | raw V8 stack on stderr, unhandled | exit 1 + the sanitized failure message |
| manifest resolves to the **wrong** file | announces an unrelated package's version, or `.version(undefined)` crashes commander several calls later | refused up front |

The second is the nastier one and was found by the original test, not by reading code: `../package.json` from a relocated bundle resolves onto whatever package root sits above it — during development it landed on `/tmp/package.json`.

## Changes

- `parseManifestVersion` validates the parsed value: exact semver (`1.0.2`, `1.1.0-rc.1`) or refuse. A range, a number, a truncated `1.2`, or a missing field never becomes the announced version.
- The call is guarded, so an unreadable manifest exits 1 through `sanitizedErrorMessage` like every other error path.
- Content cases are tested **in process** against the extracted parser; a single subprocess covers the end-to-end sanitized contract. One spawn, not one per case — extra concurrent load is exactly what breaks this suite's timing-sensitive tests.
- `npmPack()` in `package-contents.test.ts` accepts both `npm pack --json` shapes: **npm 11 emits an array, npm 12 keys the reports by package name.** CI's `node-version: 24` still resolves npm 11.17 so nothing has noticed, but on a machine with npm 12.0.2 the suite currently starts from a red baseline (`packed.filename` of `undefined` in `beforeAll`). Verified both ways in the same directory: `npx npm@11.17.0 pack --json` → array; local npm 12 → keyed object.

## Validation

- TDD: the refusal cases confirmed red against the unmodified source (5 failing), green after.
- Mutation-tested: removing the semver check turns all 4 refusal cases red — they do not pass by accident.
- `typecheck` clean · full suite **208 passing** · `npm run build` + `dist/bin.js --version` == manifest (the same check `cli.yml` runs).
- The one remaining red, `catalog-id-conventions`' live-catalog scan timing out at 30s, **fails identically on the unchanged base** on the same machine (load average 50 at the time) and passed CI three days ago — pre-existing environmental, untouched here.