### PR TITLE
catalog: add delef-dsh-plugin-auto-review (creator submission)

### DIFF
--- a/catalog/plugins/delef-dsh-plugin-auto-review.yaml
+++ b/catalog/plugins/delef-dsh-plugin-auto-review.yaml
@@ -1,0 +1,50 @@
+schemaVersion: 1
+id: delef-dsh-plugin-auto-review
+name: dsh-plugin-auto-review
+description:
+  en: Automatically review native DeepSeek Harness tool approval requests through a configured DSH LLM route, with Web controls and fail-closed handling
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: security-permissions-approvals
+tags:
+  - deepseek-harness
+  - dsh-plugin
+  - approvals
+  - security
+  - automation
+  - llm
+  - web-ui
+  - settings
+  - headless
+source:
+  repository: https://github.com/delef/dsh-plugin-auto-review
+  repositoryNodeId: R_kgDOUNA1nA
+  subpath: null
+  commit: b3a619ede575bc3c90d08c824d7d610671cb33ea
+creator:
+  github: delef
+package:
+  ecosystem: npm
+  name: dsh-plugin-auto-review
+  version: 0.1.0
+  integrity: sha512-v1qHPxejpucTuRu0NElredGyooLOWdf6XeS2dFnQs0i8t0ug13pMG3Gji1XG+1YNiSYwD6HB44Mrx601/u159A==
+dsh:
+  profiles:
+    - web
+    - headless
+  evidencePath: cordis.patch.yml
+repositoryScope: dedicated
+license:
+  spdx: Apache-2.0
+verification:
+  status: eligible
+  checkedAt: 2026-09-03T13:03:48.000Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: exact-repository
+  stars: 1
+provenance:
+  discussion: null
+  comment: null


### PR DESCRIPTION
## Plugin scope and source

- Plugin ID: `delef-dsh-plugin-auto-review`
- Dedicated branch: `add-delef-dsh-plugin-auto-review`
- Submission type: `creator`
- Created by `delef`
- Creator profile: https://github.com/delef
- Original source repository: https://github.com/delef/dsh-plugin-auto-review
- Repository node ID: `R_kgDOUNA1nA`
- Source commit: `b3a619ede575bc3c90d08c824d7d610671cb33ea`
- Plugin subpath: `null`
- Artifact kind, primary category and tags: `plugin`; `security-permissions-approvals`; approvals, security, automation, LLM, Web UI, settings, and headless
- Curated English description evidence path: `README.md`
- SPDX license evidence at the pinned commit: `LICENSE`, Apache-2.0
- Canonical exact-version package: `dsh-plugin-auto-review@0.1.0`, pinned with SHA-512 SRI in the entry
- Native DSH integration evidence: `package.json#dsh.bundle` and `cordis.patch.yml`
- Existing smoke evidence for the exact pin: `not run` for this catalog submission; entry is `eligible` with `smokeTest: null`
- Repository scope and star evidence: dedicated repository, 1 GitHub star checked on 2026-09-03
- Existing entry/open-PR collision search result: no matching entry or open PR found

The plugin is provider-neutral. The first release includes Codex Guardian and Grok escalation policies, while custom routes can use another compatible DSH provider or API adapter.

### What makes `dsh-plugin-auto-review` different

Auto Review does not use one generic approval prompt for every model. Its policy layer reproduces each supported provider's own review behavior and decision semantics inside DSH—for the first release, Codex Guardian and Grok escalation. The policy is separate from model transport, so those behaviors can run through routes exposed by `dsh-plugin-subscriptions` or another compatible DSH LLM adapter.

## Checklist

- [x] I used one dedicated branch and this PR changes exactly one plugin entry.
- [x] The source is the original creator repository, not an umbrella, aggregator or other catalog.
- [x] The source commit is a full 40-character OID.
- [x] The creator handle/profile, node ID, subpath, DSH integration, install pin and license are evidenced.
- [x] The entry uses `eligible` with `smokeTest: null` for `not run`.
- [x] I did not execute plugin or package lifecycle code to prepare this contribution.
- [x] Dedicated stars are recorded for the exact repository.
- [x] I checked for the same canonical repository/subpath, package and install target.
- [x] I understand that a direct creator PR supersedes an open curated or automation PR.
- [x] Creator Git authorship is preserved by this creator-authored commit and PR.
- [x] The entry is explicitly unofficial.
- [x] This PR contains no credentials, private contact details or other secrets.

Validation:

- `npx --yes omni-dsh-plugins catalog validate --catalog .` — 3,615 entries valid
- `npx --yes omni-dsh-plugins catalog github-forms-check .` — 3 forms valid

The separate docs-count check reports the expected pre-merge count change from 3,614 to 3,615. This PR intentionally does not modify generated documentation because the catalog policy requires exactly one plugin YAML file.

> This is an unofficial community project. It is not affiliated with, endorsed by, or sponsored by DeepSeek. DeepSeek names and marks belong to their respective owner.