### PR TITLE
chore(ci): restore the npm-release environment — the trusted publisher is configured with it

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-release
     defaults:
       run:
         working-directory: cli


### PR DESCRIPTION
1.0.2 published successfully through trusted publishing with the publisher configured as environment `npm-release`. Removing the environment from the workflow (#3691, plano B) broke the match again for 1.0.3 (OIDC exchange 404). Restoring the line matches the publisher configuration that is proven to work; plano B is unnecessary.