### PR TITLE
Add sunshiner04-dsh-session-manager (archived-session manager for DSH web)

### DIFF
--- a/catalog/plugins/sunshiner04-dsh-session-manager.yaml
+++ b/catalog/plugins/sunshiner04-dsh-session-manager.yaml
@@ -1,0 +1,44 @@
+schemaVersion: 1
+id: sunshiner04-dsh-session-manager
+name: dsh-session-manager
+description:
+  en: Settings-page manager for archived DeepSeek Harness sessions: restore an archived session to its previous workspace position or permanently delete it (direct physical delete, optional backup checkbox removed in favor of irreversible deletion with a confirm dialog). Also adds a red permanently-delete item to the session context menu, /sessions slash commands, and three agent tools. Deleting an open session works immediately: the lingering in-memory summary is hidden via an archive-set tombstone and cleaned up at the next restart.
+  evidencePath: README.md
+unofficial: true
+kind: plugin
+primaryCategory: sessions-productivity
+tags:
+  - sessions
+  - archive
+  - delete
+  - restore
+  - settings-page
+  - slash-commands
+  - agent-tools
+  - dsh
+source:
+  repository: https://github.com/SunshineR04/dsh-session-manager
+  repositoryNodeId: R_kgDOUPhlxg
+  commit: b3de482adee11260f54ab97cfc7f594bd062d7ed
+creator:
+  github: SunshineR04
+package:
+  ecosystem: source
+dsh:
+  profiles:
+    - web
+  evidencePath: cordis.patch.yml
+repositoryScope: single
+license:
+  spdx: MIT
+verification:
+  status: eligible
+  checkedAt: 2026-09-05T19:47:45.000Z
+  repositoryIdentity: resolved
+  smokeTest: null
+popularity:
+  starsPolicy: undefined-parent-repository
+  stars: null
+provenance:
+  discussion: null
+  comment: null

--- a/catalog/plugins/sunshiner04-dsh-session-manager.yaml
+++ b/catalog/plugins/sunshiner04-dsh-session-manager.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: sunshiner04-dsh-session-manager
 name: dsh-session-manager
 description:
-  en: Settings-page manager for archived DeepSeek Harness sessions: restore an archived session to its previous workspace position or permanently delete it (direct physical delete, optional backup checkbox removed in favor of irreversible deletion with a confirm dialog). Also adds a red permanently-delete item to the session context menu, /sessions slash commands, and three agent tools. Deleting an open session works immediately: the lingering in-memory summary is hidden via an archive-set tombstone and cleaned up at the next restart.
+  en: Settings-page manager for archived DeepSeek Harness sessions: restore an archived session to its previous workspace position or permanently delete it (direct physical delete, optional backup checkbox removed in favor of irreversible deletion with a confirm dialog). Also adds a red permanently-delete item to the session context menu. Deleting an open session works immediately: the lingering in-memory summary is hidden via an archive-set tombstone and cleaned up at the next restart.
   evidencePath: README.md
 unofficial: true
 kind: plugin


### PR DESCRIPTION
## Plugin

`sunshiner04-dsh-session-manager` — a DeepSeek Harness plugin that manages archived sessions from a first-class Settings page.

## Required evidence

- **Canonical repository**: https://github.com/SunshineR04/dsh-session-manager
- **Repository node ID**: `R_kgDOUPhlxg`
- **Pinned commit**: `b3de482adee11260f54ab97cfc7f594bd062d7ed` (current `main`)
- **Creator**: @SunshineR04
- **License**: MIT (`LICENSE` at the pinned commit)
- **dsh manifest**: `dsh.bundle.patch: ./cordis.patch.yml` + `dsh.client.platform: web` in `package.json`; `cordis.patch.yml` at the repository root
- **Install**: `dsh plugin --profile web add github:SunshineR04/dsh-session-manager`

## What it does

- Settings page (Settings → Session Manager): list archived sessions with title, workspace, project directory, update time and running state; **restore** or **permanently delete** each
- Red **Delete permanently** item in the session context menu (DOM + React-fiber augmentation, passive degrade)
- `/sessions` slash commands (`archived`, `restore`, `delete`, `pending`) and three agent tools
- Deleting an **open** session works immediately: registry accounting and files are removed at once; the lingering in-memory summary is hidden via an archive-set tombstone and cleaned up at the next restart
- No telemetry, no network calls, MIT

Single YAML file under `catalog/plugins/` on a dedicated branch, as required.