### PR TITLE
chore(cli): prepare 1.0.4 with the fast-uri security patch

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1260,9 +1260,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Prepare omni-dsh-plugins@1.0.4 to ship the reviewed fast-uri 3.1.7 fix from #3696. The existing 1.0.3 npm bundle contains fast-uri, so merging only the lockfile would leave the published artifact unchanged.

This candidate preserves the original Dependabot commit and adds only the package version plus matching root lockfile version fields. No CLI behavior or unrelated dependency resolutions are changed by the version commit. Four public fast-uri advisories are addressed by the dependency patch; the separate Vitest advisories remain outside this release change.

Depends on #3696. Integrate that dependency change first and reconcile this candidate with main before creating the cli-v1.0.4 tag. No tag or npm publication has been performed.

Validation: isolated installation with lifecycle scripts disabled, build, exact four-file package allowlist and offline installation of the local tarball all passed. The installed binary reported 1.0.4, answered --help and validated a local empty catalog. The build dependency was confirmed as fast-uri@3.1.7. GitHub CLI and catalog checks passed on commit 96baba044cf55270a4df7b96b6a60b5629204d72. The release workflow will verify and smoke the exact tarball again before any authorized npm publication.
